### PR TITLE
fix: add text-wrap balance to EN hero to prevent orphan words

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -653,6 +653,7 @@ const randomArticlesData = JSON.stringify(allArticles);
     letter-spacing: 0.05em;
     line-height: 1.2;
     text-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    text-wrap: balance;
   }
 
   /* Description text - elegant and simple */
@@ -666,6 +667,7 @@ const randomArticlesData = JSON.stringify(allArticles);
     font-weight: 300;
     color: rgba(255, 255, 255, 0.85);
     text-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+    text-wrap: balance;
   }
 
   .hero-description br {


### PR DESCRIPTION
## 📝 Content Summary
                                                                                      
- Added text-wrap: balance to .hero-subtitle and .hero-description in the English homepage hero section to prevent orphan words (e.g., "Island" or "Taiwan" appearing alone on a wrapped line).  


before
<img width="1130" height="558" alt="image" src="https://github.com/user-attachments/assets/0da37170-2d77-4545-af95-cc6ba69068b7" />

after
<img width="925" height="526" alt="image" src="https://github.com/user-attachments/assets/194a9191-7b2e-42c5-9f41-215506515ccd" />
