### PR TITLE
fix: 圖片載入失敗時顯示優雅的 alt text 佔位符

### DIFF
--- a/src/pages/[category]/[slug].astro
+++ b/src/pages/[category]/[slug].astro
@@ -150,6 +150,13 @@ renderer.link = ({ href, title, text }) => {
   return `<a href="${href}"${titleAttr}${targetAttr}>${text}</a>`;
 };
 
+// Broken image fallback: show styled alt text placeholder
+renderer.image = ({ href, title, text }) => {
+  const titleAttr = title ? ` title="${title}"` : '';
+  const altText = text || '';
+  return `<img src="${href}" alt="${altText}"${titleAttr} loading="lazy" onerror="this.onerror=null;this.classList.add('img-broken')" />`;
+};
+
 const processedContent = marked.parse(resolvedContent, { renderer });
 ---
 
@@ -842,6 +849,23 @@ const processedContent = marked.parse(resolvedContent, { renderer });
     margin: 2.5rem auto;
     display: block;
     box-shadow: 0 2px 8px rgba(0,0,0,0.06);
+  }
+
+  /* 圖片載入失敗的優雅降級 */
+  .content img.img-broken {
+    min-height: 120px;
+    max-height: 120px;
+    background: #f8f9fa;
+    border: 1.5px dashed #d0d5dd;
+    box-shadow: none;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.85rem;
+    color: #667085;
+    text-align: center;
+    padding: 1rem;
+    line-height: 1.5;
+    word-break: break-word;
+    overflow: hidden;
   }
 
   /* 圖片說明文字 */

--- a/src/pages/[category]/index.astro
+++ b/src/pages/[category]/index.astro
@@ -121,7 +121,15 @@ function resolveWikilinks(md: string, currentCategory: string) {
 }
 
 const resolvedContent = hubContent ? resolveWikilinks(hubContent, category) : '';
-const hubHtml = resolvedContent ? marked.parse(resolvedContent) : '';
+
+// Broken image fallback for hub pages
+const hubRenderer = new marked.Renderer();
+hubRenderer.image = ({ href, title, text }) => {
+  const titleAttr = title ? ` title="${title}"` : '';
+  const altText = text || '';
+  return `<img src="${href}" alt="${altText}"${titleAttr} loading="lazy" onerror="this.onerror=null;this.classList.add('img-broken')" />`;
+};
+const hubHtml = resolvedContent ? marked.parse(resolvedContent, { renderer: hubRenderer }) : '';
 
 // Split hub HTML into sections at <h2> boundaries for chart injection (economy only)
 const isEconomy = category === 'economy';
@@ -502,6 +510,21 @@ const otherCategories = Object.keys(categoryConfig)
     margin: 2rem auto;
     display: block;
     box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  }
+  .hub-prose img.img-broken {
+    min-height: 120px;
+    max-height: 120px;
+    background: #f8f9fa;
+    border: 1.5px dashed #d0d5dd;
+    box-shadow: none;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.85rem;
+    color: #667085;
+    text-align: center;
+    padding: 1rem;
+    line-height: 1.5;
+    word-break: break-word;
+    overflow: hidden;
   }
   .hub-prose em {
     font-size: 0.85rem;

--- a/src/pages/en/[category]/[slug].astro
+++ b/src/pages/en/[category]/[slug].astro
@@ -131,6 +131,13 @@ renderer.link = ({ href, title, text }) => {
   return `<a href="${href}"${titleAttr}${targetAttr}>${text}</a>`;
 };
 
+// Broken image fallback: show styled alt text placeholder
+renderer.image = ({ href, title, text }) => {
+  const titleAttr = title ? ` title="${title}"` : '';
+  const altText = text || '';
+  return `<img src="${href}" alt="${altText}"${titleAttr} loading="lazy" onerror="this.onerror=null;this.classList.add('img-broken')" />`;
+};
+
 const processedContent = marked.parse(resolvedContent, { renderer });
 ---
 
@@ -700,6 +707,23 @@ const processedContent = marked.parse(resolvedContent, { renderer });
     margin: 2rem auto;
     display: block;
     box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  }
+
+  /* Graceful fallback for broken images */
+  .content img.img-broken {
+    min-height: 120px;
+    max-height: 120px;
+    background: #f8f9fa;
+    border: 1.5px dashed #d0d5dd;
+    box-shadow: none;
+    font-family: system-ui, -apple-system, sans-serif;
+    font-size: 0.85rem;
+    color: #667085;
+    text-align: center;
+    padding: 1rem;
+    line-height: 1.5;
+    word-break: break-word;
+    overflow: hidden;
   }
 
   .content p > em:only-child {


### PR DESCRIPTION
## 問題

部分修復 #46 — 圖片載入失敗的 **fallback 機制**（治標）。

目前 `public/images/wiki/` 中有 ~45 張被引用但不存在的圖片，導致文章頁和分類 Hub 頁顯示瀏覽器預設的破圖 icon。這個 PR 讓破圖變成乾淨的佔位符，在圖片補齊之前也不會影響閱讀體驗。

## 改動

### marked.js 自訂 `renderer.image()`
- 為所有 `<img>` 加上 `loading="lazy"`（效能優化）
- 加上 `onerror` handler：載入失敗時 `this.onerror=null`（防無限迴圈）+ 加上 `.img-broken` class

### CSS `.img-broken` 樣式
- 淺灰底（`#f8f9fa`）+ 虛線邊框（`#d0d5dd`）
- 高度縮為 `120px`，不佔據原本 `450px` 的大片空間
- 顯示 alt text（如「台北士林夜市景象」），讓讀者知道這裡原本是什麼圖
- 支援長文字自動斷行，不溢出

### 覆蓋範圍
| 頁面 | 檔案 |
|------|------|
| 文章頁（繁中） | `src/pages/[category]/[slug].astro` |
| 文章頁（英文） | `src/pages/en/[category]/[slug].astro` |
| 分類 Hub 頁 | `src/pages/[category]/index.astro` |

### 不影響
- 正常載入的圖片（`onerror` 不觸發，`.img-broken` 不加）
- `CategoryGrid.astro`（已有自己的 `onerror` 隱藏圖片顯示 icon）

## 後續

缺失圖片的下載（治本）會在另一個 PR 處理 — 需要先確認部分圖片的 Wikimedia Commons 原始 URL。