### PR TITLE
feat: 新增圖片健康檢查工具 (npm run check-images)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,6 +330,9 @@ bun run preview
 - **Squoosh**：圖片壓縮優化
 - **Canva**：簡單設計工具
 - **Unsplash**：免費圖片資源
+- **圖片健康檢查**：提交 PR 前請執行 `npm run check-images`，確認所有引用的圖片都存在於 `public/` 目錄中
+- **Wikimedia Commons**：使用 CC 授權圖片時，解析度建議 800–1200px 寬，並在圖片下方標注來源與授權
+- ⚠️ AI 生成的圖片 attribution 連結（`File:...`）不一定正確，提交前請手動驗證連結是否有效
 
 #### 參考資源
 - **台灣百科全書**：基礎資料查證

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "astro preview",
     "sync": "bash scripts/sync.sh",
     "sync:build": "bash scripts/sync.sh && astro build",
+    "check-images": "node scripts/check-images.mjs",
     "astro": "astro"
   },
   "dependencies": {

--- a/scripts/check-images.mjs
+++ b/scripts/check-images.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Image Health Check for Taiwan.md
+ *
+ * Scans markdown and Astro files for image references,
+ * verifies they exist in public/, and reports missing ones.
+ *
+ * Usage:
+ *   node scripts/check-images.mjs          # human-readable output
+ *   node scripts/check-images.mjs --json   # JSON output for CI
+ *
+ * Exit codes:
+ *   0 = all images present
+ *   1 = missing images found
+ */
+
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { join, relative } from 'path';
+
+const ROOT = new URL('..', import.meta.url).pathname;
+const PUBLIC = join(ROOT, 'public');
+const jsonMode = process.argv.includes('--json');
+
+// Recursively find files matching extensions
+function findFiles(dir, extensions) {
+  const results = [];
+  if (!existsSync(dir)) return results;
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...findFiles(full, extensions));
+    } else if (extensions.some(ext => entry.name.endsWith(ext))) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+// Extract image references from a markdown file
+function extractFromMarkdown(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  const lines = content.split('\n');
+  const refs = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const imgMatch = lines[i].match(/!\[([^\]]*)\]\(\/images\/([^)]+)\)/);
+    if (!imgMatch) continue;
+
+    const alt = imgMatch[1];
+    const path = `/images/${imgMatch[2]}`;
+
+    // Look for attribution in the next 2 lines
+    let attribution = null;
+    for (let j = i + 1; j <= i + 2 && j < lines.length; j++) {
+      const attrMatch = lines[j].match(/File:([^)\]]+)/);
+      if (attrMatch) {
+        attribution = `File:${attrMatch[1]}`;
+        break;
+      }
+    }
+
+    refs.push({
+      path,
+      alt,
+      source: `${relative(ROOT, filePath)}:${i + 1}`,
+      attribution,
+    });
+  }
+  return refs;
+}
+
+// Extract image references from an Astro file
+function extractFromAstro(filePath) {
+  const content = readFileSync(filePath, 'utf-8');
+  const refs = [];
+
+  // Match: cover: '/images/...', src="/images/..."
+  const regex = /(?:cover|src)[:=]\s*['"](\/(images\/[^'"]+))['"]/g;
+  let match;
+  while ((match = regex.exec(content)) !== null) {
+    const path = match[1];
+    const lineNum = content.substring(0, match.index).split('\n').length;
+    refs.push({
+      path,
+      alt: '',
+      source: `${relative(ROOT, filePath)}:${lineNum}`,
+      attribution: null,
+    });
+  }
+  return refs;
+}
+
+// Main
+const allRefs = [];
+
+// Scan knowledge/**/*.md
+for (const f of findFiles(join(ROOT, 'knowledge'), ['.md'])) {
+  allRefs.push(...extractFromMarkdown(f));
+}
+
+// Scan src/components/**/*.astro
+for (const f of findFiles(join(ROOT, 'src', 'components'), ['.astro'])) {
+  allRefs.push(...extractFromAstro(f));
+}
+
+// Deduplicate by path (keep first occurrence for reporting)
+const seen = new Map();
+for (const ref of allRefs) {
+  if (!seen.has(ref.path)) {
+    seen.set(ref.path, ref);
+  }
+}
+const unique = [...seen.values()];
+
+// Check existence
+const results = unique.map(ref => ({
+  ...ref,
+  exists: existsSync(join(PUBLIC, ref.path)),
+}));
+
+const ok = results.filter(r => r.exists);
+const missing = results.filter(r => !r.exists);
+
+// Output
+if (jsonMode) {
+  const output = {
+    total: results.length,
+    ok: ok.length,
+    missing: missing.length,
+    images: missing.map(r => ({
+      path: r.path,
+      alt: r.alt,
+      usedIn: r.source,
+      attribution: r.attribution || null,
+    })),
+  };
+  console.log(JSON.stringify(output, null, 2));
+} else {
+  console.log('Image Health Check — taiwan-md');
+  console.log('================================');
+  console.log(`Scanned: ${allRefs.length} references (${results.length} unique)`);
+  console.log(`✅ ${ok.length} OK`);
+  console.log(`❌ ${missing.length} missing`);
+
+  if (missing.length > 0) {
+    console.log('');
+    for (const r of missing) {
+      console.log(`  ${r.path}`);
+      if (r.alt) console.log(`    alt: ${r.alt}`);
+      console.log(`    used in: ${r.source}`);
+      if (r.attribution) {
+        console.log(`    attribution: ${r.attribution} ← can download via API`);
+      } else {
+        console.log(`    attribution: (none found) ← needs manual sourcing`);
+      }
+      console.log('');
+    }
+  } else {
+    console.log('\nAll images present!');
+  }
+}
+
+process.exit(missing.length > 0 ? 1 : 0);

--- a/scripts/sync.sh
+++ b/scripts/sync.sh
@@ -132,5 +132,11 @@ echo "🔄 處理檔案數: $SYNCED_COUNT"
 echo ""
 echo "✨ knowledge/ SSOT → src/content/ 投影層完整同步完成"
 echo "🔧 frontmatter 格式已統一修復"
+
+# 3. 圖片健康檢查
+echo ""
+echo "🖼️ 步驟 3: 圖片健康檢查..."
+node scripts/check-images.mjs || echo "  ⚠️  有缺失圖片，請執行 npm run check-images 查看細節"
+
 echo ""
 echo "▶️  下一步：執行 npm run build 建構網站"


### PR DESCRIPTION
## 動機

AI 寫文章時會自動生成圖片引用和 attribution 連結，但圖片檔案不一定存在（Issue #46 發現 32 張缺失）。目前沒有任何機制在 build 前檢查這件事。

這個工具讓問題在早期就被發現，避免圖片缺失累積到讀者反映才處理。

## 新增內容

### `scripts/check-images.mjs`

零依賴的 Node.js 腳本，掃描所有圖片引用並驗證存在性。

```bash
npm run check-images          # 人類可讀
npm run check-images -- --json  # JSON（CI 用）
```

**掃描範圍：**
- `knowledge/**/*.md` — SSOT
- `src/components/**/*.astro` — CategoryGrid 等組件

**輸出範例：**
```
Image Health Check — taiwan-md
================================
Scanned: 49 references (45 unique)
✅ 45 OK
❌ 0 missing

All images present!
```

缺失時會顯示 alt text、引用位置、以及是否有 Wikimedia attribution 連結（標示「can download via API」或「needs manual sourcing」）。

**Exit codes：** 0 全通過、1 有缺失

### 整合

- `package.json`：新增 `"check-images"` script
- `sync.sh`：sync 完自動跑圖片檢查
- `CONTRIBUTING.md`：圖片處理段落補充檢查指引 + AI attribution 驗證提醒

### 不做的事

- 不自動下載（只報告，修復交給人決定）
- 不掃 `src/content/`（是 knowledge/ 的投影）
- 不驗證圖片是否損壞（只檢查存在性）