### PR TITLE
fix: 修正 fredchu 的 contributor avatar URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Thanks to these wonderful people ([emoji key](https://allcontributors.org/docs/e
   <tr>
     <td align="center"><a href="https://github.com/hansai-art"><img src="https://avatars.githubusercontent.com/u/132933660?v=4" width="80px;" alt="hansai-art"/><br /><sub><b>hansai-art</b></sub></a><br />🖋 💻 🔍</td>
     <td align="center"><a href="https://github.com/luofreddy"><img src="https://avatars.githubusercontent.com/u/85281073?v=4" width="80px;" alt="luofreddy"/><br /><sub><b>luofreddy</b></sub></a><br />💻</td>
-    <td align="center"><a href="https://github.com/fredchu"><img src="https://avatars.githubusercontent.com/u/282984?v=4" width="80px;" alt="fredchu"/><br /><sub><b>fredchu</b></sub></a><br />🔍 🐛 🖋 📖</td>
+    <td align="center"><a href="https://github.com/fredchu"><img src="https://avatars.githubusercontent.com/u/1243384?v=4" width="80px;" alt="fredchu"/><br /><sub><b>fredchu</b></sub></a><br />🔍 🐛 🖋 📖</td>
     <td align="center"><a href="https://github.com/Rushyuheng"><img src="https://avatars.githubusercontent.com/u/82425707?v=4" width="80px;" alt="Rushyuheng"/><br /><sub><b>Rushyuheng</b></sub></a><br />🖋</td>
     <td align="center"><a href="https://github.com/f312213213"><img src="https://avatars.githubusercontent.com/u/71749524?v=4" width="80px;" alt="f312213213"/><br /><sub><b>f312213213</b></sub></a><br />💻 🌍</td>
     <td align="center"><a href="https://github.com/siansiansu"><img src="https://avatars.githubusercontent.com/u/33390878?v=4" width="80px;" alt="siansiansu"/><br /><sub><b>siansiansu</b></sub></a><br />🖋</td>


### PR DESCRIPTION
README.md 的 all-contributors 區塊裡，fredchu 的 avatar URL 指向錯誤的 GitHub user ID。

- 錯誤：`u/282984`（別人的帳號）
- 正確：`u/1243384`（fredchu）