### PR TITLE
fix: limit Protico to production hosts and add disclosure 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,35 @@ docs/
 
 ---
 
+## 🔐 Protico Community Chat Disclosure
+
+Selected pages on the public site currently embed a sponsor-provided Protico community chat / lobby widget:
+
+- `/`
+- `/about`
+- `/contribute`
+- `/en/contribute`
+
+This note is here so contributors know what the embed is for, what client-side context it may use, and when it loads.
+
+| Data / behavior | Why it exists |
+|-----------------|---------------|
+| Persistent anonymous UUID and related usage context | Used as a defensive moderation and reliability mechanism: to understand the client environment in which an error occurred, help returning visitors recover continuity in a public lobby, and distinguish repeated behavior in cases involving abuse, safety issues, or clear community-guideline violations. |
+| User-Agent, session/context, and page URL | Used for compatibility debugging, incident investigation, and moderation follow-up in a public discussion space. |
+| Browser language preference | Used to present the lobby UI in the language that best matches the visitor's browser preferences. |
+| Payment-related cookies set by the widget (for example Stripe cookies) | Present because the Protico widget supports payment-related features such as highlighted / paid messages in some deployments. |
+
+Notes:
+
+- The values above are treated as pseudonymous technical context. Taiwan.md does not intentionally pass separate real-name, email, or site account profile fields from this repository into the Protico embed.
+- Taiwan.md does not use this integration as a standalone cross-product tracking system. In practice, these signals are intended for moderation, debugging, language selection, and continuity within the public chat experience.
+- Unless a user separately authenticates or voluntarily provides additional identifying information through the widget flow itself, these values are not meant to identify a person on their own.
+- Stripe-related capability exists in the underlying widget design, including support for paid or highlighted messages, but that feature is not currently enabled as an open-source Taiwan.md community feature. Any future enablement would be reviewed separately.
+- The Protico script is only loaded on the public production hostnames (`taiwan.md` / `www.taiwan.md`). It is not loaded in local development, localhost, or local preview.
+- The widget is a third-party sponsored component, and its browser-side implementation is provided by Protico.
+
+---
+
 ## 🔄 Perspectives — 平行宇宙觀點系統
 
 Taiwan.md doesn't arbitrate truth. **We present multiple truths and let readers decide.**

--- a/src/components/ProticoScript.astro
+++ b/src/components/ProticoScript.astro
@@ -1,0 +1,11 @@
+<script is:inline>
+  (() => {
+    const allowedHosts = new Set(['taiwan.md', 'www.taiwan.md']);
+    if (!allowedHosts.has(window.location.hostname)) return;
+
+    const script = document.createElement('script');
+    script.src = 'https://main.protico.io/api/v1/taiwan.md/protico-frame.js';
+    script.async = true;
+    document.head.appendChild(script);
+  })();
+</script>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import ProticoScript from '../components/ProticoScript.astro';
 ---
 
 <Layout title="關於 Taiwan.md" description="Taiwan.md 的創站故事、創辦人介紹與聯繫方式">
@@ -475,7 +476,7 @@ import Layout from '../layouts/Layout.astro';
             <p class="tier-desc">個人贊助者，README 感謝名單</p>
             <div class="tier-logos">
               <a href="https://protico.io" target="_blank" class="supporter-link">
-                <strong>Protico</strong> — Howei Young
+                <strong>Protico</strong> — Howie Young
               </a>
             </div>
           </div>
@@ -525,8 +526,8 @@ import Layout from '../layouts/Layout.astro';
 
   </div>
 
-  <!-- Protico Community Chat Bubble — sponsored by Howei Young -->
-  <script src="https://main.protico.io/api/v1/taiwan.md/protico-frame.js"></script>
+  <!-- Protico Community Chat Bubble — sponsored by Howie Young -->
+  <ProticoScript />
 </Layout>
 
 <style>

--- a/src/pages/contribute.astro
+++ b/src/pages/contribute.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../layouts/Layout.astro';
+import ProticoScript from '../components/ProticoScript.astro';
 ---
 
 <Layout title="我想貢獻 — Taiwan.md" description="不需要會寫程式，你也能幫助世界認識台灣">
@@ -516,8 +517,8 @@ import Layout from '../layouts/Layout.astro';
 
   </div>
 
-  <!-- Protico Community Chat Bubble — sponsored by Howei Young -->
-  <script src="https://main.protico.io/api/v1/taiwan.md/protico-frame.js"></script>
+  <!-- Protico Community Chat Bubble — sponsored by Howie Young -->
+  <ProticoScript />
 </Layout>
 
 <script is:inline>

--- a/src/pages/en/contribute.astro
+++ b/src/pages/en/contribute.astro
@@ -1,5 +1,6 @@
 ---
 import Layout from '../../layouts/Layout.astro';
+import ProticoScript from '../../components/ProticoScript.astro';
 ---
 
 <Layout title="I Want to Contribute — Taiwan.md" description="No programming skills needed. You can help the world understand Taiwan" lang="en">
@@ -516,8 +517,8 @@ Topic I want to write: [Specific topic, e.g.: Taiwan coffee culture development 
 
   </div>
 
-  <!-- Protico Community Chat Bubble — sponsored by Howei Young -->
-  <script src="https://main.protico.io/api/v1/taiwan.md/protico-frame.js"></script>
+  <!-- Protico Community Chat Bubble — sponsored by Howie Young -->
+  <ProticoScript />
 </Layout>
 
 <script is:inline>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import Layout from '../layouts/Layout.astro';
 import CategoryGrid from '../components/CategoryGrid.astro';
 import { getCollection } from 'astro:content';
+import ProticoScript from '../components/ProticoScript.astro';
 // Fetch recent commits from GitHub API (works in shallow clone CI/CD environments)
 let recentCommits: { hash: string; date: string; message: string }[] = [];
 try {
@@ -1100,9 +1101,8 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     });
 </script>
 
-<!-- Protico Community Chat Bubble — sponsored by Howei Young -->
-<script src="https://main.protico.io/api/v1/taiwan.md/protico-frame.js"
-></script>
+<!-- Protico Community Chat Bubble — sponsored by Howie Young -->
+<ProticoScript />
 
 <style>
   /* ===== SKIP LINK FOR ACCESSIBILITY ===== */


### PR DESCRIPTION
Add a README disclosure for the Protico chat widget and only load the script on taiwan.md production hostnames.

## 📝 這個 PR 做了什麼？

這個 PR 針對 Protico 社群聊天小工具做了兩件事：

1. 將 Protico script 改為只在正式站台 `taiwan.md` / `www.taiwan.md` 載入，避免在本地開發、localhost、local preview 等情境下自動連到第三方服務。
2. 在 README 補上 Protico embed disclosure，說明社群大廳元件的載入頁面、用途，以及相關技術資訊的預期使用情境。
3. 更正 Community Sponsor 名稱 (Howie > Howie)

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [x] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

註：
- 本 PR 為技術 / 文件變更，前 3 項內容檢查不適用。

## 🔗 相關 Issue

Closes #60 

## 📸 截圖（如果是視覺改動）

無

