### PR TITLE
fix: 修正全站按鈕文字垂直偏移問題

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1151,9 +1151,9 @@ const navConfig = [
 
   /* Global link styles */
   main
-    a:not(.nav-link):not(.btn-primary):not(.btn-secondary):not(.card-link):not(
+    a:not(.nav-link):not([class*='btn']):not(.card-link):not(
       .logo
-    ):not(.category-card):not(.lang-btn):not(.floating-md):not(.search-item) {
+    ):not(.category-card):not(.floating-md):not(.search-item) {
     color: #475569;
     text-decoration: none;
     border-bottom: 1px solid #cbd5e1;
@@ -1161,9 +1161,9 @@ const navConfig = [
     transition: all 0.2s ease;
   }
   main
-    a:not(.nav-link):not(.btn-primary):not(.btn-secondary):not(.card-link):not(
+    a:not(.nav-link):not([class*='btn']):not(.card-link):not(
       .logo
-    ):not(.category-card):not(.lang-btn):not(.floating-md):not(
+    ):not(.category-card):not(.floating-md):not(
       .search-item
     ):hover {
     color: #1a1a2e;
@@ -1171,9 +1171,9 @@ const navConfig = [
   }
   /* External links (with target="_blank") get an icon */
   main
-    a[target='_blank']:not(.nav-link):not(.btn-primary):not(.btn-secondary):not(
+    a[target='_blank']:not(.nav-link):not([class*='btn']):not(
       .card-link
-    ):not(.logo):not(.category-card):not(.lang-btn):not(.floating-md)::after {
+    ):not(.logo):not(.category-card):not(.floating-md)::after {
     content: '↗';
     font-size: 0.8em;
     margin-left: 0.2em;


### PR DESCRIPTION
## 摘要

修復 #83 — 全站按鈕文字向下偏移的問題。

**根本原因：** Layout.astro 的全域連結樣式對 `<main>` 內所有 `<a>` 套用 `padding-bottom: 1px` 和 `border-bottom`，但排除清單只列了 `.btn-primary`、`.btn-secondary`、`.lang-btn`。全站共有 38+ 種按鈕 class（`.btn-cta`、`.btn`、`.link-btn`、`.path-btn`、`.feature-btn` 等），全部被影響。

**修復方式：** 將個別排除 `:not(.btn-primary):not(.btn-secondary):not(.lang-btn)` 替換為通用的 `:not([class*="btn"])`，一次涵蓋所有按鈕 class，也適用於未來新增的按鈕。

涉及 3 組 CSS selector：
1. 全域連結樣式（color、border-bottom、padding-bottom）
2. 全域連結 hover 樣式
3. 外部連結 `::after` 圖示（↗）

### Playwright 自動化驗證結果

| 頁面 | 按鈕數 | 狀態 |
|------|--------|------|
| `/`（首頁） | 8 | ✅ padding 對稱 |
| `/data` | 1 | ✅ |
| `/contribute` | 3 | ✅ |
| `/projects` | 12 | ✅ |
| `/resources` | 1 | ✅ |
| `/en` | 6 | ✅ |
| 文章頁 | 8 | ✅ |
| 一般連結 | — | ✅ 底線樣式保留 |

## 測試計畫

- [ ] 首頁 CTA 按鈕（「開始探索」、「Star on GitHub」）— 文字垂直置中
- [ ] `/contribute`「前往 GitHub」按鈕 — 無多餘 `↗` 圖示，文字置中
- [ ] `/data`「← 回到資源頁」按鈕 — 文字置中
- [ ] 文章頁底部按鈕 — 文字置中
- [ ] 一般內文連結仍保有底線樣式

🤖 Generated with [Claude Code](https://claude.com/claude-code)