### PR TITLE
fix: replace Chinese remnants in English UI pages (#45)

### DIFF
--- a/src/pages/en/[category]/[slug].astro
+++ b/src/pages/en/[category]/[slug].astro
@@ -114,7 +114,7 @@ if (!categoryInfo) {
   throw new Error(`Unknown category: ${category}`);
 }
 
-// 推薦文章 (簡化版，取同分類的其他文章)
+// Related articles (simplified: other articles in the same category)
 const otherCategories = Object.keys(categoryConfig)
   .filter(cat => cat !== category)
   .slice(0, 3)
@@ -335,7 +335,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
           </div>
         </div>
 
-        <!-- 延伸閱讀：同分類其他文章 -->
+        <!-- Further reading: other articles in the same category -->
         {relatedArticles.length > 0 && (
           <div class="related-articles">
             <h3 class="related-title">Further Reading</h3>
@@ -375,7 +375,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
         <div class="article-footer-actions">
           <hr class="section-divider" />
           
-          <!-- 推薦下一篇 (Retention Loop) -->
+          <!-- Recommended next article (Retention Loop) -->
           {relatedArticles.length > 0 && (
             <div class="recommended-reading">
               <h3 class="footer-section-title">You might also like</h3>
@@ -427,7 +427,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
 
           <hr class="section-divider" />
 
-          <!-- 社交分享 (Sharing Loop) -->
+          <!-- Social sharing (Sharing Loop) -->
           <div class="social-sharing">
             <h3 class="footer-section-title">Share with others</h3>
             <div class="sharing-buttons">
@@ -1174,7 +1174,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
     letter-spacing: 0.04em;
   }
 
-  /* 推薦下一篇 */
+  /* Recommended next */
   .recommended-reading {
     margin: 3rem 0;
   }
@@ -1224,7 +1224,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
     width: fit-content;
   }
 
-  /* 貢獻區塊 */
+  /* Contribute section */
   .contribute-note {
     font-size: 0.95rem;
     line-height: 1.8;
@@ -1282,7 +1282,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
     font-size: 1.1rem;
   }
 
-  /* 社交分享 */
+  /* Social sharing */
   .social-sharing {
     margin: 3rem 0;
     text-align: center;

--- a/src/pages/en/[category]/index.astro
+++ b/src/pages/en/[category]/index.astro
@@ -105,10 +105,10 @@ function resolveWikilinks(md: string, currentCategory: string) {
 const resolvedContent = hubContent ? resolveWikilinks(hubContent, category) : '';
 const hubHtml = resolvedContent ? marked.parse(resolvedContent) : '';
 
-// 其他分類（跨分類導航用）
+// Other categories (cross-category navigation)
 const otherCategories = Object.keys(categoryConfig)
   .filter(cat => cat !== category)
-  .slice(0, 5) // 只顯示5個
+  .slice(0, 5) // show only 5
   .map(cat => ({
     key: cat,
     ...categoryConfig[cat as CategoryKey]
@@ -169,7 +169,7 @@ const otherCategories = Object.keys(categoryConfig)
                           <span class="status-tag">{article.status}</span>
                         )}
                         {article.lang && (
-                          <span class="lang-tag">{article.lang === 'zh-TW' ? '中文' : 'EN'}</span>
+                          <span class="lang-tag">{article.lang === 'zh-TW' ? 'ZH' : 'EN'}</span>
                         )}
                       </div>
                       {article.featured && (
@@ -212,7 +212,7 @@ const otherCategories = Object.keys(categoryConfig)
         </section>
       )}
 
-      <!-- 探索其他面向 -->
+      <!-- Explore other aspects -->
       <section class="explore-more">
         <h2 class="explore-title">Explore Other Aspects of Taiwan</h2>
         <div class="categories-grid">

--- a/src/pages/en/map.astro
+++ b/src/pages/en/map.astro
@@ -92,33 +92,33 @@ import Layout from '../../layouts/Layout.astro';
           <!-- Knowledge markers -->
           <g id="markers">
             <!-- North Region -->
-            <circle cx="350" cy="200" r="8" fill="#f39c12" class="marker" data-region="north" data-category="food" data-title="Shilin Night Market" data-link="/food/夜市文化" data-desc="Iconic night market culture in Taiwan"></circle>
-            <circle cx="330" cy="180" r="8" fill="#27ae60" class="marker" data-region="north" data-category="nature" data-title="Yangmingshan National Park" data-link="/nature/國家公園" data-desc="Taiwan's first national park"></circle>
-            <circle cx="370" cy="220" r="8" fill="#ff5722" class="marker" data-region="north" data-category="economy" data-title="Taipei 101" data-link="/economy/經濟奇蹟" data-desc="Symbol of Taiwan's economic miracle"></circle>
-            <circle cx="360" cy="210" r="8" fill="#e74c3c" class="marker" data-region="north" data-category="history" data-title="Chiang Kai-shek Memorial Hall" data-link="/history/戒嚴時期" data-desc="Historical landmark of Taiwan's martial law period"></circle>
-            <circle cx="365" cy="215" r="8" fill="#8bc34a" class="marker" data-region="north" data-category="lifestyle" data-title="Ximending" data-link="/lifestyle/便利商店文化" data-desc="Birthplace of Taiwan's convenience store culture"></circle>
-            <circle cx="380" cy="240" r="8" fill="#3498db" class="marker" data-region="north" data-category="technology" data-title="Hsinchu Science Park" data-link="/technology/半導體產業" data-desc="Taiwan's semiconductor industry hub"></circle>
+            <circle cx="350" cy="200" r="8" fill="#f39c12" class="marker" data-region="north" data-category="food" data-title="Shilin Night Market" data-link="/en/food/night-market-culture" data-desc="Iconic night market culture in Taiwan"></circle>
+            <circle cx="330" cy="180" r="8" fill="#27ae60" class="marker" data-region="north" data-category="nature" data-title="Yangmingshan National Park" data-link="/en/nature/national-parks" data-desc="Taiwan's first national park"></circle>
+            <circle cx="370" cy="220" r="8" fill="#ff5722" class="marker" data-region="north" data-category="economy" data-title="Taipei 101" data-link="/en/economy/economic-miracle" data-desc="Symbol of Taiwan's economic miracle"></circle>
+            <circle cx="360" cy="210" r="8" fill="#e74c3c" class="marker" data-region="north" data-category="history" data-title="Chiang Kai-shek Memorial Hall" data-link="/en/history/martial-law-era" data-desc="Historical landmark of Taiwan's martial law period"></circle>
+            <circle cx="365" cy="215" r="8" fill="#8bc34a" class="marker" data-region="north" data-category="lifestyle" data-title="Ximending" data-link="/en/lifestyle/convenience-store-culture" data-desc="Birthplace of Taiwan's convenience store culture"></circle>
+            <circle cx="380" cy="240" r="8" fill="#3498db" class="marker" data-region="north" data-category="technology" data-title="Hsinchu Science Park" data-link="/en/technology/semiconductor-industry" data-desc="Taiwan's semiconductor industry hub"></circle>
 
             <!-- Central Region -->
-            <circle cx="320" cy="420" r="8" fill="#27ae60" class="marker" data-region="central" data-category="nature" data-title="Sun Moon Lake" data-link="/nature/國家公園" data-desc="Taiwan's most beautiful alpine lake"></circle>
-            <circle cx="340" cy="380" r="8" fill="#9b59b6" class="marker" data-region="central" data-category="culture" data-title="Lukang" data-link="/culture/廟宇文化與民間信仰" data-desc="Important center of Taiwan's temple culture"></circle>
-            <circle cx="360" cy="370" r="8" fill="#e91e63" class="marker" data-region="central" data-category="art" data-title="Taichung National Theater" data-link="/art/當代藝術" data-desc="Important venue for contemporary art in Taiwan"></circle>
+            <circle cx="320" cy="420" r="8" fill="#27ae60" class="marker" data-region="central" data-category="nature" data-title="Sun Moon Lake" data-link="/en/nature/national-parks" data-desc="Taiwan's most beautiful alpine lake"></circle>
+            <circle cx="340" cy="380" r="8" fill="#9b59b6" class="marker" data-region="central" data-category="culture" data-title="Lukang" data-link="/en/culture/temple-culture-and-religion" data-desc="Important center of Taiwan's temple culture"></circle>
+            <circle cx="360" cy="370" r="8" fill="#e91e63" class="marker" data-region="central" data-category="art" data-title="Taichung National Theater" data-link="/en/art" data-desc="Important venue for contemporary art in Taiwan"></circle>
 
             <!-- South Region -->
-            <circle cx="320" cy="650" r="8" fill="#e74c3c" class="marker" data-region="south" data-category="history" data-title="Tainan Ancient Capital" data-link="/history/荷西明鄭時期" data-desc="Taiwan's historical and cultural ancient capital"></circle>
-            <circle cx="340" cy="680" r="8" fill="#ff5722" class="marker" data-region="south" data-category="economy" data-title="Kaohsiung Port" data-link="/economy/經濟奇蹟" data-desc="Important maritime economic hub of Taiwan"></circle>
-            <circle cx="350" cy="800" r="8" fill="#27ae60" class="marker" data-region="south" data-category="nature" data-title="Kenting National Park" data-link="/nature/國家公園" data-desc="Taiwan's southernmost national park"></circle>
-            <circle cx="300" cy="720" r="8" fill="#9b59b6" class="marker" data-region="south" data-category="culture" data-title="Liudui Hakka Culture" data-link="/culture/族群（閩南客家原住民外省新住民）" data-desc="Hakka cultural preservation area in southern Taiwan"></circle>
+            <circle cx="320" cy="650" r="8" fill="#e74c3c" class="marker" data-region="south" data-category="history" data-title="Tainan Ancient Capital" data-link="/en/history/dutch-spanish-and-koxinga-era" data-desc="Taiwan's historical and cultural ancient capital"></circle>
+            <circle cx="340" cy="680" r="8" fill="#ff5722" class="marker" data-region="south" data-category="economy" data-title="Kaohsiung Port" data-link="/en/economy/economic-miracle" data-desc="Important maritime economic hub of Taiwan"></circle>
+            <circle cx="350" cy="800" r="8" fill="#27ae60" class="marker" data-region="south" data-category="nature" data-title="Kenting National Park" data-link="/en/nature/national-parks" data-desc="Taiwan's southernmost national park"></circle>
+            <circle cx="300" cy="720" r="8" fill="#9b59b6" class="marker" data-region="south" data-category="culture" data-title="Liudui Hakka Culture" data-link="/en/culture/indigenous-cultures" data-desc="Hakka cultural preservation area in southern Taiwan"></circle>
 
             <!-- East Region -->
-            <circle cx="420" cy="350" r="8" fill="#27ae60" class="marker" data-region="east" data-category="nature" data-title="Taroko National Park" data-link="/nature/國家公園" data-desc="World-class canyon landscape"></circle>
-            <circle cx="430" cy="450" r="8" fill="#2ecc71" class="marker" data-region="east" data-category="geography" data-title="East Rift Valley" data-link="/geography/台灣五大地形與地理結構" data-desc="Important geographical landscape of Taiwan"></circle>
-            <circle cx="480" cy="600" r="8" fill="#9b59b6" class="marker" data-region="east" data-category="culture" data-title="Orchid Island" data-link="/culture/原住民族文化" data-desc="Indigenous culture preservation site"></circle>
-            <circle cx="425" cy="470" r="8" fill="#f39c12" class="marker" data-region="east" data-category="food" data-title="Chishang" data-link="/food/台灣茶文化" data-desc="High-quality rice production area in Taiwan"></circle>
+            <circle cx="420" cy="350" r="8" fill="#27ae60" class="marker" data-region="east" data-category="nature" data-title="Taroko National Park" data-link="/en/nature/national-parks" data-desc="World-class canyon landscape"></circle>
+            <circle cx="430" cy="450" r="8" fill="#2ecc71" class="marker" data-region="east" data-category="geography" data-title="East Rift Valley" data-link="/en/geography/outlying-islands" data-desc="Important geographical landscape of Taiwan"></circle>
+            <circle cx="480" cy="600" r="8" fill="#9b59b6" class="marker" data-region="east" data-category="culture" data-title="Orchid Island" data-link="/en/culture/indigenous-cultures" data-desc="Indigenous culture preservation site"></circle>
+            <circle cx="425" cy="470" r="8" fill="#f39c12" class="marker" data-region="east" data-category="food" data-title="Chishang" data-link="/en/food/tea-culture" data-desc="High-quality rice production area in Taiwan"></circle>
 
             <!-- Islands -->
-            <circle cx="150" cy="450" r="6" fill="#2ecc71" class="marker island-marker" data-region="islands" data-category="geography" data-title="Penghu" data-link="/geography/離島與海洋文化" data-desc="Representative of Taiwan's maritime culture"></circle>
-            <circle cx="80" cy="400" r="6" fill="#e74c3c" class="marker island-marker" data-region="islands" data-category="history" data-title="Kinmen" data-link="/history/戒嚴時期" data-desc="Witness to cross-strait confrontation history"></circle>
+            <circle cx="150" cy="450" r="6" fill="#2ecc71" class="marker island-marker" data-region="islands" data-category="geography" data-title="Penghu" data-link="/en/geography/outlying-islands" data-desc="Representative of Taiwan's maritime culture"></circle>
+            <circle cx="80" cy="400" r="6" fill="#e74c3c" class="marker island-marker" data-region="islands" data-category="history" data-title="Kinmen" data-link="/en/history/martial-law-era" data-desc="Witness to cross-strait confrontation history"></circle>
           </g>
         </svg>
 


### PR DESCRIPTION
## Summary
- **map.astro**: Replace all Chinese `data-link` URLs with English article paths (e.g. `/food/夜市文化` → `/en/food/night-market-culture`)
- **[category]/index.astro**: Change `中文` language tag to `ZH` for consistency in English UI
- **[category]/[slug].astro**: Translate Chinese HTML/CSS comments to English
- Chinese comments in `[category]/index.astro` also translated to English

## Notes
- Intentional Chinese text preserved: cultural term examples in `contribute.astro` and founder name in `about.astro`
- `categoryConfig.ts` and `Layout.astro` already have proper `isEn` i18n switches — no changes needed there

## Test plan
- [ ] Visit `/en/map` and click map markers — links should navigate to English articles
- [ ] Visit `/en/{category}` — language tags should show `ZH` / `EN` instead of `中文` / `EN`
- [ ] Verify no Chinese text visible in English UI pages

Closes #45