### PR TITLE
fix(en): enable random discovery button with slot machine animation

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1948,19 +1948,58 @@ const randomArticlesData = JSON.stringify(allArticles);
 document.addEventListener('DOMContentLoaded', function() {
   // Random discovery functionality
   const randomBtn = document.getElementById('random-discovery-btn');
-  const articles = JSON.parse(randomArticlesData);
-  
+  let articles = [];
+
+  try {
+    articles = randomArticlesData ? JSON.parse(randomArticlesData) : [];
+  } catch (e) {
+    articles = [];
+  }
+
   if (randomBtn && articles.length > 0) {
+    // Fisher-Yates shuffle for true randomness without repeats
+    let shuffled = [...articles];
+    for (let i = shuffled.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+    }
+    let currentIndex = 0;
+
     randomBtn.addEventListener('click', function() {
-      const randomIndex = Math.floor(Math.random() * articles.length);
-      const randomArticle = articles[randomIndex];
-      
-      // Add click animation
-      randomBtn.style.transform = 'scale(0.95)';
-      setTimeout(() => {
-        randomBtn.style.transform = 'scale(1)';
-        window.location.href = randomArticle.url;
-      }, 150);
+      // Reshuffle when we've gone through all articles
+      if (currentIndex >= shuffled.length) {
+        currentIndex = 0;
+        for (let i = shuffled.length - 1; i > 0; i--) {
+          const j = Math.floor(Math.random() * (i + 1));
+          [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+        }
+      }
+
+      const randomArticle = shuffled[currentIndex++];
+
+      // Slot machine animation - cycle through random titles
+      const textEl = randomBtn.querySelector('.random-text');
+      const subtitleEl = randomBtn.querySelector('.random-subtitle');
+
+      randomBtn.style.pointerEvents = 'none';
+      let ticks = 0;
+      const totalTicks = 8;
+      const interval = setInterval(() => {
+        const preview = shuffled[Math.floor(Math.random() * shuffled.length)];
+        textEl.textContent = preview.title;
+        subtitleEl.textContent = preview.category;
+        textEl.style.opacity = 0.5 + (ticks / totalTicks) * 0.5;
+        ticks++;
+        if (ticks >= totalTicks) {
+          clearInterval(interval);
+          textEl.textContent = randomArticle.title;
+          subtitleEl.textContent = randomArticle.category;
+          textEl.style.opacity = 1;
+          setTimeout(() => {
+            window.location.href = randomArticle.url;
+          }, 400);
+        }
+      }, 80);
     });
   }
 


### PR DESCRIPTION
## Summary
- Fix English "Discover Taiwan Randomly" button which was non-functional due to `getCollection('en')` returning empty at build time
- Replace broken content collection call with direct filesystem reads from `knowledge/en/`, matching the approach used by `[slug].astro` pages
- Port the slot machine animation from the Chinese homepage (Fisher-Yates shuffle, cycling titles with fade-in, navigate after landing)

## Demo
![demo](https://github.com/user-attachments/assets/53d768dc-4767-40e8-96ad-d7f2e9a5c82d)

## Test plan
- [x] Build succeeds (583 pages, no errors)
- [x] `randomArticlesData` populated with English articles in built output
- [x] Slot machine animation cycles through random titles before navigating
- [x] Article counts per category now display correctly on English homepage

🤖 Generated with [Claude Code](https://claude.com/claude-code)