### PR TITLE
fix: 修正中英文切換 404 問題

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -139,44 +139,55 @@ const i18n = {
   },
 };
 
-// Language switch logic — uses _translations.json for article slug mapping
+// Language switch logic — use _translations.json for article pages
 let zhLink = '/';
 let enLink = '/en';
 
-// Load translations map for accurate language switching
-let translationsMap: Record<string, string> = {};
+// Build translation lookup from _translations.json
+const translationMap = new Map<string, string>(); // enUrl → zhUrl
+const reverseMap = new Map<string, string>();      // zhUrl → enUrl
 try {
   const translationsPath = resolve(process.cwd(), 'knowledge', '_translations.json');
-  translationsMap = JSON.parse(await readFile(translationsPath, 'utf-8'));
+  const raw = await readFile(translationsPath, 'utf-8');
+  const translations: Record<string, string> = JSON.parse(raw);
+  const categoryFolderToSlug: Record<string, string> = {
+    History: 'history', Geography: 'geography', Culture: 'culture',
+    Food: 'food', Art: 'art', Music: 'music', Technology: 'technology',
+    Nature: 'nature', People: 'people', Society: 'society',
+    Economy: 'economy', Lifestyle: 'lifestyle', About: 'about',
+  };
+  for (const [enFile, zhFile] of Object.entries(translations)) {
+    const enParts = enFile.replace(/\.md$/, '').split('/');
+    const zhParts = zhFile.replace(/\.md$/, '').split('/');
+    if (enParts.length >= 3 && zhParts.length >= 2) {
+      const enCatSlug = categoryFolderToSlug[enParts[1]] || enParts[1].toLowerCase();
+      const zhCatSlug = categoryFolderToSlug[zhParts[0]] || zhParts[0].toLowerCase();
+      const enUrl = `/en/${enCatSlug}/${enParts[2]}`;
+      const zhUrl = `/${zhCatSlug}/${encodeURIComponent(zhParts[1])}`;
+      translationMap.set(enUrl, zhUrl);
+      reverseMap.set(zhUrl, enUrl);
+    }
+  }
 } catch {}
 
-// Build reverse map: zh path → en path
-const zhToEn: Record<string, string> = {};
-for (const [enFile, zhFile] of Object.entries(translationsMap)) {
-  // enFile: "en/Culture/slug-name.md" → "/en/culture/slug-name"
-  // zhFile: "Culture/中文名稱.md" → "/culture/中文名稱"
-  const enParts = enFile.replace(/\.md$/, '').split('/');
-  const zhParts = (zhFile as string).replace(/\.md$/, '').split('/');
-  if (enParts.length >= 3 && zhParts.length >= 2) {
-    const enUrl = `/en/${enParts[1].toLowerCase()}/${enParts[2]}`;
-    const zhUrl = `/${zhParts[0].toLowerCase()}/${zhParts[1]}`;
-    zhToEn[zhUrl] = enUrl;
-    // Also store reverse: en → zh
-    zhToEn[enUrl] = zhUrl;
-  }
-}
-
-// Normalize path (remove trailing slash)
-const normalizedPath = currentPath.replace(/\/$/, '') || '/';
-
-if (normalizedPath.startsWith('/en')) {
-  enLink = normalizedPath;
-  // Try mapped zh link first, fallback to prefix removal
-  zhLink = zhToEn[normalizedPath] || normalizedPath.replace(/^\/en/, '') || '/';
+if (currentPath.startsWith('/en')) {
+  enLink = currentPath;
+  const decoded = decodeURIComponent(currentPath);
+  zhLink = translationMap.get(decoded)
+    || translationMap.get(currentPath)
+    || (() => {
+      const match = currentPath.match(/^\/en\/([^/]+)\/[^/]+$/);
+      return match ? `/${match[1]}` : currentPath.replace(/^\/en/, '') || '/';
+    })();
 } else {
-  zhLink = normalizedPath;
-  // Try mapped en link first, fallback to prefix addition
-  enLink = zhToEn[normalizedPath] || '/en' + (normalizedPath === '/' ? '' : normalizedPath);
+  zhLink = currentPath;
+  const decoded = decodeURIComponent(currentPath);
+  enLink = reverseMap.get(decoded)
+    || reverseMap.get(currentPath)
+    || (() => {
+      const match = currentPath.match(/^\/([^/]+)\/[^/]+$/);
+      return match ? `/en/${match[1]}` : '/en' + (currentPath === '/' ? '' : currentPath);
+    })();
 }
 
 const navConfig = [


### PR DESCRIPTION
## 摘要

改進 #101 的語言切換查表邏輯 — PR #100 合入了基礎版修復，但在含特殊字元的中文 slug 上仍有問題。本 PR 補強以下幾點：

### 與 PR #100 版本的差異

| 面向 | PR #100 | 本 PR |
|------|---------|-------|
| URL encoding | 沒處理，中文 slug 直接拼接 | `encodeURIComponent` + `decodeURIComponent` |
| Fallback | 查不到就 strip `/en`（仍可能 404） | fallback 到分類首頁 |
| Category mapping | `.toLowerCase()` 假設資料夾名=slug | 顯式 `categoryFolderToSlug` 映射 |
| 資料結構 | 單一 object 雙向共用 | 分開的 `translationMap` + `reverseMap` |

### 改動範圍

只改 `src/layouts/Layout.astro`（+41 行 -30 行），替換 PR #100 的查表實作。

## Playwright 測試結果

| 測試 | 結果 |
|------|------|
| EN→ZH 文章頁（5 組） | ✅ 導到正確中文頁 |
| ZH→EN 文章頁（5 組） | ✅ 導到正確英文頁 |
| Round-trip EN→ZH→EN | ✅ 回到原本英文頁 |
| 非文章頁（首頁、about、分類、貢獻） | ✅ 維持原有行為 |

## 測試計畫

- [ ] 含括號的中文 slug（如 `族群（閩南客家原住民外省新住民）`）— 正確 encode/decode
- [ ] 沒有翻譯的文章 — fallback 到分類首頁
- [ ] 非文章頁 — 行為不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)