### PR TITLE
style: 首頁 UI/UX 整體優化 — 對齊、元件化、樣式修正

### DIFF
--- a/src/components/CategoryGrid.astro
+++ b/src/components/CategoryGrid.astro
@@ -444,7 +444,7 @@ const descriptionsEn: Record<string, string> = {
     .category-grid {
       grid-template-columns: 1fr;
       gap: 1rem;
-      margin: 2rem 0;
+      margin: 2rem 1rem;
     }
 
     .category-card {

--- a/src/components/FeatureCards.astro
+++ b/src/components/FeatureCards.astro
@@ -1,0 +1,119 @@
+---
+interface FeatureCard {
+  icon: string;
+  title: string;
+  description: string;
+}
+
+interface Props {
+  lang?: 'zh-TW' | 'en';
+  sectionTitle: string;
+  cards: FeatureCard[];
+}
+
+const { lang = 'zh-TW', sectionTitle, cards } = Astro.props;
+
+const isZh = lang === 'zh-TW';
+---
+
+<section class:list={['features', { 'features--zh': isZh }]}>
+  <h2 class="section-title">{sectionTitle}</h2>
+  <div class="features-grid">
+    {
+      cards.map((card) => (
+        <div class="feature-card">
+          <div class="feature-icon">{card.icon}</div>
+          <div class="feature-content">
+            <h3>{card.title}</h3>
+            <p>{card.description}</p>
+          </div>
+        </div>
+      ))
+    }
+  </div>
+  <slot />
+</section>
+
+<style>
+  .features {
+    margin: 6rem 0;
+  }
+
+  .section-title {
+    font-size: 2.5rem;
+    text-align: center;
+    margin-bottom: 1rem;
+    color: #1f2937;
+    font-weight: 700;
+  }
+
+  .features--zh .section-title {
+    font-weight: 800;
+    font-family:
+      'jf-lanyanghei', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+  }
+
+  .features-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+    margin: 3rem 0;
+    max-width: 1200px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .feature-card {
+    display: flex;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 2rem;
+    background: white;
+    border-radius: 16px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
+    border: 1px solid #f1f5f9;
+    transition: all 0.3s ease;
+  }
+
+  .feature-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
+    border-color: #e2e8f0;
+  }
+
+  .feature-icon {
+    font-size: 3rem;
+    flex-shrink: 0;
+    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
+  }
+
+  .feature-content h3 {
+    font-size: 1.25rem;
+    margin-bottom: 0.5rem;
+    color: #1f2937;
+    font-weight: 600;
+  }
+
+  .feature-content p {
+    color: #6b7280;
+    line-height: 1.6;
+    margin: 0;
+  }
+
+  @media (max-width: 768px) {
+    .features {
+      margin: 4rem 1rem;
+    }
+
+    .features-grid {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .feature-card {
+      flex-direction: column;
+      text-align: center;
+      gap: 1rem;
+    }
+  }
+</style>

--- a/src/components/ReadingPath.astro
+++ b/src/components/ReadingPath.astro
@@ -1,0 +1,322 @@
+---
+interface ReadingPathStep {
+  href: string;
+  title: string;
+  description: string;
+  time: string;
+}
+
+interface ReadingPathFooterItem {
+  icon: string;
+  label: string;
+}
+
+interface Props {
+  lang?: 'zh-TW' | 'en';
+  title: string;
+  subtitle: string;
+  steps: ReadingPathStep[];
+  footerItems: ReadingPathFooterItem[];
+  continueHref: string;
+  continueLabel: string;
+}
+
+const {
+  lang = 'zh-TW',
+  title,
+  subtitle,
+  steps,
+  footerItems,
+  continueHref,
+  continueLabel,
+} = Astro.props;
+
+const isEn = lang === 'en';
+---
+
+<section class:list={['reading-path', { 'reading-path--en': isEn }]}>
+  <div class="reading-path-header">
+    <h2>{title}</h2>
+    <p>{subtitle}</p>
+  </div>
+
+  <div class="reading-path-list">
+    {
+      steps.map((step, index) => (
+        <a href={step.href} class="reading-step">
+          <span class="step-number">{index + 1}</span>
+          <div class="step-content">
+            <h3>{step.title}</h3>
+            <p>{step.description}</p>
+          </div>
+          <span class="step-time">{step.time}</span>
+        </a>
+      ))
+    }
+  </div>
+
+  <div class="reading-path-footer">
+    <p>
+      {
+        footerItems.map((item, index) => (
+          <span class="footer-item">
+            {index > 0 && (
+              <span class="footer-separator" aria-hidden="true">
+                {' '}
+                |{' '}
+              </span>
+            )}
+            {item.icon} <strong>{item.label}</strong>
+          </span>
+        ))
+      }
+    </p>
+    <a href={continueHref} class="path-continue-btn">
+      {continueLabel}
+    </a>
+  </div>
+</section>
+
+<style>
+  .reading-path {
+    max-width: 900px;
+    margin: 6rem auto;
+    padding: 3rem 2rem;
+    background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
+    border-radius: 20px;
+    border: 1px solid rgba(34, 197, 94, 0.1);
+    position: relative;
+    overflow: hidden;
+  }
+
+  .reading-path::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%2322c55e' fill-opacity='0.03' fill-rule='evenodd'%3E%3Cpath d='m0 40 40-40h-40z'/%3E%3Cpath d='m0 40 40-40h-40z' transform='scale(.5) translate(40 0)'/%3E%3C/g%3E%3C/svg%3E");
+    opacity: 0.4;
+  }
+
+  .reading-path-header {
+    text-align: center;
+    margin-bottom: 3rem;
+    position: relative;
+    z-index: 2;
+  }
+
+  .reading-path-header h2 {
+    font-size: 2.2rem;
+    font-weight: 300;
+    color: #166534;
+    margin-bottom: 1rem;
+    font-family:
+      'jf-lanyangming', 'Noto Serif TC', 'Source Han Serif TC', serif;
+    letter-spacing: 0;
+  }
+
+  .reading-path--en .reading-path-header h2 {
+    font-weight: 800;
+    letter-spacing: 0.05em;
+  }
+
+  .reading-path-header p {
+    font-size: 1.2rem;
+    color: #16a34a;
+    font-weight: 600;
+    line-height: 1.6;
+  }
+
+  .reading-path-list {
+    position: relative;
+    z-index: 2;
+    --step-marker-column: 4.5rem;
+    --step-content-column: 28rem;
+    --step-time-column: 6rem;
+    --step-column-gap: 1.5rem;
+    --step-layout-width: calc(
+      var(--step-marker-column) + var(--step-content-column) +
+        var(--step-time-column) + (var(--step-column-gap) * 2)
+    );
+  }
+
+  .reading-path-list::before {
+    content: '';
+    position: absolute;
+    left: calc(
+      50% - (var(--step-layout-width) / 2) + (var(--step-marker-column) / 2)
+    );
+    top: 4rem;
+    bottom: 4rem;
+    width: 3px;
+    background: linear-gradient(
+      180deg,
+      rgba(34, 197, 94, 0.3) 0%,
+      #22c55e 25%,
+      #16a34a 50%,
+      #15803d 75%,
+      rgba(34, 197, 94, 0.3) 100%
+    );
+    border-radius: 2px;
+    z-index: 1;
+  }
+
+  .reading-step {
+    display: grid;
+    grid-template-columns:
+      var(--step-marker-column)
+      var(--step-content-column)
+      var(--step-time-column);
+    justify-content: center;
+    align-items: center;
+    padding: 1.5rem 1.5rem;
+    margin-bottom: 1rem;
+    background: white;
+    border-radius: 16px;
+    text-decoration: none;
+    transition: all 0.3s ease;
+    border: 2px solid rgba(34, 197, 94, 0.1);
+    position: relative;
+    z-index: 2;
+    gap: var(--step-column-gap);
+    box-shadow: 0 2px 8px rgba(22, 163, 74, 0.08);
+  }
+
+  .reading-step:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 25px rgba(22, 163, 74, 0.15);
+    border-color: rgba(34, 197, 94, 0.25);
+    background: rgba(240, 253, 244, 0.6);
+  }
+
+  .step-number {
+    flex-shrink: 0;
+    justify-self: center;
+    width: 3rem;
+    height: 3rem;
+    border-radius: 50%;
+    background: linear-gradient(135deg, #22c55e, #16a34a);
+    color: white;
+    font-size: 1.3rem;
+    font-weight: 800;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
+  }
+
+  .step-content {
+    display: grid;
+    width: 100%;
+    align-content: center;
+    align-items: center;
+    text-align: center;
+    gap: 0.25rem;
+  }
+
+  .step-content h3 {
+    font-size: 1.3rem;
+    font-weight: 700;
+    color: #166534;
+    margin: 0;
+    line-height: 1.2;
+    font-family:
+      'jf-jinxuanlatte', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+  }
+
+  .step-content p {
+    color: #16a34a;
+    font-size: 1rem;
+    line-height: 1.35;
+    margin: 0;
+    font-weight: 500;
+  }
+
+  .step-time {
+    flex-shrink: 0;
+    justify-self: center;
+    background: rgba(22, 163, 74, 0.1);
+    color: #166534;
+    padding: 0.5rem 1rem;
+    border-radius: 20px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    border: 1px solid rgba(34, 197, 94, 0.2);
+    min-width: 4.5rem;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .reading-path-footer {
+    text-align: center;
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid rgba(34, 197, 94, 0.2);
+    position: relative;
+    z-index: 2;
+  }
+
+  .reading-path-footer p {
+    font-size: 1.1rem;
+    color: #166534;
+    font-weight: 500;
+    margin-bottom: 1.5rem;
+    line-height: 1.6;
+  }
+
+  .footer-separator {
+    color: #16a34a;
+  }
+
+  .path-continue-btn {
+    display: inline-block;
+    background: linear-gradient(135deg, #22c55e, #16a34a);
+    color: white !important;
+    padding: 1rem 2rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 700;
+    font-size: 1.1rem;
+    transition: all 0.3s ease;
+    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.25);
+  }
+
+  .path-continue-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 20px rgba(34, 197, 94, 0.35);
+  }
+
+  @media (max-width: 768px) {
+    .reading-path {
+      margin: 4rem 1rem;
+      padding: 2rem 1rem;
+    }
+
+    .reading-path-list::before {
+      display: none;
+    }
+
+    .reading-step {
+      display: flex;
+      flex-direction: column;
+      text-align: center;
+      padding: 1.5rem;
+      gap: 1rem;
+    }
+
+    .step-content h3 {
+      font-size: 1.1rem;
+    }
+
+    .step-content p {
+      font-size: 0.9rem;
+    }
+
+    .reading-path-header h2 {
+      font-size: 1.8rem;
+    }
+
+    .reading-path-header p {
+      font-size: 1rem;
+    }
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1451,7 +1451,7 @@ const navConfig = [
   main
     a:not(.nav-link):not([class*='btn']):not(.card-link):not(.logo):not(
       .category-card
-    ):not(.floating-md):not(.search-item) {
+    ):not(.floating-md):not(.search-item):not(.reading-step):not(.update-item) {
     color: #475569;
     text-decoration: none;
     border-bottom: 1px solid #cbd5e1;
@@ -1461,7 +1461,9 @@ const navConfig = [
   main
     a:not(.nav-link):not([class*='btn']):not(.card-link):not(.logo):not(
       .category-card
-    ):not(.floating-md):not(.search-item):hover {
+    ):not(.floating-md):not(.search-item):not(.reading-step):not(
+      .update-item
+    ):hover {
     color: #1a1a2e;
     border-bottom-color: #64748b;
   }

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from '../../layouts/Layout.astro';
 import CategoryGrid from '../../components/CategoryGrid.astro';
+import ReadingPath from '../../components/ReadingPath.astro';
+import FeatureCards from '../../components/FeatureCards.astro';
 import { getCollection } from 'astro:content';
 import { readdir, readFile } from 'fs/promises';
 import { resolve, join, basename } from 'path';
@@ -102,6 +104,49 @@ for (const cat of categories) {
 }
 
 const randomArticlesData = JSON.stringify(allArticles);
+
+const readingPathSteps = [
+  {
+    href: '/en/history/democratization',
+    title: "Quiet Revolution: Taiwan's Democratization",
+    description:
+      "From authoritarianism to democracy, Asia's first peaceful transition miracle",
+    time: '6 min',
+  },
+  {
+    href: '/en/culture/ethnic-groups',
+    title: "Unity in Diversity: Taiwan's Ethnic Groups",
+    description:
+      "Four major ethnic groups weaving Taiwan's multicultural foundation",
+    time: '7 min',
+  },
+  {
+    href: '/en/food/night-market-culture',
+    title: 'The Real Taste of Taiwan: Night Market Culture',
+    description:
+      "World's densest street food social spaces with unmatched warmth",
+    time: '5 min',
+  },
+  {
+    href: '/en/technology/semiconductor-industry',
+    title: 'Silicon Shield: Semiconductor Industry',
+    description: 'How TSMC made a small island the heart of global technology',
+    time: '8 min',
+  },
+  {
+    href: '/en/lifestyle/convenience-store-culture',
+    title: 'Life Operating System: Convenience Stores',
+    description:
+      "More than stores - they're the infrastructure of an entire nation",
+    time: '4 min',
+  },
+];
+
+const readingPathFooterItems = [
+  { icon: '⏱️', label: 'Total 30 minutes' },
+  { icon: '🎯', label: '5 key domains' },
+  { icon: '🌟', label: 'Complete Taiwan overview' },
+];
 ---
 
 <Layout
@@ -297,45 +342,36 @@ const randomArticlesData = JSON.stringify(allArticles);
     </div>
   </section>
 
-  <section class="features">
-    <h2 class="section-title">Why Taiwan.md?</h2>
-    <div class="features-grid">
-      <div class="feature-card">
-        <div class="feature-icon">🎯</div>
-        <div class="feature-content">
-          <h3>Curated Perspectives</h3>
-          <p>Carefully curated deep narratives, not encyclopedic listings</p>
-        </div>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">🤖</div>
-        <div class="feature-content">
-          <h3>AI-Friendly Design</h3>
-          <p>Structured content that helps AI understand Taiwan's complexity</p>
-        </div>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">🌍</div>
-        <div class="feature-content">
-          <h3>Bilingual Global Vision</h3>
-          <p>
-            Starting from local perspectives, telling Taiwan's story in global
-            languages
-          </p>
-        </div>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">📚</div>
-        <div class="feature-content">
-          <h3>Complete Multi-dimensional</h3>
-          <p>
-            Covering 12+ domains, presenting Taiwan's three-dimensional complete
-            picture
-          </p>
-        </div>
-      </div>
-    </div>
-  </section>
+  <FeatureCards
+    lang="en"
+    sectionTitle="Why Taiwan.md?"
+    cards={[
+      {
+        icon: '🎯',
+        title: 'Curated Perspectives',
+        description:
+          'Carefully curated deep narratives, not encyclopedic listings',
+      },
+      {
+        icon: '🤖',
+        title: 'AI-Friendly Design',
+        description:
+          "Structured content that helps AI understand Taiwan's complexity",
+      },
+      {
+        icon: '🌍',
+        title: 'Bilingual Global Vision',
+        description:
+          "Starting from local perspectives, telling Taiwan's story in global languages",
+      },
+      {
+        icon: '📚',
+        title: 'Complete Multi-dimensional',
+        description:
+          "Covering 12+ domains, presenting Taiwan's three-dimensional complete picture",
+      },
+    ]}
+  />
 
   <!-- Random Discovery Taiwan -->
   <section class="random-discovery">
@@ -351,78 +387,15 @@ const randomArticlesData = JSON.stringify(allArticles);
     </div>
   </section>
 
-  <!-- 5 Essential Taiwan Articles -->
-  <section class="reading-path">
-    <div class="reading-path-header">
-      <h2>📖 Don't know where to start?</h2>
-      <p>
-        Discover the real Taiwan in 30 minutes with these 5 essential articles
-      </p>
-    </div>
-    <div class="reading-path-list">
-      <a href="/en/history/democratization" class="reading-step">
-        <span class="step-number">1</span>
-        <div class="step-content">
-          <h3>Quiet Revolution: Taiwan's Democratization</h3>
-          <p>
-            From authoritarianism to democracy, Asia's first peaceful transition
-            miracle
-          </p>
-        </div>
-        <span class="step-time">6 min</span>
-      </a>
-
-      <a href="/en/culture/ethnic-groups" class="reading-step">
-        <span class="step-number">2</span>
-        <div class="step-content">
-          <h3>Unity in Diversity: Taiwan's Ethnic Groups</h3>
-          <p>
-            Four major ethnic groups weaving Taiwan's multicultural foundation
-          </p>
-        </div>
-        <span class="step-time">7 min</span>
-      </a>
-
-      <a href="/en/food/night-market-culture" class="reading-step">
-        <span class="step-number">3</span>
-        <div class="step-content">
-          <h3>The Real Taste of Taiwan: Night Market Culture</h3>
-          <p>World's densest street food social spaces with unmatched warmth</p>
-        </div>
-        <span class="step-time">5 min</span>
-      </a>
-
-      <a href="/en/technology/semiconductor-industry" class="reading-step">
-        <span class="step-number">4</span>
-        <div class="step-content">
-          <h3>Silicon Shield: Semiconductor Industry</h3>
-          <p>How TSMC made a small island the heart of global technology</p>
-        </div>
-        <span class="step-time">8 min</span>
-      </a>
-
-      <a href="/en/lifestyle/convenience-store-culture" class="reading-step">
-        <span class="step-number">5</span>
-        <div class="step-content">
-          <h3>Life Operating System: Convenience Stores</h3>
-          <p>
-            More than stores - they're the infrastructure of an entire nation
-          </p>
-        </div>
-        <span class="step-time">4 min</span>
-      </a>
-    </div>
-
-    <div class="reading-path-footer">
-      <p>
-        ⏱️ <strong>Total 30 minutes</strong> | 🎯 <strong>5 key domains</strong> |
-        🌟 <strong>Complete Taiwan overview</strong>
-      </p>
-      <a href="#categories" class="path-continue-btn"
-        >Continue exploring more topics →</a
-      >
-    </div>
-  </section>
+  <ReadingPath
+    lang="en"
+    title="📖 Don't know where to start?"
+    subtitle="Discover the real Taiwan in 30 minutes with these 5 essential articles"
+    steps={readingPathSteps}
+    footerItems={readingPathFooterItems}
+    continueHref="#categories"
+    continueLabel="Continue exploring more topics →"
+  />
 
   <section class="language-statement">
     <div class="language-inner">
@@ -1110,190 +1083,6 @@ const randomArticlesData = JSON.stringify(allArticles);
     line-height: 1.6;
   }
 
-  /* ===== 5 Essential Taiwan Articles ===== */
-  .reading-path {
-    max-width: 900px;
-    margin: 6rem auto;
-    padding: 3rem 2rem;
-    background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
-    border-radius: 20px;
-    border: 1px solid rgba(34, 197, 94, 0.1);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .reading-path::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%2322c55e' fill-opacity='0.03' fill-rule='evenodd'%3E%3Cpath d='m0 40 40-40h-40z'/%3E%3Cpath d='m0 40 40-40h-40z' transform='scale(.5) translate(40 0)'/%3E%3C/g%3E%3C/svg%3E");
-    opacity: 0.4;
-  }
-
-  .reading-path-header {
-    text-align: center;
-    margin-bottom: 3rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .reading-path-header h2 {
-    font-size: 2.2rem;
-    font-weight: 800;
-    color: #166534;
-    margin-bottom: 1rem;
-    font-family:
-      'jf-lanyangming', 'Noto Serif TC', 'Source Han Serif TC', serif;
-    letter-spacing: 0.05em;
-  }
-
-  .reading-path-header p {
-    font-size: 1.2rem;
-    color: #16a34a;
-    font-weight: 600;
-    line-height: 1.6;
-  }
-
-  .reading-path-list {
-    position: relative;
-    z-index: 2;
-  }
-
-  /* Path connection line */
-  .reading-path-list::before {
-    content: '';
-    position: absolute;
-    left: 2.5rem;
-    top: 4rem;
-    bottom: 4rem;
-    width: 3px;
-    background: linear-gradient(
-      180deg,
-      rgba(34, 197, 94, 0.3) 0%,
-      #22c55e 25%,
-      #16a34a 50%,
-      #15803d 75%,
-      rgba(34, 197, 94, 0.3) 100%
-    );
-    border-radius: 2px;
-    z-index: 1;
-  }
-
-  .reading-step {
-    display: flex;
-    align-items: center;
-    padding: 2rem 1.5rem;
-    margin-bottom: 1rem;
-    background: white;
-    border-radius: 16px;
-    text-decoration: none;
-    transition: all 0.3s ease;
-    border: 2px solid rgba(34, 197, 94, 0.1);
-    position: relative;
-    z-index: 2;
-    gap: 1.5rem;
-    box-shadow: 0 2px 8px rgba(22, 163, 74, 0.08);
-  }
-
-  .reading-step:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 25px rgba(22, 163, 74, 0.15);
-    border-color: rgba(34, 197, 94, 0.25);
-    background: rgba(240, 253, 244, 0.6);
-  }
-
-  .step-number {
-    flex-shrink: 0;
-    width: 3rem;
-    height: 3rem;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #22c55e, #16a34a);
-    color: white;
-    font-size: 1.3rem;
-    font-weight: 800;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
-  }
-
-  .step-content {
-    flex: 1;
-  }
-
-  .step-content h3 {
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: #166534;
-    margin-bottom: 0.5rem;
-    line-height: 1.3;
-    font-family:
-      'jf-jinxuanlatte', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
-  }
-
-  .step-content p {
-    color: #16a34a;
-    font-size: 1rem;
-    line-height: 1.5;
-    margin: 0;
-    font-weight: 500;
-  }
-
-  .step-time {
-    flex-shrink: 0;
-    background: rgba(22, 163, 74, 0.1);
-    color: #166534;
-    padding: 0.5rem 1rem;
-    border-radius: 20px;
-    font-size: 0.9rem;
-    font-weight: 600;
-    border: 1px solid rgba(34, 197, 94, 0.2);
-  }
-
-  .reading-path-footer {
-    text-align: center;
-    margin-top: 3rem;
-    padding-top: 2rem;
-    border-top: 1px solid rgba(34, 197, 94, 0.2);
-    position: relative;
-    z-index: 2;
-  }
-
-  .reading-path-footer p {
-    font-size: 1.1rem;
-    color: #16a34a;
-    margin-bottom: 1.5rem;
-    font-weight: 600;
-  }
-
-  .path-continue-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.8rem 2rem;
-    background: linear-gradient(135deg, #22c55e, #16a34a);
-    color: white;
-    text-decoration: none;
-    border-radius: 50px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
-  }
-
-  .path-continue-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(34, 197, 94, 0.4);
-    background: linear-gradient(135deg, #16a34a, #15803d);
-  }
-
-  /* ===== FEATURES SECTION upgrade ===== */
-  .features {
-    margin: 6rem 0;
-  }
-
   .language-statement {
     max-width: 800px;
     margin: 0 auto 4rem;
@@ -1324,61 +1113,6 @@ const randomArticlesData = JSON.stringify(allArticles);
     color: #78716c;
     font-size: 0.9rem;
     line-height: 1.7;
-  }
-
-  .section-title {
-    font-size: 2.5rem;
-    text-align: center;
-    margin-bottom: 1rem;
-    color: #1f2937;
-    font-weight: 700;
-  }
-
-  .features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 2rem;
-    margin: 3rem 0;
-    max-width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .feature-card {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    padding: 2rem;
-    background: white;
-    border-radius: 16px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-    border: 1px solid #f1f5f9;
-    transition: all 0.3s ease;
-  }
-
-  .feature-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
-    border-color: #e2e8f0;
-  }
-
-  .feature-icon {
-    font-size: 3rem;
-    flex-shrink: 0;
-    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
-  }
-
-  .feature-content h3 {
-    font-size: 1.25rem;
-    margin-bottom: 0.5rem;
-    color: #1f2937;
-    font-weight: 600;
-  }
-
-  .feature-content p {
-    color: #6b7280;
-    line-height: 1.6;
-    margin: 0;
   }
 
   /* ===== CATEGORIES SECTION ===== */
@@ -1530,6 +1264,8 @@ const randomArticlesData = JSON.stringify(allArticles);
     gap: 0.5rem;
     position: relative;
     z-index: 2;
+    max-width: 800px;
+    margin: 0 auto;
   }
 
   .update-item {
@@ -1627,7 +1363,6 @@ const randomArticlesData = JSON.stringify(allArticles);
     padding: 4rem 2rem;
     margin: 6rem -1rem 0;
     text-align: center;
-    border-radius: 16px;
     position: relative;
     overflow: hidden;
   }
@@ -1763,7 +1498,7 @@ const randomArticlesData = JSON.stringify(allArticles);
   .contribute {
     background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
     padding: 5rem 2rem;
-    margin: 6rem -1rem 0;
+    margin: 0;
     text-align: center;
     border-radius: 16px;
     position: relative;
@@ -1937,15 +1672,8 @@ const randomArticlesData = JSON.stringify(allArticles);
       height: 35%;
     }
 
-    .features-grid {
-      grid-template-columns: 1fr;
-      gap: 1.5rem;
-    }
-
-    .feature-card {
-      flex-direction: column;
-      text-align: center;
-      gap: 1rem;
+    .language-statement {
+      margin: 0 1rem 4rem;
     }
 
     .contribute-buttons {
@@ -2029,39 +1757,6 @@ const randomArticlesData = JSON.stringify(allArticles);
 
     .random-subtitle {
       font-size: 0.85rem;
-    }
-
-    /* Reading path responsive */
-    .reading-path {
-      margin: 4rem 1rem;
-      padding: 2rem 1rem;
-    }
-
-    .reading-path-list::before {
-      display: none; /* Hide connection line on mobile */
-    }
-
-    .reading-step {
-      flex-direction: column;
-      text-align: center;
-      padding: 1.5rem;
-      gap: 1rem;
-    }
-
-    .step-content h3 {
-      font-size: 1.1rem;
-    }
-
-    .step-content p {
-      font-size: 0.9rem;
-    }
-
-    .reading-path-header h2 {
-      font-size: 1.8rem;
-    }
-
-    .reading-path-header p {
-      font-size: 1rem;
     }
   }
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,8 @@
 ---
 import Layout from '../layouts/Layout.astro';
 import CategoryGrid from '../components/CategoryGrid.astro';
+import ReadingPath from '../components/ReadingPath.astro';
+import FeatureCards from '../components/FeatureCards.astro';
 import { getCollection } from 'astro:content';
 import ProticoScript from '../components/ProticoScript.astro';
 // Fetch recent commits from GitHub API (works in shallow clone CI/CD environments)
@@ -107,6 +109,45 @@ if (allZhArticles.length > 0) {
 }
 
 const randomArticlesData = JSON.stringify(allArticles);
+
+const readingPathSteps = [
+  {
+    href: '/history/民主化',
+    title: '寧靜革命：台灣民主化',
+    description: '從威權到民主，亞洲第一的和平轉型奇蹟',
+    time: '6 min',
+  },
+  {
+    href: '/culture/族群（閩南客家原住民外省新住民）',
+    title: '多元一體：台灣族群',
+    description: '四大族群共同編織的多彩文化基底',
+    time: '7 min',
+  },
+  {
+    href: '/food/夜市文化',
+    title: '最真實的台灣味：夜市文化',
+    description: '密度世界第一的庶民美食社交空間',
+    time: '5 min',
+  },
+  {
+    href: '/technology/半導體產業',
+    title: '護國神山：半導體產業',
+    description: '台積電如何讓小島成為全球科技心臟',
+    time: '8 min',
+  },
+  {
+    href: '/lifestyle/便利商店文化',
+    title: '生活作業系統：便利商店',
+    description: '不只是商店，而是整個國家的基礎建設',
+    time: '4 min',
+  },
+];
+
+const readingPathFooterItems = [
+  { icon: '⏱️', label: '總計 30 分鐘' },
+  { icon: '🎯', label: '跨越 5 大領域' },
+  { icon: '🌟', label: '完整認識台灣' },
+];
 
 const feedbacks = [
   { name: 'Weiming Hsieh', text: '太強，要是前幾年在國外的時候有這個該多好' },
@@ -326,13 +367,15 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
           <span>⭐ Star on GitHub</span>
         </a>
       </div>
-      <p class="hero-transparency">
-        ⚠️ 本站部分文章由 AI
-        輔助產生初稿，所有內容持續由社群審核改善中。發現錯誤？<a
-          href="https://github.com/frank890417/taiwan-md/issues"
-          target="_blank">歡迎指正</a
-        >
-      </p>
+      <div class="hero-transparency">
+        <p>
+          ⚠️ 本站部分文章由 AI
+          輔助產生初稿，所有內容持續由社群審核改善中。發現錯誤？<a
+            href="https://github.com/frank890417/taiwan-md/issues"
+            target="_blank">歡迎指正</a
+          >
+        </p>
+      </div>
       <div class="hero-stats">
         <div class="stat">
           <span class="stat-icon">🏝️</span>
@@ -452,100 +495,41 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     </div>
   </section>
 
-  <!-- 5 篇認識台灣推薦路線 -->
-  <section class="reading-path">
-    <div class="reading-path-header">
-      <h2>📖 不知道從哪開始？</h2>
-      <p>用這 5 篇文章，在 30 分鐘內認識真正的台灣</p>
-    </div>
-    <div class="reading-path-list">
-      <a href="/history/民主化" class="reading-step">
-        <span class="step-number">1</span>
-        <div class="step-content">
-          <h3>寧靜革命：台灣民主化</h3>
-          <p>從威權到民主，亞洲第一的和平轉型奇蹟</p>
-        </div>
-        <span class="step-time">6 min</span>
-      </a>
+  <ReadingPath
+    title="📖 不知道從哪開始？"
+    subtitle="用這 5 篇文章，在 30 分鐘內認識真正的台灣"
+    steps={readingPathSteps}
+    footerItems={readingPathFooterItems}
+    continueHref="#categories"
+    continueLabel="繼續探索更多主題 →"
+  />
 
-      <a href="/culture/族群（閩南客家原住民外省新住民）" class="reading-step">
-        <span class="step-number">2</span>
-        <div class="step-content">
-          <h3>多元一體：台灣族群</h3>
-          <p>四大族群共同編織的多彩文化基底</p>
-        </div>
-        <span class="step-time">7 min</span>
-      </a>
-
-      <a href="/food/夜市文化" class="reading-step">
-        <span class="step-number">3</span>
-        <div class="step-content">
-          <h3>最真實的台灣味：夜市文化</h3>
-          <p>密度世界第一的庶民美食社交空間</p>
-        </div>
-        <span class="step-time">5 min</span>
-      </a>
-
-      <a href="/technology/半導體產業" class="reading-step">
-        <span class="step-number">4</span>
-        <div class="step-content">
-          <h3>護國神山：半導體產業</h3>
-          <p>台積電如何讓小島成為全球科技心臟</p>
-        </div>
-        <span class="step-time">8 min</span>
-      </a>
-
-      <a href="/lifestyle/便利商店文化" class="reading-step">
-        <span class="step-number">5</span>
-        <div class="step-content">
-          <h3>生活作業系統：便利商店</h3>
-          <p>不只是商店，而是整個國家的基礎建設</p>
-        </div>
-        <span class="step-time">4 min</span>
-      </a>
-    </div>
-
-    <div class="reading-path-footer">
-      <p>
-        ⏱️ <strong>總計 30 分鐘</strong> | 🎯 <strong>跨越 5 大領域</strong> | 🌟
-        <strong>完整認識台灣</strong>
-      </p>
-      <a href="#categories" class="path-continue-btn">繼續探索更多主題 →</a>
-    </div>
-  </section>
-
-  <section class="features">
-    <h2 class="section-title">為什麼需要 Taiwan.md？</h2>
-    <div class="features-grid">
-      <div class="feature-card">
-        <div class="feature-icon">🎯</div>
-        <div class="feature-content">
-          <h3>策展式觀點</h3>
-          <p>精心策展的深度敘事，不是百科全書式羅列</p>
-        </div>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">🤖</div>
-        <div class="feature-content">
-          <h3>AI-Friendly 設計</h3>
-          <p>結構化內容，讓AI也能理解台灣的複雜性</p>
-        </div>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">🌍</div>
-        <div class="feature-content">
-          <h3>雙語國際視野</h3>
-          <p>從在地觀點出發，用國際語言說台灣故事</p>
-        </div>
-      </div>
-      <div class="feature-card">
-        <div class="feature-icon">📚</div>
-        <div class="feature-content">
-          <h3>完整多面向</h3>
-          <p>涵蓋12+領域，呈現台灣的立體完整面貌</p>
-        </div>
-      </div>
-    </div>
+  <FeatureCards
+    lang="zh-TW"
+    sectionTitle="為什麼需要 Taiwan.md？"
+    cards={[
+      {
+        icon: '🎯',
+        title: '策展式觀點',
+        description: '精心策展的深度敘事，不是百科全書式羅列',
+      },
+      {
+        icon: '🤖',
+        title: 'AI-Friendly 設計',
+        description: '結構化內容，讓AI也能理解台灣的複雜性',
+      },
+      {
+        icon: '🌍',
+        title: '雙語國際視野',
+        description: '從在地觀點出發，用國際語言說台灣故事',
+      },
+      {
+        icon: '📚',
+        title: '完整多面向',
+        description: '涵蓋12+領域，呈現台灣的立體完整面貌',
+      },
+    ]}
+  >
     <div class="features-cta">
       <a href="/graph" class="feature-btn">🔗 知識圖譜 — 探索文章之間的連結</a>
       <a
@@ -555,7 +539,7 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
         class="feature-btn secondary">📂 瀏覽 SSOT 原始資料 ↗</a
       >
     </div>
-  </section>
+  </FeatureCards>
 
   <section class="mini-graph-section">
     <a href="/graph" class="mini-graph-link">
@@ -1307,10 +1291,13 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
   }
 
   .hero-transparency {
+    text-align: center;
+    margin-top: 2rem;
+  }
+  .hero-transparency p {
     font-size: 0.8rem;
     color: rgba(255, 255, 255, 0.6);
-    margin-top: 1rem;
-    margin-bottom: -0.5rem;
+    margin: 0;
   }
   .hero-transparency a {
     color: rgba(171, 196, 104, 0.8);
@@ -1425,185 +1412,6 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     color: rgba(255, 255, 255, 0.8);
     font-weight: 500;
     letter-spacing: 0.02em;
-  }
-
-  /* ===== 5 篇認識台灣推薦路線 ===== */
-  .reading-path {
-    max-width: 900px;
-    margin: 6rem auto;
-    padding: 3rem 2rem;
-    background: linear-gradient(135deg, #f0fdf4 0%, #ecfdf5 100%);
-    border-radius: 20px;
-    border: 1px solid rgba(34, 197, 94, 0.1);
-    position: relative;
-    overflow: hidden;
-  }
-
-  .reading-path::before {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: url("data:image/svg+xml,%3Csvg width='40' height='40' viewBox='0 0 40 40' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%2322c55e' fill-opacity='0.03' fill-rule='evenodd'%3E%3Cpath d='m0 40 40-40h-40z'/%3E%3Cpath d='m0 40 40-40h-40z' transform='scale(.5) translate(40 0)'/%3E%3C/g%3E%3C/svg%3E");
-    opacity: 0.4;
-  }
-
-  .reading-path-header {
-    text-align: center;
-    margin-bottom: 3rem;
-    position: relative;
-    z-index: 2;
-  }
-
-  .reading-path-header h2 {
-    font-size: 2.2rem;
-    font-weight: 300;
-    color: #166534;
-    margin-bottom: 1rem;
-    font-family:
-      'jf-lanyangming', 'Noto Serif TC', 'Source Han Serif TC', serif;
-    letter-spacing: 0;
-  }
-
-  .reading-path-header p {
-    font-size: 1.2rem;
-    color: #16a34a;
-    font-weight: 600;
-    line-height: 1.6;
-  }
-
-  .reading-path-list {
-    position: relative;
-    z-index: 2;
-  }
-
-  /* 路線連接線 */
-  .reading-path-list::before {
-    content: '';
-    position: absolute;
-    left: 2.5rem;
-    top: 4rem;
-    bottom: 4rem;
-    width: 3px;
-    background: linear-gradient(
-      180deg,
-      rgba(34, 197, 94, 0.3) 0%,
-      #22c55e 25%,
-      #16a34a 50%,
-      #15803d 75%,
-      rgba(34, 197, 94, 0.3) 100%
-    );
-    border-radius: 2px;
-    z-index: 1;
-  }
-
-  .reading-step {
-    display: flex;
-    align-items: center;
-    padding: 2rem 1.5rem;
-    margin-bottom: 1rem;
-    background: white;
-    border-radius: 16px;
-    text-decoration: none;
-    transition: all 0.3s ease;
-    border: 2px solid rgba(34, 197, 94, 0.1);
-    position: relative;
-    z-index: 2;
-    gap: 1.5rem;
-    box-shadow: 0 2px 8px rgba(22, 163, 74, 0.08);
-  }
-
-  .reading-step:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 8px 25px rgba(22, 163, 74, 0.15);
-    border-color: rgba(34, 197, 94, 0.25);
-    background: rgba(240, 253, 244, 0.6);
-  }
-
-  .step-number {
-    flex-shrink: 0;
-    width: 3rem;
-    height: 3rem;
-    border-radius: 50%;
-    background: linear-gradient(135deg, #22c55e, #16a34a);
-    color: white;
-    font-size: 1.3rem;
-    font-weight: 800;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
-  }
-
-  .step-content {
-    flex: 1;
-  }
-
-  .step-content h3 {
-    font-size: 1.3rem;
-    font-weight: 700;
-    color: #166534;
-    margin-bottom: 0.5rem;
-    line-height: 1.3;
-    font-family:
-      'jf-jinxuanlatte', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
-  }
-
-  .step-content p {
-    color: #16a34a;
-    font-size: 1rem;
-    line-height: 1.5;
-    margin: 0;
-    font-weight: 500;
-  }
-
-  .step-time {
-    flex-shrink: 0;
-    background: rgba(22, 163, 74, 0.1);
-    color: #166534;
-    padding: 0.5rem 1rem;
-    border-radius: 20px;
-    font-size: 0.9rem;
-    font-weight: 600;
-    border: 1px solid rgba(34, 197, 94, 0.2);
-  }
-
-  .reading-path-footer {
-    text-align: center;
-    margin-top: 3rem;
-    padding-top: 2rem;
-    border-top: 1px solid rgba(34, 197, 94, 0.2);
-    position: relative;
-    z-index: 2;
-  }
-
-  .reading-path-footer p {
-    font-size: 1.1rem;
-    color: #16a34a;
-    margin-bottom: 1.5rem;
-    font-weight: 600;
-  }
-
-  .path-continue-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.8rem 2rem;
-    background: linear-gradient(135deg, #22c55e, #16a34a);
-    color: white;
-    text-decoration: none;
-    border-radius: 50px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px rgba(34, 197, 94, 0.3);
-  }
-
-  .path-continue-btn:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(34, 197, 94, 0.4);
-    background: linear-gradient(135deg, #16a34a, #15803d);
   }
 
   /* ===== 隨機發現台灣 ===== */
@@ -1730,11 +1538,6 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     line-height: 1.6;
   }
 
-  /* ===== FEATURES SECTION 升級 ===== */
-  .features {
-    margin: 6rem 0;
-  }
-
   .language-statement {
     max-width: 800px;
     margin: 0 auto 4rem;
@@ -1768,63 +1571,6 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     color: #78716c;
     font-size: 0.9rem;
     line-height: 1.7;
-  }
-
-  .section-title {
-    font-size: 2.5rem;
-    text-align: center;
-    margin-bottom: 1rem;
-    color: #1f2937;
-    font-weight: 800;
-    font-family:
-      'jf-lanyanghei', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
-  }
-
-  .features-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-    gap: 2rem;
-    margin: 3rem 0;
-    max-width: 1200px;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  .feature-card {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    padding: 2rem;
-    background: white;
-    border-radius: 16px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-    border: 1px solid #f1f5f9;
-    transition: all 0.3s ease;
-  }
-
-  .feature-card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 12px 24px rgba(0, 0, 0, 0.1);
-    border-color: #e2e8f0;
-  }
-
-  .feature-icon {
-    font-size: 3rem;
-    flex-shrink: 0;
-    filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1));
-  }
-
-  .feature-content h3 {
-    font-size: 1.25rem;
-    margin-bottom: 0.5rem;
-    color: #1f2937;
-    font-weight: 600;
-  }
-
-  .feature-content p {
-    color: #6b7280;
-    line-height: 1.6;
-    margin: 0;
   }
 
   .features-cta {
@@ -2072,6 +1818,8 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     gap: 0.5rem;
     position: relative;
     z-index: 2;
+    max-width: 800px;
+    margin: 0 auto;
   }
 
   .update-item {
@@ -2169,7 +1917,6 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     padding: 4rem 2rem;
     margin: 6rem 0 0;
     text-align: center;
-    border-radius: 16px;
     position: relative;
     overflow: hidden;
   }
@@ -2447,7 +2194,7 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
   .contribute {
     background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
     padding: 5rem 2rem;
-    margin: 6rem 0 0;
+    margin: 0;
     text-align: center;
     border-radius: 16px;
     position: relative;
@@ -2593,7 +2340,7 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
     .hero-stats {
       grid-template-columns: repeat(2, 1fr);
       gap: 1.5rem;
-      margin: 0;
+      margin: 2rem 0 0;
       max-width: 100%;
     }
 
@@ -2625,15 +2372,8 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
       height: 35%;
     }
 
-    .features-grid {
-      grid-template-columns: 1fr;
-      gap: 1.5rem;
-    }
-
-    .feature-card {
-      flex-direction: column;
-      text-align: center;
-      gap: 1rem;
+    .language-statement {
+      margin: 0 1rem 4rem;
     }
 
     .contribute-buttons {
@@ -2702,39 +2442,6 @@ const row3 = feedbacks.filter((_: any, i: number) => i % 3 === 2);
 
     .section-divider {
       padding: 0 1rem;
-    }
-
-    /* 推薦路線響應式 */
-    .reading-path {
-      margin: 4rem 1rem;
-      padding: 2rem 1rem;
-    }
-
-    .reading-path-list::before {
-      display: none; /* 手機版隱藏連接線 */
-    }
-
-    .reading-step {
-      flex-direction: column;
-      text-align: center;
-      padding: 1.5rem;
-      gap: 1rem;
-    }
-
-    .step-content h3 {
-      font-size: 1.1rem;
-    }
-
-    .step-content p {
-      font-size: 0.9rem;
-    }
-
-    .reading-path-header h2 {
-      font-size: 1.8rem;
-    }
-
-    .reading-path-header p {
-      font-size: 1rem;
     }
 
     /* Random discovery responsive */


### PR DESCRIPTION
## Summary

針對首頁（中英文）進行一系列基本 UI/UX 改善：

- 行動裝置各區塊水平 margin 統一（Feature Cards、Category Grid、Language Statement）
- 共用元件抽出（`FeatureCards.astro`）
- Hero 區塊樣式修正（gap 變數未定義、transparency 排版）
- 移除不必要的 margin / border-radius（`.contribute`、`.newsletter`）
- 更新列表置中 + 全域連結樣式排除 `.update-item`

本次優化目標：
讓 UI 從「靠 vibe 排版」升級成「至少有點設計邏輯的介面」。

## Screenshots

| 頁面 | Before | After |
|------|--------|-------|
| 中文首頁（桌面） | <img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/72d7d230-d6b0-4a91-a5a4-eb64519e94e3" /> | <img width="2560" height="1392" alt="image" src="https://github.com/user-attachments/assets/4664da66-89e1-45fa-b01b-d1fcaab35a43" /> |

我很懶惰截圖視覺剩下部分再麻煩直接 build 確認，桌面版我這邊 Chrome / Safari 已驗證沒問題，手機版有用 DevTools大概看過

## 改動檔案
- `src/components/FeatureCards.astro`（新增）
- `src/components/ReadingPath.astro`（新增）
- `src/components/CategoryGrid.astro`
- `src/layouts/Layout.astro`
- `src/pages/index.astro`
- `src/pages/en/index.astro`

## Test plan
- [ ] 中文首頁手機版排版正常
- [ ] 英文首頁手機版排版正常
- [x] 桌面版 Chrome 顯示正常
- [x] 桌面版 Safari 顯示正常
- [x] Feature Cards 元件中英文正常渲染

🤖 Generated with [Claude Code](https://claude.com/claude-code)