### PR TITLE
style: 統一文章頁（[slug].astro）風格，並修正 set:html 注入內容的列表樣式失效問題。

### DIFF
--- a/src/pages/[category]/[slug].astro
+++ b/src/pages/[category]/[slug].astro
@@ -238,14 +238,20 @@ function resolveWikilinks(markdownContent: string) {
   function resolveOne(target: string, display?: string, bold = false) {
     const label = display || target;
     const inCat = relatedArticles.find(
-      (a: any) => a.title === target || a.slug === target || a.slug === encodeURIComponent(target),
+      (a: any) =>
+        a.title === target ||
+        a.slug === target ||
+        a.slug === encodeURIComponent(target),
     );
     if (inCat) {
       const url = `/${category}/${inCat.slug}`;
       return bold ? `[**${label}**](${url})` : `[${label}](${url})`;
     }
     const cross = allArticles.find(
-      (a: any) => a.title === target || a.slug === target || a.slug === encodeURIComponent(target),
+      (a: any) =>
+        a.title === target ||
+        a.slug === target ||
+        a.slug === encodeURIComponent(target),
     );
     if (cross) {
       const url = `/${cross.category}/${cross.slug}`;
@@ -815,7 +821,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
   }
 
   .header-content {
-    max-width: 960px;
+    max-width: var(--container-reading);
     margin: 0 auto;
     position: relative;
     z-index: 1;
@@ -1029,7 +1035,7 @@ const processedContent = marked.parse(resolvedContent, { renderer });
     font-size: 1.125rem;
     line-height: 2;
     color: #333;
-    max-width: 840px;
+    max-width: var(--container-reading);
     margin: 0 auto;
     letter-spacing: 0.02em;
     background: rgba(255, 255, 255, 0.82);
@@ -1131,41 +1137,40 @@ const processedContent = marked.parse(resolvedContent, { renderer });
   }
 
   /* 列表 — 寬鬆行距，不突出 */
-  .content ul,
-  .content ol {
-    margin: 1.75rem 0;
+  .content :global(ul),
+  .content :global(ol) {
     padding-left: 1.75rem;
   }
 
-  .content ul {
+  .content :global(ul) {
     list-style: disc;
   }
 
-  .content ol {
+  .content :global(ol) {
     list-style: decimal;
   }
 
-  .content ul > li,
-  .content ol > li {
+  .content :global(ul > li),
+  .content :global(ol > li) {
     margin-bottom: 0.6rem;
     padding-left: 0.35rem;
     line-height: 1.9;
   }
 
-  .content ul > li::marker {
+  .content :global(ul > li::marker) {
     color: var(--categoryColor);
   }
 
-  .content ol > li::marker {
+  .content :global(ol > li::marker) {
     color: var(--categoryColor);
     font-weight: 600;
   }
 
-  .content li > p {
+  .content :global(li > p) {
     margin-bottom: 0.75rem;
   }
 
-  .content li > p:last-child {
+  .content :global(li > p:last-child) {
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
….astro

## 📝 這個 PR 做了什麼？

  主要改動為統一文章頁（[slug].astro）的內容寬度，並修正 set:html 注入內容的列表樣式失效問題。

  寬度統一：
  - .header-content 的 max-width 從硬編碼 960px 改為 var(--container-reading)
  - .content 的 max-width 從硬編碼 840px 改為 var(--container-reading)
  - 兩者現在與全站 CSS 變數保持一致（定義於 Layout.astro）

  列表樣式修正：
  - 文章內容透過 set:html 動態注入，Astro scoped styles 不會套用至動態插入的元素
  - 將所有 ul、ol、li 相關選擇器改為 :global()，確保樣式能夠正確套用

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [x] 文章有完整的 frontmatter（title, description, date, tags, category）
- [x] 內容有附上可查證的參考資料來源
- [x] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

Before：

<img width="2560" height="1283" alt="image" src="https://github.com/user-attachments/assets/5b09cf75-0347-4d5e-a452-a108d3bf1a2b" />

<img width="2559" height="1286" alt="image" src="https://github.com/user-attachments/assets/d1ef6ade-dfaf-46b0-9d2f-f25665b1149b" />

<img width="428" height="930" alt="image" src="https://github.com/user-attachments/assets/94eaf5c2-0a45-4bdb-956b-39690b211150" />

After：

<img width="2560" height="1283" alt="螢幕擷取畫面 2026-03-21 004908" src="https://github.com/user-attachments/assets/6f1f507f-b270-4ce9-a4ea-43608437c065" />

<img width="2558" height="1285" alt="螢幕擷取畫面 2026-03-21 004934" src="https://github.com/user-attachments/assets/659449b8-6582-4302-8361-7d5d7ce06592" />

<img width="429" height="933" alt="image" src="https://github.com/user-attachments/assets/db4dbf58-b49a-4b2c-8a09-317b7244c6c4" />

