### PR TITLE
feat(es): 新增西班牙文頁面系統（/es/ routing）

### DIFF
--- a/src/pages/es/[category]/[slug].astro
+++ b/src/pages/es/[category]/[slug].astro
@@ -1,0 +1,872 @@
+---
+import { readdir, readFile } from 'fs/promises';
+import { resolve, join, basename } from 'path';
+import { execSync } from 'child_process';
+import matter from 'gray-matter';
+import Layout from '../../../layouts/Layout.astro';
+import { marked } from 'marked';
+import ArticleHero from '../../../components/ArticleHero.astro';
+import TableOfContents from '../../../components/TableOfContents.astro';
+import ArticleSidebar from '../../../components/ArticleSidebar.astro';
+import RelatedArticleCard from '../../../components/RelatedArticleCard.astro';
+import { categoryConfig, getCategoryConfig, type CategoryKey } from '../../../utils/categoryConfig';
+import { t } from '../../../i18n/ui';
+
+// ── Git helpers ───────────────────────────────────────────────────────────────
+let _gitCache: Map<string, { contributors: string[]; lastModified: string }> | null = null;
+
+function buildGitCache() {
+  if (_gitCache) return _gitCache;
+  _gitCache = new Map();
+  try {
+    const logOutput = execSync(
+      `git -c core.quotePath=false log --name-only --format="COMMIT_BY:%an" -- "knowledge/es/"`,
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+    );
+    let currentAuthor = '';
+    for (const line of logOutput.split('\n')) {
+      if (line.startsWith('COMMIT_BY:')) {
+        currentAuthor = line.slice(10);
+      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
+        const key = resolve(process.cwd(), line);
+        const entry = _gitCache.get(key) || { contributors: [], lastModified: '' };
+        if (!entry.contributors.includes(currentAuthor)) entry.contributors.push(currentAuthor);
+        _gitCache.set(key, entry);
+      }
+    }
+    const dateOutput = execSync(
+      `git -c core.quotePath=false log --format="COMMIT_DATE:%aI" --name-only -- "knowledge/es/"`,
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+    );
+    let currentDate = '';
+    const seenFiles = new Set<string>();
+    for (const line of dateOutput.split('\n')) {
+      if (line.startsWith('COMMIT_DATE:')) {
+        currentDate = line.slice(12);
+      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
+        const key = resolve(process.cwd(), line);
+        if (!seenFiles.has(key)) {
+          seenFiles.add(key);
+          const entry = _gitCache.get(key) || { contributors: [], lastModified: '' };
+          entry.lastModified = currentDate;
+          _gitCache.set(key, entry);
+        }
+      }
+    }
+  } catch (e) {
+    console.error('Git cache error:', (e as Error).message);
+  }
+  return _gitCache;
+}
+
+function getGitInfo(filePath: string) {
+  return buildGitCache().get(filePath) || { contributors: [], lastModified: '' };
+}
+
+// ── Category → folder mapping ─────────────────────────────────────────────────
+const categoryMapping: Record<string, string> = {
+  history: 'History', geography: 'Geography', culture: 'Culture',
+  food: 'Food', art: 'Art', music: 'Music', technology: 'Technology',
+  nature: 'Nature', people: 'People', society: 'Society',
+  economy: 'Economy', lifestyle: 'Lifestyle',
+};
+
+// ── getStaticPaths ────────────────────────────────────────────────────────────
+export async function getStaticPaths() {
+  const _categoryMapping: Record<string, string> = {
+    history: 'History', geography: 'Geography', culture: 'Culture',
+    food: 'Food', art: 'Art', music: 'Music', technology: 'Technology',
+    nature: 'Nature', people: 'People', society: 'Society',
+    economy: 'Economy', lifestyle: 'Lifestyle',
+  };
+
+  let __gitCache: Map<string, { contributors: string[]; lastModified: string }> | null = null;
+  function _buildGitCache() {
+    if (__gitCache) return __gitCache;
+    __gitCache = new Map();
+    try {
+      const logOutput = execSync(
+        `git -c core.quotePath=false log --name-only --format="COMMIT_BY:%an" -- "knowledge/es/"`,
+        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+      );
+      let currentAuthor = '';
+      for (const line of logOutput.split('\n')) {
+        if (line.startsWith('COMMIT_BY:')) currentAuthor = line.slice(10);
+        else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
+          const key = resolve(process.cwd(), line);
+          const entry = __gitCache.get(key) || { contributors: [], lastModified: '' };
+          if (!entry.contributors.includes(currentAuthor)) entry.contributors.push(currentAuthor);
+          __gitCache.set(key, entry);
+        }
+      }
+      const dateOutput = execSync(
+        `git -c core.quotePath=false log --format="COMMIT_DATE:%aI" --name-only -- "knowledge/es/"`,
+        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 }
+      );
+      let currentDate = '';
+      const seen = new Set<string>();
+      for (const line of dateOutput.split('\n')) {
+        if (line.startsWith('COMMIT_DATE:')) currentDate = line.slice(12);
+        else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
+          const key = resolve(process.cwd(), line);
+          if (!seen.has(key)) {
+            seen.add(key);
+            const entry = __gitCache.get(key) || { contributors: [], lastModified: '' };
+            entry.lastModified = currentDate;
+            __gitCache.set(key, entry);
+          }
+        }
+      }
+    } catch {}
+    return __gitCache;
+  }
+
+  const paths: any[] = [];
+  for (const [categorySlug, folderName] of Object.entries(_categoryMapping)) {
+    try {
+      const folderPath = resolve(process.cwd(), 'knowledge', 'es', folderName);
+      const files = await readdir(folderPath);
+      for (const file of files.filter(f => f.endsWith('.md') && !f.startsWith('_'))) {
+        const filePath = join(folderPath, file);
+        const fileContent = await readFile(filePath, 'utf-8');
+        const { data: frontmatter, content } = matter(fileContent);
+        const slug = basename(file, '.md');
+        let gitInfo = { contributors: [] as string[], lastModified: '' };
+        try { gitInfo = _buildGitCache().get(filePath) || gitInfo; } catch {}
+        paths.push({
+          params: { category: categorySlug, slug },
+          props: {
+            title: frontmatter.title || slug,
+            description: frontmatter.description || '',
+            content,
+            frontmatter,
+            lang: 'es',
+            contributors: gitInfo.contributors,
+            lastModified: gitInfo.lastModified,
+          },
+        });
+      }
+    } catch {}
+  }
+  return paths;
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+const { title, description, content, frontmatter, lang = 'es', contributors = [], lastModified = '' } = Astro.props;
+const { category, slug } = Astro.params;
+
+const categoryInfo = getCategoryConfig(category);
+if (!categoryInfo) throw new Error(`Unknown category: ${category}`);
+
+// ── Category name for ES locale ───────────────────────────────────────────────
+const categoryNameEs = categoryInfo.name_es || categoryInfo.name;
+
+// ── Related articles (same category, up to 3) ─────────────────────────────────
+let relatedArticles: any[] = [];
+try {
+  const folderName = categoryMapping[category as string];
+  if (folderName) {
+    const folderPath = resolve(process.cwd(), 'knowledge', 'es', folderName);
+    const files = (await readdir(folderPath)).filter(f => f.endsWith('.md') && !f.startsWith('_'));
+    for (const file of files) {
+      const articleSlug = basename(file, '.md');
+      if (articleSlug === slug) continue;
+      const filePath = join(folderPath, file);
+      const { data: fm } = matter(await readFile(filePath, 'utf-8'));
+      relatedArticles.push({
+        title: fm.title || articleSlug,
+        slug: articleSlug,
+        description: fm.description || '',
+        category,
+      });
+    }
+    relatedArticles = relatedArticles.slice(0, 3);
+  }
+} catch {}
+
+// ── Random explore list ───────────────────────────────────────────────────────
+let allArticles: Array<{ title: string; slug: string; category: string }> = [];
+try {
+  for (const [catSlug, folderName] of Object.entries(categoryMapping)) {
+    if (catSlug === category) continue;
+    try {
+      const catPath = resolve(process.cwd(), 'knowledge', 'es', folderName);
+      for (const file of (await readdir(catPath)).filter(f => f.endsWith('.md') && !f.startsWith('_'))) {
+        const articleSlug = basename(file, '.md');
+        const { data: fm } = matter(await readFile(join(catPath, file), 'utf-8'));
+        allArticles.push({ title: fm.title || articleSlug, slug: articleSlug, category: catSlug });
+      }
+    } catch {}
+  }
+} catch {}
+
+// ── Other categories ──────────────────────────────────────────────────────────
+const otherCategories = Object.keys(categoryConfig)
+  .filter(cat => cat !== category)
+  .slice(0, 3)
+  .map(cat => ({ key: cat, ...categoryConfig[cat as CategoryKey] }));
+
+// ── Markdown → HTML ───────────────────────────────────────────────────────────
+function resolveWikilinks(md: string) {
+  if (!md) return md;
+  return md.replace(/\[\[([^\]|]+?)(?:\|([^\]]+?))?\]\]/g, (_, target, display) => {
+    return `**${display || target}**`;
+  });
+}
+
+const renderer = new marked.Renderer();
+
+renderer.heading = ({ text, depth }) => {
+  const id = text
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[^\w\u00c0-\u024f-]/g, '')
+    .slice(0, 60);
+  return `<h${depth} id="${id}">${text}</h${depth}>`;
+};
+
+renderer.link = ({ href, title, text }) => {
+  const isExternal = href?.startsWith('http://') || href?.startsWith('https://');
+  const titleAttr = title ? ` title="${title}"` : '';
+  const targetAttr = isExternal ? ' target="_blank" rel="noopener noreferrer"' : '';
+  return `<a href="${href}"${titleAttr}${targetAttr}>${text}</a>`;
+};
+
+renderer.image = ({ href, title, text }) => {
+  const titleAttr = title ? ` title="${title}"` : '';
+  return `<img src="${href}" alt="${text || ''}"${titleAttr} loading="lazy" onerror="this.onerror=null;this.classList.add('img-broken')" />`;
+};
+
+const processedContent = marked.parse(resolveWikilinks(content), { renderer }) as string;
+
+// ── Reading time (Spanish ~220 wpm) ───────────────────────────────────────────
+const estimatedReadingTime = frontmatter.readingTime
+  || Math.max(1, Math.round(content.replace(/\s+/g, ' ').length / 220));
+
+const articleUrl = `https://taiwan.md/es/${category}/${slug}`;
+const encodedUrl = encodeURIComponent(articleUrl);
+const encodedTitle = encodeURIComponent(title);
+---
+
+<Layout
+  title={title}
+  description={description}
+  type="article"
+  datePublished={frontmatter.date || new Date().toISOString()}
+  dateModified={frontmatter.modified || frontmatter.date || new Date().toISOString()}
+  content={content}
+  tags={frontmatter.tags}
+  category={categoryNameEs}
+  lang="es"
+>
+  <!-- Reading progress bar -->
+  <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>
+
+  <main class="article-page" lang="es">
+
+    <!-- ── Hero ─────────────────────────────────────────────────── -->
+    <ArticleHero
+      title={title}
+      description={description}
+      category={category}
+      categoryName={categoryNameEs}
+      categoryColor={categoryInfo.color}
+      coverImage={categoryInfo.cover}
+      slug={slug}
+      lang="es"
+    />
+
+    <!-- ── Three-column body ─────────────────────────────────────── -->
+    <div class="article-shell">
+
+      <!-- Left: Table of Contents -->
+      <div class="col-toc" aria-label={t('article.toc', 'es')}>
+        <TableOfContents content={processedContent} />
+      </div>
+
+      <!-- Center: Article content -->
+      <article class="col-body" data-pagefind-body>
+
+        <!-- Status / date strip -->
+        <div class="article-meta-strip">
+          {frontmatter.status && (
+            <span class="status-badge" style={`background:${categoryInfo.colorLight}; color:${categoryInfo.color};`}>
+              {frontmatter.status}
+            </span>
+          )}
+          {frontmatter.date && (
+            <time class="meta-date" datetime={frontmatter.date}>
+              {new Date(frontmatter.date).toLocaleDateString('es-ES', { year:'numeric', month:'long', day:'numeric' })}
+            </time>
+          )}
+          <span class="meta-lang">{t('article.langLabel', 'es')}</span>
+        </div>
+
+        <!-- Prose body -->
+        <div class="prose" set:html={processedContent}></div>
+
+        <!-- Sources -->
+        {frontmatter.source && frontmatter.source.length > 0 && (
+          <div class="sources-block">
+            <h3 class="sources-heading">{t('article.sources', 'es')}</h3>
+            <ul class="sources-list">
+              {frontmatter.source.map((url: string) => (
+                <li>
+                  <a href={url} target="_blank" rel="noopener noreferrer" class="source-link">{url}</a>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        <!-- AI Disclaimer -->
+        <div class="ai-disclaimer">
+          <div class="disclaimer-icon" aria-hidden="true">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
+          </div>
+          <div class="disclaimer-text">
+            <strong>{t('article.disclaimer.title', 'es')}</strong>
+            {t('article.disclaimer.body', 'es')}
+          </div>
+        </div>
+
+        <!-- Contribution row -->
+        <div class="contribute-row">
+          <a
+            href={`https://github.com/frank890417/taiwan-md/edit/main/knowledge/es/${categoryMapping[category as string]}/${slug}.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="contribute-btn contribute-btn--primary"
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+            {t('article.editPage', 'es')}
+          </a>
+          <a
+            href={`https://github.com/frank890417/taiwan-md/issues/new?title=${encodeURIComponent(`Feedback: ${title}`)}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            class="contribute-btn contribute-btn--ghost"
+          >
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+            {t('article.reportIssue', 'es')}
+          </a>
+        </div>
+
+        <!-- Tags + bottom share row -->
+        <div class="bottom-meta">
+          {frontmatter.tags && frontmatter.tags.length > 0 && (
+            <div class="bottom-tags">
+              {frontmatter.tags.map((tag: string) => (
+                <span class="bottom-tag"
+                      style={`color:${categoryInfo.color}; background:${categoryInfo.colorLight}; border-color:${categoryInfo.color}28;`}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div class="bottom-share">
+            <span class="share-label">{t('article.shareLabel', 'es')}</span>
+            <a href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`}
+               target="_blank" rel="noopener noreferrer" class="share-btn" aria-label="Compartir en X">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-4.714-6.231-5.401 6.231H2.744l7.73-8.835L1.254 2.25H8.08l4.256 5.636L18.244 2.25zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </a>
+            <a href={`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`}
+               target="_blank" rel="noopener noreferrer" class="share-btn" aria-label="Compartir en Facebook">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M18 2h-3a5 5 0 00-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 011-1h3z"/></svg>
+            </a>
+            <a href={`https://social-plugins.line.me/lineit/share?url=${encodedUrl}`}
+               target="_blank" rel="noopener noreferrer" class="share-btn" aria-label="Compartir en LINE">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M19.365 9.863c.349 0 .63.285.63.631 0 .345-.281.63-.63.63H17.61v1.125h1.755c.349 0 .63.283.63.630 0 .344-.281.629-.63.629h-2.386c-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63h2.386c.346 0 .627.285.627.63 0 .349-.281.63-.63.63H17.61V9.863h1.755zm-3.855 3.016c0 .27-.174.51-.432.596-.064.021-.133.031-.199.031-.211 0-.391-.09-.51-.25l-2.443-3.317v2.94c0 .344-.279.629-.631.629-.346 0-.626-.285-.626-.629V8.108c0-.27.173-.51.43-.595.06-.023.136-.033.194-.033.195 0 .375.104.495.254l2.462 3.33V8.108c0-.345.282-.63.63-.63.345 0 .63.285.63.63v4.771zm-5.741 0c0 .344-.282.629-.631.629-.345 0-.627-.285-.627-.629V8.108c0-.345.282-.63.63-.63.346 0 .628.285.628.63v4.771zm-2.466.629H4.917c-.345 0-.63-.285-.63-.629V8.108c0-.345.285-.63.63-.63.348 0 .63.285.63.63v4.141h1.756c.348 0 .629.283.629.63 0 .344-.282.629-.629.629M24 10.314C24 4.943 18.615.572 12 .572S0 4.943 0 10.314c0 4.811 4.27 8.842 10.035 9.608.391.082.923.258 1.058.59.12.301.079.766.038 1.08l-.164 1.02c-.045.301-.24 1.186 1.049.645 1.291-.539 6.916-4.078 9.436-6.975C23.176 14.393 24 12.458 24 10.314"/></svg>
+            </a>
+            <button class="share-btn copy-btn-bottom" type="button" aria-label={t('article.copyLink', 'es')}
+                    data-copied-text={t('article.copied', 'es')}>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10 13a5 5 0 007.54.54l3-3a5 5 0 00-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 00-7.54-.54l-3 3a5 5 0 007.07 7.07l1.71-1.71"/></svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Return navigation -->
+        <div class="return-nav">
+          <a href={`/es/${category}`} class="return-btn return-btn--primary"
+             style={`background:${categoryInfo.color};`}>
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="15 18 9 12 15 6"/></svg>
+            {t('article.backToCategory', 'es')} {categoryNameEs}
+          </a>
+          <a href="/es" class="return-btn return-btn--ghost">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            {t('article.backToHome', 'es')}
+          </a>
+        </div>
+      </article>
+
+      <!-- Right: Sidebar -->
+      <div class="col-sidebar">
+        <ArticleSidebar
+          title={title}
+          tags={frontmatter.tags}
+          readingTime={estimatedReadingTime}
+          date={frontmatter.date}
+          lastModified={lastModified || frontmatter.modified}
+          contributors={contributors}
+          category={category}
+          categoryName={categoryNameEs}
+          categoryColor={categoryInfo.color}
+          slug={slug}
+          lang="es"
+        />
+      </div>
+
+    </div><!-- /article-shell -->
+
+    <!-- ── Related articles ───────────────────────────────────────── -->
+    {relatedArticles.length > 0 && (
+      <section class="related-section">
+        <div class="related-inner">
+          <div class="section-header">
+            <p class="section-kicker">{t('article.furtherReading', 'es')}</p>
+            <h2 class="section-title">{t('article.moreInCategory', 'es')}</h2>
+          </div>
+          <div class="related-grid">
+            {relatedArticles.map(article => (
+              <RelatedArticleCard
+                title={article.title}
+                slug={article.slug}
+                category={category}
+                categoryName={categoryNameEs}
+                categoryColor={categoryInfo.color}
+                description={article.description}
+                coverImage={categoryInfo.cover}
+                lang="es"
+              />
+            ))}
+          </div>
+          <div class="related-cta">
+            <a href={`/es/${category}`} class="view-all-btn" style={`color:${categoryInfo.color}; border-color:${categoryInfo.color}30;`}>
+              {t('article.viewAll', 'es')} {categoryNameEs} {t('article.articles', 'es')}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+            </a>
+          </div>
+        </div>
+      </section>
+    )}
+
+    <!-- ── Random explore ────────────────────────────────────────── -->
+    {allArticles.length > 0 && (
+      <div class="random-explore-row">
+        <button class="random-btn" id="randomBtn" type="button">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><polyline points="16 3 21 3 21 8"/><line x1="4" y1="20" x2="21" y2="3"/><polyline points="21 16 21 21 16 21"/><line x1="15" y1="15" x2="21" y2="21"/></svg>
+          {t('article.randomExplore', 'es')}
+        </button>
+      </div>
+    )}
+
+    <!-- ── Explore other categories ──────────────────────────────── -->
+    <section class="explore-section">
+      <div class="explore-inner">
+        <div class="section-header">
+          <p class="section-kicker">{t('article.exploreTaiwan', 'es')}</p>
+          <h2 class="section-title">{t('article.moreAspects', 'es')}</h2>
+        </div>
+        <div class="explore-grid">
+          {otherCategories.map(cat => (
+            <a href={`/es/${cat.key}`} class="explore-card">
+              <div class="explore-card-accent" style={`background:${cat.color};`} aria-hidden="true"></div>
+              <div class="explore-card-body">
+                <span class="explore-cat-name" style={`color:${cat.color};`}>{cat.name_es || cat.name}</span>
+                <p class="explore-cat-desc">{cat.description_es || cat.description}</p>
+                <span class="explore-cta" style={`color:${cat.color};`}>
+                  {t('article.startExplore', 'es')}
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><polyline points="9 18 15 12 9 6"/></svg>
+                </span>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+
+  </main>
+</Layout>
+
+<!-- ── Scripts ──────────────────────────────────────────────────────────────── -->
+<script>
+  function updateProgress() {
+    const body = document.querySelector('.prose') as HTMLElement;
+    if (!body) return;
+    const scrolled = window.scrollY;
+    const top      = body.offsetTop;
+    const height   = body.offsetHeight;
+    const winH     = window.innerHeight;
+    const progress = Math.min(Math.max((scrolled - top + winH * 0.3) / height * 100, 0), 100);
+    const bar      = document.getElementById('reading-progress');
+    if (bar) bar.style.width = progress + '%';
+  }
+  window.addEventListener('scroll', updateProgress, { passive: true });
+  window.addEventListener('resize', updateProgress, { passive: true });
+  updateProgress();
+
+  const copyBtnBottom = document.querySelector<HTMLButtonElement>('.copy-btn-bottom');
+  if (copyBtnBottom) {
+    copyBtnBottom.addEventListener('click', () => {
+      navigator.clipboard.writeText(window.location.href).then(() => {
+        copyBtnBottom.style.color = '#006D77';
+        setTimeout(() => { copyBtnBottom.style.color = ''; }, 2200);
+      }).catch(() => {
+        const ta = document.createElement('textarea');
+        ta.value = window.location.href;
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      });
+    });
+  }
+</script>
+
+<script define:vars={{ allArticles }}>
+  const btn = document.getElementById('randomBtn');
+  if (btn && allArticles?.length) {
+    btn.addEventListener('click', () => {
+      const pick = allArticles[Math.floor(Math.random() * allArticles.length)];
+      window.location.href = '/es/' + pick.category + '/' + pick.slug;
+    });
+  }
+</script>
+
+<style define:vars={{ catColor: categoryInfo.color, catColorLight: categoryInfo.colorLight }}>
+
+/* ── Reading progress ──────────────────────────────────────────────────── */
+.reading-progress {
+  position: fixed;
+  top: 0; left: 0;
+  width: 0%;
+  height: 3px;
+  background: var(--catColor);
+  z-index: 9999;
+  transition: width 0.1s linear;
+}
+
+.article-page {
+  background: #F8F1E9;
+  min-height: 100vh;
+}
+
+.article-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 4rem 2rem 5rem;
+  display: grid;
+  grid-template-columns: 220px 1fr 200px;
+  grid-template-areas: "toc body sidebar";
+  gap: 3.5rem;
+  align-items: start;
+}
+
+.col-toc     { grid-area: toc; }
+.col-body    { grid-area: body; min-width: 0; }
+.col-sidebar { grid-area: sidebar; }
+
+.article-meta-strip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 2.5rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid rgba(26,60,52,0.08);
+}
+
+.status-badge {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  padding: 0.25rem 0.75rem;
+  border-radius: 100px;
+}
+
+.meta-date {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.8rem;
+  color: #7A8B7E;
+}
+
+.meta-lang {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.75rem;
+  color: #9AA89E;
+  border: 1px solid rgba(26,60,52,0.12);
+  padding: 0.2rem 0.6rem;
+  border-radius: 100px;
+  margin-left: auto;
+}
+
+/* ── Prose — Inter for Spanish (longer words, better with sans-serif) ─── */
+.prose {
+  font-family: 'Inter', 'Satoshi', system-ui, sans-serif;
+  font-size: 1.05rem;
+  line-height: 1.85;
+  color: #2C2C2C;
+}
+
+.prose :global(h1) {
+  font-size: clamp(1.6rem, 3vw, 2.1rem);
+  font-weight: 700;
+  color: #1A3C34;
+  margin: 3.5rem 0 1.25rem;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+}
+.prose :global(h2) {
+  font-size: clamp(1.3rem, 2.5vw, 1.65rem);
+  font-weight: 700;
+  color: #1A3C34;
+  margin: 3.5rem 0 1.1rem;
+  padding-bottom: 0.6rem;
+  border-bottom: 1.5px solid rgba(26,60,52,0.12);
+  line-height: 1.3;
+}
+.prose :global(h3) {
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  font-weight: 600;
+  color: #1A3C34;
+  margin: 2.5rem 0 0.85rem;
+  padding-left: 0.85rem;
+  border-left: 3px solid var(--catColor);
+  line-height: 1.35;
+}
+.prose :global(h4) {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #3A4F44;
+  margin: 2rem 0 0.65rem;
+}
+.prose :global(p) {
+  margin-bottom: 1.6rem;
+  color: #2C2C2C;
+}
+.prose :global(a) {
+  color: #006D77;
+  text-decoration: underline;
+  text-decoration-color: rgba(0,109,119,0.35);
+  text-underline-offset: 3px;
+  transition: text-decoration-color 0.2s;
+}
+.prose :global(a:hover) { text-decoration-color: #006D77; }
+.prose :global(ul) { list-style: disc; padding-left: 1.5rem; margin-bottom: 1.6rem; }
+.prose :global(ol) { list-style: decimal; padding-left: 1.5rem; margin-bottom: 1.6rem; }
+.prose :global(li) { margin-bottom: 0.45rem; line-height: 1.75; }
+.prose :global(blockquote) {
+  border-left: 4px solid var(--catColor);
+  background: linear-gradient(to right, rgba(26,60,52,0.04), transparent);
+  margin: 2.5rem 0;
+  padding: 1.5rem 1.75rem;
+  border-radius: 0 12px 12px 0;
+  font-style: italic;
+  color: #3A4F44;
+  font-size: 1.05rem;
+}
+.prose :global(blockquote p) { margin-bottom: 0; }
+.prose :global(strong) { font-weight: 700; color: #1A3C34; }
+.prose :global(code) {
+  font-family: 'Courier New', monospace;
+  font-size: 0.88em;
+  background: rgba(26,60,52,0.06);
+  color: #1A3C34;
+  padding: 0.15em 0.45em;
+  border-radius: 4px;
+}
+.prose :global(pre) {
+  background: #1A3C34;
+  color: #F8F1E9;
+  padding: 1.5rem;
+  border-radius: 12px;
+  overflow-x: auto;
+  margin: 2rem 0;
+  font-size: 0.875rem;
+}
+.prose :global(pre code) { background: transparent; color: inherit; padding: 0; }
+.prose :global(img) {
+  width: 100%;
+  max-height: 480px;
+  object-fit: cover;
+  border-radius: 12px;
+  margin: 2rem 0;
+  box-shadow: 0 4px 24px rgba(26,60,52,0.10);
+}
+.prose :global(img.img-broken) {
+  min-height: 120px;
+  background: rgba(26,60,52,0.04);
+  border: 2px dashed rgba(26,60,52,0.15);
+}
+.prose :global(table) { width: 100%; border-collapse: collapse; margin: 2rem 0; font-size: 0.92rem; }
+.prose :global(th) {
+  background: rgba(26,60,52,0.06);
+  font-weight: 600;
+  color: #1A3C34;
+  padding: 0.75rem 1rem;
+  text-align: left;
+  border-bottom: 2px solid rgba(26,60,52,0.15);
+}
+.prose :global(td) { padding: 0.7rem 1rem; border-bottom: 1px solid rgba(26,60,52,0.07); color: #3A4F44; }
+.prose :global(tr:last-child td) { border-bottom: none; }
+.prose :global(hr) { border: none; border-top: 1.5px solid rgba(26,60,52,0.1); margin: 3rem 0; }
+
+/* ── Sources ─────────────────────────────────────────── */
+.sources-block {
+  margin: 3rem 0;
+  padding: 2rem;
+  background: rgba(26,60,52,0.03);
+  border-radius: 16px;
+  border: 1px solid rgba(26,60,52,0.08);
+}
+.sources-heading {
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: #1A3C34;
+  margin-bottom: 1rem;
+}
+.sources-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.5rem; }
+.source-link { font-size: 0.82rem; color: #006D77; text-decoration: none; word-break: break-all; }
+.source-link:hover { text-decoration: underline; }
+
+/* ── AI Disclaimer ─────────────────────────────────── */
+.ai-disclaimer {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+  margin: 3rem 0 2rem;
+  padding: 1.25rem 1.5rem;
+  background: rgba(193,125,94,0.06);
+  border: 1px solid rgba(193,125,94,0.18);
+  border-radius: 12px;
+}
+.disclaimer-icon { flex-shrink: 0; color: #C17D5E; margin-top: 0.15rem; }
+.disclaimer-text { font-family: 'Inter', system-ui, sans-serif; font-size: 0.83rem; color: #5A4A42; line-height: 1.6; }
+.disclaimer-text strong {
+  display: block; font-weight: 600; color: #C17D5E; margin-bottom: 0.3rem;
+  font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.08em;
+}
+
+/* ── Contribution row ──────────────────────────────── */
+.contribute-row { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 2rem 0; }
+.contribute-btn {
+  display: inline-flex; align-items: center; gap: 0.45rem;
+  font-family: 'Inter', system-ui, sans-serif;
+  font-size: 0.82rem; font-weight: 500;
+  padding: 0.55rem 1.1rem; border-radius: 100px; text-decoration: none; transition: all 0.2s;
+}
+.contribute-btn--primary { background: #1A3C34; color: #F8F1E9; }
+.contribute-btn--primary:hover { background: #243d36; }
+.contribute-btn--ghost { background: transparent; color: #1A3C34; border: 1px solid rgba(26,60,52,0.2); }
+.contribute-btn--ghost:hover { background: rgba(26,60,52,0.05); }
+
+/* ── Bottom meta ───────────────────────────────────── */
+.bottom-meta {
+  display: flex; align-items: center; justify-content: space-between;
+  flex-wrap: wrap; gap: 1rem; margin: 3rem 0 2rem;
+  padding-top: 2rem; border-top: 1px solid rgba(26,60,52,0.08);
+}
+.bottom-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+.bottom-tag {
+  font-family: 'Inter', system-ui, sans-serif; font-size: 0.75rem; font-weight: 500;
+  padding: 0.25rem 0.7rem; border-radius: 100px; border: 1px solid;
+}
+.bottom-share { display: flex; align-items: center; gap: 0.4rem; }
+.share-label { font-family: 'Inter', system-ui, sans-serif; font-size: 0.78rem; color: #7A8B7E; margin-right: 0.25rem; }
+.share-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 34px; height: 34px; border-radius: 50%;
+  background: rgba(26,60,52,0.06); color: #1A3C34;
+  border: none; cursor: pointer; text-decoration: none; transition: background 0.2s, color 0.2s;
+}
+.share-btn:hover { background: #1A3C34; color: #F8F1E9; }
+
+/* ── Return nav ────────────────────────────────────── */
+.return-nav { display: flex; gap: 0.75rem; flex-wrap: wrap; margin: 2.5rem 0 1rem; }
+.return-btn {
+  display: inline-flex; align-items: center; gap: 0.45rem;
+  font-family: 'Inter', system-ui, sans-serif; font-size: 0.82rem; font-weight: 500;
+  padding: 0.55rem 1.25rem; border-radius: 100px; text-decoration: none; transition: all 0.2s;
+}
+.return-btn--primary { color: #F8F1E9; }
+.return-btn--primary:hover { opacity: 0.88; }
+.return-btn--ghost { background: transparent; color: #1A3C34; border: 1px solid rgba(26,60,52,0.2); }
+.return-btn--ghost:hover { background: rgba(26,60,52,0.06); }
+
+/* ── Related section ───────────────────────────────── */
+.related-section { background: white; padding: 5rem 2rem; margin-top: 2rem; }
+.related-inner { max-width: 1280px; margin: 0 auto; }
+.section-header { text-align: center; margin-bottom: 3rem; }
+.section-kicker {
+  font-family: 'Inter', system-ui, sans-serif; font-size: 0.72rem; font-weight: 600;
+  text-transform: uppercase; letter-spacing: 0.2em; color: #9AA89E; margin-bottom: 0.6rem;
+}
+.section-title {
+  font-family: 'Inter', serif; font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 700; color: #1A3C34; line-height: 1.25;
+}
+.related-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.5rem; }
+.related-cta { text-align: center; margin-top: 2.5rem; }
+.view-all-btn {
+  display: inline-flex; align-items: center; gap: 0.5rem;
+  font-family: 'Inter', system-ui, sans-serif; font-size: 0.88rem; font-weight: 500;
+  padding: 0.65rem 1.5rem; border-radius: 100px; border: 1.5px solid;
+  text-decoration: none; transition: all 0.2s;
+}
+.view-all-btn:hover { background: rgba(0,0,0,0.04); }
+
+/* ── Random explore ────────────────────────────────── */
+.random-explore-row { display: flex; justify-content: center; padding: 2.5rem 2rem; background: #F8F1E9; }
+.random-btn {
+  display: inline-flex; align-items: center; gap: 0.6rem;
+  font-family: 'Inter', system-ui, sans-serif; font-size: 0.88rem; font-weight: 500;
+  padding: 0.75rem 1.75rem; border-radius: 100px;
+  border: 1.5px solid rgba(26,60,52,0.2); background: white; color: #1A3C34;
+  cursor: pointer; transition: all 0.2s;
+}
+.random-btn:hover { background: #1A3C34; color: #F8F1E9; border-color: #1A3C34; }
+
+/* ── Explore section ───────────────────────────────── */
+.explore-section { background: #F8F1E9; padding: 5rem 2rem; }
+.explore-inner { max-width: 1280px; margin: 0 auto; }
+.explore-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1.25rem; }
+.explore-card {
+  display: flex; text-decoration: none; background: white; border-radius: 16px; overflow: hidden;
+  border: 1px solid rgba(26,60,52,0.06); box-shadow: 0 2px 8px rgba(26,60,52,0.05);
+  transition: transform 0.25s, box-shadow 0.25s;
+}
+.explore-card:hover { transform: translateY(-4px); box-shadow: 0 8px 32px rgba(26,60,52,0.12); }
+.explore-card-accent { width: 5px; flex-shrink: 0; }
+.explore-card-body { padding: 1.4rem 1.5rem; display: flex; flex-direction: column; gap: 0.4rem; }
+.explore-cat-name { font-family: 'Inter', system-ui, sans-serif; font-size: 0.92rem; font-weight: 700; letter-spacing: -0.01em; }
+.explore-cat-desc { font-family: 'Inter', system-ui, sans-serif; font-size: 0.82rem; color: #6A7D72; line-height: 1.55; margin: 0; }
+.explore-cta {
+  display: inline-flex; align-items: center; gap: 0.3rem;
+  font-family: 'Inter', system-ui, sans-serif; font-size: 0.78rem; font-weight: 600; margin-top: 0.35rem;
+}
+
+/* ── Responsive ────────────────────────────────────── */
+@media (max-width: 1024px) {
+  .article-shell {
+    grid-template-columns: 1fr;
+    grid-template-areas: "body" "sidebar";
+    padding: 2.5rem 1.5rem 4rem;
+    gap: 2rem;
+  }
+  .col-toc { display: none; }
+}
+
+@media (max-width: 640px) {
+  .article-shell { padding: 1.5rem 1rem 3rem; }
+  .bottom-meta { flex-direction: column; align-items: flex-start; }
+  .return-nav { flex-direction: column; }
+  .return-btn { justify-content: center; }
+  .related-section, .explore-section { padding: 3.5rem 1rem; }
+}
+</style>

--- a/src/pages/es/[category]/index.astro
+++ b/src/pages/es/[category]/index.astro
@@ -1,0 +1,602 @@
+---
+import { readdir, readFile } from 'fs/promises';
+import { resolve, join, basename } from 'path';
+import matter from 'gray-matter';
+import Layout from '../../../layouts/Layout.astro';
+import CategoryHero from '../../../components/CategoryHero.astro';
+import { marked } from 'marked';
+import { categoryConfig, getCategoryConfig, type CategoryKey } from '../../../utils/categoryConfig';
+
+export async function getStaticPaths() {
+  const categories = Object.keys(categoryConfig);
+  const categoryMapping: Record<string, string> = {
+    history: 'History', geography: 'Geography', culture: 'Culture',
+    food: 'Food', art: 'Art', music: 'Music',
+    technology: 'Technology', nature: 'Nature', people: 'People',
+    society: 'Society', economy: 'Economy', lifestyle: 'Lifestyle',
+  };
+
+  const paths = [];
+
+  for (const category of categories) {
+    const folderName = categoryMapping[category];
+    const articles: any[] = [];
+
+    try {
+      const esFolderPath = resolve(process.cwd(), 'knowledge', 'es', folderName);
+      const esFiles = await readdir(esFolderPath);
+      const esMarkdownFiles = esFiles.filter((file) => file.endsWith('.md') && !file.startsWith('_'));
+
+      for (const file of esMarkdownFiles) {
+        const filePath = join(esFolderPath, file);
+        const fileContent = await readFile(filePath, 'utf-8');
+        const { data: frontmatter } = matter(fileContent);
+        const slug = basename(file, '.md');
+
+        articles.push({
+          slug,
+          title: frontmatter.title || slug,
+          description: frontmatter.description || '',
+          status: frontmatter.status || '',
+          readingTime: frontmatter.readingTime || null,
+          featured: frontmatter.featured || false,
+        });
+      }
+    } catch {}
+
+    // Try ES hub first, fall back to EN hub
+    let hubContent = '';
+    try {
+      const esFolderPath = resolve(process.cwd(), 'knowledge', 'es', folderName);
+      const esHubFiles = await readdir(esFolderPath);
+      const esHubFile = esHubFiles.find(f => f.startsWith('_') && f.includes('Hub'));
+      if (esHubFile) {
+        const raw = await readFile(join(esFolderPath, esHubFile), 'utf-8');
+        hubContent = matter(raw).content.replace(/^#\s+.+\n/, '').trim();
+      }
+    } catch {}
+    if (!hubContent) {
+      try {
+        const enFolderPath = resolve(process.cwd(), 'knowledge', 'en', folderName);
+        const enHubFiles = await readdir(enFolderPath);
+        const enHubFile = enHubFiles.find(f => f.startsWith('_') && f.includes('Hub'));
+        if (enHubFile) {
+          const raw = await readFile(join(enFolderPath, enHubFile), 'utf-8');
+          hubContent = matter(raw).content.replace(/^#\s+.+\n/, '').trim();
+        }
+      } catch {}
+    }
+
+    paths.push({
+      params: { category },
+      props: {
+        categoryInfo: categoryConfig[category as CategoryKey],
+        category,
+        hubContent,
+        articles: articles.sort((a, b) => {
+          if (a.featured && !b.featured) return -1;
+          if (!a.featured && b.featured) return 1;
+          return a.title.localeCompare(b.title, 'es');
+        }),
+      },
+    });
+  }
+
+  return paths;
+}
+
+const { categoryInfo, category, hubContent, articles } = Astro.props;
+
+const hubHtml = hubContent ? marked.parse(hubContent) : '';
+
+const otherCategories = Object.keys(categoryConfig)
+  .filter(cat => cat !== category)
+  .slice(0, 5)
+  .map(cat => ({
+    key: cat,
+    ...categoryConfig[cat as CategoryKey]
+  }));
+---
+
+<Layout
+  title={`${categoryInfo.name_es} - Taiwan.md`}
+  description={`${categoryInfo.description_es} - Base de conocimiento de Taiwán`}
+  lang="es"
+>
+  <main class="category-page">
+    <CategoryHero
+      name={categoryInfo.name_es}
+      description={categoryInfo.description_es}
+      coverUrl={categoryInfo.cover}
+      gradient={categoryInfo.gradient}
+      articleCount={articles.length}
+      homeHref="/es"
+      homeLabel="Inicio"
+      countSuffix="artículos"
+    />
+
+    <div class="container">
+      <!-- Hub Content -->
+      {hubHtml && (
+        <section class="hub-content">
+          <div class="hub-prose" set:html={hubHtml} />
+        </section>
+      )}
+
+      <!-- Articles Section -->
+      <h2 class="articles-heading">Lectura Adicional</h2>
+      {articles.length > 0 ? (
+        <section class="articles-section">
+          <div class="articles-grid">
+            {articles.map((article, index) => (
+              <article class={`article-card ${index === 0 && article.featured ? 'featured-card' : ''}`}>
+                <a href={`/es/${category}/${article.slug}`} class="card-link">
+                  <div class="card-cover" style={categoryInfo.cover ? `background-image: url('${categoryInfo.cover}');` : `background: ${categoryInfo.gradient};`}></div>
+
+                  <div class="card-body">
+                    <div class="card-header">
+                      <div class="article-meta">
+                        {article.status && (
+                          <span class="status-tag">{article.status}</span>
+                        )}
+                      </div>
+                      {article.featured && (
+                        <div class="featured-badge">Destacado</div>
+                      )}
+                    </div>
+
+                    <h3 class="article-title">{article.title}</h3>
+                    <p class="article-excerpt">{article.description}</p>
+
+                    <div class="card-footer">
+                      {article.readingTime && (
+                        <span class="reading-time">{article.readingTime} min de lectura</span>
+                      )}
+                      <span class="read-more">Leer más →</span>
+                    </div>
+                  </div>
+                </a>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : (
+        <div class="coming-soon">
+          <div class="coming-soon-content">
+            <h2>Contenido Próximamente</h2>
+            <p>Los artículos de esta categoría están siendo traducidos. ¡Vuelve pronto!</p>
+            <p class="category-desc">{categoryInfo.description_es}</p>
+            <div class="action-buttons">
+              <a href="/es" class="btn-primary">Volver al Inicio</a>
+              <a href="https://github.com/frank890417/taiwan-md" target="_blank" class="btn-secondary">Contribuir</a>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <!-- Other Categories -->
+      <section class="explore-more">
+        <h2 class="explore-title">Explorar Otros Aspectos de Taiwán</h2>
+        <div class="categories-grid">
+          {otherCategories.map(cat => (
+            <a href={`/es/${cat.key}`} class="category-card" style={`border-color: ${cat.color}; color: ${cat.color};`}>
+              <div class="category-card-name">{cat.name_es}</div>
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
+  </main>
+</Layout>
+
+<style define:vars={{ categoryColor: categoryInfo.color, categoryColorLight: categoryInfo.colorLight }}>
+  .category-page {
+    min-height: 100vh;
+  }
+
+  /* Container */
+  .container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+
+  /* Hub Content */
+  .hub-content {
+    margin: 2.5rem 0 3rem;
+    padding: 2.5rem 3rem;
+    background: white;
+    border-radius: 20px;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.06);
+  }
+  .hub-prose {
+    font-size: 1.05rem;
+    line-height: 2;
+    color: #334155;
+    max-width: 720px;
+    margin: 0 auto;
+  }
+  .hub-prose > h1:first-child {
+    display: none;
+  }
+  .hub-prose > blockquote:first-child {
+    font-size: 1.15rem;
+    font-style: normal;
+    font-weight: 600;
+    border-left: 4px solid #4a7c28;
+    padding: 1rem 1.5rem;
+    margin: 0 0 2rem 0;
+    background: #f0f7ee;
+    border-radius: 0 8px 8px 0;
+    color: #2d5016;
+    line-height: 1.9;
+  }
+  .hub-prose blockquote {
+    border-left: 3px solid #cbd5e1;
+    padding: 0.75rem 1.25rem;
+    margin: 1.5rem 0;
+    background: #f8fafc;
+    border-radius: 0 8px 8px 0;
+    font-style: italic;
+    color: #475569;
+  }
+  .hub-prose h2 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin: 4rem 0 1.2rem;
+    color: #1a1a2e;
+    padding-bottom: 0.6rem;
+    border-bottom: 2px solid #e2e8f0;
+    letter-spacing: 0.02em;
+  }
+  .hub-prose h3 {
+    font-size: 1.2rem;
+    font-weight: 600;
+    margin: 3rem 0 0.75rem;
+    color: #334155;
+  }
+  .hub-prose p {
+    margin: 1.2rem 0;
+  }
+  .hub-prose ul, .hub-prose ol {
+    padding-left: 2rem;
+    margin: 1rem 0;
+    list-style-position: inside;
+  }
+  .hub-prose li {
+    margin: 0.5rem 0;
+    line-height: 1.8;
+  }
+  .hub-prose a {
+    color: #334155;
+    text-decoration: none;
+    border-bottom: 1.5px solid #94a3b8;
+    padding-bottom: 1px;
+    transition: all 0.2s;
+  }
+  .hub-prose a:hover {
+    color: #1a1a2e;
+    border-bottom-color: #1a1a2e;
+  }
+  .hub-prose img {
+    max-width: 100%;
+    max-height: 400px;
+    object-fit: cover;
+    border-radius: 12px;
+    margin: 2rem auto;
+    display: block;
+    box-shadow: 0 4px 12px rgba(0,0,0,0.08);
+  }
+  .hub-prose em {
+    font-size: 0.85rem;
+    color: #64748b;
+    display: block;
+    text-align: center;
+    margin: -1rem 0 1.5rem;
+  }
+  .hub-prose table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+    font-size: 0.95rem;
+  }
+  .hub-prose th, .hub-prose td {
+    padding: 0.75rem 1rem;
+    border: 1px solid #e2e8f0;
+    text-align: left;
+  }
+  .hub-prose th {
+    background: #f8fafc;
+    font-weight: 600;
+    color: #1e293b;
+  }
+  .hub-prose tr:hover { background: #f8fafc; }
+  .hub-prose strong { color: #1e293b; }
+  .hub-prose hr {
+    border: none;
+    border-top: 1px solid #e2e8f0;
+    margin: 2.5rem 0;
+  }
+
+  /* Articles */
+  .articles-heading {
+    font-size: 1.6rem;
+    margin: 0 0 1.5rem 0;
+    color: #1e293b;
+    font-weight: 800;
+    font-family: var(--font-editorial);
+  }
+
+  .articles-section {
+    margin-bottom: 4rem;
+  }
+
+  .articles-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 2.5rem;
+  }
+
+  .featured-card {
+    grid-column: 1 / -1;
+    max-width: 740px;
+    margin: 0 auto;
+  }
+
+  .article-card {
+    background: #F8F1E9;
+    border-radius: 20px;
+    overflow: hidden;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.07);
+    transition: transform 0.22s ease, box-shadow 0.22s ease;
+  }
+
+  .article-card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 8px 28px rgba(0,0,0,0.12);
+  }
+
+  .card-link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+  }
+
+  .card-cover {
+    height: 180px;
+    background-size: cover;
+    background-position: center;
+  }
+
+  .featured-card .card-cover {
+    height: 240px;
+  }
+
+  .card-body {
+    padding: 1.5rem 1.75rem 1.75rem;
+  }
+
+  .card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-bottom: 0.75rem;
+  }
+
+  .article-meta {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .status-tag {
+    background: var(--categoryColorLight);
+    color: var(--categoryColor);
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 500;
+  }
+
+  .featured-badge {
+    background: linear-gradient(45deg, #fbbf24, #f59e0b);
+    color: white;
+    padding: 0.3rem 0.8rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 600;
+  }
+
+  .article-title {
+    font-size: 1.3rem;
+    font-weight: 700;
+    line-height: 1.35;
+    margin-bottom: 0.6rem;
+    color: #1A3C34;
+    font-family: var(--font-editorial);
+  }
+
+  .featured-card .article-title {
+    font-size: 1.55rem;
+  }
+
+  .article-excerpt {
+    font-size: 0.9rem;
+    color: #4a5568;
+    line-height: 1.8;
+    margin-bottom: 1.25rem;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .card-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 0.85rem;
+  }
+
+  .reading-time {
+    color: #4a5568;
+  }
+
+  .read-more {
+    color: #006D77;
+    font-weight: 500;
+  }
+
+  /* Coming Soon */
+  .coming-soon {
+    text-align: center;
+    padding: 4rem 2rem;
+  }
+
+  .coming-soon-content {
+    max-width: 500px;
+    margin: 0 auto;
+  }
+
+  .coming-soon-content h2 {
+    font-size: 2.2rem;
+    color: #1f2937;
+    margin-bottom: 1rem;
+    font-weight: 800;
+    font-family: var(--font-editorial);
+  }
+
+  .coming-soon-content p {
+    color: #6b7280;
+    margin-bottom: 1.5rem;
+    line-height: 1.6;
+    font-size: 1.05rem;
+  }
+
+  .category-desc {
+    font-style: italic;
+    color: var(--categoryColor);
+    margin-bottom: 3rem !important;
+    font-weight: 500;
+  }
+
+  .action-buttons {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .btn-primary, .btn-secondary {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.95rem 1.6rem;
+    text-decoration: none;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 0.95rem;
+    justify-content: center;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  }
+
+  .btn-primary {
+    background: var(--categoryColor);
+    color: white;
+    border: 1px solid var(--categoryColor);
+  }
+
+  .btn-primary:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  .btn-secondary {
+    background: white;
+    color: var(--categoryColor);
+    border: 1px solid var(--categoryColor);
+  }
+
+  .btn-secondary:hover {
+    background: var(--categoryColor);
+    color: white;
+    transform: translateY(-2px);
+  }
+
+  /* Explore More */
+  .explore-more {
+    margin-top: 5rem;
+    padding: 3rem 0;
+    border-top: 1px solid #e5e7eb;
+  }
+
+  .explore-title {
+    text-align: center;
+    font-size: 1.8rem;
+    font-weight: 800;
+    color: #1f2937;
+    margin-bottom: 2rem;
+    font-family: var(--font-editorial);
+  }
+
+  .categories-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 1rem;
+  }
+
+  .category-card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 1.5rem 1rem;
+    background: white;
+    border: 1px solid;
+    border-radius: 20px;
+    text-decoration: none;
+    transition: transform 0.22s ease, box-shadow 0.22s ease;
+    text-align: center;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  }
+
+  .category-card:hover {
+    transform: translateY(-3px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.1);
+  }
+
+  .category-card-name {
+    font-weight: 600;
+    font-size: 1.05rem;
+  }
+
+  /* Responsive */
+  @media (max-width: 768px) {
+    .container {
+      padding: 1rem;
+    }
+
+    .hub-content {
+      padding: 1.5rem 1.25rem;
+      border-radius: 16px;
+    }
+
+    .articles-grid {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+    }
+
+    .featured-card {
+      grid-column: 1;
+    }
+
+    .action-buttons {
+      flex-direction: column;
+      align-items: center;
+    }
+
+    .categories-grid {
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+  }
+</style>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,0 +1,499 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import TopicsMasonry from '../../components/TopicsMasonry.astro';
+import HeroSection from '../../components/HeroSection.astro';
+import JourneyCard from '../../components/JourneyCard.astro';
+import WhyCard from '../../components/WhyCard.astro';
+import WelcomeModal from '../../components/WelcomeModal.astro';
+import SideTools from '../../components/SideTools.astro';
+import { t } from '../../i18n/ui';
+import { readdir, readFile } from 'fs/promises';
+import { resolve, basename } from 'path';
+import matter from 'gray-matter';
+
+const lang = 'es';
+
+// Fetch recent commits
+let recentCommits: { hash: string; date: string; message: string }[] = [];
+try {
+  const res = await fetch('https://api.github.com/repos/frank890417/taiwan-md/commits?per_page=5');
+  if (res.ok) {
+    const data = await res.json();
+    recentCommits = data.map((c: any) => ({
+      hash: c.sha,
+      date: c.commit.author.date,
+      message: c.commit.message.split('\n')[0],
+    }));
+  }
+} catch {}
+
+function commitIcon(msg: string) {
+  if (msg.startsWith('feat')) return 'feat';
+  if (msg.startsWith('fix')) return 'fix';
+  if (msg.startsWith('content')) return 'content';
+  if (msg.startsWith('docs')) return 'docs';
+  return 'update';
+}
+
+function timeAgo(dateStr: string) {
+  const now = new Date();
+  const then = new Date(dateStr);
+  const diff = Math.floor((now.getTime() - then.getTime()) / 1000);
+  if (diff < 3600) return `hace ${Math.floor(diff / 60)}m`;
+  if (diff < 86400) return `hace ${Math.floor(diff / 3600)}h`;
+  if (diff < 604800) return `hace ${Math.floor(diff / 86400)}d`;
+  return then.toLocaleDateString('es-ES', { month: 'short', day: 'numeric' });
+}
+
+const categoryFolders = [
+  { id: 'history', name: 'History' }, { id: 'geography', name: 'Geography' },
+  { id: 'culture', name: 'Culture' }, { id: 'food', name: 'Food' },
+  { id: 'art', name: 'Art' }, { id: 'music', name: 'Music' },
+  { id: 'technology', name: 'Technology' }, { id: 'nature', name: 'Nature' },
+  { id: 'people', name: 'People' }, { id: 'society', name: 'Society' },
+  { id: 'economy', name: 'Economy' }, { id: 'lifestyle', name: 'Lifestyle' },
+];
+
+let allArticles: { title: string; url: string; category: string }[] = [];
+// Try es/ first, then fall back to en/
+for (const cat of categoryFolders) {
+  try {
+    const esDirPath = resolve(process.cwd(), 'knowledge', 'es', cat.name);
+    const esFiles = await readdir(esDirPath);
+    for (const file of esFiles.filter(f => f.endsWith('.md') && !f.startsWith('_'))) {
+      const content = await readFile(resolve(esDirPath, file), 'utf-8');
+      const { data: fm } = matter(content);
+      const slug = basename(file, '.md');
+      allArticles.push({
+        title: fm.title || slug,
+        url: `/es/${cat.id}/${encodeURIComponent(slug)}`,
+        category: cat.name,
+      });
+    }
+  } catch {}
+}
+// Fill in with en/ articles if es/ is sparse
+if (allArticles.length < 10) {
+  for (const cat of categoryFolders) {
+    try {
+      const enDirPath = resolve(process.cwd(), 'knowledge', 'en', cat.name);
+      const enFiles = await readdir(enDirPath);
+      for (const file of enFiles.filter(f => f.endsWith('.md') && !f.startsWith('_'))) {
+        const content = await readFile(resolve(enDirPath, file), 'utf-8');
+        const { data: fm } = matter(content);
+        const slug = basename(file, '.md');
+        allArticles.push({
+          title: fm.title || slug,
+          url: `/en/${cat.id}/${encodeURIComponent(slug)}`,
+          category: cat.name,
+        });
+      }
+    } catch {}
+  }
+}
+if (allArticles.length === 0) {
+  allArticles = [
+    { title: 'Democratización', url: '/en/history/democratization', category: 'History' },
+    { title: 'Industria de semiconductores', url: '/en/technology/semiconductor-industry', category: 'Technology' },
+  ];
+}
+const randomArticlesData = JSON.stringify(allArticles);
+---
+
+<Layout title="Base de Conocimiento de Taiwán - Taiwan.md"
+        description="La base de conocimiento de código abierto sobre Taiwán. Perspectivas curadas de personas que aman Taiwán, para el mundo hispanohablante."
+        lang="es">
+  <!-- Hero -->
+  <HeroSection lang={lang} />
+
+  <!-- Journey Paths -->
+  <section class="py-32 px-6 max-w-7xl mx-auto animate-on-scroll" id="journey">
+    <div class="text-center mb-16">
+      <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-3">{t('journey.subtitle', lang)}</p>
+      <h2 class="text-3xl md:text-5xl font-serif font-bold text-forest leading-heading">{t('journey.title', lang)}</h2>
+    </div>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 lg:gap-8">
+      <JourneyCard
+        title={t('journey.nature.title', lang)}
+        description={t('journey.nature.desc', lang)}
+        image="https://images.unsplash.com/photo-1558981403-c5f9899a28bc?w=800&q=80"
+        imageAlt="Taroko Gorge marble cliffs"
+        href="/es/nature"
+        readTime="15"
+        ctaText={t('journey.begin', lang)}
+        tall={true}
+      />
+      <JourneyCard
+        title={t('journey.history.title', lang)}
+        description={t('journey.history.desc', lang)}
+        image="https://images.unsplash.com/photo-1470004914212-05527e49370b?w=800&q=80"
+        imageAlt="Traditional Taiwan temple"
+        href="/es/history"
+        readTime="20"
+        ctaText={t('journey.begin', lang)}
+      />
+      <JourneyCard
+        title={t('journey.culture.title', lang)}
+        description={t('journey.culture.desc', lang)}
+        image="https://images.unsplash.com/photo-1493780474015-ba834fd0ce2f?w=800&q=80"
+        imageAlt="Taiwan temple festival"
+        href="/es/culture"
+        readTime="18"
+        ctaText={t('journey.begin', lang)}
+      />
+      <JourneyCard
+        title={t('journey.flavors.title', lang)}
+        description={t('journey.flavors.desc', lang)}
+        image="https://images.unsplash.com/photo-1563245372-f21724e3856d?w=800&q=80"
+        imageAlt="Taiwan night market food"
+        href="/es/food"
+        readTime="12"
+        ctaText={t('journey.begin', lang)}
+        tall={true}
+      />
+    </div>
+  </section>
+
+  <!-- Cover Story -->
+  <section class="py-28 bg-forest-50/40 animate-on-scroll">
+    <div class="max-w-3xl mx-auto px-6">
+      <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-3 text-center">Historia de Portada</p>
+      <h2 class="text-3xl md:text-4xl font-serif font-bold text-forest mb-12 text-center leading-heading">¿Cómo entender Taiwán?</h2>
+      <div class="space-y-8 text-forest-600 leading-loose text-lg">
+        <p>
+          Taiwán es una isla de apenas 36,000 kilómetros cuadrados, pero contiene toda la complejidad del mundo.
+          Durante cuatro siglos, todos los que pisaron esta isla vieron un Taiwán diferente a través de ojos distintos.
+        </p>
+
+        <div class="space-y-6 border-l-2 border-teal/30 pl-8 my-12">
+          <blockquote class="text-forest italic text-base">
+            "Las montañas, los ríos y los arroyos son los cuerpos de nuestros ancestros. Somos los hijos de la tierra."
+            <cite class="block text-sm text-forest-400 not-italic mt-2">— Literatura oral Atayal</cite>
+          </blockquote>
+          <blockquote class="text-forest italic text-base">
+            "Ilha Formosa" — Isla Hermosa.
+            <cite class="block text-sm text-forest-400 not-italic mt-2">— Navegantes portugueses, 1584</cite>
+          </blockquote>
+          <blockquote class="text-forest italic text-base">
+            "Cuando ves Taiwán, descubres que esta tierra es más hermosa de lo que imaginabas, y también más frágil de lo que imaginabas."
+            <cite class="block text-sm text-forest-400 not-italic mt-2">— Chi Po-lin, "Más allá de la belleza: Taiwán desde las alturas", 2013</cite>
+          </blockquote>
+        </div>
+
+        <p class="text-lg">
+          Desde los mitos de creación de los pueblos austronesios hasta el ascenso del imperio de los semiconductores,
+          desde el silencio de la ley marcial hasta la primera legalización del matrimonio igualitario en Asia.
+          La historia de Taiwán no es una línea recta, sino una red.
+        </p>
+        <p class="text-lg">
+          <strong class="text-forest">Taiwan.md no pretende darte respuestas.</strong>
+          Lo que queremos hacer es darte un mapa — un mapa que te permita adentrarte en Taiwán por tu cuenta.
+        </p>
+        <a href="/es/about" class="inline-flex items-center gap-2 text-teal font-semibold hover:text-teal-600 transition-colors no-underline border-none mt-4">
+          Leer la colección completa de citas
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Random Discovery -->
+  <section class="py-20 px-6 animate-on-scroll">
+    <div class="max-w-lg mx-auto text-center">
+      <button id="random-discovery-btn" class="group w-full bg-gradient-to-br from-forest-50 to-teal-50 rounded-3xl border border-forest-100/30 shadow-card hover:shadow-lg transition-all p-10 cursor-pointer">
+        <svg class="w-10 h-10 mx-auto mb-3 text-teal opacity-60 group-hover:opacity-100 transition-opacity" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 00-3.7-3.7 48.678 48.678 0 00-7.324 0 4.006 4.006 0 00-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3l-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 003.7 3.7 48.656 48.656 0 007.324 0 4.006 4.006 0 003.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3l-3 3" /></svg>
+        <span class="random-text text-2xl font-serif font-bold text-forest block">Descubre Taiwán al Azar</span>
+        <span class="random-subtitle text-sm text-forest-400 block mt-2">Explora historias inesperadas</span>
+      </button>
+    </div>
+  </section>
+
+  <!-- Reading Path -->
+  <section class="py-28 px-6 max-w-4xl mx-auto animate-on-scroll">
+    <div class="text-center mb-14">
+      <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-3">Ruta Curada</p>
+      <h2 class="text-3xl md:text-4xl font-serif font-bold text-forest leading-heading">¿No sabes por dónde empezar?</h2>
+      <p class="text-forest-400 mt-3 text-lg">Descubre el verdadero Taiwán en 30 minutos con estos 5 artículos esenciales</p>
+    </div>
+    <div class="space-y-4">
+      <a href="/en/history/democratization" class="flex items-center gap-3 md:gap-5 p-4 md:p-5 rounded-2xl bg-white border border-forest-100/30 hover:border-teal/30 hover:shadow-card transition-all no-underline group">
+        <span class="flex-shrink-0 w-12 h-12 rounded-xl bg-teal/10 text-teal text-lg font-bold flex items-center justify-center font-serif">1</span>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-lg font-bold text-forest group-hover:text-teal transition-colors">Revolución Silenciosa: Democratización de Taiwán</h3>
+          <p class="text-sm text-forest-400 truncate mt-0.5">Del autoritarismo a la democracia, el primer milagro de transición pacífica de Asia</p>
+        </div>
+        <span class="flex-shrink-0 text-xs text-forest-400 font-medium bg-forest-50 px-3 py-1.5 rounded-full">6 min</span>
+      </a>
+      <a href="/en/culture/ethnic-groups" class="flex items-center gap-3 md:gap-5 p-4 md:p-5 rounded-2xl bg-white border border-forest-100/30 hover:border-teal/30 hover:shadow-card transition-all no-underline group">
+        <span class="flex-shrink-0 w-12 h-12 rounded-xl bg-terracotta/10 text-terracotta text-lg font-bold flex items-center justify-center font-serif">2</span>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-lg font-bold text-forest group-hover:text-teal transition-colors">Unidad en la Diversidad: Grupos Étnicos de Taiwán</h3>
+          <p class="text-sm text-forest-400 truncate mt-0.5">Cuatro grandes grupos étnicos tejiendo la base multicultural de Taiwán</p>
+        </div>
+        <span class="flex-shrink-0 text-xs text-forest-400 font-medium bg-forest-50 px-3 py-1.5 rounded-full">7 min</span>
+      </a>
+      <a href="/en/food/night-market-culture" class="flex items-center gap-3 md:gap-5 p-4 md:p-5 rounded-2xl bg-white border border-forest-100/30 hover:border-teal/30 hover:shadow-card transition-all no-underline group">
+        <span class="flex-shrink-0 w-12 h-12 rounded-xl bg-teal/10 text-teal text-lg font-bold flex items-center justify-center font-serif">3</span>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-lg font-bold text-forest group-hover:text-teal transition-colors">El Verdadero Sabor de Taiwán: Cultura de los Mercados Nocturnos</h3>
+          <p class="text-sm text-forest-400 truncate mt-0.5">Los espacios sociales de comida callejera más densos del mundo, con una calidez insuperable</p>
+        </div>
+        <span class="flex-shrink-0 text-xs text-forest-400 font-medium bg-forest-50 px-3 py-1.5 rounded-full">5 min</span>
+      </a>
+      <a href="/en/technology/semiconductor-industry" class="flex items-center gap-3 md:gap-5 p-4 md:p-5 rounded-2xl bg-white border border-forest-100/30 hover:border-teal/30 hover:shadow-card transition-all no-underline group">
+        <span class="flex-shrink-0 w-12 h-12 rounded-xl bg-terracotta/10 text-terracotta text-lg font-bold flex items-center justify-center font-serif">4</span>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-lg font-bold text-forest group-hover:text-teal transition-colors">El Escudo de Silicio: Industria de Semiconductores</h3>
+          <p class="text-sm text-forest-400 truncate mt-0.5">Cómo TSMC convirtió a una pequeña isla en el corazón de la tecnología global</p>
+        </div>
+        <span class="flex-shrink-0 text-xs text-forest-400 font-medium bg-forest-50 px-3 py-1.5 rounded-full">8 min</span>
+      </a>
+      <a href="/en/lifestyle/convenience-store-culture" class="flex items-center gap-3 md:gap-5 p-4 md:p-5 rounded-2xl bg-white border border-forest-100/30 hover:border-teal/30 hover:shadow-card transition-all no-underline group">
+        <span class="flex-shrink-0 w-12 h-12 rounded-xl bg-teal/10 text-teal text-lg font-bold flex items-center justify-center font-serif">5</span>
+        <div class="flex-1 min-w-0">
+          <h3 class="text-lg font-bold text-forest group-hover:text-teal transition-colors">Sistema Operativo de Vida: Tiendas de Conveniencia</h3>
+          <p class="text-sm text-forest-400 truncate mt-0.5">Más que tiendas — son la infraestructura de toda una nación</p>
+        </div>
+        <span class="flex-shrink-0 text-xs text-forest-400 font-medium bg-forest-50 px-3 py-1.5 rounded-full">4 min</span>
+      </a>
+    </div>
+    <div class="text-center mt-10 text-sm text-forest-400">
+      <p>‹ <strong>Total 30 minutos</strong> · <strong>5 áreas clave</strong> · <strong>Visión completa de Taiwán</strong></p>
+    </div>
+  </section>
+
+  <!-- Why Taiwan.md? -->
+  <section class="py-28 px-6 bg-white animate-on-scroll">
+    <div class="max-w-6xl mx-auto">
+      <div class="text-center mb-16">
+        <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-3">Por qué Taiwan.md</p>
+        <h2 class="text-3xl md:text-4xl font-serif font-bold text-forest leading-heading">¿Por qué Taiwan.md?</h2>
+      </div>
+      <div class="space-y-20">
+        <WhyCard
+          title="Perspectivas Curadas"
+          description="Narrativas profundas cuidadosamente seleccionadas, no listados enciclopédicos. Cada artículo está contextualizado, presentando la textura completa de la historia de Taiwán."
+          image="https://images.unsplash.com/photo-1524492412937-b28074a5d7da?w=600&q=80"
+          imageAlt="Perspectiva curada sobre Taiwán"
+        />
+        <WhyCard
+          title="Diseño AI-Friendly"
+          description="Contenido estructurado en Markdown que permite a los modelos de IA comprender la complejidad de Taiwán. Desde llms.txt hasta marcado semántico, cada decisión de diseño facilita que las máquinas entiendan y difundan el conocimiento."
+          image="https://images.unsplash.com/photo-1451187580459-43490279c0fa?w=600&q=80"
+          imageAlt="Contenido estructurado AI-friendly"
+          reversed={true}
+        />
+        <WhyCard
+          title="Visión Multilingüe Global"
+          description="Partiendo de perspectivas locales, contando la historia de Taiwán en idiomas globales. Chino Tradicional, inglés, español — permitiendo que el mundo escuche la propia voz de Taiwán."
+          image="https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?w=600&q=80"
+          imageAlt="Perspectiva internacional multilingüe"
+        />
+        <WhyCard
+          title="Multidimensional Completo"
+          description="Cubriendo más de 12 áreas temáticas, presentando el panorama tridimensional completo de Taiwán. Desde semiconductores hasta la cultura de los mercados nocturnos, desde la democratización hasta las leyendas indígenas — sin simplificaciones."
+          image="https://images.unsplash.com/photo-1470004914212-05527e49370b?w=600&q=80"
+          imageAlt="Cobertura multidimensional completa"
+          reversed={true}
+        />
+      </div>
+      <div class="flex flex-wrap justify-center gap-5 mt-16">
+        <a href="/es/graph" class="btn-primary">Grafo del Conocimiento</a>
+        <a href="https://github.com/frank890417/taiwan-md/tree/main/knowledge" target="_blank" rel="noopener noreferrer" class="btn-secondary">Explorar Datos Fuente</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- Categories -->
+  <section class="py-28 px-6 animate-on-scroll" id="categories">
+    <div class="text-center mb-14">
+      <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-3">Explorar</p>
+      <h2 class="text-3xl md:text-5xl font-serif font-bold text-forest leading-heading">Descubre Taiwán</h2>
+    </div>
+
+    <div class="max-w-3xl mx-auto mb-16 space-y-5 text-forest-600 leading-loose text-base">
+      <p>
+        Esta isla abarca apenas 36,000 kilómetros cuadrados, pero contiene un microcosmos del mundo entero.
+        Desde la cima de 3,952 metros del Yushan hasta las fosas abisales del Pacífico,
+        <a href="/es/geography" class="text-teal font-semibold no-underline border-none hover:text-teal-600">la geografía aquí</a> es una transmisión en vivo de la formación de montañas.
+      </p>
+      <p>
+        Hace cuatrocientos años, los holandeses construyeron el Fuerte Zeelandia en Tainan. Pero lo que verdaderamente hace a Taiwán ser Taiwán es
+        <a href="/es/history" class="text-teal font-semibold no-underline border-none hover:text-teal-600">ese largo despertar</a> del autoritarismo a la democracia.
+        Cada momento de dolor y resistencia ha hecho más clara el alma de esta isla.
+      </p>
+      <p>
+        <a href="/es/culture" class="text-teal font-semibold no-underline border-none hover:text-teal-600">La cultura de Taiwán</a> no es un crisol, sino un rompecabezas —
+        cada pieza mantiene su propio color y forma, ensambladas en una imagen sin precedentes.
+      </p>
+      <p>
+        Entra en cualquier mercado nocturno de Taiwán, y <a href="/es/food" class="text-teal font-semibold no-underline border-none hover:text-teal-600">los sabores de esta isla</a> son
+        la versión gustativa de su historia de inmigración. Los taiwaneses cuentan historias a través de la comida, preservan memorias a través de la cocina.
+      </p>
+      <p>
+        Las obleas de TSMC no son solo chips de silicio, sino prueba de la posición de Taiwán en el mapa tecnológico global.
+        <a href="/es/technology" class="text-teal font-semibold no-underline border-none hover:text-teal-600">Esta isla tecnológica</a> ha evolucionado de la manufactura por contrato a la I+D innovadora.
+      </p>
+    </div>
+
+    <div class="flex items-center gap-4 max-w-7xl mx-auto mb-10">
+      <div class="flex-1 h-px bg-forest-100/50"></div>
+      <span class="text-sm text-forest-400 font-medium">Navegación Rápida</span>
+      <div class="flex-1 h-px bg-forest-100/50"></div>
+    </div>
+
+    <TopicsMasonry lang={lang} />
+  </section>
+
+  <!-- Traditional Chinese Statement -->
+  <section class="py-24 bg-forest-50/40 animate-on-scroll">
+    <div class="max-w-3xl mx-auto px-6 text-center">
+      <h3 class="text-2xl font-serif font-bold text-forest mb-6 leading-heading">¿Por qué Chino Tradicional?</h3>
+      <div class="text-forest-600 leading-loose space-y-4 text-left">
+        <p>Taiwan.md elige el <strong class="text-forest">Chino Tradicional</strong> como idioma predeterminado — no es solo una decisión técnica, es una declaración cultural.</p>
+        <p>El Chino Tradicional es uno de los sistemas de escritura más antiguos del mundo que aún se usa en la vida cotidiana, y Taiwán es la única región importante a nivel global que utiliza el Chino Tradicional como escritura oficial.</p>
+        <p class="text-sm text-forest-400 italic">
+          Taiwán usa el Chino Tradicional — el sistema de escritura más antiguo del mundo aún en uso cotidiano,
+          y Taiwán es su último gran hogar. Creemos que nuestro idioma y cultura merecen ser vistos y comprendidos.
+          Esta versión en español sirve como puente para ayudar al mundo a descubrir la riqueza de Taiwán.
+          También tenemos una <a href="/" class="text-teal">中文版本</a> y una <a href="/en" class="text-teal">versión en inglés</a>.
+        </p>
+      </div>
+    </div>
+  </section>
+
+  <!-- Recent Updates -->
+  {recentCommits.length > 0 && (
+    <section class="py-20 px-6">
+      <div class="max-w-3xl mx-auto">
+        <div class="text-center mb-10">
+          <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-2">Actualizaciones en Vivo</p>
+          <h2 class="text-2xl font-serif font-bold text-forest">Últimas Actualizaciones</h2>
+          <p class="text-sm text-forest-400 mt-2">Taiwan.md está creciendo</p>
+        </div>
+        <div class="space-y-3">
+          {recentCommits.slice(0, 3).map(commit => (
+            <a href={`https://github.com/frank890417/taiwan-md/commit/${commit.hash}`} target="_blank" rel="noopener noreferrer"
+               class="flex items-center gap-4 p-4 rounded-2xl bg-white border border-forest-100/30 hover:border-teal/20 hover:shadow-card transition-all no-underline">
+              <span class="text-lg">{commitIcon(commit.message)}</span>
+              <span class="flex-1 text-sm text-forest truncate">{commit.message}</span>
+              <span class="flex-shrink-0 text-xs text-forest-400 bg-forest-50 px-3 py-1.5 rounded-full">{timeAgo(commit.date)}</span>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <!-- Newsletter -->
+  <iframe name="newsletter-iframe" style="display:none;"></iframe>
+  <section class="py-24 bg-forest text-white">
+    <div class="max-w-3xl mx-auto px-6">
+      <div class="text-center md:text-left md:flex md:items-center md:justify-between md:gap-12">
+        <div class="mb-8 md:mb-0">
+          <h2 class="text-2xl font-serif font-bold mb-2">Suscríbete a Taiwan.md</h2>
+          <p class="text-cream-200/80 text-sm">Recibe las mejores historias de Taiwán en tu bandeja de entrada.</p>
+        </div>
+        <form id="newsletter-form"
+              action="https://docs.google.com/forms/d/e/1FAIpQLSfNY5y6p8xM0oVL4PSOmOYoPZDTSNykZtMDLNmQnQrSr5-59w/formResponse"
+              method="POST" target="newsletter-iframe" class="flex-1 max-w-md">
+          <div class="flex flex-col sm:flex-row gap-3">
+            <input type="email" name="entry.1578963213" placeholder="tu@email.com" required
+                   class="flex-1 px-5 py-3 rounded-full bg-white/10 border border-white/20 text-white placeholder-white/40 text-sm focus:outline-none focus:ring-2 focus:ring-teal/50" />
+            <button type="submit" class="px-5 sm:px-7 py-3 bg-teal text-white rounded-full font-semibold text-sm hover:bg-teal-600 transition-colors whitespace-nowrap">Suscribirse</button>
+          </div>
+        </form>
+      </div>
+      <div id="newsletter-success" class="hidden mt-6 text-teal-200 font-semibold text-center md:text-left">¡Gracias por suscribirte!</div>
+      <p class="text-xs text-cream-300/60 mt-4 text-center md:text-left">Sin spam, cancela en cualquier momento.</p>
+    </div>
+  </section>
+
+  <!-- Contribute -->
+  <section class="py-28 px-6 text-center animate-on-scroll">
+    <div class="max-w-2xl mx-auto">
+      <p class="text-sm uppercase tracking-[0.25em] text-teal font-medium mb-3">Código Abierto</p>
+      <h2 class="text-3xl md:text-4xl font-serif font-bold text-forest mb-4 leading-heading">Únete a Nosotros</h2>
+      <p class="text-forest-400 text-lg mb-10">Taiwan.md es un proyecto de código abierto impulsado por la comunidad. Tanto si eres taiwanés local como un amigo internacional interesado en Taiwán, damos la bienvenida a tus conocimientos y perspectivas.</p>
+      <div class="flex flex-wrap justify-center gap-5">
+        <a href="/en/contribute" class="inline-flex items-center gap-2.5 px-10 py-4 bg-teal text-white font-semibold text-lg rounded-full hover:bg-teal-600 transition-all duration-300 shadow-lg hover:shadow-xl hover:-translate-y-0.5">
+          Guía de Contribución
+          <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M17 8l4 4m0 0l-4 4m4-4H3" /></svg>
+        </a>
+        <a href="https://github.com/frank890417/taiwan-md" class="inline-flex items-center gap-2.5 px-10 py-4 bg-forest/5 text-forest font-semibold text-lg rounded-full border border-forest/15 hover:bg-forest/10 transition-all duration-300" target="_blank" rel="noopener noreferrer">
+          <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+          Proyecto en GitHub
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <WelcomeModal lang={lang} />
+  <SideTools lang={lang} />
+</Layout>
+
+<script is:inline define:vars={{ randomArticlesData }}>
+  function initRandomDiscovery() {
+    var randomBtn = document.getElementById('random-discovery-btn');
+    if (!randomBtn || randomBtn.__randomInit) return;
+    randomBtn.__randomInit = true;
+
+    var articles = [];
+    try { articles = JSON.parse(randomArticlesData); } catch(e) {}
+
+    if (articles.length > 0) {
+      var shuffled = articles.slice();
+      for (var i = shuffled.length - 1; i > 0; i--) {
+        var j = Math.floor(Math.random() * (i + 1));
+        var tmp = shuffled[i]; shuffled[i] = shuffled[j]; shuffled[j] = tmp;
+      }
+      var currentIndex = 0;
+
+      randomBtn.addEventListener('click', function() {
+        if (currentIndex >= shuffled.length) {
+          currentIndex = 0;
+          for (var i = shuffled.length - 1; i > 0; i--) {
+            var j = Math.floor(Math.random() * (i + 1));
+            var tmp = shuffled[i]; shuffled[i] = shuffled[j]; shuffled[j] = tmp;
+          }
+        }
+        var article = shuffled[currentIndex++];
+        var textEl = randomBtn.querySelector('.random-text');
+        var subtitleEl = randomBtn.querySelector('.random-subtitle');
+        randomBtn.style.pointerEvents = 'none';
+        var ticks = 0;
+        var interval = setInterval(function() {
+          var preview = shuffled[Math.floor(Math.random() * shuffled.length)];
+          if (textEl) textEl.textContent = preview.title;
+          if (subtitleEl) subtitleEl.textContent = preview.category;
+          ticks++;
+          if (ticks >= 8) {
+            clearInterval(interval);
+            if (textEl) textEl.textContent = article.title;
+            if (subtitleEl) subtitleEl.textContent = article.category;
+            setTimeout(function() { window.location.href = article.url; }, 400);
+          }
+        }, 80);
+      });
+    }
+  }
+
+  function initNewsletter() {
+    var form = document.getElementById('newsletter-form');
+    if (!form || form.__newsletterInit) return;
+    form.__newsletterInit = true;
+    form.addEventListener('submit', function() {
+      setTimeout(function() {
+        var el = document.getElementById('newsletter-success');
+        if (el) el.classList.remove('hidden');
+      }, 500);
+    });
+  }
+
+  initRandomDiscovery();
+  initNewsletter();
+  document.addEventListener('astro:page-load', function() {
+    initRandomDiscovery();
+    initNewsletter();
+  });
+</script>


### PR DESCRIPTION
## 摘要

本 PR 為系列拆分 PR 的第四支（**PR D / 6**），新增完整的西班牙文頁面路由系統。

> **依賴**：建議先合併 [PR A](https://github.com/frank890417/taiwan-md/pull/122)、[PR B](https://github.com/frank890417/taiwan-md/pull/123)、[PR C](https://github.com/frank890417/taiwan-md/pull/124)

---

## 新增頁面（全為新增，無修改現有檔案）

| 路由 | 檔案 | 說明 |
|------|------|------|
| `/es/` | `src/pages/es/index.astro` | 西班牙文首頁 |
| `/es/[category]/` | `src/pages/es/[category]/index.astro` | 西班牙文分類 Hub 頁 |
| `/es/[category]/[slug]` | `src/pages/es/[category]/[slug].astro` | 西班牙文文章頁 |

### 功能特點
- `es/index.astro`：完整對齊 EN 首頁結構（Journey 高亮卡片、CoverStory、RandomDiscovery、WhyCard 等）
- RandomDiscovery：優先顯示 `knowledge/es/` 文章，無 ES 文章時 fallback 至 `knowledge/en/` 文章
- 分類頁支援全部 12 個分類（history、geography、culture…）
- 文章頁整合 ArticleHero、ArticleSidebar、TableOfContents、SideTools、TextToSpeech
- SEO：hreflang `es` alternate、OG locale `es_419`、ES breadcrumb JSON-LD

---

## 測試

- [ ] `/es/` 西班牙文首頁正常渲染
- [ ] `/es/history/` 分類頁正常顯示文章列表
- [ ] `/es/history/qing-dynasty-rule` 等文章頁正常渲染
- [ ] 語言切換器可在 zh-TW / EN / ES 之間正確跳轉
- [ ] hreflang alternate 連結正確（可用 browser devtools 確認）