### PR TITLE
fix: correct translation mapping slug for taiwan-energy-transition-an…

### DIFF
--- a/knowledge/_translations.json
+++ b/knowledge/_translations.json
@@ -126,7 +126,7 @@
   "en/Economy/taiwan-companies-china-steel.md": "Economy/台灣企業：中鋼.md",
   "en/Economy/taiwan-companies-chunghwa-telecom.md": "Economy/台灣企業：中華電信.md",
   "en/Economy/taiwan-companies-giant-manufacturing.md": "Economy/台灣企業：巨大機械.md",
-  "en/Economy/taiwan-energy-transition-and-green-energy-industry.md": "Economy/台灣能源轉型與綠能產業.md",
+  "en/Economy/taiwan-energy-transition-and-green-industry.md": "Economy/台灣能源轉型與綠能產業.md",
   "en/Economy/taiwan-enterprise-ase-semiconductor.md": "Economy/台灣企業：日月光半導體.md",
   "en/Economy/taiwan-enterprise-cathay-financial.md": "Economy/台灣企業：國泰金控.md",
   "en/Economy/taiwan-enterprise-chang-chun-petrochemical.md": "Economy/台灣企業：長春石化.md",


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修正 `_translations.json` 中能源轉型文章的英文 slug 對應錯誤。原本記錄為 `taiwan-energy-transition-and-green-energy-industry.md`，實際檔案為 `taiwan-energy-transition-and-green-industry.md`，導致中文頁面點選語言切換時出現 404。
**修正前：** `"en/Economy/taiwan-energy-transition-and-green-energy-industry.md"`
**修正後：** `"en/Economy/taiwan-energy-transition-and-green-industry.md"`

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [ ] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [x] 文章有完整的 frontmatter（title, description, date, tags, category）
- [x] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [x] 內容有附上可查證的參考資料來源
- [x] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

Closes #

## 📸 截圖（如果是視覺改動）

