### PR TITLE
ci: make translation PR labeling resilient

### DIFF
--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -16,22 +16,31 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Auto-label translation PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['translation']
-            });
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: ['translation']
+              });
+            } catch (error) {
+              if (error.status === 403) {
+                core.warning('Skipping auto-label due token scope for forked PR');
+              } else {
+                throw error;
+              }
+            }
 
       - name: Check translation format
         run: |


### PR DESCRIPTION
## Why this

Recent Translation PR checks are showing as `action_required` on PRs touching translation dirs. The `Auto-label translation PR` step in `.github/workflows/translation-check.yml` currently calls `issues.addLabels` without accounting for forked PR token scope, which fails with `Resource not accessible by integration`.

## What changed

- Added `issues: write` to workflow permissions (when allowed by token scope)
- Restricted auto-label step to same-repo PRs (`head.repo.full_name == github.repository`)
- Wrapped label API call in `try/catch` and emit warning on 403 from forked-pr token instead of failing the check

This keeps existing translation checks and branch protection intent, but avoids unnecessary hard failures that block valid PRs in CI.

## Notes

No content/site changes; this is infrastructure to make translation PRs reviewable again.