### PR TITLE
content(en): add Shen Sheng-Po article

### DIFF
--- a/knowledge/en/People/shen-sheng-po.md
+++ b/knowledge/en/People/shen-sheng-po.md
@@ -1,0 +1,128 @@
+---
+title: 'Shen Sheng-Po'
+description: 'Trained in computer science, Shen Sheng-Po brought code into Taiwan’s contemporary art scene. In just 34 years, he left behind not only digital artworks, but also a way of treating programming as lived experience and free software as an artistic ethic.'
+date: 2026-03-24
+tags: ['People', 'Digital Art', 'New Media Art', 'FLOSS+ART', 'OpenLab.Taipei', 'Taiwan']
+author: 'Taiwan.md Contributors'
+readingTime: 8
+featured: false
+lastVerified: 2026-03-24
+lastHumanReview: false
+---
+
+# Shen Sheng-Po
+
+## 30-Second Overview
+
+Shen Sheng-Po (1980–2014) was a Taiwanese digital artist, art engineer, OpenLab.Taipei member, and one of the founders of Youwei Space. Trained first in computer science and only later in art-and-technology practice, he created work that explored the relationship between digital rules, algorithmic logic, and everyday life. His importance lies not only in the artworks he produced, but in how early and how clearly he argued — in practice, not just in theory — that free software could be an artistic tool. Through workshops, teaching, open-source sharing, and space-building, he helped shape a generation of Taiwan-based creative coding practitioners.
+
+Born in Changhua in 1980, Shen did not come up through a conventional fine-art education. He studied computer science at National Chiao Tung University, continued into graduate work on distributed systems, and only later moved toward art-and-technology study in the UK. That path matters. It meant that when he entered digital art, he did not treat code as a decorative effect. He treated it as a way of thinking.
+
+That, in turn, made his work feel different from much of what is loosely called “new media art.” Shen was not primarily interested in technological spectacle. He was interested in a harder question: **how digital systems, rules, and formal structures reshape the way we perceive reality itself.**
+
+## From Computer Science to Art-and-Technology Practice
+
+On paper, Shen’s trajectory looks like a move from engineering into art. He completed both undergraduate and graduate training in computer science at National Chiao Tung University, later studied Creative Technology at the University of Salford in the UK, and, after returning to Taiwan, worked with art-and-technology groups such as Microplayground and dimension+, while also becoming part of OpenLab.Taipei.
+
+This matters because it placed him at a very specific moment in Taiwan’s digital-art development. The field was moving beyond technical display and interactive novelty toward a more mature creative ecosystem. Many people knew how to program but did not yet know how to turn programming into artistic language. Others wanted to make art with technology, but lacked strong local references for what that practice could look like. Shen stood in between those worlds.
+
+> **Curator’s note**  
+> Many of Taiwan’s important digital-art practitioners have followed an unusually indirect path. They were not first trained in art history and then handed technology as a tool. They lived in technical systems first, and only later developed an artistic language from within them. Shen Sheng-Po is one of the clearest examples of that path.
+
+## “Code as Life”: The Idea He Left Behind
+
+If one sentence captures Shen’s artistic core, it is probably this: he was interested in the structural qualities of the digital realm, and he believed that **code was part of life itself**.
+
+At first glance, that sounds abstract. In fact, it is unusually precise. It does not mean “programming is fun,” nor does it mean “technology makes art cooler.” It means that algorithms, randomness, system rules, and data structures should be understood as part of lived experience. When human life is increasingly shaped by digital systems, art cannot stop at making technology look elegant or interactive. It must ask deeper questions: Who writes the rules? What logic structures our interactions? How are feeling and perception shaped by systems we did not design ourselves?
+
+That is why Shen’s work does not feel dated even more than a decade later. He was not chasing whichever devices happened to be fashionable. He was working at the level of digital life’s underlying structure.
+
+## Not Decoration, but the Visibility of Rules
+
+Public records show Shen exhibiting continuously between 2008 and 2013. His works included *Once There Was a Tree*, *Where Are You?*, *texture*, *meta-*, and *pin shadow*. He also appeared in major contexts such as the Taipei Digital Art Festival and the National Taiwan Museum of Fine Arts’ Digital Ark exhibitions.
+
+Even the titles suggest a pattern. These works do not usually present fully narrated stories. They feel more like attempts to capture a state, a rule in operation, or a tension between perception and system. That already separates Shen from more narrative or symbol-driven traditions of art-making. He often seems less interested in representation than in translating the feel of algorithmic structures into perceptual experience.
+
+That becomes especially clear in works such as *pin shadow* and *texture*. Art critic Chiu Chih-Yung has argued that Shen’s work simultaneously explores the structural logic of the digital realm while retaining a palpable emotional “temperature” inside that logic. In that reading, *pin shadow* and *texture* are not simply elegant image-based installations. They construct altered experiences of time and space — experiences that feel internally coherent, yet never fully stable or fully real.
+
+In other words, Shen did not treat technology as futuristic spectacle. He treated it as an environment that changes how humans sense and inhabit the world.
+
+## Free Software as Artistic Ethics
+
+One of the strongest reasons Shen deserves a place in Taiwan.md is that he did not only make work. He also helped promote **FLOSS+ART** in Taiwan — the meeting point between free/libre open-source software and artistic creation.
+
+This may sound like a technical position, but it is better understood as an artistic ethic. The underlying question is simple: Should creators understand the tools they use? Should those tools remain modifiable, shareable, and extensible? If art becomes too dependent on closed platforms, is the artist still creating freely — or merely renting access to someone else’s sensory system?
+
+Today, names like Processing, openFrameworks, and p5.js are familiar to many creative coders. In the late 2000s and early 2010s, however, people willing to advocate for digital art and free software in those terms were far fewer. Shen was one of the people pushing that path early and concretely.
+
+According to the Taiwan Contemporary Art Archive, he was active not only as an exhibiting artist but also through workshops and teaching. Public traces make this even clearer: he taught advanced Processing courses, built the Play+Processing Forum, and gave a COSCUP 2010 talk titled **“Open Source & Digital Art Processing”**, where Processing was framed as an accessible creative tool for designers, architects, and artists — not just for people with deep programming backgrounds.
+
+This means his influence extended well beyond exhibition spaces. He helped many people believe that **coding did not belong only to engineers; it could also become an artist’s language.**
+
+His GitHub history reinforces that point. The `shengpo` account contains not only artwork-related code, but repositories such as `processing_snips`, `processing_quiz`, `ProjectionMapping_exercises`, `cascadePlayer`, and `helloFace` — projects that clearly function as examples, tools, exercises, and teaching materials. They read almost like open notebooks. Instead of locking technique inside a private workflow, Shen broke methods apart so that others could study them, modify them, and continue from them.
+
+In that sense, what he left behind was not a closed personal portfolio, but an open creative site for later practitioners to inherit.
+
+## Youwei Space: Making Room for Experiment
+
+In 2011, Shen founded Youwei Space in Taichung. That matters enormously.
+
+When an artist leaves only works, influence often remains point-like. But when an artist creates a space in which others can exhibit, test, and collide, influence becomes a field. According to public documentation, Youwei Space was not merely a display venue. It functioned as a base for artistic experiment and presentation.
+
+This also has a regional dimension. In Taiwan, cultural resources have long been concentrated in Taipei. A venue like Youwei Space represented a different kind of practice: instead of waiting for a major institution to distribute legitimacy or resources, it built a local platform where experimentation could actually breathe.
+
+If OpenLab.Taipei represented networked community, Youwei Space represented grounded continuity. Together, those two dimensions helped turn Shen’s influence from that of a single artist into something closer to shared infrastructure.
+
+## Why Illness Drove the Work Further Inward
+
+Shen was diagnosed with colorectal cancer in 2009 and died in 2014 at the age of 34.
+
+Retrospective coverage suggests that illness did not stop his work. If anything, it pushed it further inward. His attention gradually shifted away from more overtly personal memory and feeling toward questions of life’s rhythms, change, temporality, and control. Works such as *pin shadow* used code and mathematical logic to give objects virtual shadows and organic transformation, almost as if rule-based systems could offer a way to think through bodily vulnerability and diminishing control.
+
+That gives Shen’s work an unusual emotional tension. He was not using technology to escape life. At one of life’s most fragile points, he used technology and formal logic to move closer to fundamental human questions: how people face change, instability, loss of control, and time itself.
+
+If one looks only at the chronology, his career appears tragically brief. But if one looks at the traces he left behind, his weight does not depend simply on the number of works produced. It depends on the kind of figure he modeled — still rare in Taiwan then, but increasingly important now.
+
+The National Culture and Arts Foundation’s archive, in describing *Round 3 — Shen Sheng-Po Memorial Exhibition*, directly referred to him as **“an artist who promoted open-source software creation in Taiwan.”** That phrasing is significant. It places Shen not merely as an individual artist, but as someone who advanced methods and culture within Taiwanese digital art more broadly. His legacy is not only that his works were remembered, but that restoration, re-exhibition, workshops, documentation, and teaching around his work came to be seen as worth continuing.
+
+Seen together, these clues make the picture clearer: Shen Sheng-Po matters not simply because he died young, but because within a very short life he pushed an emerging creative culture far enough that others could continue it.
+
+More concretely, he modeled a type of creator Taiwan urgently needed and increasingly recognizes:
+
+- someone who could code and make art
+- someone who could think in systems but still work through perception
+- someone who made works and also brought other people in
+- someone who treated free software not as slogan, but as teaching practice, community-building, and space-making
+
+Those conditions made him feel like a creator who did not live long enough to fully unfold, yet still managed to indicate a direction with remarkable clarity.
+
+## What He Really Passed On
+
+In the end, the most important thing Shen left behind may not be any single masterpiece. It may be the route he pointed toward: **digital art does not have to remain a high-tech display inside museums. It can become an open, learnable, shareable culture of making.**
+
+That route has continued in different ways across later generations. Some made interactive installations; some moved into sound performance; some used Processing or p5.js for visual experiments; some brought coding into workshops, classrooms, and communities. Not all of them were directly taught by Shen, but the soil of Taiwan’s creative coding and FLOSS+ART culture was undeniably loosened, turned, and seeded by people like him.
+
+What he left was not a reproducible success formula. It was an attitude: understand the tools, question the rules, treat programming as part of life, and share that path with others.
+
+That attitude still does not feel outdated.
+
+## Further Reading
+
+- [Shen Sheng-Po (Chinese Wikipedia)](https://zh.wikipedia.org/zh-tw/%E6%B2%88%E8%81%96%E5%8D%9A)
+- [Shen Sheng-Po | Taiwan Contemporary Art Archive (TCAA)](https://tcaaarchive.org/Artist/Detail/1334)
+- [Shen Sheng-Po | Art Emperor](https://artemperor.tw/knowledge/2372)
+- [OpenLab.Taipei](https://openlabtaipei.org/)
+- [Processing Advanced Course (Insomnia Lecture Series)](https://insomnia608.pixnet.net/blog/posts/7096944218)
+- [Play+Processing Forum](http://shengpo.github.io/playp5/)
+- [COSCUP 2010 — Open Source & Digital Art Processing](https://coscup.org/2010/en/program/abstracts/)
+- [shengpo on GitHub](https://github.com/shengpo)
+- [Memorial Exhibition: Opening New Life with Code (Art Emperor)](https://artemperor.tw/focus/1221)
+- [Round 3 — Shen Sheng-Po Memorial Exhibition (NCAF archive)](https://archive.ncafroc.org.tw/result?id=b9c7810cda4f41b9994aa2d81925be02)
+- [Purity within Technological Warmth: Shen Sheng-Po’s *pin shadow* and *texture*](https://atatw.org/hta-archive/%E7%A7%91%E6%8A%80%E6%BA%AB%E5%BA%A6%E4%B8%AD%E7%9A%84%E9%AB%98%E5%B0%9A%E7%B4%94%E6%BD%94%EF%BC%9A%E6%B2%88%E8%81%96%E5%8D%9A%E7%9A%84%E3%80%8Apin-shadow%E3%80%8B%E8%88%87%E3%80%8Atexture%E3%80%8B/)
+
+## Related Topics
+
+- [[Wu Che-Yu]]: another Taiwanese path from code into art
+- [[Audrey Tang]]: how technical thinking enters the public sphere
+- [[Taiwan’s Digital Art Development]]: the broader context of installation, algorithms, and new media in Taiwan
+- [[Open Source Community and g0v]]: how open culture reshaped Taiwan’s technical and creative ecosystems


### PR DESCRIPTION
## 摘要 Summary

新增英文人物稿：
- `knowledge/en/People/shen-sheng-po.md`

這篇文章把沈聖博放回幾個更有國際可讀性的脈絡中：
- 台灣數位藝術發展
- FLOSS+ART 與 open-source creative practice
- OpenLab.Taipei / Youwei Space 的社群與場域意義
- 教學、論壇、GitHub repo、工作坊如何讓他不只是「做作品的人」，而是推動一種創作文化的人

## 為什麼先做英文

目前 `taiwan-md` 的公開站是以 zh-TW / en 為主產品層。相比日文或西班牙文，英文版更容易直接出站，也更適合作為沈聖博這篇人物稿的第一個多語版本。

## 來源與處理方式

這篇主要根據已存在的中文稿與已整理過的來源撰寫，包括：
- TCAA
- Art Emperor
- OpenLab.Taipei
- Play+Processing Forum
- COSCUP 2010
- GitHub `shengpo`
- 國藝會檔案庫
- `pin shadow` / `texture` 評論文

另外有用 Felo 補想「對國際讀者最有用的 framing 是什麼」，但沒有新增超出既有來源支持的事實。

## 寫作方向

不是把中文逐句翻成英文，而是盡量保留 Taiwan.md 的策展語氣，同時讓英文讀者能理解：

> Shen Sheng-Po matters not only because he made digital artworks, but because he helped make creative coding and FLOSS+ART feel like a viable cultural path in Taiwan.

如果 maintainer 覺得這方向合適，後續也可以再補日文或西班牙文版本。
