### PR TITLE
fix: 修復英文 People 分類 64 篇文章的 YAML frontmatter 錯誤 (#209)

### DIFF
--- a/knowledge/en/People/a-mei.md
+++ b/knowledge/en/People/a-mei.md
@@ -3,8 +3,8 @@ title: 'A‑Mei (張惠妹)'
 description: 'A Puyuma (卑南) powerhouse whose voice reshaped Mandopop and whose advocacy made her a symbol of Indigenous pride and LGBTQ+ allyship in Taiwan.'
 date: 2026-03-19
 tags:
-subcategory: 'Music'
   ['music', 'indigenous', 'Puyuma', 'Mandopop', 'LGBTQ+ ally', 'performance']
+subcategory: 'Music'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/andre-chiang-taiwanese-culinary-innovator.md
+++ b/knowledge/en/People/andre-chiang-taiwanese-culinary-innovator.md
@@ -3,8 +3,8 @@ title: 'André Chiang: Taiwanese Culinary Innovator'
 description: "Taiwan's international celebrity chef, top 50 world restaurants chef, RAW founder, globally renowned for his 'Octaphilosophy'"
 date: 2026-03-19
 tags:
-subcategory: 'Food & Craft'
   ['People', 'André Chiang', 'Chef', 'Michelin', 'RAW', 'Culinary', 'Taiwan']
+subcategory: 'Food & Craft'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/audrey-tang.md
+++ b/knowledge/en/People/audrey-tang.md
@@ -3,7 +3,6 @@ title: 'Audrey Tang'
 description: "World's first transgender cabinet minister and pioneering practitioner of open government and digital democracy"
 date: 2026-03-17
 tags:
-subcategory: 'Education & Society'
   [
     people,
     Audrey Tang,
@@ -14,6 +13,7 @@ subcategory: 'Education & Society'
     open government,
     vTaiwan,
   ]
+subcategory: 'Education & Society'
 translatedFrom: 'People/唐鳳.md'
 sourceHash: 'de5ca5'
 ---

--- a/knowledge/en/People/bobby-chen-indie-music-pioneer.md
+++ b/knowledge/en/People/bobby-chen-indie-music-pioneer.md
@@ -3,7 +3,6 @@ title: 'Bobby Chen (陳昇)'
 description: "Independent music pioneer and creative genius who has hosted New Year's Eve concerts for 30 consecutive years in Taiwan's music scene"
 date: 2026-03-19
 tags:
-subcategory: 'Music'
   [
     'music',
     'independent music',
@@ -12,6 +11,7 @@ subcategory: 'Music'
     'folk',
     'rock',
   ]
+subcategory: 'Music'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/brigitte-lin-legendary-actress.md
+++ b/knowledge/en/People/brigitte-lin-legendary-actress.md
@@ -3,7 +3,6 @@ title: 'Brigitte Lin: From Romance Icon to Martial Arts Legend'
 description: "The legendary actress who dominated both Qiong Yao romance films and Tsui Hark's martial arts cinema, becoming an eternal icon of Chinese cinema"
 date: 2026-03-20
 tags:
-subcategory: 'Film & Theater'
   [
     'Brigitte Lin',
     'actress',
@@ -11,6 +10,7 @@ subcategory: 'Film & Theater'
     'The Swordsman II',
     'Chinese cinema',
   ]
+subcategory: 'Film & Theater'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/che-yu-wu.md
+++ b/knowledge/en/People/che-yu-wu.md
@@ -3,7 +3,6 @@ title: 'Che-Yu Wu (吳哲宇) — A Media Artist Who Grows Life in Code'
 description: 'A Taiwanese new media artist and educator whose algorithmic works have appeared at the Venice Biennale and Art Basel, and who teaches thousands to think with code.'
 date: 2026-03-19
 tags:
-subcategory: 'Arts & Design'
   [
     'new media art',
     'generative art',
@@ -12,6 +11,7 @@ subcategory: 'Arts & Design'
     'education',
     'people',
   ]
+subcategory: 'Arts & Design'
 author: 'Taiwan.md Contributors'
 readingTime: 10
 featured: false

--- a/knowledge/en/People/chen-chien-jen.md
+++ b/knowledge/en/People/chen-chien-jen.md
@@ -3,8 +3,8 @@ title: 'Chen Chien-jen'
 description: 'An epidemiologist-turned-statesman who helped steer Taiwan through SARS and COVID-19'
 date: 2026-03-19
 tags:
-subcategory: 'Politics & Democracy'
   [people, Chen Chien-jen, epidemiology, public health, vice president, premier]
+subcategory: 'Politics & Democracy'
 translatedFrom: 'knowledge/People/陳建仁.md'
 ---
 

--- a/knowledge/en/People/chen-chun-liang-design-poet.md
+++ b/knowledge/en/People/chen-chun-liang-design-poet.md
@@ -3,7 +3,6 @@ title: 'Chen Chun-liang: The Design Poet of Taiwan'
 description: 'Visionary graphic designer and founder of FreeFall Design, pioneer who redefined Taiwan design with poetic sensibility'
 date: 2026-03-20
 tags:
-subcategory: 'Arts & Design'
   [
     'graphic designer',
     'design education',
@@ -11,6 +10,7 @@ subcategory: 'Arts & Design'
     'design philosophy',
     'design poet',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/chen-shu-chu-vegetable-vendor-philanthropist.md
+++ b/knowledge/en/People/chen-shu-chu-vegetable-vendor-philanthropist.md
@@ -3,7 +3,6 @@ title: 'Chen Shu-chu'
 description: 'A vegetable vendor from Taitung whose ordinary acts of kindness define what true wealth means'
 date: 2026-03-19
 tags:
-subcategory: 'Education & Society'
   [
     People,
     Philanthropy,
@@ -13,6 +12,7 @@ subcategory: 'Education & Society'
     Forbes,
     Education donations,
   ]
+subcategory: 'Education & Society'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/chen-shui-bian-controversial-president.md
+++ b/knowledge/en/People/chen-shui-bian-controversial-president.md
@@ -3,7 +3,6 @@ title: 'Chen Shui-bian: The Controversial Pioneer of Democratic Transition'
 description: "Taiwan's 10th and 11th President, central figure in the historic 2000 power transition, a polarizing leader in Taiwan's democratization"
 date: 2026-03-20
 tags:
-subcategory: 'Politics & Democracy'
   [
     'president',
     'power transition',
@@ -11,6 +10,7 @@ subcategory: 'Politics & Democracy'
     'Taipei mayor',
     'corruption case',
   ]
+subcategory: 'Politics & Democracy'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/chi-huey-wong-glycoscience-pioneer.md
+++ b/knowledge/en/People/chi-huey-wong-glycoscience-pioneer.md
@@ -3,7 +3,6 @@ title: 'Chi-Huey Wong: Pioneer of Glycoscience'
 description: 'World-renowned authority in carbohydrate chemistry, former president of Academia Sinica, and Nobel Prize candidate'
 date: 2026-03-20
 tags:
-subcategory: 'Science & Academia'
   [
     'academia',
     'chemistry',
@@ -12,6 +11,7 @@ subcategory: 'Science & Academia'
     'carbohydrate chemistry',
     'Tanvex controversy',
   ]
+subcategory: 'Science & Academia'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/chi-po-lin.md
+++ b/knowledge/en/People/chi-po-lin.md
@@ -1,6 +1,6 @@
 ---
 title: 'Chi Po-lin'
-description: 'How a government clerk who couldn\'t afford helicopters on his salary mortgaged his house to create Taiwan\'s most successful documentary'
+description: "How a government clerk who couldn't afford helicopters on his salary mortgaged his house to create Taiwan's most successful documentary"
 date: 2026-03-23
 tags: ['People', 'Chi Po-lin', 'Documentary', 'Beyond Beauty Taiwan', 'Director', 'Photographer', 'Aerial Photography', 'Environment']
 subcategory: 'Arts and Creativity'

--- a/knowledge/en/People/chien-ming-wang-mlb-sinker-ace.md
+++ b/knowledge/en/People/chien-ming-wang-mlb-sinker-ace.md
@@ -3,8 +3,8 @@ title: "Chien-Ming Wang: Taiwan's Sinker Ball Ace Who Conquered MLB"
 description: 'The Taiwanese pitcher whose devastating sinker ball dominated Major League Baseball, creating a nationwide phenomenon and inspiring a generation'
 date: 2026-03-20
 tags:
-subcategory: 'Sports'
   ['Chien-Ming Wang', 'baseball', 'MLB', 'New York Yankees', 'Taiwan sports']
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/cho-yun-hsu-bridging-historian.md
+++ b/knowledge/en/People/cho-yun-hsu-bridging-historian.md
@@ -3,7 +3,6 @@ title: 'Cho-yun Hsu: Bridging East and West as a Master Historian'
 description: 'Master historian, author of The Course of Chinese History, Professor Emeritus at University of Pittsburgh'
 date: 2026-03-20
 tags:
-subcategory: 'Science & Academia'
   [
     'historian',
     'historiography',
@@ -11,6 +10,7 @@ subcategory: 'Science & Academia'
     'cultural history',
     'scholar',
   ]
+subcategory: 'Science & Academia'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/chu-ching-wu.md
+++ b/knowledge/en/People/chu-ching-wu.md
@@ -3,7 +3,6 @@ title: 'Chu Ching-Wu (朱經武)'
 description: 'Taiwan-born physicist whose 1987 high‑temperature superconductivity breakthrough reshaped modern materials science'
 date: 2026-03-20
 tags:
-subcategory: 'Sports'
   [
     'physicist',
     'superconductivity',
@@ -11,6 +10,7 @@ subcategory: 'Sports'
     'Academia Sinica',
     'University of Houston',
   ]
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 featured: true
 ---

--- a/knowledge/en/People/chu-tien-wen.md
+++ b/knowledge/en/People/chu-tien-wen.md
@@ -3,7 +3,6 @@ title: 'Chu Tien-wen'
 description: 'Novelist and screenwriter who shaped Taiwan New Cinema, author of Notes of a Desolate Man'
 date: 2026-03-19
 tags:
-subcategory: 'Literature'
   [
     'literature',
     'screenwriting',
@@ -11,6 +10,7 @@ subcategory: 'Literature'
     'Notes of a Desolate Man',
     'Taiwan New Cinema',
   ]
+subcategory: 'Literature'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/chuang-chih-yuan-table-tennis-legend.md
+++ b/knowledge/en/People/chuang-chih-yuan-table-tennis-legend.md
@@ -3,7 +3,6 @@ title: 'Chuang Chih-yuan'
 description: 'Table tennis legend, four-time Olympian, the solitary warrior who conquered European professional leagues'
 date: 2026-03-20
 tags:
-subcategory: 'Sports'
   [
     'Sports',
     'Table Tennis',
@@ -11,6 +10,7 @@ subcategory: 'Sports'
     'Professional Table Tennis',
     'European League',
   ]
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/crowd-lu-indie-folk-treasure.md
+++ b/knowledge/en/People/crowd-lu-indie-folk-treasure.md
@@ -3,7 +3,6 @@ title: 'Crowd Lu (盧廣仲)'
 description: "Taiwanese singer-songwriter and actor who captured hearts with his grassroots charm and unique vocal style, becoming the youngest triple-crown winner of Taiwan's Golden Melody, Golden Bell, and Golden Horse Awards"
 date: 2026-03-20
 tags:
-subcategory: 'Music'
   [
     people,
     crowd-lu,
@@ -14,6 +13,7 @@ subcategory: 'Music'
     tainan,
     taiwan,
   ]
+subcategory: 'Music'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/deng-yu-xian-taiwanese-song-composer.md
+++ b/knowledge/en/People/deng-yu-xian-taiwanese-song-composer.md
@@ -3,7 +3,6 @@ title: 'Deng Yu-xian'
 description: "Father of Taiwanese songs, composer of classics like 'Longing for Spring Breeze,' 'Rainy Night Flower,' and 'Moonlit Night Sorrow'"
 date: 2026-03-20
 tags:
-subcategory: 'Music'
   [
     'music',
     'taiwanese-songs',
@@ -12,6 +11,7 @@ subcategory: 'Music'
     'classical-music',
     'taoyuan',
   ]
+subcategory: 'Music'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/du-congming-founder-of-modern-medicine-in-taiwan.md
+++ b/knowledge/en/People/du-congming-founder-of-modern-medicine-in-taiwan.md
@@ -3,7 +3,6 @@ title: 'Du Congming: Founder of Modern Medicine in Taiwan'
 description: "Taiwan's first medical doctor and father of modern medicine in Taiwan"
 date: 2026-03-19
 tags:
-subcategory: 'Science & Academia'
   [
     'Medicine',
     'Medical Doctor',
@@ -11,6 +10,7 @@ subcategory: 'Science & Academia'
     'Kyoto Imperial University',
     'Pharmacology',
   ]
+subcategory: 'Science & Academia'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/ethan-tu.md
+++ b/knowledge/en/People/ethan-tu.md
@@ -3,7 +3,6 @@ title: 'Ethan Tu (杜奕瑾)'
 description: 'Founder of PTT, former Microsoft AI lead, and creator of Taiwan AI Labs—an architect of Taiwan’s digital public sphere'
 date: 2026-03-19
 tags:
-subcategory: 'Tech & Business'
   [
     People,
     Ethan Tu,
@@ -12,6 +11,7 @@ subcategory: 'Tech & Business'
     Digital Democracy,
     Artificial Intelligence,
   ]
+subcategory: 'Tech & Business'
 author: 'idlccp02'
 readingTime: 8
 featured: true

--- a/knowledge/en/People/fang-hsu-chung.md
+++ b/knowledge/en/People/fang-hsu-chung.md
@@ -3,7 +3,6 @@ title: 'Fang Hsu-Chung (方序中)'
 description: 'The designer behind the Golden Melody and Golden Horse visual identities, founder of The Good Design Company, and a leading voice in Taiwan’s branding scene'
 date: 2026-03-19
 tags:
-subcategory: 'Arts & Design'
   [
     'designer',
     'visual identity',
@@ -11,6 +10,7 @@ subcategory: 'Arts & Design'
     'Golden Melody Awards',
     'Golden Horse Awards',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/fang-yi-sheu-body-storyteller.md
+++ b/knowledge/en/People/fang-yi-sheu-body-storyteller.md
@@ -3,7 +3,6 @@ title: 'Fang-Yi Sheu (許芳宜)'
 description: "From a small-town girl in Yilan to principal dancer at Martha Graham Dance Company and founder of LAFA — she tells Taiwan's most powerful stories through movement"
 date: 2026-03-19
 tags:
-subcategory: 'Arts & Design'
   [
     'dance',
     'performing arts',
@@ -12,6 +11,7 @@ subcategory: 'Arts & Design'
     'modern dance',
     'contemporary dance',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/gwei-lun-mei-versatile-taiwanese-actress.md
+++ b/knowledge/en/People/gwei-lun-mei-versatile-taiwanese-actress.md
@@ -3,7 +3,6 @@ title: 'Gwei Lun-Mei'
 description: "From 'Secret' to international film festivals, a low-key method actress who represents Taiwan's new generation of cinema talent"
 date: 2026-03-20
 tags:
-subcategory: 'Film & Theater'
   [
     'Gwei Lun-Mei',
     'actress',
@@ -11,6 +10,7 @@ subcategory: 'Film & Theater'
     'international film festivals',
     'method acting',
   ]
+subcategory: 'Film & Theater'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/hong-chih-kuo-taiwanese-left-handed-pitcher.md
+++ b/knowledge/en/People/hong-chih-kuo-taiwanese-left-handed-pitcher.md
@@ -3,7 +3,6 @@ title: "Hong-Chih Kuo: Taiwan's Left-Handed Ace"
 description: "Left-handed pitcher who made his mark in MLB with the Los Angeles Dodgers, representing Taiwan's baseball pride on the international stage"
 date: 2026-03-20
 tags:
-subcategory: 'Sports'
   [
     'sports',
     'baseball',
@@ -12,6 +11,7 @@ subcategory: 'Sports'
     'left-handed pitcher',
     'Taiwan baseball',
   ]
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/hou-hsiao-hsien.md
+++ b/knowledge/en/People/hou-hsiao-hsien.md
@@ -2,7 +2,6 @@
 title: 'Hou Hsiao-hsien'
 category: People
 tags:
-subcategory: 'Film & Theater'
   [
     person,
     Hou Hsiao-hsien,
@@ -12,6 +11,7 @@ subcategory: 'Film & Theater'
     Cannes Film Festival,
     cinema art,
   ]
+subcategory: 'Film & Theater'
 date: 2026-03-17
 ---
 

--- a/knowledge/en/People/huang-chun-ming-taiwanese-literary-master.md
+++ b/knowledge/en/People/huang-chun-ming-taiwanese-literary-master.md
@@ -1,8 +1,8 @@
 ---
 title: 'Huang Chun-ming: Master of Taiwanese Literary Humanism'
-description: 'Author of "The Sandwich Man" and "The Days of Looking at the Sea," representative writer of Yilan nativist literature and chronicler of ordinary people\'s lives'
+description: 'Author of "The Sandwich Man" and "The Days of Looking at the Sea," representative writer of Yilan nativist literature and chronicler of ordinary people''s lives'
 date: 2026-03-19
-tags: [people, Huang Chun-ming, The Sandwich Man, The Days of Looking at the Sea, nativist literature, Yilan, ordinary people]
+tags: ['Taiwan history', 'book collector', 'Huang Zhen-nan', 'Taiwanese history', 'Living Water Bookstore']
 subcategory: 'Literature'
 lastVerified: 2026-03-19
 lastHumanReview: false

--- a/knowledge/en/People/huang-kuo-chen.md
+++ b/knowledge/en/People/huang-kuo-chen.md
@@ -1,6 +1,6 @@
 ---
-title: 'Huang Kuo-chen: Teaching Taiwan's Children to "Understand" Not Just "Finish Reading"'
-description: 'Founder of Pin Xue Tang, promoting reading literacy education in Taiwan, working to change the educational predicament of "good at tests but bad at thinking"'
+title: "Huang Kuo-chen: Teaching Taiwan's Children to 'Understand' Not Just 'Finish Reading'"
+description: "Founder of Pin Xue Tang, promoting reading literacy education in Taiwan, working to change the educational predicament of 'good at tests but bad at thinking'"
 date: 2026-03-20
 tags: ['Education', 'Reading Literacy', 'Pin Xue Tang', 'Reading Comprehension', 'Educational Innovation', 'Literacy Education']
 subcategory: 'Education & Society'

--- a/knowledge/en/People/huang-zhen-nan-book-collector-historian.md
+++ b/knowledge/en/People/huang-zhen-nan-book-collector-historian.md
@@ -1,6 +1,6 @@
 ---
-title: 'Huang Zhen-nan: The Takenouchi Yutaka of Book Collecting and Taiwan\'s Living History Source'
-description: 'Huang Zhen-nan is a Taiwanese cultural historian, book collector, and writer who gained fame through his PTT username Sizumaru and runs the "Living Water Bookstore" social media presence sharing Taiwan history and antiquarian book culture. Author of "The Most Entertaining Taiwan History Ever," he\'s dubbed "the Takenouchi Yutaka of book collecting" for making serious Taiwan history accessible and engaging.'
+title: "Huang Zhen-nan: The Takenouchi Yutaka of Book Collecting and Taiwan's Living History Source"
+description: 'Huang Zhen-nan is a Taiwanese cultural historian, book collector, and writer who gained fame through his PTT username Sizumaru and runs the "Living Water Bookstore" social media presence sharing Taiwan history and antiquarian book culture. Author of "The Most Entertaining Taiwan History Ever," he''s dubbed "the Takenouchi Yutaka of book collecting" for making serious Taiwan history accessible and engaging.'
 date: 2026-03-20T00:00:00Z
 updated: 2026-03-20T00:00:00Z
 tags: ['Taiwan history', 'book collector', 'Huang Zhen-nan', 'Taiwanese history', 'Living Water Bookstore']

--- a/knowledge/en/People/jam-hsiao-rain-god-pop-star.md
+++ b/knowledge/en/People/jam-hsiao-rain-god-pop-star.md
@@ -3,7 +3,6 @@ title: 'Jam Hsiao'
 description: "Taiwan's 'Rain God,' Golden Melody Award winner who transformed from street performer to international superstar"
 date: 2026-03-20
 tags:
-subcategory: 'Music'
   [
     'music',
     'pop-music',
@@ -12,6 +11,7 @@ subcategory: 'Music'
     'golden-melody-award',
     'rain-god',
   ]
+subcategory: 'Music'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/jamie-lin-ai-industry-pioneer.md
+++ b/knowledge/en/People/jamie-lin-ai-industry-pioneer.md
@@ -3,13 +3,13 @@ title: 'Jamie Lin (Chien-Li Feng)'
 description: 'Former Google Taiwan Managing Director, AI industry pioneer, technology talent development advocate'
 date: 2026-03-20
 tags:
-subcategory: 'Tech & Business'
   [
     'Google',
     'Artificial Intelligence',
     'Technology Industry',
     'Talent Development',
   ]
+subcategory: 'Tech & Business'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/jensen-huang.md
+++ b/knowledge/en/People/jensen-huang.md
@@ -3,8 +3,8 @@ title: 'Jensen Huang'
 description: 'Co-founder and CEO of NVIDIA, the ‘godfather of AI,’ whose vision and Taiwan ties reshaped global computing'
 date: 2026-03-19
 tags:
-subcategory: 'Tech & Business'
   [People, Jensen Huang, NVIDIA, AI, Semiconductors, Technology, Taiwan, Tainan]
+subcategory: 'Tech & Business'
 lastVerified: 2026-03-19
 featured: true
 ---

--- a/knowledge/en/People/jimmy-liao.md
+++ b/knowledge/en/People/jimmy-liao.md
@@ -3,7 +3,6 @@ title: 'Jimmy Liao'
 description: 'Taiwan’s most internationally recognized picture‑book artist, whose poetic illustrations turned ‘繪本’ (picture books) into a bridge between childhood and adult emotion.'
 date: 2026-03-19
 tags:
-subcategory: 'Arts & Design'
   [
     'people',
     'illustration',
@@ -12,6 +11,7 @@ subcategory: 'Arts & Design'
     'yilan',
     'visual culture',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/jj-lin-singaporean-mandopop-king.md
+++ b/knowledge/en/People/jj-lin-singaporean-mandopop-king.md
@@ -3,7 +3,6 @@ title: 'JJ Lin (Lin Jun Jie)'
 description: "Singapore-born Mandopop superstar who became a creative powerhouse in the Chinese-speaking world through hits like 'Jiangnan'"
 date: 2026-03-19
 tags:
-subcategory: 'Music'
   [
     'music',
     'singer-songwriter',
@@ -12,6 +11,7 @@ subcategory: 'Music'
     'pop music',
     'Golden Melody Awards',
   ]
+subcategory: 'Music'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/kevin-lin-ultramarathon-desert-pioneer.md
+++ b/knowledge/en/People/kevin-lin-ultramarathon-desert-pioneer.md
@@ -3,8 +3,8 @@ title: 'Kevin Lin Yi-jie'
 description: "Taiwanese ultramarathon legend who conquered Earth's most extreme environments on foot, first person to run across the Sahara Desert"
 date: 2026-03-19
 tags:
-subcategory: 'Sports'
   ['people', 'ultramarathon', 'extreme exploration', 'athlete', 'Sahara Desert']
+subcategory: 'Sports'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/kuo-hsing-chun-olympic-weightlifting-champion.md
+++ b/knowledge/en/People/kuo-hsing-chun-olympic-weightlifting-champion.md
@@ -3,7 +3,6 @@ title: 'Kuo Hsing-chun'
 description: "Taiwan's weightlifting goddess, Tokyo 2021 Olympic gold medalist, triple Olympic record holder in the 59kg category"
 date: 2026-03-19
 tags:
-subcategory: 'Sports'
   [
     People,
     Kuo Hsing-chun,
@@ -13,6 +12,7 @@ subcategory: 'Sports'
     Athletes,
     Taiwan,
   ]
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/lai-ching-te.md
+++ b/knowledge/en/People/lai-ching-te.md
@@ -5,7 +5,6 @@ category: 'People'
 date: '2026-03-19'
 author: 'Taiwan.md'
 tags:
-subcategory: 'Politics & Democracy'
   [
     'President',
     'Physician',
@@ -14,6 +13,7 @@ subcategory: 'Politics & Democracy'
     'Public Health',
     'Tainan',
   ]
+subcategory: 'Politics & Democracy'
 readingTime: 12
 featured: true
 lastVerified: 2026-03-19

--- a/knowledge/en/People/lee-yuan-tseh.md
+++ b/knowledge/en/People/lee-yuan-tseh.md
@@ -2,7 +2,6 @@
 title: 'Lee Yuan-tseh'
 category: People
 tags:
-subcategory: 'Science & Academia'
   [
     person,
     Lee Yuan-tseh,
@@ -12,6 +11,7 @@ subcategory: 'Science & Academia'
     Academia Sinica,
     Taiwan,
   ]
+subcategory: 'Science & Academia'
 date: 2026-03-17
 ---
 

--- a/knowledge/en/People/li-ang.md
+++ b/knowledge/en/People/li-ang.md
@@ -3,8 +3,8 @@ title: 'Li Ang'
 description: 'A feminist literary pioneer whose bold novels confronted patriarchy, sexuality, and violence in Taiwan'
 date: 2026-03-19
 tags:
-subcategory: 'Literature'
   [people, Li Ang, feminist literature, Taiwanese literature, gender, Lukang]
+subcategory: 'Literature'
 translatedFrom: 'knowledge/People/李昂.md'
 ---
 

--- a/knowledge/en/People/li-zongsheng.md
+++ b/knowledge/en/People/li-zongsheng.md
@@ -3,7 +3,6 @@ title: 'Li Zongsheng (Jonathan Lee)'
 description: 'Taiwan’s master songwriter and producer whose songs turned life’s joys and losses into a shared language'
 date: 2026-03-19
 tags:
-subcategory: 'Music'
   [
     'music',
     'singer-songwriter',
@@ -12,6 +11,7 @@ subcategory: 'Music'
     'lyricism',
     'life philosophy',
   ]
+subcategory: 'Music'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/lin-yi-hsiung-democracy-advocate-tragedy-survivor.md
+++ b/knowledge/en/People/lin-yi-hsiung-democracy-advocate-tragedy-survivor.md
@@ -3,7 +3,6 @@ title: 'Lin Yi-hsiung'
 description: "Pioneer of Taiwan's democracy movement, survivor of the Lin family massacre, anti-nuclear activist who exemplifies resilience in tragedy"
 date: 2026-03-19
 tags:
-subcategory: 'Politics & Democracy'
   [
     'democracy movement',
     'Lin family massacre',
@@ -11,6 +10,7 @@ subcategory: 'Politics & Democracy'
     'political victim',
     'Tzulin Foundation',
   ]
+subcategory: 'Politics & Democracy'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/lu-guan-wei-junyiacademy-founder.md
+++ b/knowledge/en/People/lu-guan-wei-junyiacademy-founder.md
@@ -1,6 +1,6 @@
 ---
 title: 'Lu Guan-wei: From Medical School to Education Revolutionary'
-description: 'Founder of Taiwan's Khan Academy - how a doctor gave up medicine to democratize education'
+description: "Founder of Taiwan's Khan Academy - how a doctor gave up medicine to democratize education"
 date: 2026-03-20
 tags: ['Education', 'Junyi Academy', 'Online learning', 'Educational technology', 'Social enterprise', 'Rural education']
 subcategory: 'Education & Society'

--- a/knowledge/en/People/lung-ying-tai.md
+++ b/knowledge/en/People/lung-ying-tai.md
@@ -3,7 +3,6 @@ title: 'Lung Ying-tai'
 description: "Author of 'Wild Fire,' one of the most influential essayists in the Chinese-speaking world and former Taiwan Minister of Culture"
 date: 2026-03-20
 tags:
-subcategory: 'Literature'
   [
     people,
     Lung Ying-tai,
@@ -13,6 +12,7 @@ subcategory: 'Literature'
     Minister of Culture,
     public intellectual,
   ]
+subcategory: 'Literature'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/ming-hua-yuan.md
+++ b/knowledge/en/People/ming-hua-yuan.md
@@ -3,8 +3,8 @@ title: 'Ming Hua Yuan'
 description: 'From outdoor temple stages to the Taipei Arena, Taiwan’s leading gezai opera troupe proves that tradition is not the past—it is a living present'
 date: 2026-03-19
 tags:
-subcategory: 'Arts & Design'
   [gezai-opera, traditional-arts, performing-arts, ming-hua-yuan, chen-sheng-fu]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-19
 translatedFrom: 'People/明華園.md'
 sourceHash: 'bfd12b'

--- a/knowledge/en/People/nieh-yung-jen.md
+++ b/knowledge/en/People/nieh-yung-jen.md
@@ -3,7 +3,6 @@ title: 'Nieh Yung-jen (聶永真)'
 description: 'Taiwanese graphic designer and AGI member, known for Golden Melody Awards visuals and presidential inauguration identities'
 date: 2026-03-19
 tags:
-subcategory: 'Arts & Design'
   [
     'people',
     'Nieh Yung-jen',
@@ -13,6 +12,7 @@ subcategory: 'Arts & Design'
     'visual identity',
     'Taiwan',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/pai-hsien-yung-literary-master.md
+++ b/knowledge/en/People/pai-hsien-yung-literary-master.md
@@ -3,7 +3,6 @@ title: 'Pai Hsien-yung (白先勇)'
 description: "Literary master, author of 'Taipei People,' and champion of Kunqu opera revival in modern Chinese literature"
 date: 2026-03-19
 tags:
-subcategory: 'Literature'
   [
     'literature',
     'Taipei People',
@@ -12,6 +11,7 @@ subcategory: 'Literature'
     'modern literature',
     'Chinese literature',
   ]
+subcategory: 'Literature'
 lastVerified: 2026-03-19
 featured: true
 ---

--- a/knowledge/en/People/shih-ming-te.md
+++ b/knowledge/en/People/shih-ming-te.md
@@ -3,7 +3,6 @@ title: 'Shih Ming-te'
 description: 'Leader of the Kaohsiung Incident and a democracy pioneer who spent 25 years in prison for Taiwan’s freedom'
 date: 2026-03-19
 tags:
-subcategory: 'Politics & Democracy'
   [
     'democracy',
     'Kaohsiung Incident',
@@ -11,6 +10,7 @@ subcategory: 'Politics & Democracy'
     'Red Shirt Movement',
     'political leadership',
   ]
+subcategory: 'Politics & Democracy'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/stan-lai-theater-innovation-master.md
+++ b/knowledge/en/People/stan-lai-theater-innovation-master.md
@@ -3,7 +3,6 @@ title: 'Stan Lai: Master of Theater Innovation'
 description: 'Founder of Performance Workshop, creator of Secret Love in Peach Blossom Land, godfather of Chinese-language theater'
 date: 2026-03-20
 tags:
-subcategory: 'Arts & Design'
   [
     'Stan Lai',
     'theater',
@@ -11,6 +10,7 @@ subcategory: 'Arts & Design'
     'Secret Love in Peach Blossom Land',
     'theater director',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/steve-chang.md
+++ b/knowledge/en/People/steve-chang.md
@@ -3,7 +3,6 @@ title: 'Steve Chang (張明正)'
 description: 'Founder of Trend Micro and a pioneer who proved Taiwan’s software industry could lead globally in cybersecurity.'
 date: 2026-03-19
 tags:
-subcategory: 'Tech & Business'
   [
     'technology',
     'cybersecurity',
@@ -11,6 +10,7 @@ subcategory: 'Tech & Business'
     'entrepreneurship',
     'trend micro',
   ]
+subcategory: 'Tech & Business'
 lastVerified: 2026-03-19
 ---
 

--- a/knowledge/en/People/su-wei-hsieh-wimbledon-champion.md
+++ b/knowledge/en/People/su-wei-hsieh-wimbledon-champion.md
@@ -3,7 +3,6 @@ title: "Su-Wei Hsieh: Taiwan's Tennis Trailblazer"
 description: "2013 Wimbledon women's doubles champion, Taiwan's first Grand Slam titlist"
 date: 2026-03-20
 tags:
-subcategory: 'Sports'
   [
     'sports',
     'tennis',
@@ -12,6 +11,7 @@ subcategory: 'Sports'
     "women's doubles",
     'professional tennis',
   ]
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/tai-tzu-ying.md
+++ b/knowledge/en/People/tai-tzu-ying.md
@@ -2,8 +2,8 @@
 title: 'Tai Tzu-ying'
 category: People
 tags:
-subcategory: 'Sports'
   [person, Tai Tzu-ying, badminton, world number one, Olympics, athlete, Taiwan]
+subcategory: 'Sports'
 date: 2026-03-17
 ---
 

--- a/knowledge/en/People/teresa-teng.md
+++ b/knowledge/en/People/teresa-teng.md
@@ -3,7 +3,6 @@ title: 'Teresa Teng — The Voice That United Asia'
 description: "From Taiwan's countryside to Asian superstardom: How Teresa Teng's voice transcended political boundaries and created the first pan-Asian pop culture phenomenon"
 date: 2026-03-17
 tags:
-subcategory: 'Music'
   [
     'music',
     'singer',
@@ -12,6 +11,7 @@ subcategory: 'Music'
     'mandarin-pop',
     'cultural-diplomacy',
   ]
+subcategory: 'Music'
 author: 'Taiwan.md Contributors'
 readingTime: 16
 featured: true

--- a/knowledge/en/People/tsai-ming-liang.md
+++ b/knowledge/en/People/tsai-ming-liang.md
@@ -3,7 +3,6 @@ title: 'Tsai Ming‑liang'
 description: 'Venice Golden Lion winner and master of slow cinema, a Malaysian‑Chinese director rooted in Taiwan'
 date: 2026-03-19
 tags:
-subcategory: 'Film & Theater'
   [
     'Director',
     'Tsai Ming‑liang',
@@ -11,6 +10,7 @@ subcategory: 'Film & Theater'
     'Venice Film Festival',
     'Malaysian Chinese',
   ]
+subcategory: 'Film & Theater'
 lastVerified: 2026-03-19
 featured: true
 ---

--- a/knowledge/en/People/tung-tzu-hsien-tech-humanist.md
+++ b/knowledge/en/People/tung-tzu-hsien-tech-humanist.md
@@ -3,8 +3,8 @@ title: 'Tung Tzu-hsien (童子賢)'
 description: "Chairman and CEO of Pegatron Corporation, a tech industry leader who bridges technology and humanities, and key supporter of Taiwan's Eslite Bookstore"
 date: 2026-03-20
 tags:
-subcategory: 'Tech & Business'
   [people, tung-tzu-hsien, pegatron, technology, humanities, eslite-bookstore]
+subcategory: 'Tech & Business'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/wei-te-sheng-taiwanese-epic-filmmaker.md
+++ b/knowledge/en/People/wei-te-sheng-taiwanese-epic-filmmaker.md
@@ -3,7 +3,6 @@ title: 'Wei Te-sheng'
 description: "Writing Taiwan's epic through cinema, from Cape No. 7 to Seediq Bale—a dream practitioner"
 date: 2026-03-19
 tags:
-subcategory: 'Film & Theater'
   [
     People,
     Director,
@@ -13,6 +12,7 @@ subcategory: 'Film & Theater'
     Cape No. 7,
     Seediq Bale,
   ]
+subcategory: 'Film & Theater'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/wu-ming-yi.md
+++ b/knowledge/en/People/wu-ming-yi.md
@@ -2,7 +2,6 @@
 title: 'Wu Ming-Yi'
 category: People
 tags:
-subcategory: 'Literature'
   [
     person,
     Wu Ming-Yi,
@@ -12,6 +11,7 @@ subcategory: 'Literature'
     Man Booker Prize,
     novelist,
   ]
+subcategory: 'Literature'
 date: 2026-03-17
 ---
 

--- a/knowledge/en/People/xiao-qing-yang-grammy-designer.md
+++ b/knowledge/en/People/xiao-qing-yang-grammy-designer.md
@@ -3,7 +3,6 @@ title: 'Xiao Qing-yang'
 description: 'Four-time Grammy nominee for Best Album Package Design, visual designer who brought Taiwan to the world stage'
 date: 2026-03-20
 tags:
-subcategory: 'Arts & Design'
   [
     'designer',
     'grammy-award',
@@ -11,6 +10,7 @@ subcategory: 'Arts & Design'
     'visual-design',
     'taiwanese-culture',
   ]
+subcategory: 'Arts & Design'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/yang-dechang.md
+++ b/knowledge/en/People/yang-dechang.md
@@ -3,7 +3,6 @@ title: 'Edward Yang (楊德昌)'
 description: 'A leading voice of the Taiwan New Cinema movement, Cannes Best Director, and the poet of urban alienation'
 date: 2026-03-19
 tags:
-subcategory: 'Film & Theater'
   [
     'director',
     'Taiwan New Cinema',
@@ -11,6 +10,7 @@ subcategory: 'Film & Theater'
     'Cannes Film Festival',
     'urban cinema',
   ]
+subcategory: 'Film & Theater'
 lastVerified: 2026-03-19
 featured: true
 ---

--- a/knowledge/en/People/yang-yung-wei-judo-olympic-silver.md
+++ b/knowledge/en/People/yang-yung-wei-judo-olympic-silver.md
@@ -3,7 +3,6 @@ title: 'Yang Yung-Wei'
 description: "Taiwan judoka who won silver medal in men's 60kg at 2021 Tokyo Olympics, Taiwan's first Olympic judo medal"
 date: 2026-03-20
 tags:
-subcategory: 'Sports'
   [
     'people',
     'Yang Yung-Wei',
@@ -15,6 +14,7 @@ subcategory: 'Sports'
     'indigenous',
     'Paiwan',
   ]
+subcategory: 'Sports'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/yeh-kuo-yi-electronics-manufacturing-pioneer.md
+++ b/knowledge/en/People/yeh-kuo-yi-electronics-manufacturing-pioneer.md
@@ -3,8 +3,8 @@ title: 'Yeh Kuo-Yi'
 description: "Founder of Inventec Group, pioneer of Taiwan's electronics contract manufacturing industry, laptop computer manufacturing giant"
 date: 2026-03-20
 tags:
-subcategory: 'Tech & Business'
   ['Inventec', 'Electronics Contract Manufacturing', 'ODM', 'Laptop Computers']
+subcategory: 'Tech & Business'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/yung-ching-wang-formosa-plastics-founder.md
+++ b/knowledge/en/People/yung-ching-wang-formosa-plastics-founder.md
@@ -3,7 +3,6 @@ title: "Y.C. Wang: From Rice Shop to Petrochemical Empire - Taiwan's Management 
 description: "The legendary entrepreneur who built Formosa Plastics Group from humble beginnings, becoming Taiwan's most revered business leader and industrial pioneer"
 date: 2026-03-20
 tags:
-subcategory: 'Tech & Business'
   [
     'Y.C. Wang',
     'Formosa Plastics',
@@ -11,6 +10,7 @@ subcategory: 'Tech & Business'
     'petrochemicals',
     'entrepreneurship',
   ]
+subcategory: 'Tech & Business'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/zhong-lihe-nativeland-eternal-seeker.md
+++ b/knowledge/en/People/zhong-lihe-nativeland-eternal-seeker.md
@@ -3,7 +3,6 @@ title: 'Zhong Lihe: The Eternal Seeker of Nativeland'
 description: "Author of 'The Man from Nativeland', revered as the Father of Taiwan Literature, a literary warrior who persisted in writing despite poverty and illness"
 date: 2026-03-20
 tags:
-subcategory: 'Literature'
   [
     people,
     Zhong Lihe,
@@ -12,6 +11,7 @@ subcategory: 'Literature'
     Li Mountain Farm,
     nativist literature,
   ]
+subcategory: 'Literature'
 lastVerified: 2026-03-20
 ---
 

--- a/knowledge/en/People/陳偉殷.md
+++ b/knowledge/en/People/陳偉殷.md
@@ -1,6 +1,6 @@
 ---
 title: 'Wei-Yin Chen'
-description: 'The left-hander who signed Taiwan's highest sports contract but only received 47% of the money'
+description: "The left-hander who signed Taiwan's highest sports contract but only received 47% of the money"
 date: 2026-03-22
 tags: [people, baseball, sports, professional athlete, MLB, NPB]
 subcategory: 'Sports'

--- a/knowledge/en/People/齊柏林.md
+++ b/knowledge/en/People/齊柏林.md
@@ -1,6 +1,6 @@
 ---
 title: 'Chi Po-lin'
-description: 'How a civil servant who couldn't afford helicopters on his salary mortgaged his house to create Taiwan's most successful documentary'
+description: "How a civil servant who couldn't afford helicopters on his salary mortgaged his house to create Taiwan's most successful documentary"
 date: 2026-03-22
 tags: [People, Chi Po-lin, Documentary, Beyond Beauty Taiwan from Above, Director, Photographer, Aerial Photography, Environment]
 category: 'People'


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

兩類問題導致 gray-matter 解析中斷，使分頁只顯示部分文章：

1. tags/subcategory 欄位順序錯置（56 個檔案）
   - tags: 後直接接 subcategory: 再接陣列，造成無效 YAML
   - 修正為 tags: [array] 在前，subcategory: 在後 
2. 單引號字串內含直引號（8 個檔案）
   - 含 \' 或 Taiwan's / couldn't 等 apostrophe 的 description/title
   - 改用雙引號包裹解決

修復後英文 People 分頁從 4 篇恢復為完整的 122 篇

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [ ] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #209

## 📸 截圖（如果是視覺改動）
無
