### PR TITLE
feat(search): 支援單字搜尋（prefix match）

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -565,12 +565,7 @@ const jfClass = [
               '<div class="search-hint">' + hintEmpty + '</div>';
             return;
           }
-          // Require at least 2 chars to search (avoids noisy single-char queries)
-          if (q.length < 2) {
-            results.innerHTML =
-              '<div class="search-hint">' + hintEmpty + '</div>';
-            return;
-          }
+          // Single-char queries are handled by prefix match
           if (_searchMode === 'loading') {
             results.innerHTML =
               '<div class="search-hint">' +


### PR DESCRIPTION
## 改了什麼

在 MiniSearch 搜尋加入 `prefix: true`，讓單個中/英文字也能搜到結果。

**改動只有 1 行**（Layout.astro）。

## 原理

目前索引用 bigram tokens（「齊柏」「柏林」），搜「齊」時找不到完全匹配的 token。
加了 prefix match 後，「齊」會匹配「齊柏」這個 token 的前綴，就能命中齊柏林的文章。

## 搜尋效果

| 查詢 | 之前 | 之後 |
|------|------|------|
| 齊 | ❌ 無結果 | ✅ 命中齊柏林相關文章 |
| 台 | ❌ 無結果 | ✅ 命中含「台灣」「台北」的文章 |
| A | ❌ 無結果 | ✅ 命中英文文章 |
| 珍珠奶茶 | ✅ 正常 | ✅ 不受影響 |

## 不影響

- 索引不需重建，build time 不變
- MiniSearch bundle size 不變
- 多字搜尋行為不變，BM25 排序 + 2% 分數門檻仍有效過濾低相關結果

## 測試方式

```bash
npm run prebuild
npm run dev
# 開搜尋 (Cmd+K)，輸入單個字測試
```

Ref: #207 (comment) by @frank890417