### PR TITLE
fix: keep header fixed across pages

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -460,7 +460,7 @@ const categoryList = [
       });
     });
 
-    // If banner is visible on homepage, offset the fixed header below it
+    // Keep the header below the language banner on homepage only.
     const isHero = header.hasAttribute('data-hero');
     if (isHero) {
       const banner = document.getElementById('lang-banner');
@@ -555,11 +555,13 @@ const categoryList = [
   }
 
   /* =============================================
-     HEADER — FIXED OVERLAY
+     HEADER — GLOBAL FIXED BAR
   ============================================= */
   header {
-    position: sticky;
+    position: fixed;
     top: 0;
+    left: 0;
+    right: 0;
     z-index: 100;
     background: var(--header-bg);
     backdrop-filter: blur(var(--header-blur));
@@ -570,12 +572,6 @@ const categoryList = [
       backdrop-filter 0.45s cubic-bezier(0.4, 0, 0.2, 1),
       border-color 0.45s cubic-bezier(0.4, 0, 0.2, 1),
       box-shadow 0.45s cubic-bezier(0.4, 0, 0.2, 1);
-  }
-  /* Homepage: fixed overlay so hero flows behind */
-  header[data-hero] {
-    position: fixed;
-    left: 0;
-    right: 0;
   }
   .header-inner {
     max-width: var(--container-wide);

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -36,10 +36,13 @@ const {
 // Search index now loaded via /api/search-index.json (fetch API)
 const isEn = lang === 'en';
 const categorySlug = category?.toLowerCase() || '';
+const currentPath = Astro.url.pathname.replace(/\/$/, '') || '/';
+const isHome = currentPath === '/' || currentPath === '/en';
 // justfont: only put the body font class on <body> to avoid rate-limit.
 // Other font classes go on specific elements (h1-h6, blockquote, nav, etc.)
 const jfClass = [
   'jf-jinxuanlatte-regular',
+  isHome ? 'page-home' : 'page-default',
   categorySlug ? `jf-${categorySlug}` : '',
 ]
   .filter(Boolean)
@@ -888,6 +891,9 @@ const jfClass = [
     max-width: 100vw;
     overflow-x: hidden;
   }
+  body.page-default main {
+    padding-top: 56px;
+  }
   main img {
     max-width: 100%;
     max-height: 400px;
@@ -957,6 +963,9 @@ const jfClass = [
   @media (max-width: 768px) {
     html {
       font-size: 100%;
+    }
+    body.page-default main {
+      padding-top: 52px;
     }
     .floating-md {
       bottom: 1rem;


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

目前並非所有頁面的導航列都會隨畫面捲動，導致在不同頁面間切換較不方便
不確定這是否為預期設計，此 PR 將各頁面的導航列行為統一成可隨頁面捲動，以改善操作體驗
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

<!-- 可選：貼上前後對比截圖 -->
ex:
https://github.com/user-attachments/assets/fb6088a3-ff42-4d15-af47-c75645e9b4b7

fixed:
https://github.com/user-attachments/assets/9c3d63e9-eff2-46cc-b7d1-d3b1c9d697fd





