### PR TITLE
fix: fetch full git history for accurate revision counts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- `deploy.yml` 的 `fetch-depth: 2` 改為 `fetch-depth: 0`，讓 build 環境有完整 git history

## 原因

`fetch-depth: 2` 讓 GitHub Actions 只 clone 最近 2 個 commit，導致 `git log` 在 build 時只看到 2 筆歷史。文章的 `revisionCount`、`contributors` 在部署後全部不正確。

實測驗證：齊柏林本地有 9 個 commit，但 `fetch-depth: 2` 只看到 2 個。

這是 Astro 靜態站用 `git log` 追蹤修改歷史時的[已知陷阱](https://github.com/actions/checkout#checkout-v4)。

## 改動

1 個檔案、1 行：`fetch-depth: 2` → `fetch-depth: 0`

## 副作用

CI clone 時間會稍微增加（需下載完整 git history），但對 ~930 篇文章的 repo 影響有限。

Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)