### PR TITLE
fix: en discovery page spacing

### DIFF
--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -118,6 +118,8 @@ const readingPathFooterItems = [
 
   <CoverStory />
 
+  <RandomDiscovery articlesJson={randomArticlesData} />
+
   <FeatureCards
     lang="en"
     sectionTitle="Why Taiwan.md?"
@@ -148,8 +150,6 @@ const readingPathFooterItems = [
       },
     ]}
   />
-
-  <RandomDiscovery articlesJson={randomArticlesData} />
 
   <ReadingPath
     lang="en"


### PR DESCRIPTION
## 問題

修復 #228

英文首頁（`/en/`）的 discovery 區塊有異常的垂直間距。原因是 `en/index.astro` 裡 `FeatureCards` 放在 `RandomDiscovery` 前面，兩個元件的 margin 疊加（5rem + 4rem = 9rem），造成過大的空白。

## 修正

調換 `RandomDiscovery` 和 `FeatureCards` 的順序，與中文版一致。只改一行，不動 CSS。

## 驗證

- `npm run build` 通過（933 頁，所有分類正常）