### PR TITLE
fix: restore markdown typography and line breaks in article/hub pages

### DIFF
--- a/src/pages/[category]/[slug].astro
+++ b/src/pages/[category]/[slug].astro
@@ -311,6 +311,7 @@ renderer.image = ({ href, title, text }) => {
 
 const processedContent = marked.parse(resolveWikilinks(content), {
   renderer,
+  breaks: true,
 }) as string;
 
 // ── Estimate reading time if not in frontmatter ────────────────────────────────

--- a/src/pages/[category]/index.astro
+++ b/src/pages/[category]/index.astro
@@ -223,7 +223,7 @@ hubRenderer.link = ({ href, title, text }) => {
   return `<a href="${h}"${titleAttr}>${text}</a>`;
 };
 const rawHubHtml = resolvedContent
-  ? marked.parse(resolvedContent, { renderer: hubRenderer })
+  ? marked.parse(resolvedContent, { renderer: hubRenderer, breaks: true })
   : '';
 
 // Post-process: add callout/pull-quote classes to blockquotes
@@ -813,10 +813,10 @@ const otherCategories = categories
     max-width: 840px;
     margin: 0 auto;
   }
-  .hub-prose > h1:first-child {
+  .hub-prose :global(h1:first-child) {
     display: none;
   }
-  .hub-prose > blockquote:first-child {
+  .hub-prose :global(blockquote:first-child) {
     font-size: 1.15rem;
     font-style: normal;
     font-weight: 600;
@@ -828,7 +828,7 @@ const otherCategories = categories
     color: #2d5016;
     line-height: 1.9;
   }
-  .hub-prose blockquote {
+  .hub-prose :global(blockquote) {
     border-left: 4px solid #4a7c28;
     background: linear-gradient(to right, rgba(26, 60, 52, 0.04), transparent);
     margin: 2.5rem 0;
@@ -838,7 +838,7 @@ const otherCategories = categories
     color: #3a4f44;
     font-size: 1.05rem;
   }
-  .hub-prose blockquote p {
+  .hub-prose :global(blockquote p) {
     margin-bottom: 0;
   }
 
@@ -898,7 +898,7 @@ const otherCategories = categories
     border-radius: 2px;
   }
 
-  .hub-prose h2 {
+  .hub-prose :global(h2) {
     font-size: var(--title-subsection-size);
     font-weight: 800;
     margin: 4rem 0 1.2rem;
@@ -909,7 +909,7 @@ const otherCategories = categories
     line-height: var(--title-line-height);
     font-family: var(--font-editorial);
   }
-  .hub-prose h3 {
+  .hub-prose :global(h3) {
     font-size: var(--title-minor-size);
     font-weight: 700;
     margin: 3rem 0 0.75rem;
@@ -918,33 +918,33 @@ const otherCategories = categories
     letter-spacing: 0.02em;
     font-family: var(--font-editorial);
   }
-  .hub-prose p {
+  .hub-prose :global(p) {
     margin: 1.1rem 0;
     text-align: justify;
     color: #2c2c2c;
   }
-  .hub-prose ul {
+  .hub-prose :global(ul) {
     list-style: disc;
     padding-left: 1.5rem;
     margin-bottom: 1.1rem;
   }
-  .hub-prose ol {
+  .hub-prose :global(ol) {
     list-style: decimal;
     padding-left: 1.5rem;
     margin-bottom: 1.1rem;
   }
-  .hub-prose li {
+  .hub-prose :global(li) {
     margin-bottom: 0.3rem;
     line-height: 1.65;
   }
-  .hub-prose a {
+  .hub-prose :global(a) {
     color: #334155;
     text-decoration: none;
     border-bottom: 1.5px solid #94a3b8;
     padding-bottom: 1px;
     transition: all 0.2s;
   }
-  .hub-prose a:hover {
+  .hub-prose :global(a:hover) {
     color: #1a1a2e;
     border-bottom-color: #1a1a2e;
   }
@@ -995,7 +995,7 @@ const otherCategories = categories
     font-size: inherit;
   }
 
-  .hub-prose img {
+  .hub-prose :global(img) {
     width: 100%;
     max-height: 480px;
     object-fit: cover;
@@ -1003,26 +1003,26 @@ const otherCategories = categories
     margin: 2rem 0;
     box-shadow: 0 4px 24px rgba(26, 60, 52, 0.1);
   }
-  .hub-prose img.img-broken {
+  .hub-prose :global(img.img-broken) {
     min-height: 120px;
     background: rgba(26, 60, 52, 0.04);
     border: 2px dashed rgba(26, 60, 52, 0.15);
     border-radius: 12px;
   }
-  .hub-prose em {
+  .hub-prose :global(em) {
     font-size: 0.85rem;
     color: #64748b;
     display: block;
     text-align: center;
     margin: -1rem 0 1.5rem;
   }
-  .hub-prose table {
+  .hub-prose :global(table) {
     width: 100%;
     border-collapse: collapse;
     margin: 2rem 0;
     font-size: 0.9rem;
   }
-  .hub-prose th {
+  .hub-prose :global(th) {
     background: rgba(26, 60, 52, 0.05);
     color: #1a3c34;
     font-weight: 600;
@@ -1030,19 +1030,19 @@ const otherCategories = categories
     padding: 0.75rem 1rem;
     border-bottom: 2px solid rgba(26, 60, 52, 0.12);
   }
-  .hub-prose td {
+  .hub-prose :global(td) {
     padding: 0.65rem 1rem;
     border-bottom: 1px solid rgba(26, 60, 52, 0.06);
     color: #3a4f44;
   }
-  .hub-prose tr:hover td {
+  .hub-prose :global(tr:hover td) {
     background: rgba(26, 60, 52, 0.02);
   }
-  .hub-prose strong {
+  .hub-prose :global(strong) {
     font-weight: 700;
     color: #1a3c34;
   }
-  .hub-prose hr {
+  .hub-prose :global(hr) {
     border: none;
     border-top: 1px solid rgba(26, 60, 52, 0.1);
     margin: 3rem 0;

--- a/src/pages/en/[category]/[slug].astro
+++ b/src/pages/en/[category]/[slug].astro
@@ -352,6 +352,7 @@ renderer.image = ({ href, title, text }) => {
 
 const processedContent = marked.parse(resolveWikilinks(content), {
   renderer,
+  breaks: true,
 }) as string;
 
 // ── Reading time ───────────────────────────────────────────────────────────────

--- a/src/pages/en/[category]/index.astro
+++ b/src/pages/en/[category]/index.astro
@@ -214,7 +214,7 @@ function enrichBlockquotes(html: string): string {
   );
 }
 
-const rawHubHtml = resolvedContent ? marked.parse(resolvedContent, { renderer: hubRenderer }) : '';
+const rawHubHtml = resolvedContent ? marked.parse(resolvedContent, { renderer: hubRenderer, breaks: true }) : '';
 const hubHtml = enrichBlockquotes(rawHubHtml as string);
 
 const lang = getLangFromUrl(Astro.url);
@@ -519,10 +519,10 @@ const otherCategories = categories
     max-width: 720px;
     margin: 0 auto;
   }
-  .hub-prose > h1:first-child {
+  .hub-prose :global(h1:first-child) {
     display: none;
   }
-  .hub-prose > blockquote:first-child {
+  .hub-prose :global(blockquote:first-child) {
     font-size: 1.15rem;
     font-style: normal;
     font-weight: 600;
@@ -534,7 +534,7 @@ const otherCategories = categories
     color: #2d5016;
     line-height: 1.9;
   }
-  .hub-prose blockquote {
+  .hub-prose :global(blockquote) {
     border-left: 4px solid #4a7c28;
     background: linear-gradient(to right, rgba(26, 60, 52, 0.04), transparent);
     margin: 2.5rem 0;
@@ -544,7 +544,7 @@ const otherCategories = categories
     color: #3a4f44;
     font-size: 1.05rem;
   }
-  .hub-prose blockquote p {
+  .hub-prose :global(blockquote p) {
     margin-bottom: 0;
   }
 
@@ -626,7 +626,7 @@ const otherCategories = categories
     color: #2d5016;
   }
 
-  .hub-prose h2 {
+  .hub-prose :global(h2) {
     font-size: 1.5rem;
     font-weight: 700;
     margin: 4rem 0 1.2rem;
@@ -635,38 +635,38 @@ const otherCategories = categories
     border-bottom: 2px solid #e2e8f0;
     letter-spacing: 0.02em;
   }
-  .hub-prose h3 {
+  .hub-prose :global(h3) {
     font-size: 1.2rem;
     font-weight: 600;
     margin: 3rem 0 0.75rem;
     color: #334155;
   }
-  .hub-prose p {
+  .hub-prose :global(p) {
     margin: 1.2rem 0;
     text-align: justify;
   }
-  .hub-prose ul,
-  .hub-prose ol {
+  .hub-prose :global(ul),
+  .hub-prose :global(ol) {
     padding-left: 2rem;
     margin: 1rem 0;
     list-style-position: inside;
   }
-  .hub-prose li {
+  .hub-prose :global(li) {
     margin: 0.5rem 0;
     line-height: 1.8;
   }
-  .hub-prose a {
+  .hub-prose :global(a) {
     color: #334155;
     text-decoration: none;
     border-bottom: 1.5px solid #94a3b8;
     padding-bottom: 1px;
     transition: all 0.2s;
   }
-  .hub-prose a:hover {
+  .hub-prose :global(a:hover) {
     color: #1a1a2e;
     border-bottom-color: #1a1a2e;
   }
-  .hub-prose img {
+  .hub-prose :global(img) {
     max-width: 100%;
     max-height: 400px;
     object-fit: cover;
@@ -675,37 +675,37 @@ const otherCategories = categories
     display: block;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   }
-  .hub-prose em {
+  .hub-prose :global(em) {
     font-size: 0.85rem;
     color: #64748b;
     display: block;
     text-align: center;
     margin: -1rem 0 1.5rem;
   }
-  .hub-prose table {
+  .hub-prose :global(table) {
     width: 100%;
     border-collapse: collapse;
     margin: 1.5rem 0;
     font-size: 0.95rem;
   }
-  .hub-prose th,
-  .hub-prose td {
+  .hub-prose :global(th),
+  .hub-prose :global(td) {
     padding: 0.75rem 1rem;
     border: 1px solid #e2e8f0;
     text-align: left;
   }
-  .hub-prose th {
+  .hub-prose :global(th) {
     background: #f8fafc;
     font-weight: 600;
     color: #1e293b;
   }
-  .hub-prose tr:hover {
+  .hub-prose :global(tr:hover) {
     background: #f8fafc;
   }
-  .hub-prose strong {
+  .hub-prose :global(strong) {
     color: #1e293b;
   }
-  .hub-prose hr {
+  .hub-prose :global(hr) {
     border: none;
     border-top: 1px solid #e2e8f0;
     margin: 2.5rem 0;


### PR DESCRIPTION
## Summary

- Add `breaks: true` to all four `marked.parse` calls so single newlines in markdown render as `<br>` instead of collapsing to spaces
- Wrap all `.hub-prose` descendant CSS selectors with `:global()` so styles apply to HTML injected via `set:html` — Astro scopes non-global rules, which was silently preventing all paragraph spacing, heading margins, blockquotes, images, tables, and link styles from applying on category hub pages

## Root cause

Astro compiles scoped styles like `.hub-prose p { margin: 1.1rem 0 }` into `.hub-prose[data-astro-cid-xxx] p[data-astro-cid-xxx]`, requiring both the container and child elements to have the scoping attribute. Elements injected via `set:html` don't receive this attribute, so all typography rules were ignored. The fix mirrors how the article pages already correctly use `.prose :global(p)`.

## Test plan

- [x] Visit `/history/` — headings, paragraph spacing, blockquotes and image captions should render correctly
- [x] Visit `/en/history/` — same check for English hub pages
- [x] Open any article page (e.g. `/history/二二八事件`) — single line breaks in blockquotes and captions render as `<br>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)