### PR TITLE
ci: automate article creation from content issues

### DIFF
--- a/.github/scripts/extract-article.js
+++ b/.github/scripts/extract-article.js
@@ -1,0 +1,442 @@
+const fs = require('fs');
+
+const ALLOWED_CATEGORIES = new Set([
+  'Art',
+  'Culture',
+  'Economy',
+  'Food',
+  'Geography',
+  'History',
+  'Lifestyle',
+  'Music',
+  'Nature',
+  'People',
+  'Society',
+  'Technology',
+]);
+
+function getTodayDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function setOutput(name, value) {
+  fs.appendFileSync(process.env.GITHUB_OUTPUT, `${name}<<EOF\n${value}\nEOF\n`);
+}
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function failValidation(messages) {
+  const normalizedMessages = messages
+    .filter(Boolean)
+    .map((message) => String(message).trim().replace(/^-\s+/, ''));
+  fail(normalizedMessages.map((message) => `- ${message}`).join('\n'));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractSection(bodyText, label, nextLabels = []) {
+  const normalized = bodyText.replace(/\r\n/g, '\n');
+  const nextSectionPattern = nextLabels.length
+    ? `(?=\\n###\\s*(?:${nextLabels.map(escapeRegExp).join('|')})\\s*\\n|$)`
+    : '(?=$)';
+  const pattern = new RegExp(
+    `###\\s*${escapeRegExp(label)}\\s*\\n([\\s\\S]*?)${nextSectionPattern}`,
+  );
+  const match = normalized.match(pattern);
+  return match ? match[1].trim() : '';
+}
+
+function extractFrontmatterTitle(markdown) {
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  const frontmatterMatch = normalized.match(/^---\n([\s\S]*?)\n---/);
+
+  if (!frontmatterMatch) {
+    return '';
+  }
+
+  const titleMatch = frontmatterMatch[1].match(
+    /^title:\s*["']?(.+?)["']?\s*$/m,
+  );
+  return titleMatch ? titleMatch[1].trim() : '';
+}
+
+function unquote(value) {
+  const trimmed = value.trim();
+  if (
+    (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).trim();
+  }
+  return trimmed;
+}
+
+function normalizeCategory(rawCategory) {
+  const cleaned = unquote(rawCategory || '')
+    .replace(/\s*\(.*?\)\s*$/, '')
+    .trim();
+  return ALLOWED_CATEGORIES.has(cleaned) ? cleaned : '';
+}
+
+function parseTagsValue(rawValue) {
+  if (!rawValue) {
+    return null;
+  }
+
+  const trimmed = rawValue.trim();
+  if (!trimmed) {
+    return [];
+  }
+
+  const normalizeTagItem = (item) => {
+    let normalized = item.trim();
+
+    for (let index = 0; index < 3; index += 1) {
+      const unescaped = normalized
+        .replace(/^\\(["'])/, '$1')
+        .replace(/\\(["'])$/, '$1')
+        .trim();
+
+      const unquoted = unquote(unescaped).trim();
+      if (unquoted === normalized) {
+        break;
+      }
+
+      normalized = unquoted;
+    }
+
+    return normalized;
+  };
+
+  if (trimmed.startsWith('[') && trimmed.endsWith(']')) {
+    const inner = trimmed.slice(1, -1).trim();
+    if (!inner) {
+      return [];
+    }
+
+    return inner
+      .split(',')
+      .map((item) => normalizeTagItem(item))
+      .filter(Boolean);
+  }
+
+  return trimmed
+    .split(',')
+    .map((item) => normalizeTagItem(item))
+    .filter(Boolean);
+}
+
+function formatFrontmatterValue(key, value) {
+  if (key === 'tags') {
+    return JSON.stringify(value);
+  }
+
+  if (key === 'featured') {
+    return value ? 'true' : 'false';
+  }
+
+  if (key === 'date' && /^\d{4}-\d{2}-\d{2}$/.test(String(value))) {
+    return String(value);
+  }
+
+  if (typeof value === 'number' || /^\d+(\.\d+)?$/.test(String(value))) {
+    return String(value);
+  }
+
+  if (value === 'true' || value === 'false') {
+    return value;
+  }
+
+  return JSON.stringify(value);
+}
+
+function normalizeUnknownFrontmatterValue(value) {
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return '';
+  }
+
+  if (trimmed === 'true' || trimmed === 'false') {
+    return trimmed;
+  }
+
+  if (/^\d+(\.\d+)?$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  return unquote(trimmed);
+}
+
+function parseFrontmatter(markdown) {
+  const normalized = markdown.replace(/\r\n/g, '\n');
+  const frontmatterMatch = normalized.match(
+    /^---\n([\s\S]*?)\n---\n?([\s\S]*)$/,
+  );
+
+  if (!frontmatterMatch) {
+    return null;
+  }
+
+  const rawFrontmatter = frontmatterMatch[1];
+  const body = frontmatterMatch[2] || '';
+  const lines = rawFrontmatter.split('\n');
+  const entries = [];
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+
+    if (!line.trim()) {
+      continue;
+    }
+
+    const keyMatch = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.*)$/);
+    if (!keyMatch) {
+      fail(`frontmatter 格式無法解析：${line}`);
+    }
+
+    const key = keyMatch[1];
+    let value = keyMatch[2];
+
+    if (value === '' && key === 'tags') {
+      const tagLines = [];
+      let nextIndex = index + 1;
+      while (nextIndex < lines.length) {
+        const listMatch = lines[nextIndex].match(/^\s*-\s*(.+)\s*$/);
+        if (!listMatch) {
+          break;
+        }
+        tagLines.push(listMatch[1]);
+        nextIndex += 1;
+      }
+      value = `[${tagLines.join(', ')}]`;
+      index = nextIndex - 1;
+    }
+
+    entries.push({ key, value });
+  }
+
+  return { entries, body };
+}
+
+function normalizeArticleContent(content, today = getTodayDate()) {
+  const parsed = parseFrontmatter(content);
+  if (!parsed) {
+    fail('文章內容必須以 frontmatter 開頭，且至少包含 title 與 description');
+  }
+
+  const entryMap = new Map(
+    parsed.entries.map((entry) => [entry.key, entry.value]),
+  );
+  const title = unquote(entryMap.get('title') || '');
+  const description = unquote(entryMap.get('description') || '');
+  const errors = [];
+
+  if (!title) {
+    errors.push('frontmatter 缺少必要欄位：title');
+  }
+
+  if (!description) {
+    errors.push('frontmatter 缺少必要欄位：description');
+  }
+
+  const normalizedCategory = normalizeCategory(entryMap.get('category') || '');
+
+  if (!normalizedCategory) {
+    errors.push(
+      `frontmatter 缺少有效的 category，必須是以下其中一種：${Array.from(ALLOWED_CATEGORIES).join(', ')}`,
+    );
+  }
+
+  if (errors.length > 0) {
+    failValidation(errors);
+  }
+
+  const tags = parseTagsValue(entryMap.get('tags'));
+  const featuredValue = false;
+
+  const normalizedEntries = [
+    ['title', title],
+    ['description', description],
+    [
+      'author',
+      unquote(entryMap.get('author') || '') || 'Taiwan.md Contributors',
+    ],
+    ['date', unquote(entryMap.get('date') || '') || today],
+  ];
+
+  if (tags !== null) {
+    normalizedEntries.push(['tags', tags]);
+  }
+
+  normalizedEntries.push(['category', normalizedCategory]);
+  normalizedEntries.push(['featured', featuredValue]);
+
+  const consumedKeys = new Set([
+    'title',
+    'description',
+    'author',
+    'date',
+    'tags',
+    'category',
+    'featured',
+    'feature',
+  ]);
+
+  for (const entry of parsed.entries) {
+    if (consumedKeys.has(entry.key)) {
+      continue;
+    }
+    normalizedEntries.push([
+      entry.key,
+      normalizeUnknownFrontmatterValue(entry.value),
+    ]);
+  }
+
+  const frontmatter = normalizedEntries
+    .map(([key, value]) => `${key}: ${formatFrontmatterValue(key, value)}`)
+    .join('\n');
+
+  const normalizedBody = parsed.body.replace(/^\n+/, '');
+  return {
+    content: `---\n${frontmatter}\n---\n\n${normalizedBody}`,
+    articleTitle: title,
+    category: normalizedCategory,
+  };
+}
+
+function slugifyArticleTitle(title, fallback) {
+  const slug = String(title || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9\u4e00-\u9fff\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return slug || fallback;
+}
+
+function extractArticleFromIssue(issue) {
+  if (!issue) {
+    fail('找不到 issue payload');
+  }
+
+  const body = issue.body || '';
+  const rawContent = extractSection(body, '文章內容 / Article Content', [
+    '參考資料 / Sources',
+  ]);
+  const categoryRaw = extractSection(body, '分類 / Category', [
+    '文章內容 / Article Content',
+  ]);
+  const errors = [];
+
+  if (!rawContent) {
+    errors.push('找不到「文章內容 / Article Content」欄位');
+  }
+
+  if (rawContent === '_No response_') {
+    errors.push('「文章內容 / Article Content」欄位是空的');
+  }
+
+  const issueCategory = normalizeCategory(categoryRaw);
+
+  if (!issueCategory) {
+    errors.push(
+      `issue 的「分類 / Category」無效，必須是以下其中一種：${Array.from(ALLOWED_CATEGORIES).join(', ')}`,
+    );
+  }
+
+  let normalizedArticle = null;
+  if (rawContent && rawContent !== '_No response_') {
+    try {
+      normalizedArticle = normalizeArticleContent(rawContent);
+    } catch (error) {
+      const message = error.message || String(error);
+      errors.push(
+        ...message
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean),
+      );
+    }
+  }
+
+  if (
+    normalizedArticle &&
+    issueCategory &&
+    normalizedArticle.category !== issueCategory
+  ) {
+    errors.push(
+      `issue 的分類 (${issueCategory}) 與 frontmatter 的 category (${normalizedArticle.category}) 必須相同`,
+    );
+  }
+
+  if (errors.length > 0) {
+    failValidation(errors);
+  }
+
+  const content = normalizedArticle.content;
+  const articleTitle = normalizedArticle.articleTitle;
+  const slug = slugifyArticleTitle(articleTitle, `article-${issue.number}`);
+  const dir = `knowledge/${normalizedArticle.category}`;
+  const filename = `${slug}.md`;
+  const filepath = `${dir}/${filename}`;
+  const branch = `content/issue-${issue.number}-article`;
+
+  if (fs.existsSync(filepath)) {
+    failValidation([`檔案已存在，無法建立：${filepath}`]);
+  }
+
+  return {
+    content,
+    articleTitle,
+    category: normalizedArticle.category,
+    dir,
+    filename,
+    filepath,
+    branch,
+  };
+}
+
+function main() {
+  try {
+    const issuePath = process.env.GITHUB_EVENT_PATH;
+    if (!issuePath) {
+      fail('找不到 GITHUB_EVENT_PATH');
+    }
+
+    const event = JSON.parse(fs.readFileSync(issuePath, 'utf8'));
+    const extracted = extractArticleFromIssue(event.issue);
+
+    setOutput('content', extracted.content);
+    setOutput('article_title', extracted.articleTitle);
+    setOutput('category', extracted.category);
+    setOutput('dir', extracted.dir);
+    setOutput('filename', extracted.filename);
+    setOutput('filepath', extracted.filepath);
+    setOutput('branch', extracted.branch);
+  } catch (error) {
+    console.error(error.message || error);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  ALLOWED_CATEGORIES,
+  extractArticleFromIssue,
+  extractSection,
+  extractFrontmatterTitle,
+  normalizeArticleContent,
+  normalizeCategory,
+  parseTagsValue,
+  slugifyArticleTitle,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/.github/workflows/create-article-from-issue.yml
+++ b/.github/workflows/create-article-from-issue.yml
@@ -1,0 +1,92 @@
+name: Create article from content issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  create-article:
+    if: contains(github.event.issue.labels.*.name, 'content')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract article content from issue form
+        id: extract
+        shell: bash
+        run: |
+          error_log="$(mktemp)"
+          if ! node .github/scripts/extract-article.js 2>"$error_log"; then
+            {
+              echo "message<<EOF"
+              cat "$error_log"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+            rm -f "$error_log"
+            exit 1
+          fi
+          rm -f "$error_log"
+
+      - name: Create markdown file
+        run: |
+          mkdir -p "${{ steps.extract.outputs.dir }}"
+          cat > "${{ steps.extract.outputs.filepath }}" <<'EOF'
+          ${{ steps.extract.outputs.content }}
+          EOF
+
+      - name: Create pull request
+        id: create-pull-request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          branch: ${{ steps.extract.outputs.branch }}
+          commit-message: "article: ${{ steps.extract.outputs.article_title }}"
+          title: "article: ${{ steps.extract.outputs.article_title }}"
+          body: |
+            此 PR 由內容提案 issue 自動產生。
+
+            對應 issue：#${{ github.event.issue.number }} ${{ github.event.issue.title }}
+
+            產生檔案：`${{ steps.extract.outputs.filepath }}`
+
+            Closes #${{ github.event.issue.number }}
+          labels: |
+            content
+            automated pr
+          delete-branch: true
+
+      - name: Comment on issue
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const prNumber = "${{ steps.create-pull-request.outputs.pull-request-number }}";
+            if (prNumber) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body: `已根據 issue 內容建立檔案並開啟 PR：#${prNumber}`
+              });
+            }
+
+      - name: Comment error on issue
+        if: failure() && steps.extract.outcome == 'failure'
+        uses: actions/github-script@v7
+        env:
+          ERROR_MESSAGE: ${{ steps.extract.outputs.message }}
+        with:
+          script: |
+            const errorMessage = process.env.ERROR_MESSAGE || '未知錯誤';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `建立文章失敗，錯誤訊息如下：\n\n\`\`\`\n${errorMessage}\n\`\`\`\n\n請直接修改這個 issue 的內容，儲存後會自動重新執行。`
+            });


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

這個 PR 加入 create-article-from-issue github action，用來直接將 issue 發起的文章轉為 PR，可以在 https://github.com/link1522/test-actions 這個 repo 中測試看看

說明如下:

## 用法

當使用者透過 issue 的 「文章提案 / Article Proposal」 模板直接建立文章提案時，這個 action 會立即執行檢查（可參考下方檢查項目）。若全部檢查通過，系統會自動建立 PR，並建立對應檔案；若未通過，則會在當前 issue 中留言說明未通過的原因。使用者可直接在該 issue 內修改內容，儲存後，action 便會再次執行檢查

## 觸發條件

- 在用戶開啟 issue，且 issue 上有 `content` tag
- 用戶修改帶有 `content` tag 的 issue

## 檢查項目

- `文章內容 / Article Content` 欄位為空時，會在 issue 留下明確錯誤訊息。
- 文章內容若沒有 frontmatter，會回報錯誤。
- frontmatter 缺少 `title` 時，會回報錯誤。
- frontmatter 缺少 `description` 時，會回報錯誤。
- frontmatter 的 `category` 不在允許清單時，會回報錯誤。
- issue 的分類與 frontmatter 的 `category` 不一致時，會回報錯誤。
- frontmatter `author` 未提供時，會自動補上 `Taiwan.md Contributors`。
- frontmatter `date` 未提供時，會自動補上執行當天日期。
- frontmatter `featured` 會被正規化為 `false`。
- frontmatter `tags` 可被正確轉為標準陣列格式。
- 創建的目標檔案是否已存在。

## 其他

- 文章檔會建立在 `knowledge/<category>/` 目錄下。
- 檔名會由文章標題 slugify 產生；若無法 slugify，會 fallback 為 `article-<issue-number>.md`。
- 成功時會自動建立 PR，PR 內容包含對應 issue 與產生檔案路徑。
- 成功時會在原 issue 留言告知 PR 編號。
- 驗證失敗時會在原 issue 留言，且提示可直接修改 issue 重新執行。
- 要啟用這個 action 需要開啟 Allow GitHub Actions to create and approve pull requests (位於 Settings > Actions > General)
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

<!-- 可選：貼上前後對比截圖 -->
