### PR TITLE
fix: 修正 contribute 頁面複製按鈕無法觸發的問題

### DIFF
--- a/src/templates/contribute.template.astro
+++ b/src/templates/contribute.template.astro
@@ -538,7 +538,7 @@ const t = useTranslations(lang);
 
         <div class="ai-prompt">
           <code>{t('contribute.token.oneline.prompt')}</code>
-          <button class="copy-btn" onclick="copyTranslatePrompt()"
+          <button class="copy-btn" data-copy="translate-prompt"
             >{t('contribute.copy.button')}</button
           >
         </div>
@@ -570,7 +570,7 @@ const t = useTranslations(lang);
             >bash &lt;(curl -s
             https://raw.githubusercontent.com/frank890417/taiwan-md/main/scripts/translate.sh)</code
           >
-          <button class="copy-btn" onclick="copyOneLine()"
+          <button class="copy-btn" data-copy="one-line-command"
             >{t('contribute.copy.button')}</button
           >
         </div>
@@ -705,29 +705,29 @@ const t = useTranslations(lang);
 
 <script is:inline define:vars={{ copiedText: '✅ 已複製', copyText: '📋 複製' }}
 >
-  function copyTranslatePrompt() {
-    const text =
-      '讀取 https://raw.githubusercontent.com/frank890417/taiwan-md/main/TRANSLATE_PROMPT.md 的完整內容，然後按照裡面的指示引導我翻譯一篇 Taiwan.md 文章。';
-    navigator.clipboard.writeText(text).then(() => {
-      const btn = event.target;
-      btn.textContent = copiedText;
-      setTimeout(() => {
-        btn.textContent = copyText;
-      }, 2000);
-    });
-  }
+  const copyTextMap = {
+    'translate-prompt':
+      '讀取 https://raw.githubusercontent.com/frank890417/taiwan-md/main/TRANSLATE_PROMPT.md 的完整內容，然後按照裡面的指示引導我翻譯一篇 Taiwan.md 文章。',
+    'one-line-command':
+      'bash <(curl -s https://raw.githubusercontent.com/frank890417/taiwan-md/main/scripts/translate.sh)',
+  };
 
-  function copyOneLine() {
-    const command =
-      'bash <(curl -s https://raw.githubusercontent.com/frank890417/taiwan-md/main/scripts/translate.sh)';
-    navigator.clipboard.writeText(command).then(() => {
-      const btn = event.target;
-      btn.textContent = copiedText;
+  document.querySelectorAll('[data-copy]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      const text = copyTextMap[button.dataset.copy];
+
+      if (!text) {
+        return;
+      }
+
+      await navigator.clipboard.writeText(text);
+      button.textContent = copiedText;
+
       setTimeout(() => {
-        btn.textContent = copyText;
+        button.textContent = copyText;
       }, 2000);
     });
-  }
+  });
 </script>
 
 <style>


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

這次修改修正了 contribute 頁面中兩個複製按鈕點擊後報 `copyTranslatePrompt is not defined`  與 `copyOneLine is not defined` 的問題，根因是 inline onclick 呼叫了未暴露到全域的函式。

  ## Changes

  - 移除 contribute 頁面兩個複製按鈕上的 inline onclick 呼叫
  - 為翻譯 prompt 與一鍵腳本按鈕加入 data-copy 標記，作為事件處理依據
  - 將複製內容整理成對應表，在同一段 script 中統一處理複製邏輯
  - 以 addEventListener 綁定按鈕點擊事件，取代 window 全域函式依賴
  
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

<img width="1816" height="711" alt="image" src="https://github.com/user-attachments/assets/9131fd9e-e675-4bb1-9329-fc8afb4f2a4e" />

<img width="1777" height="446" alt="image" src="https://github.com/user-attachments/assets/99e6a0c3-a2d6-486c-b5e3-8721d423fa4a" />

<!-- 可選：貼上前後對比截圖 -->
