### PR TITLE
fix: keep header above overlapping content

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -578,7 +578,7 @@ const categoryList = [
     top: 0;
     left: 0;
     right: 0;
-    z-index: 100;
+    z-index: 9999;
     width: 100%;
   }
 


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

增加 header z-index，避免被其他元素覆蓋
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

https://github.com/user-attachments/assets/350c548c-8e03-4b87-a3ec-e54b848f22e9



<!-- 可選：貼上前後對比截圖 -->
