### PR TITLE
fix: correct PTT article slug casing

### DIFF
--- a/public/api/dashboard-articles.json
+++ b/public/api/dashboard-articles.json
@@ -4220,7 +4220,7 @@
   },
   {
     "title": "PTT 批踢踢：台灣最頑固的公共廣場",
-    "slug": "ptt批踢踢",
+    "slug": "PTT批踢踢",
     "category": "technology",
     "subcategory": "社群與數位文化",
     "date": "2026-03-21",


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

監測 >  文章總覽表 中，"PTT 批踢踢：台灣最頑固的公共廣場" 文章連結錯誤，直接導向 404

slug 應改成 "PTT批踢踢"
(PTT 大寫)
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [ ] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

<!-- 可選：貼上前後對比截圖 -->
