### PR TITLE
fix: keep dashboard growth tooltip within chart bounds

### DIFF
--- a/src/templates/dashboard.template.astro
+++ b/src/templates/dashboard.template.astro
@@ -1272,6 +1272,7 @@ const isEn = lang === 'en';
 
     // Tooltip interaction
     const tooltip = document.getElementById('growth-tooltip');
+    const tooltipMargin = 12;
     container.querySelectorAll('.growth-dot-hover').forEach((el) => {
       el.addEventListener('mouseenter', function (e) {
         const idx = parseInt(this.dataset.idx, 10);
@@ -1279,13 +1280,33 @@ const isEn = lang === 'en';
         const mmdd = d.date.slice(5).replace('-', '/');
         tooltip.innerHTML = `<strong>${mmdd}</strong><br>+${d.daily} ${isEn ? 'new' : '新增'}<br>${isEn ? 'Total' : '累計'}: ${d.cumulative}`;
         tooltip.style.display = 'block';
+        tooltip.style.visibility = 'hidden';
         const cx = xPos(idx);
         const cy = yPos(d.cumulative);
-        tooltip.style.left = Math.min(cx, w - 100) + 'px';
-        tooltip.style.top = cy - 60 + 'px';
+        const tooltipWidth = tooltip.offsetWidth;
+        const tooltipHeight = tooltip.offsetHeight;
+        const minLeft = container.scrollLeft + tooltipMargin;
+        const maxLeft =
+          container.scrollLeft +
+          container.clientWidth -
+          tooltipWidth -
+          tooltipMargin;
+        const preferredLeft = cx + tooltipMargin;
+        const left = Math.max(minLeft, Math.min(preferredLeft, maxLeft));
+        const minTop = tooltipMargin;
+        const maxTop = chartH - tooltipHeight - tooltipMargin;
+        const preferredTop = cy - tooltipHeight - tooltipMargin;
+        const top =
+          preferredTop >= minTop
+            ? preferredTop
+            : Math.min(cy + tooltipMargin, maxTop);
+        tooltip.style.left = `${left}px`;
+        tooltip.style.top = `${Math.max(minTop, top)}px`;
+        tooltip.style.visibility = 'visible';
       });
       el.addEventListener('mouseleave', () => {
         tooltip.style.display = 'none';
+        tooltip.style.visibility = 'visible';
       });
     });
   }
@@ -1596,7 +1617,9 @@ const isEn = lang === 'en';
     if (insightsEl) {
       const brandShare =
         search.totals?.clicks > 0
-          ? Math.round(((search.brand?.clicks || 0) / search.totals.clicks) * 100)
+          ? Math.round(
+              ((search.brand?.clicks || 0) / search.totals.clicks) * 100,
+            )
           : 0;
       const successfulCrawls = cloudflare.aiCrawlers?.http200 || 0;
       insightsEl.innerHTML =
@@ -1619,20 +1642,18 @@ const isEn = lang === 'en';
             body: isEn
               ? `Only ${fmtNum(search.totals?.clicks)} clicks came in over the last 24h, and ${brandShare}% were brand searches. Discovery is still ahead of capture.`
               : `過去 24 小時只有 ${fmtNum(search.totals?.clicks)} 次點擊，其中 ${brandShare}% 仍是品牌詞。被看見的速度，仍快於被接住的速度。`,
-            meta:
-              opportunities[0]
-                ? `${opportunities[0].query} · ${fmtNum(opportunities[0].impressions)} imp · #${fmtRank(opportunities[0].position)}`
-                : '',
+            meta: opportunities[0]
+              ? `${opportunities[0].query} · ${fmtNum(opportunities[0].impressions)} imp · #${fmtRank(opportunities[0].position)}`
+              : '',
           },
           {
             title: isEn ? 'Edge + AI' : '邊緣與 AI',
             body: isEn
               ? `${fmtNum(cloudflare.aiCrawlers?.detectedRequests)} AI crawler requests arrived in the last 24h; ${fmtNum(successfulCrawls)} returned HTTP 200.`
               : `過去 24 小時 Cloudflare 看見 ${fmtNum(cloudflare.aiCrawlers?.detectedRequests)} 次 AI crawler 請求，其中 ${fmtNum(successfulCrawls)} 次成功拿到 HTTP 200。`,
-            meta:
-              cloudflare.aiCrawlers?.topCrawler
-                ? `${cloudflare.aiCrawlers.topCrawler.name} ${fmtNum(cloudflare.aiCrawlers.topCrawler.requests)} · ${cloudflare.aiCrawlers.topPath?.path || ''}`
-                : '',
+            meta: cloudflare.aiCrawlers?.topCrawler
+              ? `${cloudflare.aiCrawlers.topCrawler.name} ${fmtNum(cloudflare.aiCrawlers.topCrawler.requests)} · ${cloudflare.aiCrawlers.topPath?.path || ''}`
+              : '',
           },
         ]
           .map(
@@ -1758,8 +1779,7 @@ const isEn = lang === 'en';
         Spain: '🇪🇸',
         Italy: '🇮🇹',
       };
-      const maxUsers =
-        topCountries[0]?.requests || topCountries[0]?.users || 1;
+      const maxUsers = topCountries[0]?.requests || topCountries[0]?.users || 1;
       countriesEl.innerHTML =
         `<h3 class="subsection-title">${isEn ? '🌍 Edge Geography (24h)' : '🌍 邊緣流量地理（24h）'}</h3>` +
         '<div class="ga-countries-list">' +
@@ -2640,6 +2660,7 @@ const isEn = lang === 'en';
     pointer-events: none;
     z-index: 10;
     white-space: nowrap;
+    max-width: calc(100% - 24px);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   }
 


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

  這次 PR 修正 /dashboard 頁面成長時間軸圖表的 tooltip 定位問題。原本在靠近右側或上方的資料點 hover 時，tooltip 可能超出圖表可視範圍，導致內容被截斷或看不完整；現在會依 tooltip 實際尺寸與圖表可視邊界重新計算位置。

  ## Changes

  - 調整成長時間軸 tooltip 的定位邏輯，改為讀取 tooltip 實際寬高後再決定顯示位置
  - 針對左右邊界加入夾制，避免 tooltip 在圖表右側或水平捲動區域中超出可視範圍
  - 針對上下邊界加入夾制，優先顯示在資料點上方，空間不足時自動改顯示在下方
  - 補上 tooltip max-width，降低窄視窗下內容撐出容器的機率

  ## Impact

  - 影響範圍限定於 src/templates/dashboard.template.astro
  - 只影響 /dashboard 頁面成長時間軸的前端互動與顯示
  - 不影響 API、資料結構、權限、後端流程或建置設定
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

Before
![1775785100528](https://github.com/user-attachments/assets/eabeda3c-e7fe-4fe6-b6f8-a4960ae57e9f)

After
![1775785101960](https://github.com/user-attachments/assets/e552dd4d-0f8e-4d97-a143-6a18e6123346)


<!-- 可選：貼上前後對比截圖 -->
