### PR TITLE
fix: resolve contributor GitHub profile links from contributor metadata

### DIFF
--- a/src/components/ArticleSidebar.astro
+++ b/src/components/ArticleSidebar.astro
@@ -6,6 +6,8 @@
 import { useTranslatedPath, useTranslations } from '../i18n/utils';
 import type { Locale } from '../i18n/ui';
 
+type Contributor = string | { name: string; login: string };
+
 interface Props {
   title: string;
   tags?: string[];
@@ -14,7 +16,7 @@ interface Props {
   lastModified?: string;
   commitHash?: string;
   revisionCount?: number;
-  contributors?: string[];
+  contributors?: Contributor[];
   category: string;
   categoryName: string;
   categoryColor: string;
@@ -79,6 +81,12 @@ const hashLabel =
 const shareXLabel = lang === 'zh-TW' ? '分享到 X' : 'Share on X';
 const shareFBLabel = lang === 'zh-TW' ? '分享到 Facebook' : 'Share on Facebook';
 const shareLINELabel = lang === 'zh-TW' ? '分享到 LINE' : 'Share on LINE';
+
+const normalizedContributors = contributors.map((contributor) =>
+  typeof contributor === 'string'
+    ? { name: contributor, login: contributor }
+    : contributor,
+);
 ---
 
 <!--
@@ -350,20 +358,20 @@ const shareLINELabel = lang === 'zh-TW' ? '分享到 LINE' : 'Share on LINE';
 
   <!-- Contributors -->
   {
-    contributors.length > 0 && (
+    normalizedContributors.length > 0 && (
       <div class="border-b border-[rgba(26,60,52,0.08)] py-5 last:border-b-0">
         <p class="mb-[0.85rem] font-['Inter',system-ui,sans-serif] text-[0.67rem] font-bold uppercase tracking-[0.2em] text-[#9aa89e]">
           貢獻者
         </p>
         <div class="flex flex-wrap gap-[0.4rem]">
-          {contributors.map((name) => (
+          {normalizedContributors.map((contributor) => (
             <a
-              href={`https://github.com/${name}`}
+              href={`https://github.com/${contributor.login}`}
               target="_blank"
               rel="noopener noreferrer"
               class="rounded-full border border-[rgba(0,109,119,0.15)] bg-[rgba(0,109,119,0.07)] px-[0.6rem] py-[0.22rem] font-['Inter',system-ui,sans-serif] text-[0.75rem] text-[#006d77] no-underline transition-colors duration-150 hover:bg-[rgba(0,109,119,0.14)]"
             >
-              {name}
+              {contributor.name}
             </a>
           ))}
         </div>

--- a/src/pages/[category]/[slug].astro
+++ b/src/pages/[category]/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import { readdir, readFile } from 'fs/promises';
 import { resolve, join, basename } from 'path';
-import { execSync } from 'child_process';
 import matter from 'gray-matter';
 import Layout from '../../layouts/Layout.astro';
 import { marked } from 'marked';
@@ -18,75 +17,23 @@ import {
   getCategoryConfigs,
   type CategoryKey,
 } from '../../utils/categoryConfig';
+import {
+  buildGitInfoCache,
+  emptyGitInfo,
+  type GitInfo,
+} from '../../utils/contributors';
 
 // ── Git helpers ───────────────────────────────────────────────────────────────
-let _gitCache: Map<
-  string,
-  {
-    contributors: string[];
-    lastModified: string;
-    commitHash: string;
-    revisionCount: number;
-  }
-> | null = null;
+let _gitCache: Map<string, GitInfo> | null = null;
 
 function buildGitCache() {
   if (_gitCache) return _gitCache;
-  _gitCache = new Map();
-  try {
-    const logOutput = execSync(
-      `git log --full-history -z --name-only --format="COMMIT|%H|%aI|%an" -- "knowledge/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentHash = '';
-    let currentDate = '';
-    let currentAuthor = '';
-
-    // git log -z: commit headers and filenames are SEPARATE NUL-terminated tokens.
-    // Format: "COMMIT|hash|date|author\0\nfilename\0COMMIT|...\0\nfilename\0"
-    for (let token of logOutput.split('\0')) {
-      // git prepends a \n before the first filename after each commit header
-      token = token.replace(/^\n+/, '').trim();
-      if (!token) continue;
-
-      if (token.startsWith('COMMIT|')) {
-        const parts = token.split('|');
-        currentHash = parts[1] || '';
-        currentDate = parts[2] || '';
-        currentAuthor = parts[3] || '';
-      } else if (token.startsWith('knowledge/') && token.endsWith('.md')) {
-        const key = resolve(process.cwd(), token).normalize('NFC');
-        let entry = _gitCache.get(key);
-        if (!entry) {
-          entry = {
-            contributors: [],
-            lastModified: currentDate,
-            commitHash: currentHash,
-            revisionCount: 0,
-          };
-          _gitCache.set(key, entry);
-        }
-        entry.revisionCount += 1;
-        if (currentAuthor && !entry.contributors.includes(currentAuthor)) {
-          entry.contributors.push(currentAuthor);
-        }
-      }
-    }
-  } catch (e) {
-    console.error('Git cache error:', (e as Error).message);
-  }
+  _gitCache = buildGitInfoCache('knowledge/');
   return _gitCache;
 }
 
 function getGitInfo(filePath: string) {
-  return (
-    buildGitCache().get(filePath) || {
-      contributors: [],
-      lastModified: '',
-      commitHash: '',
-      revisionCount: 0,
-    }
-  );
+  return buildGitCache().get(filePath) || emptyGitInfo();
 }
 
 // ── Category → folder mapping ─────────────────────────────────────────────────
@@ -145,12 +92,7 @@ export async function getStaticPaths() {
         const fileContent = await readFile(filePath, 'utf-8');
         const { data: frontmatter, content } = safeMatter(fileContent);
         const slug = basename(file, '.md');
-        let gitInfo = {
-          contributors: [] as string[],
-          lastModified: '',
-          commitHash: '',
-          revisionCount: 0,
-        };
+        let gitInfo = emptyGitInfo();
         try {
           gitInfo = getGitInfo(filePath);
         } catch {}

--- a/src/pages/en/[category]/[slug].astro
+++ b/src/pages/en/[category]/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import { readdir, readFile } from 'fs/promises';
 import { resolve, join, basename } from 'path';
-import { execSync } from 'child_process';
 import matter from 'gray-matter';
 import Layout from '../../../layouts/Layout.astro';
 import { marked } from 'marked';
@@ -15,6 +14,11 @@ import {
   getCategoryConfigs,
   type CategoryKey,
 } from '../../../utils/categoryConfig';
+import {
+  buildGitInfoCache,
+  emptyGitInfo,
+  type GitInfo,
+} from '../../../utils/contributors';
 
 const safeMatter = (fileContent: string) => {
   try {
@@ -24,69 +28,6 @@ const safeMatter = (fileContent: string) => {
     return { data: {}, content: stripped };
   }
 };
-
-// ── Git helpers ───────────────────────────────────────────────────────────────
-let _gitCache: Map<
-  string,
-  { contributors: string[]; lastModified: string }
-> | null = null;
-
-function buildGitCache() {
-  if (_gitCache) return _gitCache;
-  _gitCache = new Map();
-  try {
-    const logOutput = execSync(
-      `git -c core.quotePath=false log --name-only --format="COMMIT_BY:%an" -- "knowledge/en/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentAuthor = '';
-    for (const line of logOutput.split('\n')) {
-      if (line.startsWith('COMMIT_BY:')) {
-        currentAuthor = line.slice(10);
-      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
-        const key = resolve(process.cwd(), line);
-        const entry = _gitCache.get(key) || {
-          contributors: [],
-          lastModified: '',
-        };
-        if (!entry.contributors.includes(currentAuthor))
-          entry.contributors.push(currentAuthor);
-        _gitCache.set(key, entry);
-      }
-    }
-    const dateOutput = execSync(
-      `git -c core.quotePath=false log --format="COMMIT_DATE:%aI" --name-only -- "knowledge/en/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentDate = '';
-    const seenFiles = new Set<string>();
-    for (const line of dateOutput.split('\n')) {
-      if (line.startsWith('COMMIT_DATE:')) {
-        currentDate = line.slice(12);
-      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
-        const key = resolve(process.cwd(), line);
-        if (!seenFiles.has(key)) {
-          seenFiles.add(key);
-          const entry = _gitCache.get(key) || {
-            contributors: [],
-            lastModified: '',
-          };
-          entry.lastModified = currentDate;
-          _gitCache.set(key, entry);
-        }
-      }
-    }
-  } catch (e) {
-    console.error('Git cache error:', (e as Error).message);
-  }
-  return _gitCache;
-}
-
-function getGitInfo(filePath: string) {
-  return (
-    buildGitCache().get(filePath) || { contributors: [], lastModified: '' }
-  );
-}
 
 // ── Category → folder mapping ─────────────────────────────────────────────────
 const categoryMapping: Record<string, string> = {
@@ -130,57 +71,10 @@ export async function getStaticPaths() {
     lifestyle: 'Lifestyle',
   };
 
-  // Build git cache for this function scope
-  let __gitCache: Map<
-    string,
-    {
-      contributors: string[];
-      lastModified: string;
-      commitHash: string;
-      revisionCount: number;
-    }
-  > | null = null;
+  let __gitCache: Map<string, GitInfo> | null = null;
   function _buildGitCache() {
     if (__gitCache) return __gitCache;
-    __gitCache = new Map();
-    try {
-      const logOutput = execSync(
-        `git log --full-history -z --name-only --format="COMMIT|%H|%aI|%an" -- "knowledge/en/"`,
-        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-      );
-      let currentHash = '';
-      let currentDate = '';
-      let currentAuthor = '';
-
-      // git log -z: commit headers and filenames are SEPARATE NUL-terminated tokens.
-      for (let token of logOutput.split('\0')) {
-        token = token.replace(/^\n+/, '').trim();
-        if (!token) continue;
-
-        if (token.startsWith('COMMIT|')) {
-          const parts = token.split('|');
-          currentHash = parts[1] || '';
-          currentDate = parts[2] || '';
-          currentAuthor = parts[3] || '';
-        } else if (token.startsWith('knowledge/') && token.endsWith('.md')) {
-          const key = resolve(process.cwd(), token).normalize('NFC');
-          let entry = __gitCache.get(key);
-          if (!entry) {
-            entry = {
-              contributors: [],
-              lastModified: currentDate,
-              commitHash: currentHash,
-              revisionCount: 0,
-            };
-            __gitCache.set(key, entry);
-          }
-          entry.revisionCount += 1;
-          if (currentAuthor && !entry.contributors.includes(currentAuthor)) {
-            entry.contributors.push(currentAuthor);
-          }
-        }
-      }
-    } catch {}
+    __gitCache = buildGitInfoCache('knowledge/en/');
     return __gitCache;
   }
 
@@ -196,12 +90,7 @@ export async function getStaticPaths() {
         const fileContent = await readFile(filePath, 'utf-8');
         const { data: frontmatter, content } = safeMatter(fileContent);
         const slug = basename(file, '.md');
-        let gitInfo = {
-          contributors: [] as string[],
-          lastModified: '',
-          commitHash: '',
-          revisionCount: 0,
-        };
+        let gitInfo = emptyGitInfo();
         try {
           gitInfo = _buildGitCache().get(filePath) || gitInfo;
         } catch {}

--- a/src/pages/ja/[category]/[slug].astro
+++ b/src/pages/ja/[category]/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import { readdir, readFile } from 'fs/promises';
 import { resolve, join, basename } from 'path';
-import { execSync } from 'child_process';
 import matter from 'gray-matter';
 import Layout from '../../../layouts/Layout.astro';
 import { marked } from 'marked';
@@ -15,6 +14,11 @@ import {
   getCategoryConfigs,
   type CategoryKey,
 } from '../../../utils/categoryConfig';
+import {
+  buildGitInfoCache,
+  emptyGitInfo,
+  type GitInfo,
+} from '../../../utils/contributors';
 
 const safeMatter = (fileContent: string) => {
   try {
@@ -24,69 +28,6 @@ const safeMatter = (fileContent: string) => {
     return { data: {}, content: stripped };
   }
 };
-
-// ── Git helpers ───────────────────────────────────────────────────────────────
-let _gitCache: Map<
-  string,
-  { contributors: string[]; lastModified: string }
-> | null = null;
-
-function buildGitCache() {
-  if (_gitCache) return _gitCache;
-  _gitCache = new Map();
-  try {
-    const logOutput = execSync(
-      `git -c core.quotePath=false log --name-only --format="COMMIT_BY:%an" -- "knowledge/ja/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentAuthor = '';
-    for (const line of logOutput.split('\n')) {
-      if (line.startsWith('COMMIT_BY:')) {
-        currentAuthor = line.slice(10);
-      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
-        const key = resolve(process.cwd(), line);
-        const entry = _gitCache.get(key) || {
-          contributors: [],
-          lastModified: '',
-        };
-        if (!entry.contributors.includes(currentAuthor))
-          entry.contributors.push(currentAuthor);
-        _gitCache.set(key, entry);
-      }
-    }
-    const dateOutput = execSync(
-      `git -c core.quotePath=false log --format="COMMIT_DATE:%aI" --name-only -- "knowledge/ja/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentDate = '';
-    const seenFiles = new Set<string>();
-    for (const line of dateOutput.split('\n')) {
-      if (line.startsWith('COMMIT_DATE:')) {
-        currentDate = line.slice(12);
-      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
-        const key = resolve(process.cwd(), line);
-        if (!seenFiles.has(key)) {
-          seenFiles.add(key);
-          const entry = _gitCache.get(key) || {
-            contributors: [],
-            lastModified: '',
-          };
-          entry.lastModified = currentDate;
-          _gitCache.set(key, entry);
-        }
-      }
-    }
-  } catch (e) {
-    console.error('Git cache error:', (e as Error).message);
-  }
-  return _gitCache;
-}
-
-function getGitInfo(filePath: string) {
-  return (
-    buildGitCache().get(filePath) || { contributors: [], lastModified: '' }
-  );
-}
 
 // ── Category → folder mapping ─────────────────────────────────────────────────
 const categoryMapping: Record<string, string> = {
@@ -130,57 +71,10 @@ export async function getStaticPaths() {
     lifestyle: 'Lifestyle',
   };
 
-  // Build git cache for this function scope
-  let __gitCache: Map<
-    string,
-    {
-      contributors: string[];
-      lastModified: string;
-      commitHash: string;
-      revisionCount: number;
-    }
-  > | null = null;
+  let __gitCache: Map<string, GitInfo> | null = null;
   function _buildGitCache() {
     if (__gitCache) return __gitCache;
-    __gitCache = new Map();
-    try {
-      const logOutput = execSync(
-        `git log --full-history -z --name-only --format="COMMIT|%H|%aI|%an" -- "knowledge/ja/"`,
-        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-      );
-      let currentHash = '';
-      let currentDate = '';
-      let currentAuthor = '';
-
-      // git log -z: commit headers and filenames are SEPARATE NUL-terminated tokens.
-      for (let token of logOutput.split('\0')) {
-        token = token.replace(/^\n+/, '').trim();
-        if (!token) continue;
-
-        if (token.startsWith('COMMIT|')) {
-          const parts = token.split('|');
-          currentHash = parts[1] || '';
-          currentDate = parts[2] || '';
-          currentAuthor = parts[3] || '';
-        } else if (token.startsWith('knowledge/') && token.endsWith('.md')) {
-          const key = resolve(process.cwd(), token).normalize('NFC');
-          let entry = __gitCache.get(key);
-          if (!entry) {
-            entry = {
-              contributors: [],
-              lastModified: currentDate,
-              commitHash: currentHash,
-              revisionCount: 0,
-            };
-            __gitCache.set(key, entry);
-          }
-          entry.revisionCount += 1;
-          if (currentAuthor && !entry.contributors.includes(currentAuthor)) {
-            entry.contributors.push(currentAuthor);
-          }
-        }
-      }
-    } catch {}
+    __gitCache = buildGitInfoCache('knowledge/ja/');
     return __gitCache;
   }
 
@@ -272,12 +166,7 @@ export async function getStaticPaths() {
           );
           continue;
         }
-        let gitInfo = {
-          contributors: [] as string[],
-          lastModified: '',
-          commitHash: '',
-          revisionCount: 0,
-        };
+        let gitInfo = emptyGitInfo();
         try {
           gitInfo = _buildGitCache().get(jaFilePath) || gitInfo;
         } catch {}

--- a/src/pages/ko/[category]/[slug].astro
+++ b/src/pages/ko/[category]/[slug].astro
@@ -1,7 +1,6 @@
 ---
 import { readdir, readFile } from 'fs/promises';
 import { resolve, join, basename } from 'path';
-import { execSync } from 'child_process';
 import matter from 'gray-matter';
 import Layout from '../../../layouts/Layout.astro';
 import { marked } from 'marked';
@@ -15,6 +14,11 @@ import {
   getCategoryConfigs,
   type CategoryKey,
 } from '../../../utils/categoryConfig';
+import {
+  buildGitInfoCache,
+  emptyGitInfo,
+  type GitInfo,
+} from '../../../utils/contributors';
 
 const safeMatter = (fileContent: string) => {
   try {
@@ -24,69 +28,6 @@ const safeMatter = (fileContent: string) => {
     return { data: {}, content: stripped };
   }
 };
-
-// ── Git helpers ───────────────────────────────────────────────────────────────
-let _gitCache: Map<
-  string,
-  { contributors: string[]; lastModified: string }
-> | null = null;
-
-function buildGitCache() {
-  if (_gitCache) return _gitCache;
-  _gitCache = new Map();
-  try {
-    const logOutput = execSync(
-      `git -c core.quotePath=false log --name-only --format="COMMIT_BY:%an" -- "knowledge/ko/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentAuthor = '';
-    for (const line of logOutput.split('\n')) {
-      if (line.startsWith('COMMIT_BY:')) {
-        currentAuthor = line.slice(10);
-      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
-        const key = resolve(process.cwd(), line);
-        const entry = _gitCache.get(key) || {
-          contributors: [],
-          lastModified: '',
-        };
-        if (!entry.contributors.includes(currentAuthor))
-          entry.contributors.push(currentAuthor);
-        _gitCache.set(key, entry);
-      }
-    }
-    const dateOutput = execSync(
-      `git -c core.quotePath=false log --format="COMMIT_DATE:%aI" --name-only -- "knowledge/ko/"`,
-      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-    );
-    let currentDate = '';
-    const seenFiles = new Set<string>();
-    for (const line of dateOutput.split('\n')) {
-      if (line.startsWith('COMMIT_DATE:')) {
-        currentDate = line.slice(12);
-      } else if (line.startsWith('knowledge/') && line.endsWith('.md')) {
-        const key = resolve(process.cwd(), line);
-        if (!seenFiles.has(key)) {
-          seenFiles.add(key);
-          const entry = _gitCache.get(key) || {
-            contributors: [],
-            lastModified: '',
-          };
-          entry.lastModified = currentDate;
-          _gitCache.set(key, entry);
-        }
-      }
-    }
-  } catch (e) {
-    console.error('Git cache error:', (e as Error).message);
-  }
-  return _gitCache;
-}
-
-function getGitInfo(filePath: string) {
-  return (
-    buildGitCache().get(filePath) || { contributors: [], lastModified: '' }
-  );
-}
 
 // ── Category → folder mapping ─────────────────────────────────────────────────
 const categoryMapping: Record<string, string> = {
@@ -130,57 +71,10 @@ export async function getStaticPaths() {
     lifestyle: 'Lifestyle',
   };
 
-  // Build git cache for this function scope
-  let __gitCache: Map<
-    string,
-    {
-      contributors: string[];
-      lastModified: string;
-      commitHash: string;
-      revisionCount: number;
-    }
-  > | null = null;
+  let __gitCache: Map<string, GitInfo> | null = null;
   function _buildGitCache() {
     if (__gitCache) return __gitCache;
-    __gitCache = new Map();
-    try {
-      const logOutput = execSync(
-        `git log --full-history -z --name-only --format="COMMIT|%H|%aI|%an" -- "knowledge/ko/"`,
-        { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
-      );
-      let currentHash = '';
-      let currentDate = '';
-      let currentAuthor = '';
-
-      // git log -z: commit headers and filenames are SEPARATE NUL-terminated tokens.
-      for (let token of logOutput.split('\0')) {
-        token = token.replace(/^\n+/, '').trim();
-        if (!token) continue;
-
-        if (token.startsWith('COMMIT|')) {
-          const parts = token.split('|');
-          currentHash = parts[1] || '';
-          currentDate = parts[2] || '';
-          currentAuthor = parts[3] || '';
-        } else if (token.startsWith('knowledge/') && token.endsWith('.md')) {
-          const key = resolve(process.cwd(), token).normalize('NFC');
-          let entry = __gitCache.get(key);
-          if (!entry) {
-            entry = {
-              contributors: [],
-              lastModified: currentDate,
-              commitHash: currentHash,
-              revisionCount: 0,
-            };
-            __gitCache.set(key, entry);
-          }
-          entry.revisionCount += 1;
-          if (currentAuthor && !entry.contributors.includes(currentAuthor)) {
-            entry.contributors.push(currentAuthor);
-          }
-        }
-      }
-    } catch {}
+    __gitCache = buildGitInfoCache('knowledge/ko/');
     return __gitCache;
   }
 
@@ -261,12 +155,7 @@ export async function getStaticPaths() {
           );
           continue;
         }
-        let gitInfo = {
-          contributors: [] as string[],
-          lastModified: '',
-          commitHash: '',
-          revisionCount: 0,
-        };
+        let gitInfo = emptyGitInfo();
         try {
           gitInfo = _buildGitCache().get(koFilePath) || gitInfo;
         } catch {}

--- a/src/utils/contributors.ts
+++ b/src/utils/contributors.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { execSync } from 'child_process';
+
+export type Contributor = {
+  name: string;
+  login: string;
+};
+
+export type GitInfo = {
+  contributors: Contributor[];
+  lastModified: string;
+  commitHash: string;
+  revisionCount: number;
+};
+
+type ContributorProfile = {
+  name: string;
+  login: string;
+};
+
+let contributorProfiles: Map<string, ContributorProfile> | null = null;
+
+function contributorKey(value: string) {
+  return value.toLowerCase().replace(/[\s._-]+/g, '');
+}
+
+function getContributorProfiles() {
+  if (contributorProfiles) return contributorProfiles;
+
+  contributorProfiles = new Map();
+  try {
+    const configPath = resolve(process.cwd(), '.all-contributorsrc');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    for (const contributor of config.contributors || []) {
+      if (!contributor.login || !contributor.name) continue;
+      const profile = {
+        name: contributor.name,
+        login: contributor.login,
+      };
+      contributorProfiles.set(contributorKey(contributor.name), profile);
+      contributorProfiles.set(contributorKey(contributor.login), profile);
+    }
+  } catch (e) {
+    console.error('Contributor profile error:', (e as Error).message);
+  }
+
+  return contributorProfiles;
+}
+
+export function resolveContributor(
+  authorName: string,
+  authorEmail: string,
+): Contributor {
+  const githubNoreplyMatch = authorEmail.match(
+    /^(?:\d+\+)?([^@]+)@users\.noreply\.github\.com$/i,
+  );
+  const githubLogin = githubNoreplyMatch?.[1]?.toLowerCase();
+  const profile =
+    getContributorProfiles().get(contributorKey(githubLogin || '')) ||
+    getContributorProfiles().get(contributorKey(authorName));
+  const login = githubLogin || profile?.login || authorName;
+  const isAuthorNameLogin =
+    profile && contributorKey(authorName) === contributorKey(profile.login);
+
+  return {
+    name: isAuthorNameLogin
+      ? profile.name
+      : authorName || profile?.name || login,
+    login,
+  };
+}
+
+export function emptyGitInfo(): GitInfo {
+  return {
+    contributors: [],
+    lastModified: '',
+    commitHash: '',
+    revisionCount: 0,
+  };
+}
+
+export function buildGitInfoCache(knowledgePath: string) {
+  const cache = new Map<string, GitInfo>();
+
+  try {
+    const logOutput = execSync(
+      `git log --full-history -z --name-only --format="COMMIT|%H|%aI|%an|%ae" -- "${knowledgePath}"`,
+      { encoding: 'utf-8', maxBuffer: 10 * 1024 * 1024 },
+    );
+    let currentHash = '';
+    let currentDate = '';
+    let currentContributor: Contributor | null = null;
+
+    for (let token of logOutput.split('\0')) {
+      token = token.replace(/^\n+/, '').trim();
+      if (!token) continue;
+
+      if (token.startsWith('COMMIT|')) {
+        const parts = token.split('|');
+        currentHash = parts[1] || '';
+        currentDate = parts[2] || '';
+        currentContributor = resolveContributor(parts[3] || '', parts[4] || '');
+      } else if (token.startsWith('knowledge/') && token.endsWith('.md')) {
+        const key = resolve(process.cwd(), token).normalize('NFC');
+        let entry = cache.get(key);
+        if (!entry) {
+          entry = {
+            contributors: [],
+            lastModified: currentDate,
+            commitHash: currentHash,
+            revisionCount: 0,
+          };
+          cache.set(key, entry);
+        }
+        entry.revisionCount += 1;
+        if (
+          currentContributor &&
+          !entry.contributors.some(
+            (contributor) => contributor.login === currentContributor?.login,
+          )
+        ) {
+          entry.contributors.push(currentContributor);
+        }
+      }
+    }
+  } catch (e) {
+    console.error('Git cache error:', (e as Error).message);
+  }
+
+  return cache;
+}


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

## Summary

這次修改修正文章頁貢獻者連結錯誤的問題。原本系統直接把 Git author name 當成 GitHub 帳號，導致像 Terry、Fred Chu 這類顯示名稱會連到錯誤的 GitHub URL。現在改
成統一解析 contributor 的顯示名稱與 GitHub login，並套用到 zh-TW、en、ja、ko 文章頁。

## Changes

- 新增 src/utils/contributors.ts，集中處理 Git commit contributors 解析邏輯。
- 透過 GitHub noreply email 解析真實 GitHub login，例如 Terry <88765055+Link1515@users.noreply.github.com> 會連到 link1515。
- 透過 .all-contributorsrc 的 name/login 對照，修正 Fred Chu 這類非 noreply commit author 的 GitHub 連結。
- 將 zh-TW、en、ja、ko 四套文章 slug route 改為共用同一套 contributor git cache 邏輯。
- 更新 ArticleSidebar，支援 { name, login } contributor 格式，顯示使用 name，GitHub URL 使用 login。
- 保留舊的 string[] contributor 輸入相容性，避免其他呼叫端立即破壞。

## Impact

- 影響文章頁側欄的「貢獻者」顯示與 GitHub 連結。
- 影響範圍包含 zh-TW、en、ja、ko 文章頁。
- 不影響 API、資料庫 schema、權限或背景工作。
- 既有只傳 string[] 的使用方式仍可運作，但會沿用舊行為：字串同時作為顯示名稱與 GitHub login。

## Testing

- 已執行 Prettier check，相關檔案格式通過。
- 已掃描確認 zh-TW/en/ja/ko route 不再殘留舊的 %an string-only contributor 邏輯。
- 已手動驗證代表性 contributor 對應：
  - Fred Chu → https://github.com/fredchu
  - Terry → https://github.com/link1515
  - frank890417 → 顯示 Che-Yu Wu，連到 https://github.com/frank890417
  - weilin lai → https://github.com/weilinlai719
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🎨 如果動到樣式（非內容 PR 才需要）

- [ ] 沒有 hardcode 新的 hex color — 用 `var(--token)` 或 Tailwind 任意值（`bg-[#xxxxxx]`）
- [ ] 優先 inline Tailwind 工具類；scoped `<style>` 只在重複 pattern、JS 狀態機、`:global()`、或 CSS 變數 state machine 時使用
- [ ] 沒有新增 `@layer components`、`@apply`、或 `@theme` bridge —— Phase 7 刻意移除它們
- [ ] 如果刪掉 class 的 markup，同一個 commit 也把對應 scoped rule 刪掉
- [ ] 參考 [`docs/refactor/DESIGN.md`](../docs/refactor/DESIGN.md) 的 decision tree 確認策略

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

<!-- 可選：貼上前後對比截圖 -->
