### PR TITLE
fix: support native JA/KO slug links in lang switcher

### DIFF
--- a/src/utils/getLangSwitchPath.ts
+++ b/src/utils/getLangSwitchPath.ts
@@ -177,10 +177,12 @@ export async function getLangSwitchPath(currentPath: string) {
           const enEntry = zhToEnEntry[zhFile];
           const langCatSlug =
             categoryFolderToSlug[langParts[1]] || langParts[1].toLowerCase();
-          const urlCatSlug = enEntry ? enEntry.catSlug : langCatSlug;
-          const urlSlug = enEntry ? enEntry.slug : langParts[2];
-          const langUrl = `/${langPrefix}/${urlCatSlug}/${urlSlug}`;
-          addTranslation(langUrl, zhUrl, langPrefix);
+          if (enEntry) {
+            const canonicalLangUrl = `/${langPrefix}/${enEntry.catSlug}/${enEntry.slug}`;
+            addTranslation(canonicalLangUrl, zhUrl, langPrefix);
+          }
+          const nativeLangUrl = `/${langPrefix}/${langCatSlug}/${langParts[2]}`;
+          addTranslation(nativeLangUrl, zhUrl, langPrefix);
         }
       } else if (langParts.length === 2 && zhParts.length === 1) {
         const langPrefix = langParts[0];


### PR DESCRIPTION
## Summary
- support locale-native ja/ko slugs in `getLangSwitchPath` in addition to canonical EN-slug URLs
- keep the current canonical route convention intact while improving compatibility for existing native-slug links
- narrow, low-risk fix related to the route/mapping inconsistency discussed in #398

## Why
Issue #398 shows that some JA content exists with locale-native file slugs such as `ja/Technology/ai-development.md`, while current cross-language routing conventions prefer EN slugs. This patch does not redesign the route architecture. Instead, it makes the lang switcher more tolerant by registering both canonical and native ja/ko URL mappings for the same zh source article.

That means we preserve the current stable EN-slug convention, but avoid unnecessarily losing valid translation links when native locale slugs already exist in `_translations.json`.

Closes #398