### PR TITLE
fix(search): fix article-card selector mismatch in category pages

### DIFF
--- a/src/pages/[category]/index.astro
+++ b/src/pages/[category]/index.astro
@@ -739,7 +739,7 @@ const otherCategories = categories
     if (!grid) return;
 
     const cards = Array.from(
-      grid.querySelectorAll('.article-card'),
+      grid.querySelectorAll('.article-row'),
     ) as HTMLElement[];
     const subcategorySections = Array.from(
       grid.querySelectorAll('.subcategory-section'),
@@ -790,7 +790,7 @@ const otherCategories = categories
       // Hide subcategory sections with no visible cards
       subcategorySections.forEach((section) => {
         const sectionCards = section.querySelectorAll(
-          '.article-card',
+          '.article-row',
         ) as NodeListOf<HTMLElement>;
         const anyVisible = Array.from(sectionCards).some(
           (c) => c.style.display !== 'none',


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修復 `zh-TW` 分類頁面搜尋功能預設失效的問題。在近期的 HTML 重構中，文章卡片的 class 更改為 `.article-row`，但 `src/pages/[category]/index.astro` 的 JavaScript 查詢依然尋找 `.article-card`，導致符合條件的數量被錯誤計算為 0 並顯示「找不到符合條件的文章」。此 PR 將選擇器修正為 `.article-row` 以恢復正常的標題比對搜尋。

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🔗 相關 Issue

Closes #

## 📸 截圖（如果是視覺改動）
