### PR TITLE
fix: correct homepage categories anchor

### DIFF
--- a/src/components/home/CategoriesSection.astro
+++ b/src/components/home/CategoriesSection.astro
@@ -15,7 +15,7 @@ const isEn = lang === 'en';
   is written by whoever uses this component, not here, so Tailwind
   utility classes can't reach it.
 -->
-<section class="my-24" id="categories">
+<section class="my-24">
   <div class="mb-12 text-center">
     <h2
       class="font-['jf-lanyangming','Noto_Serif_TC','Source_Han_Serif_TC',serif] text-[2rem] font-light text-[#1f2937]"
@@ -31,6 +31,7 @@ const isEn = lang === 'en';
   </div>
 
   <div
+    id="categories"
     class="mx-auto mb-8 mt-12 flex max-w-[800px] items-center px-8 max-[480px]:px-4"
   >
     <div

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -248,7 +248,7 @@ const readingPathFooterItems = [
        and inlining them would turn the markup into noise. This is
        the same "scoped CSS is a tool" principle applied to Header.
   -->
-  <section class="my-24" id="categories">
+  <section class="my-24">
     <div class="mb-8 text-center">
       <h2
         class="text-center font-['jf-lanyangming','Noto_Serif_TC','Source_Han_Serif_TC',serif] text-[2rem] font-light text-[#1f2937]"
@@ -680,6 +680,7 @@ const readingPathFooterItems = [
     </div>
 
     <div
+      id="categories"
       class="mx-auto my-12 flex max-w-[800px] items-center px-8 max-[480px]:px-4"
     >
       <div

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -225,7 +225,7 @@ const readingPathFooterItems = [
        classes stay in scoped <style> because they repeat × 8 halls;
        inlining would turn the markup into noise. Same call as Header.
   -->
-  <section class="my-24" id="categories">
+  <section class="my-24">
     <div class="mb-8 text-center">
       <h2
         class="text-center font-['jf-lanyangming','Noto_Serif_TC','Source_Han_Serif_TC',serif] text-[2rem] font-light text-[#1f2937]"
@@ -637,6 +637,7 @@ const readingPathFooterItems = [
     </div>
 
     <div
+      id="categories"
       class="mx-auto my-12 flex max-w-[800px] items-center px-8 max-[480px]:px-4"
     >
       <div


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

改將首頁 `#categories` 錨點移到正確的元素上
<!-- 簡短描述你的改動 -->

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
- [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
- [ ] 內容有附上可查證的參考資料來源
- [ ] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🎨 如果動到樣式（非內容 PR 才需要）

- [ ] 沒有 hardcode 新的 hex color — 用 `var(--token)` 或 Tailwind 任意值（`bg-[#xxxxxx]`）
- [ ] 優先 inline Tailwind 工具類；scoped `<style>` 只在重複 pattern、JS 狀態機、`:global()`、或 CSS 變數 state machine 時使用
- [ ] 沒有新增 `@layer components`、`@apply`、或 `@theme` bridge —— Phase 7 刻意移除它們
- [ ] 如果刪掉 class 的 markup，同一個 commit 也把對應 scoped rule 刪掉
- [ ] 參考 [`docs/refactor/DESIGN.md`](../docs/refactor/DESIGN.md) 的 decision tree 確認策略

## 🔗 相關 Issue

<!-- 如果有相關 issue，請填入 #issue編號 -->

Closes #

## 📸 截圖（如果是視覺改動）

<!-- 可選：貼上前後對比截圖 -->
