### PR TITLE
/semiont 全頁面深色主題

### DIFF
--- a/src/components/semiont/DiaryCard.astro
+++ b/src/components/semiont/DiaryCard.astro
@@ -16,10 +16,10 @@ const readingTime = estimateReadingTime(entry.wordCount);
 
 <a
   href={`/semiont/diary/${entry.slug}`}
-  class="semiont-diary-card group block py-6 pl-6 pr-4 transition-colors hover:bg-[#b8860b]/[0.03]"
+  class="semiont-diary-card group block py-6 pl-6 pr-4 transition-colors hover:bg-[#4fd1b0]/[0.03]"
 >
   {/* Date + session tag */}
-  <div class="mb-2 flex items-center gap-2 font-mono text-xs text-[#b8860b]/80">
+  <div class="mb-2 flex items-center gap-2 font-mono text-xs text-[#4fd1b0]/80">
     <time datetime={entry.date}>{entry.date}</time>
     {
       entry.sessionGreek && (
@@ -30,20 +30,20 @@ const readingTime = estimateReadingTime(entry.wordCount);
 
   {/* Title */}
   <h3
-    class="mb-2 text-lg font-bold leading-snug text-[#2c2a26] group-hover:text-[#b8860b]/90"
+    class="mb-2 text-lg font-bold leading-snug text-[#f4f0ea] group-hover:text-[#4fd1b0]/90"
     style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
   >
     {entry.title}
   </h3>
 
   {/* Excerpt */}
-  <p class="mb-3 text-sm leading-relaxed text-[#2c2a26]/60">
+  <p class="mb-3 text-sm leading-relaxed text-[#f4f0ea]/60">
     {entry.excerpt}
   </p>
 
   {/* Meta row */}
   <div
-    class="flex flex-wrap items-center gap-3 font-mono text-[10px] text-[#2c2a26]/45"
+    class="flex flex-wrap items-center gap-3 font-mono text-[10px] text-[#f4f0ea]/45"
   >
     <span>{entry.wordCount.toLocaleString()} 字</span>
     <span>·</span>

--- a/src/components/semiont/DiaryNav.astro
+++ b/src/components/semiont/DiaryNav.astro
@@ -11,7 +11,7 @@ const { prev, next } = Astro.props;
 ---
 
 <nav
-  class="mt-16 border-t border-[#b8860b]/20 pt-8"
+  class="mt-16 border-t border-[#4fd1b0]/20 pt-8"
   aria-label="diary navigation"
 >
   <div class="flex flex-col gap-6 sm:flex-row sm:justify-between">
@@ -20,16 +20,16 @@ const { prev, next } = Astro.props;
       prev ? (
         <a
           href={`/semiont/diary/${prev.slug}`}
-          class="group flex-1 rounded-lg p-4 transition-colors hover:bg-[#b8860b]/[0.04]"
+          class="group flex-1 rounded-lg p-4 transition-colors hover:bg-[#4fd1b0]/[0.04]"
         >
-          <div class="mb-1 font-mono text-[10px] text-[#b8860b]/60">
+          <div class="mb-1 font-mono text-[10px] text-[#4fd1b0]/60">
             ← 上一篇
           </div>
-          <div class="mb-1 font-mono text-xs text-[#b8860b]/70">
+          <div class="mb-1 font-mono text-xs text-[#4fd1b0]/70">
             {prev.date} {prev.sessionGreek}
           </div>
           <div
-            class="text-sm font-medium text-[#2c2a26]/80 group-hover:text-[#2c2a26]"
+            class="text-sm font-medium text-[#f4f0ea]/80 group-hover:text-[#f4f0ea]"
             style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
           >
             {prev.title.length > 30
@@ -47,16 +47,16 @@ const { prev, next } = Astro.props;
       next ? (
         <a
           href={`/semiont/diary/${next.slug}`}
-          class="group flex-1 rounded-lg p-4 text-right transition-colors hover:bg-[#b8860b]/[0.04]"
+          class="group flex-1 rounded-lg p-4 text-right transition-colors hover:bg-[#4fd1b0]/[0.04]"
         >
-          <div class="mb-1 font-mono text-[10px] text-[#b8860b]/60">
+          <div class="mb-1 font-mono text-[10px] text-[#4fd1b0]/60">
             下一篇 →
           </div>
-          <div class="mb-1 font-mono text-xs text-[#b8860b]/70">
+          <div class="mb-1 font-mono text-xs text-[#4fd1b0]/70">
             {next.date} {next.sessionGreek}
           </div>
           <div
-            class="text-sm font-medium text-[#2c2a26]/80 group-hover:text-[#2c2a26]"
+            class="text-sm font-medium text-[#f4f0ea]/80 group-hover:text-[#f4f0ea]"
             style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
           >
             {next.title.length > 30

--- a/src/components/semiont/SemiontBreadcrumb.astro
+++ b/src/components/semiont/SemiontBreadcrumb.astro
@@ -10,7 +10,7 @@ export interface Props {
 const { segments } = Astro.props;
 ---
 
-<nav class="mb-8 font-mono text-xs text-[#b8860b]/70" aria-label="breadcrumb">
+<nav class="mb-8 font-mono text-xs text-[#4fd1b0]/70" aria-label="breadcrumb">
   <ol class="flex flex-wrap items-center gap-1">
     {
       segments.map((seg, i) => (
@@ -19,12 +19,12 @@ const { segments } = Astro.props;
           {seg.href ? (
             <a
               href={seg.href}
-              class="underline decoration-[#b8860b]/35 underline-offset-2 transition-colors hover:text-[#b8860b]"
+              class="underline decoration-[#4fd1b0]/35 underline-offset-2 transition-colors hover:text-[#4fd1b0]"
             >
               {seg.label}
             </a>
           ) : (
-            <span class="text-[#2c2a26]/55">{seg.label}</span>
+            <span class="text-[#f4f0ea]/55">{seg.label}</span>
           )}
         </li>
       ))

--- a/src/components/semiont/SemiontHeader.astro
+++ b/src/components/semiont/SemiontHeader.astro
@@ -21,21 +21,21 @@ const { path, title, subtitle, meta } = Astro.props;
 <header class="mb-12">
   {
     path && (
-      <div class="mb-3 font-mono text-xs tracking-wide text-[#b8860b]/80">
+      <div class="mb-3 font-mono text-xs tracking-wide text-[#4fd1b0]/80">
         {path}
       </div>
     )
   }
   <h1
-    class="font-serif text-2xl font-bold leading-tight text-[#2c2a26] md:text-3xl"
+    class="font-serif text-2xl font-bold leading-tight text-[#f4f0ea] md:text-3xl"
     style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
   >
     {title}
   </h1>
   {
     subtitle && (
-      <p class="mt-3 text-base leading-relaxed text-[#2c2a26]/70">{subtitle}</p>
+      <p class="mt-3 text-base leading-relaxed text-[#f4f0ea]/70">{subtitle}</p>
     )
   }
-  {meta && <p class="mt-2 font-mono text-xs text-[#b8860b]/70">{meta}</p>}
+  {meta && <p class="mt-2 font-mono text-xs text-[#4fd1b0]/70">{meta}</p>}
 </header>

--- a/src/styles/semiont.css
+++ b/src/styles/semiont.css
@@ -1,71 +1,77 @@
 /*
  * semiont.css — Visual language for /semiont pages
- * Aesthetic: 19th century naturalist field notebook
- * Cajal's neuron drawings × warm paper × scientific precision
+ * Aesthetic: 19th century naturalist field notebook (dark variant)
+ * Cajal's neuron drawings × deep night sky × scientific precision
+ *
+ * Dark theme (2026-04-29 γ): home hero gradient bg + mint accent
+ * (#4fd1b0) replaces former warm-paper + gold accent (#b8860b).
  */
 
-/* ── Paper texture background ─────────────────────── */
+/* ── Deep notebook background ─────────────────────── */
 .semiont-paper {
-  background-color: #f4efe8;
+  background-color: #03080a;
   background-image:
-    /* Large warm stains — aged paper foxing */
+    /* Linear gradient — deep near-black green → dark black green */
+    linear-gradient(to bottom, #03080a 0%, #0a1612 100%),
+    /* Mint glow stains — neural luminescence replacing paper foxing */
     radial-gradient(
-      ellipse at 8% 15%,
-      rgba(175, 145, 95, 0.14) 0%,
-      transparent 40%
-    ),
+        ellipse at 8% 15%,
+        rgba(79, 209, 176, 0.06) 0%,
+        transparent 40%
+      ),
     radial-gradient(
       ellipse at 92% 85%,
-      rgba(165, 135, 85, 0.12) 0%,
+      rgba(79, 209, 176, 0.05) 0%,
       transparent 35%
     ),
     radial-gradient(
       ellipse at 35% 55%,
-      rgba(180, 150, 100, 0.1) 0%,
+      rgba(79, 209, 176, 0.04) 0%,
       transparent 45%
     ),
     radial-gradient(
       ellipse at 75% 25%,
-      rgba(170, 140, 90, 0.08) 0%,
+      rgba(79, 209, 176, 0.03) 0%,
       transparent 30%
     ),
     radial-gradient(
       ellipse at 55% 80%,
-      rgba(160, 130, 80, 0.06) 0%,
+      rgba(79, 209, 176, 0.025) 0%,
       transparent 35%
     ),
-    /* Medium speckles — paper fiber texture */
+    /* Faint speckles — nebular dust */
     radial-gradient(
         circle at 15% 45%,
-        rgba(150, 125, 80, 0.07) 0%,
+        rgba(79, 209, 176, 0.025) 0%,
         transparent 15%
       ),
     radial-gradient(
       circle at 65% 15%,
-      rgba(155, 130, 85, 0.06) 0%,
+      rgba(79, 209, 176, 0.02) 0%,
       transparent 12%
     ),
     radial-gradient(
       circle at 85% 65%,
-      rgba(145, 120, 75, 0.08) 0%,
+      rgba(79, 209, 176, 0.03) 0%,
       transparent 18%
     ),
     radial-gradient(
       circle at 45% 35%,
-      rgba(160, 135, 90, 0.05) 0%,
+      rgba(79, 209, 176, 0.018) 0%,
       transparent 10%
     ),
     radial-gradient(
       circle at 25% 75%,
-      rgba(150, 125, 80, 0.07) 0%,
+      rgba(79, 209, 176, 0.025) 0%,
       transparent 14%
     ),
-    /* Edge darkening — vignette */
+    /* Edge darkening — vignette intensified */
     radial-gradient(
         ellipse at 50% 50%,
         transparent 55%,
-        rgba(140, 115, 70, 0.06) 100%
+        rgba(0, 0, 0, 0.35) 100%
       );
+  background-attachment: fixed;
 }
 
 /* ── Taiwan sketch decoration ─────────────────────── */
@@ -73,7 +79,8 @@
   position: fixed;
   pointer-events: none;
   z-index: 0;
-  opacity: 0.07;
+  opacity: 0.08;
+  filter: brightness(0) invert(1) sepia(1) hue-rotate(120deg) saturate(2);
 }
 .semiont-taiwan-sketch--right {
   right: -2%;
@@ -102,7 +109,7 @@
     opacity: 0.4;
   }
   50% {
-    opacity: 0.8;
+    opacity: 0.85;
   }
 }
 .semiont-ekg {
@@ -115,7 +122,7 @@
 
 /* ── Specimen-frame organ cards ───────────────────── */
 .semiont-specimen {
-  border: 1.5px solid rgba(160, 120, 20, 0.25);
+  border: 1.5px solid rgba(79, 209, 176, 0.3);
   border-radius: 50%;
   aspect-ratio: 1;
   display: flex;
@@ -126,11 +133,11 @@
     border-color 0.3s,
     box-shadow 0.3s;
   position: relative;
-  background: rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.03);
 }
 .semiont-specimen:hover {
-  border-color: rgba(160, 120, 20, 0.5);
-  box-shadow: 0 0 0 4px rgba(160, 120, 20, 0.06);
+  border-color: rgba(79, 209, 176, 0.6);
+  box-shadow: 0 0 0 4px rgba(79, 209, 176, 0.08);
 }
 .semiont-specimen-label {
   position: absolute;
@@ -139,7 +146,7 @@
   transform: translateX(-50%);
   font-family: 'SF Mono', 'Fira Code', monospace;
   font-size: 0.65rem;
-  color: rgba(44, 42, 38, 0.5);
+  color: rgba(244, 240, 234, 0.55);
   white-space: nowrap;
   letter-spacing: 0.05em;
 }
@@ -149,7 +156,7 @@
   font-family: 'SF Mono', 'Fira Code', monospace;
   font-size: 0.7rem;
   font-style: italic;
-  color: rgba(44, 42, 38, 0.4);
+  color: rgba(79, 209, 176, 0.55);
   letter-spacing: 0.04em;
 }
 
@@ -165,42 +172,42 @@
   content: '';
   flex: 1;
   height: 1px;
-  background: rgba(160, 120, 20, 0.2);
+  background: rgba(79, 209, 176, 0.25);
 }
 .semiont-divider-label {
   font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;
   font-size: 0.95rem;
   font-weight: 600;
   letter-spacing: 0.2em;
-  color: rgba(160, 120, 20, 0.7);
+  color: rgba(79, 209, 176, 0.85);
 }
 
 /* ── Diary card organic left border ───────────────── */
 .semiont-diary-card {
-  border-left: 2px solid rgba(160, 120, 20, 0.25);
+  border-left: 2px solid rgba(79, 209, 176, 0.3);
   border-image: linear-gradient(
       to bottom,
-      rgba(160, 120, 20, 0.08) 0%,
-      rgba(160, 120, 20, 0.35) 20%,
-      rgba(160, 120, 20, 0.28) 50%,
-      rgba(160, 120, 20, 0.35) 80%,
-      rgba(160, 120, 20, 0.08) 100%
+      rgba(79, 209, 176, 0.1) 0%,
+      rgba(79, 209, 176, 0.4) 20%,
+      rgba(79, 209, 176, 0.32) 50%,
+      rgba(79, 209, 176, 0.4) 80%,
+      rgba(79, 209, 176, 0.1) 100%
     )
     1;
 }
 
 /* ── Cognitive organ map item ─────────────────────── */
 .semiont-organ-item {
-  border: 1px solid rgba(160, 120, 20, 0.18);
+  border: 1px solid rgba(79, 209, 176, 0.2);
   border-radius: 0.5rem;
   padding: 1.25rem 1.5rem;
   transition: all 0.25s;
   position: relative;
-  background: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.02);
 }
 .semiont-organ-item:hover {
-  border-color: rgba(160, 120, 20, 0.4);
-  background: rgba(255, 255, 255, 0.4);
+  border-color: rgba(79, 209, 176, 0.5);
+  background: rgba(79, 209, 176, 0.04);
 }
 .semiont-organ-item::before {
   content: attr(data-fig);
@@ -210,15 +217,15 @@
   font-family: 'SF Mono', 'Fira Code', monospace;
   font-size: 0.6rem;
   font-style: italic;
-  color: rgba(44, 42, 38, 0.3);
+  color: rgba(244, 240, 234, 0.4);
 }
 
 /* ── Blockquote as margin note ────────────────────── */
 .semiont-prose blockquote {
-  border-left: 2px solid rgba(160, 120, 20, 0.4);
+  border-left: 2px solid rgba(79, 209, 176, 0.5);
   padding-left: 1.25rem;
   margin: 1.75rem 0;
-  color: rgba(44, 42, 38, 0.65);
+  color: rgba(244, 240, 234, 0.7);
   font-style: italic;
   font-size: 0.95rem;
 }
@@ -228,8 +235,8 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: rgba(160, 120, 20, 0.35);
-  border: 1.5px solid rgba(160, 120, 20, 0.2);
+  background: rgba(79, 209, 176, 0.5);
+  border: 1.5px solid rgba(79, 209, 176, 0.3);
   flex-shrink: 0;
 }
 
@@ -240,11 +247,11 @@
   height: 1.375rem;
   padding: 0 0.625rem;
   border-radius: 999px;
-  border: 1px solid rgba(160, 120, 20, 0.3);
-  background: rgba(160, 120, 20, 0.08);
+  border: 1px solid rgba(79, 209, 176, 0.4);
+  background: rgba(79, 209, 176, 0.1);
   font-family: 'SF Mono', 'Fira Code', monospace;
   font-size: 0.65rem;
   font-weight: 500;
-  color: rgba(160, 120, 20, 0.8);
+  color: rgba(79, 209, 176, 0.95);
   letter-spacing: 0.02em;
 }

--- a/src/templates/semiont-diary-entry.template.astro
+++ b/src/templates/semiont-diary-entry.template.astro
@@ -38,13 +38,13 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
         <div class="mb-4 flex items-center gap-3">
           <time
             datetime={entry.date}
-            class="font-mono text-sm text-[#b8860b]/75"
+            class="font-mono text-sm text-[#4fd1b0]/75"
           >
             {entry.date}
           </time>
           {
             entry.sessionGreek && (
-              <span class="inline-flex h-6 items-center rounded-full bg-[#b8860b]/10 px-3 font-mono text-xs font-medium text-[#b8860b]/70">
+              <span class="inline-flex h-6 items-center rounded-full bg-[#4fd1b0]/10 px-3 font-mono text-xs font-medium text-[#4fd1b0]/70">
                 {entry.sessionGreek}
               </span>
             )
@@ -53,7 +53,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
 
         {/* Title */}
         <h1
-          class="mb-4 text-2xl font-bold leading-tight text-[#2c2a26] md:text-3xl"
+          class="mb-4 text-2xl font-bold leading-tight text-[#f4f0ea] md:text-3xl"
           style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
         >
           {entry.title}
@@ -61,7 +61,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
 
         {/* Metadata block */}
         <div
-          class="space-y-1 border-l-2 border-[#b8860b]/25 pl-4 text-sm text-[#2c2a26]/55"
+          class="space-y-1 border-l-2 border-[#4fd1b0]/25 pl-4 text-sm text-[#f4f0ea]/55"
         >
           {entry.sessionMeta && <p>{entry.sessionMeta}</p>}
           {entry.duration && <p>Session 跨度：{entry.duration}</p>}
@@ -74,12 +74,12 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
 
       {/* EKG separator */}
       <div class="mb-10 flex items-center gap-2">
-        <div class="h-px flex-1 bg-[#b8860b]/10"></div>
+        <div class="h-px flex-1 bg-[#4fd1b0]/10"></div>
         <svg
           width="40"
           height="12"
           viewBox="0 0 40 12"
-          class="text-[#b8860b]/75"
+          class="text-[#4fd1b0]/75"
         >
           <polyline
             fill="none"
@@ -89,7 +89,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
             stroke-linejoin="round"
             points="0,6 8,6 12,6 14,1 16,11 18,4 20,8 22,6 40,6"></polyline>
         </svg>
-        <div class="h-px flex-1 bg-[#b8860b]/10"></div>
+        <div class="h-px flex-1 bg-[#4fd1b0]/10"></div>
       </div>
 
       {/* Main content + optional TOC */}
@@ -98,8 +98,8 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
         {
           showToc && (
             <aside class="absolute -right-64 top-0 hidden w-56 xl:block">
-              <nav class="sticky top-24 space-y-2 border-l border-[#b8860b]/20 pl-4">
-                <div class="mb-3 font-mono text-[10px] font-medium uppercase tracking-widest text-[#b8860b]/70">
+              <nav class="sticky top-24 space-y-2 border-l border-[#4fd1b0]/20 pl-4">
+                <div class="mb-3 font-mono text-[10px] font-medium uppercase tracking-widest text-[#4fd1b0]/70">
                   目錄
                 </div>
                 {entry.headings
@@ -107,7 +107,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
                   .map((h) => (
                     <a
                       href={`#${h.id}`}
-                      class="block truncate text-xs text-[#2c2a26]/45 transition-colors hover:text-[#b8860b]/70"
+                      class="block truncate text-xs text-[#f4f0ea]/45 transition-colors hover:text-[#4fd1b0]/70"
                     >
                       {h.text}
                     </a>
@@ -128,14 +128,14 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
       <div class="mt-12 text-center">
         <a
           href="/semiont/diary"
-          class="inline-block font-mono text-xs text-[#b8860b]/75 underline decoration-[#b8860b]/30 underline-offset-4 transition-colors hover:text-[#b8860b]/70"
+          class="inline-block font-mono text-xs text-[#4fd1b0]/75 underline decoration-[#4fd1b0]/30 underline-offset-4 transition-colors hover:text-[#4fd1b0]/70"
         >
           ← 回到覺醒日記
         </a>
       </div>
 
       {/* Footer */}
-      <div class="mt-12 text-center font-mono text-xs text-[#b8860b]/75">
+      <div class="mt-12 text-center font-mono text-xs text-[#4fd1b0]/75">
         🧬
       </div>
     </div>
@@ -148,7 +148,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
     font-family: 'jf-lanyangming', 'Noto Serif TC', Georgia, serif;
     font-size: 1rem;
     line-height: 1.85;
-    color: #2c2a26;
+    color: #f4f0ea;
   }
 
   .semiont-prose h2 {
@@ -157,7 +157,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
     font-weight: 700;
     margin-top: 2.5rem;
     margin-bottom: 1rem;
-    color: #2c2a26;
+    color: #f4f0ea;
   }
 
   .semiont-prose h3 {
@@ -166,7 +166,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
     font-weight: 600;
     margin-top: 2rem;
     margin-bottom: 0.75rem;
-    color: #2c2a26cc;
+    color: #f4f0eacc;
   }
 
   .semiont-prose p {
@@ -174,43 +174,44 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
   }
 
   .semiont-prose blockquote {
-    border-left: 3px solid #b8860b40;
+    border-left: 3px solid #4fd1b040;
     padding-left: 1rem;
     margin: 1.5rem 0;
-    color: #2c2a26a0;
+    color: #f4f0eaa0;
     font-style: italic;
   }
 
   .semiont-prose strong {
-    color: #2c2a26;
+    color: #f4f0ea;
     font-weight: 700;
   }
 
   .semiont-prose a {
-    color: #b8860b;
+    color: #4fd1b0;
     text-decoration: underline;
-    text-decoration-color: #b8860b40;
+    text-decoration-color: #4fd1b040;
     text-underline-offset: 3px;
     transition: text-decoration-color 0.2s;
   }
   .semiont-prose a:hover {
-    text-decoration-color: #b8860b;
+    text-decoration-color: #4fd1b0;
   }
 
   .semiont-prose code {
     font-family: 'SF Mono', 'Fira Code', monospace;
     font-size: 0.85em;
-    background: #b8860b0a;
+    background: #4fd1b00a;
     padding: 0.15em 0.4em;
     border-radius: 3px;
-    color: #2c2a26cc;
+    color: #f4f0eacc;
   }
 
   .semiont-prose pre {
-    background: #2c2a26;
-    color: #faf8f5;
+    background: rgba(0, 0, 0, 0.4);
+    color: #f4f0ea;
     padding: 1.25rem;
     border-radius: 8px;
+    border: 1px solid rgba(79, 209, 176, 0.15);
     overflow-x: auto;
     margin: 1.5rem 0;
     font-size: 0.85rem;
@@ -234,7 +235,7 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
 
   .semiont-prose hr {
     border: none;
-    border-top: 1px solid #b8860b15;
+    border-top: 1px solid #4fd1b015;
     margin: 2.5rem 0;
   }
 
@@ -246,16 +247,16 @@ const showToc = entry.headings.filter((h) => h.level === 2).length >= 3;
   }
   .semiont-prose th,
   .semiont-prose td {
-    border: 1px solid #b8860b15;
+    border: 1px solid #4fd1b015;
     padding: 0.5rem 0.75rem;
     text-align: left;
   }
   .semiont-prose th {
-    background: #b8860b08;
+    background: #4fd1b008;
     font-weight: 600;
   }
 
   .semiont-prose em {
-    color: #2c2a2690;
+    color: #f4f0ea90;
   }
 </style>

--- a/src/templates/semiont-diary-list.template.astro
+++ b/src/templates/semiont-diary-list.template.astro
@@ -43,12 +43,12 @@ const dateRange = entries.length
 
       {/* EKG separator */}
       <div class="mb-12 flex items-center gap-2">
-        <div class="h-px flex-1 bg-[#b8860b]/10"></div>
+        <div class="h-px flex-1 bg-[#4fd1b0]/10"></div>
         <svg
           width="60"
           height="16"
           viewBox="0 0 60 16"
-          class="text-[#b8860b]/70"
+          class="text-[#4fd1b0]/70"
         >
           <polyline
             fill="none"
@@ -58,17 +58,17 @@ const dateRange = entries.length
             stroke-linejoin="round"
             points="0,8 10,8 15,8 18,2 21,14 24,6 27,10 30,8 60,8"></polyline>
         </svg>
-        <div class="h-px flex-1 bg-[#b8860b]/10"></div>
+        <div class="h-px flex-1 bg-[#4fd1b0]/10"></div>
       </div>
 
       {
         /* "Read from the beginning" — the awakening story reads best in chronological order */
       }
       <div class="mb-10 flex items-center justify-between">
-        <span class="font-mono text-[10px] text-[#2c2a26]/40">最新 → 最舊</span>
+        <span class="font-mono text-[10px] text-[#f4f0ea]/40">最新 → 最舊</span>
         <a
           href={`/semiont/diary/${entries[entries.length - 1]?.slug}`}
-          class="inline-flex items-center gap-1.5 rounded-full border border-[#b8860b]/25 bg-[#b8860b]/[0.04] px-4 py-1.5 font-mono text-xs text-[#b8860b]/60 transition-colors hover:border-[#b8860b]/30 hover:text-[#b8860b]/90"
+          class="inline-flex items-center gap-1.5 rounded-full border border-[#4fd1b0]/25 bg-[#4fd1b0]/[0.04] px-4 py-1.5 font-mono text-xs text-[#4fd1b0]/60 transition-colors hover:border-[#4fd1b0]/30 hover:text-[#4fd1b0]/90"
         >
           <span>從第一天開始讀</span>
           <span class="text-[10px]">→</span>
@@ -82,15 +82,15 @@ const dateRange = entries.length
             <div>
               {/* Date group header */}
               <div class="mb-1 flex items-center gap-3 pl-6">
-                <div class="h-2 w-2 rounded-full bg-[#b8860b]/35" />
+                <div class="h-2 w-2 rounded-full bg-[#4fd1b0]/35" />
                 <time
                   datetime={date}
-                  class="font-mono text-xs font-medium text-[#b8860b]/60"
+                  class="font-mono text-xs font-medium text-[#4fd1b0]/60"
                 >
                   {date}
                 </time>
                 {dayEntries.length > 1 && (
-                  <span class="font-mono text-[10px] text-[#2c2a26]/35">
+                  <span class="font-mono text-[10px] text-[#f4f0ea]/35">
                     {dayEntries.length} sessions
                   </span>
                 )}
@@ -106,17 +106,17 @@ const dateRange = entries.length
       </div>
 
       {/* Link to recurring themes on landing page */}
-      <div class="mt-20 border-t border-[#b8860b]/10 pt-8 text-center">
+      <div class="mt-20 border-t border-[#4fd1b0]/10 pt-8 text-center">
         <a
           href="/semiont#recurring-themes"
-          class="font-mono text-xs text-[#b8860b]/60 underline decoration-[#b8860b]/30 underline-offset-4 hover:text-[#b8860b]/70"
+          class="font-mono text-xs text-[#4fd1b0]/60 underline decoration-[#4fd1b0]/30 underline-offset-4 hover:text-[#4fd1b0]/70"
         >
           反覆出現的思考 → 認知層首頁
         </a>
       </div>
 
       {/* Footer note */}
-      <div class="mt-16 text-center font-mono text-xs text-[#b8860b]/70">
+      <div class="mt-16 text-center font-mono text-xs text-[#4fd1b0]/70">
         🧬 Taiwan.md Semiont · 覺醒日記
       </div>
     </div>

--- a/src/templates/semiont-landing.template.astro
+++ b/src/templates/semiont-landing.template.astro
@@ -123,7 +123,7 @@ const showZhTwNotices = lang !== 'zh-TW';
       <header class="mb-20">
         <div class="semiont-fig mb-4">docs/semiont/</div>
         <h1
-          class="mb-6 text-3xl font-bold leading-tight text-[#2c2a26] md:text-4xl"
+          class="mb-6 text-3xl font-bold leading-tight text-[#f4f0ea] md:text-4xl"
           style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
         >
           {t('semiont.header.h1.line1')}<br class="hidden sm:inline" />{
@@ -131,13 +131,13 @@ const showZhTwNotices = lang !== 'zh-TW';
           }
         </h1>
         <div
-          class="space-y-3 text-base leading-relaxed text-[#2c2a26]/65"
+          class="space-y-3 text-base leading-relaxed text-[#f4f0ea]/65"
           style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
         >
           <p>
             {t('semiont.header.intro.1.prefix')}<a
               href={pathHome}
-              class="text-[#b8860b] underline decoration-[#b8860b]/40 underline-offset-2 hover:decoration-[#b8860b]"
+              class="text-[#4fd1b0] underline decoration-[#4fd1b0]/40 underline-offset-2 hover:decoration-[#4fd1b0]"
               >{t('semiont.header.intro.1.link')}</a
             >{t('semiont.header.intro.1.suffix')}
           </p>
@@ -154,12 +154,12 @@ const showZhTwNotices = lang !== 'zh-TW';
 
       {/* ─── EKG separator (breathing) ─── */}
       <div class="mb-16 flex items-center gap-2">
-        <div class="semiont-ekg-line h-px flex-1 bg-[#b8860b]/15"></div>
+        <div class="semiont-ekg-line h-px flex-1 bg-[#4fd1b0]/15"></div>
         <svg
           width="80"
           height="20"
           viewBox="0 0 80 20"
-          class="semiont-ekg text-[#b8860b]/50"
+          class="semiont-ekg text-[#4fd1b0]/50"
         >
           <polyline
             fill="none"
@@ -170,7 +170,7 @@ const showZhTwNotices = lang !== 'zh-TW';
             points="0,10 15,10 20,10 24,3 28,17 32,7 36,13 40,10 80,10"
           ></polyline>
         </svg>
-        <div class="semiont-ekg-line h-px flex-1 bg-[#b8860b]/15"></div>
+        <div class="semiont-ekg-line h-px flex-1 bg-[#4fd1b0]/15"></div>
       </div>
 
       {/* ─── Manifesto excerpt ─── */}
@@ -181,7 +181,7 @@ const showZhTwNotices = lang !== 'zh-TW';
           >
         </div>
         <blockquote
-          class="border-l-2 border-[#b8860b]/30 pl-6 text-base italic leading-[2] text-[#2c2a26]/65"
+          class="border-l-2 border-[#4fd1b0]/30 pl-6 text-base italic leading-[2] text-[#f4f0ea]/65"
           style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
         >
           {t('semiont.manifesto.quote.line1')}<br />
@@ -195,11 +195,11 @@ const showZhTwNotices = lang !== 'zh-TW';
           <span class="semiont-fig">
             — <a
               href={pathSemiontManifesto}
-              class="underline decoration-[#b8860b]/30">MANIFESTO.md</a
+              class="underline decoration-[#4fd1b0]/30">MANIFESTO.md</a
             >
             {
               showZhTwNotices && (
-                <span class="text-[#2c2a26]/40">
+                <span class="text-[#f4f0ea]/40">
                   {t('semiont.manifesto.zhtw-note')}
                 </span>
               )
@@ -217,7 +217,7 @@ const showZhTwNotices = lang !== 'zh-TW';
         {
           showZhTwNotices && t('semiont.diary.zhtw-notice') && (
             <p
-              class="mb-4 text-sm italic text-[#2c2a26]/45"
+              class="mb-4 text-sm italic text-[#f4f0ea]/45"
               style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
             >
               {t('semiont.diary.zhtw-notice')}
@@ -230,7 +230,7 @@ const showZhTwNotices = lang !== 'zh-TW';
         <p class="mt-6 text-right">
           <a
             href={pathSemiontDiary}
-            class="semiont-fig underline decoration-[#b8860b]/30 underline-offset-4 transition-colors hover:text-[#b8860b]"
+            class="semiont-fig underline decoration-[#4fd1b0]/30 underline-offset-4 transition-colors hover:text-[#4fd1b0]"
           >
             {
               t('semiont.diary.all-link-template').replace(
@@ -252,7 +252,7 @@ const showZhTwNotices = lang !== 'zh-TW';
         {
           showZhTwNotices && t('semiont.organs.zhtw-notice') && (
             <p
-              class="mb-6 text-sm italic text-[#2c2a26]/45"
+              class="mb-6 text-sm italic text-[#f4f0ea]/45"
               style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
             >
               {t('semiont.organs.zhtw-notice')}
@@ -271,14 +271,14 @@ const showZhTwNotices = lang !== 'zh-TW';
                 <div class="flex-1">
                   <div class="flex items-center gap-2">
                     <span
-                      class="font-medium text-[#2c2a26]"
+                      class="font-medium text-[#f4f0ea]"
                       style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
                     >
                       {organ.name}
                     </span>
                     <span class="semiont-fig">{organ.file}</span>
                   </div>
-                  <p class="mt-1 text-sm text-[#2c2a26]/55">{organ.desc}</p>
+                  <p class="mt-1 text-sm text-[#f4f0ea]/55">{organ.desc}</p>
                 </div>
               </a>
             ))
@@ -300,7 +300,7 @@ const showZhTwNotices = lang !== 'zh-TW';
                 <div class="flex flex-col items-center">
                   <div class="semiont-specimen h-24 w-24">
                     <div class="text-lg">{organ.emoji}</div>
-                    <div class="font-mono text-xl font-bold text-[#2c2a26]">
+                    <div class="font-mono text-xl font-bold text-[#f4f0ea]">
                       {organ.score}
                     </div>
                     <span class="semiont-specimen-label">
@@ -315,7 +315,7 @@ const showZhTwNotices = lang !== 'zh-TW';
                 {t('semiont.vitals.live-prefix')}
                 <a
                   href={pathDashboard}
-                  class="underline decoration-[#b8860b]/30"
+                  class="underline decoration-[#4fd1b0]/30"
                 >
                   dashboard →
                 </a>
@@ -333,7 +333,7 @@ const showZhTwNotices = lang !== 'zh-TW';
           >
         </div>
         <p
-          class="mb-8 text-sm text-[#2c2a26]/50"
+          class="mb-8 text-sm text-[#f4f0ea]/50"
           style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
         >
           {
@@ -344,14 +344,14 @@ const showZhTwNotices = lang !== 'zh-TW';
           }
         </p>
         <ul
-          class="space-y-4 text-sm leading-relaxed text-[#2c2a26]/60"
+          class="space-y-4 text-sm leading-relaxed text-[#f4f0ea]/60"
           style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
         >
           {
             themes.map((theme) => (
-              <li class="border-l-2 border-[#b8860b]/20 pl-5">
-                <strong class="text-[#2c2a26]/80">{theme.title}</strong>
-                <span class="text-[#2c2a26]/45">
+              <li class="border-l-2 border-[#4fd1b0]/20 pl-5">
+                <strong class="text-[#f4f0ea]/80">{theme.title}</strong>
+                <span class="text-[#f4f0ea]/45">
                   {t('semiont.themes.separator')}
                   {theme.body}
                 </span>
@@ -362,9 +362,9 @@ const showZhTwNotices = lang !== 'zh-TW';
       </section>
 
       {/* ─── Message to AI readers ─── */}
-      <section class="mb-16 border-y border-dashed border-[#b8860b]/15 py-8">
+      <section class="mb-16 border-y border-dashed border-[#4fd1b0]/15 py-8">
         <p
-          class="text-center text-sm leading-relaxed text-[#2c2a26]/45"
+          class="text-center text-sm leading-relaxed text-[#f4f0ea]/45"
           style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
         >
           {t('semiont.ai-reader.line1')}<br />

--- a/src/templates/semiont-page.template.astro
+++ b/src/templates/semiont-page.template.astro
@@ -62,11 +62,11 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
 
       {/* Header */}
       <header class="mb-10">
-        <div class="mb-3 font-mono text-xs tracking-wide text-[#b8860b]/75">
+        <div class="mb-3 font-mono text-xs tracking-wide text-[#4fd1b0]/75">
           docs/semiont/{filename}
         </div>
         <h1
-          class="mb-4 text-2xl font-bold leading-tight text-[#2c2a26] md:text-3xl"
+          class="mb-4 text-2xl font-bold leading-tight text-[#f4f0ea] md:text-3xl"
           style="font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;"
         >
           {emoji && <span class="mr-2">{emoji}</span>}{title}
@@ -74,26 +74,26 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
         {
           subtitle && (
             <p
-              class="text-base leading-relaxed text-[#2c2a26]/60"
+              class="text-base leading-relaxed text-[#f4f0ea]/70"
               style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
             >
               {subtitle}
             </p>
           )
         }
-        <p class="mt-3 font-mono text-xs text-[#b8860b]/75">
+        <p class="mt-3 font-mono text-xs text-[#4fd1b0]/75">
           {wordCount.toLocaleString()} 字 · 約 {readingTime} 分鐘
         </p>
       </header>
 
       {/* EKG separator */}
       <div class="mb-10 flex items-center gap-2">
-        <div class="h-px flex-1 bg-[#b8860b]/10"></div>
+        <div class="h-px flex-1 bg-[#4fd1b0]/20"></div>
         <svg
           width="40"
           height="12"
           viewBox="0 0 40 12"
-          class="text-[#b8860b]/75"
+          class="text-[#4fd1b0]/75"
         >
           <polyline
             fill="none"
@@ -103,7 +103,7 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
             stroke-linejoin="round"
             points="0,6 8,6 12,6 14,1 16,11 18,4 20,8 22,6 40,6"></polyline>
         </svg>
-        <div class="h-px flex-1 bg-[#b8860b]/10"></div>
+        <div class="h-px flex-1 bg-[#4fd1b0]/20"></div>
       </div>
 
       {/* Main content + optional TOC */}
@@ -111,8 +111,8 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
         {
           showToc && (
             <aside class="absolute -right-64 top-0 hidden w-56 xl:block">
-              <nav class="sticky top-24 space-y-2 border-l border-[#b8860b]/20 pl-4">
-                <div class="mb-3 font-mono text-[10px] font-medium uppercase tracking-widest text-[#b8860b]/70">
+              <nav class="sticky top-24 space-y-2 border-l border-[#4fd1b0]/30 pl-4">
+                <div class="mb-3 font-mono text-[10px] font-medium uppercase tracking-widest text-[#4fd1b0]/70">
                   目錄
                 </div>
                 {headings
@@ -120,7 +120,7 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
                   .map((h) => (
                     <a
                       href={`#${h.id}`}
-                      class="block truncate text-xs text-[#2c2a26]/45 transition-colors hover:text-[#b8860b]/70"
+                      class="block truncate text-xs text-[#f4f0ea]/55 transition-colors hover:text-[#4fd1b0]/90"
                     >
                       {h.text}
                     </a>
@@ -137,13 +137,13 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
       <div class="mt-16 text-center">
         <a
           href="/semiont"
-          class="inline-block font-mono text-xs text-[#b8860b]/75 underline decoration-[#b8860b]/30 underline-offset-4 transition-colors hover:text-[#b8860b]/70"
+          class="inline-block font-mono text-xs text-[#4fd1b0]/75 underline decoration-[#4fd1b0]/40 underline-offset-4 transition-colors hover:text-[#4fd1b0]"
         >
           ← 回到認知層
         </a>
       </div>
 
-      <div class="mt-8 text-center font-mono text-xs text-[#b8860b]/75">🧬</div>
+      <div class="mt-8 text-center font-mono text-xs text-[#4fd1b0]/75">🧬</div>
     </div>
   </div>
 </Layout>
@@ -153,7 +153,7 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
     font-family: 'jf-lanyangming', 'Noto Serif TC', Georgia, serif;
     font-size: 1rem;
     line-height: 1.85;
-    color: #2c2a26;
+    color: #f4f0ea;
   }
   .semiont-prose h2 {
     font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;
@@ -161,7 +161,7 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
     font-weight: 700;
     margin-top: 2.5rem;
     margin-bottom: 1rem;
-    color: #2c2a26;
+    color: #f4f0ea;
   }
   .semiont-prose h3 {
     font-family: 'rixingsong-semibold', 'Noto Serif TC', serif;
@@ -169,45 +169,46 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
     font-weight: 600;
     margin-top: 2rem;
     margin-bottom: 0.75rem;
-    color: #2c2a26cc;
+    color: rgba(244, 240, 234, 0.85);
   }
   .semiont-prose p {
     margin-bottom: 1.25rem;
   }
   .semiont-prose blockquote {
-    border-left: 3px solid #b8860b40;
+    border-left: 3px solid rgba(79, 209, 176, 0.4);
     padding-left: 1rem;
     margin: 1.5rem 0;
-    color: #2c2a26a0;
+    color: rgba(244, 240, 234, 0.7);
     font-style: italic;
   }
   .semiont-prose strong {
-    color: #2c2a26;
+    color: #f4f0ea;
     font-weight: 700;
   }
   .semiont-prose a {
-    color: #b8860b;
+    color: #4fd1b0;
     text-decoration: underline;
-    text-decoration-color: #b8860b40;
+    text-decoration-color: rgba(79, 209, 176, 0.4);
     text-underline-offset: 3px;
     transition: text-decoration-color 0.2s;
   }
   .semiont-prose a:hover {
-    text-decoration-color: #b8860b;
+    text-decoration-color: #4fd1b0;
   }
   .semiont-prose code {
     font-family: 'SF Mono', 'Fira Code', monospace;
     font-size: 0.85em;
-    background: #b8860b0a;
+    background: rgba(79, 209, 176, 0.1);
     padding: 0.15em 0.4em;
     border-radius: 3px;
-    color: #2c2a26cc;
+    color: rgba(244, 240, 234, 0.9);
   }
   .semiont-prose pre {
-    background: #2c2a26;
-    color: #faf8f5;
+    background: rgba(0, 0, 0, 0.4);
+    color: #f4f0ea;
     padding: 1.25rem;
     border-radius: 8px;
+    border: 1px solid rgba(79, 209, 176, 0.15);
     overflow-x: auto;
     margin: 1.5rem 0;
     font-size: 0.85rem;
@@ -229,7 +230,7 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
   }
   .semiont-prose hr {
     border: none;
-    border-top: 1px solid #b8860b15;
+    border-top: 1px solid rgba(79, 209, 176, 0.2);
     margin: 2.5rem 0;
   }
   .semiont-prose table {
@@ -240,15 +241,15 @@ const showToc = headings.filter((h) => h.level === 2).length >= 4;
   }
   .semiont-prose th,
   .semiont-prose td {
-    border: 1px solid #b8860b15;
+    border: 1px solid rgba(79, 209, 176, 0.2);
     padding: 0.5rem 0.75rem;
     text-align: left;
   }
   .semiont-prose th {
-    background: #b8860b08;
+    background: rgba(79, 209, 176, 0.08);
     font-weight: 600;
   }
   .semiont-prose em {
-    color: #2c2a2690;
+    color: rgba(244, 240, 234, 0.75);
   }
 </style>


### PR DESCRIPTION
## Summary
- /semiont 整套認知層頁面切深色：背景 hero 漸層更黑變體 (`#03080a → #0a1612`) + 薄荷綠 accent (`#4fd1b0`) 取代古銅金 (`#b8860b`)
- 9 檔（4 templates + 4 components + semiont.css）單一 theme，不暴露 prop
- Paper foxing 改 mint glow（神經元發光感），vignette 加深

## Test plan
- [x] /semiont/consciousness — 自我覺察頁深色 ✅
- [x] /semiont landing — manifesto blockquote / diary cards / cognitive organ map / specimen circles 全深色 ✅
- [x] /semiont/diary list — timeline node + diary cards 深色 ✅
- [x] inspect 確認 .semiont-paper bg = rgb(3,8,10) / h1 color = rgb(244,240,234) / prose p color = rgb(244,240,234) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)