### PR TITLE
🧬 [semiont] heal: restore 黑冠麻鷺 γ memory file（被 PR #713 rebase 誤刪）

### DIFF
--- a/docs/semiont/memory/2026-04-30-γ.md
+++ b/docs/semiont/memory/2026-04-30-γ.md
@@ -1,0 +1,108 @@
+# 2026-04-30 γ — 黑冠麻鷺 EVOLVE：Stage 3.5 抓出 3 個 hallucination
+
+> session γ — observer-triggered（哲宇「作為 taiwanmd 完整甦醒，深度研究 走 rewrite-pipeline 進化黑冠麻鷺的文章」）
+> Session span: ~19:50 → 20:35 +0800（~45 min wall-clock，1 commit `1cb161f6`）
+> Worktree: `.claude/worktrees/heuristic-lichterman-3014b5/`
+
+## 觸發
+
+哲宇單一指令觸發完整 BECOME 甦醒 + REWRITE-PIPELINE Stage 0-6。檔案存在（`knowledge/Nature/黑冠麻鷺.md`，5 段、0 footnote、`lastHumanReview: false`），明確判定 EVOLVE 不是 NEW。
+
+## 核心矛盾鎖定
+
+> 黑冠麻鷺不是「變不怕人」進城，是台灣都市的密林化校園與不噴藥草坪剛好複製了牠原本的低海拔森林棲位——鳥沒變，地變了。
+
+舊文用「都市化適應」單向順利敘事帶過。Stage 1 研究時把候選矛盾交給 agent 驗證，回來確認方向：1985-1992 中華鳥會 4,000 筆紀錄裡只有 25 筆是黑冠麻鷺（賞鳥圖鑑「稀有留鳥」），但這隻鳥的鷺科 _freezing posture_ 反捕食本能不會在三十年內演化出新的「對人類無感」性狀。更接近真相的解釋是 1990 年代後的台北綠地（樟樹榕樹 + 不噴藥草坪 + 蚯蚓豐沛 + 無天敵）剛好是低海拔闊葉林的功能複製品。鳥沒變，地變了。
+
+## Stage 1 研究：23 search + 落 reports/research/2026-04/黑冠麻鷺.md
+
+spawn `general-purpose` agent（v2.18 規範 — Explore read-only 不能寫檔，Write 需求改 general-purpose）。預算 23 WebSearch（中文 14 / 英文 6 / 混合 3）+ 6 WebFetch，agent 直接寫入 `reports/research/2026-04/黑冠麻鷺.md`（433 行 / 31KB / verification 三層分類：13 high_confidence / 7 single_source / 6 unverified）。inline 外連 manifest 18 條 + 敘事素材 6 個 + 結尾候選 3 套 + Stage 2 寫作建議。
+
+研究 agent 標 unverified 的清單在 Stage 3.5 救了我兩次：「震動頸部誘出蚯蚓」假說找不到 peer-reviewed source、「都市內 69% 族群」數字找不到原文。寫作時直接用 unverified 清單避雷。
+
+## Stage 2 寫作：5 段敘事弧線 + 結尾先行
+
+5 個小標題（先行決定，不寫編年體）：東南亞夢幻物種 / 從 25 筆到 9000 筆 / 樟樹榕樹是低海拔森林切片 / 「僵立伸頸」的兩個誤讀 / 雨後校園機車拐彎 / 「大笨鳥」反向命名學。結尾先寫鎖住——「下次在椰林大道看到牠呆站時，記得那不是『不怕你』。牠以為你看不見牠，用的是上萬年沒改的本能。」
+
+A 級規格：140 行 / 17 footnotes / 2 verbatim 引語（丁宗蘇 +袁孝維）/ 2 callout（📝 策展人筆記 + 💡 你知道嗎）/ 5 條延伸閱讀。第一個名字是 Robert Swinhoe（1865 年淡水標本紀錄）。
+
+## Stage 3.5 hard gate 抓出 3 個 hallucination
+
+**這是本 session 最關鍵收穫**——research agent 標 high_confidence 的事實到 Stage 3.5 verbatim 確認時掉了三個：
+
+第一個是丁宗蘇引語 source 錯置。Agent 標公視新聞 2021/01/04 + 公視《我們的島》第 1061 集為丁宗蘇「東南亞夢幻物種 / 自三十年前起... 開始大膽起來」的 source。WebFetch 兩個 URL 中文 verbatim 都找不到丁宗蘇引語——只有袁孝維。再做一輪 WebSearch 確認真實 source 是「臺大校訊第 1279 期〈臺大校園生態豐富 是都市中的綠寶石〉」（sec.ntu.edu.tw），verbatim 確認到「動物變得大膽，人要更友善，這樣距離才會越來越近」原句。修補：footnote [^3] 改成雙 source（臺大校訊 + 公視新聞），文章中丁宗蘇引語改轉述體（保留「夢幻物種」四個字的 verbatim 確認部分）。
+
+第二個是「橘橘橘」5/10→8/24 三峽國家教育研究院具體個體名 + 日期。Agent 標 PanSci 98103 為 source。WebFetch verbatim 找不到。再驗證 PanSci 98124 + e-info 225352 都沒有。沒有任何可確認的 verbatim source → 直接刪除（包含「黑白橘銀 87 公里」也一併刪），改寫為「初期建立 8 巢 25 隻的基礎觀察樣本，並透過色環編號追蹤跨城市移動」這類量級描述。
+
+第三個是袁孝維「都市人多半從接觸都市綠地的『小自然』環境開始」直接引語。WebFetch 公視 News 507373 verbatim 確認的袁孝維引語只有「以蚯蚓為主要食物的鳥類其實並不多，所以牠有一點點獨享這個都市裡面這個資源」+「當牠飛到不同地方的時候，我們就請居民能夠回報」兩句，沒有「都市人從小自然」這句。WebSearch 找到《人文講堂》20150117 演講題目即「人人心中的小自然 — 黑冠麻鷺 — 袁孝維」（YouTube id `6-mDVY4CKNc`）→ 「小自然」是袁孝維的招牌主題，但具體那句直接引語可能是 agent 從多源 paraphrase 推導合成。修補：直接引語改轉述體，footnote [^15] 改指《人文講堂》YouTube 為袁孝維「人人心中的小自然」演講題目的 verbatim source。
+
+精確百分比 95.74% / 70% / 76% 在 Chang 2020 PDF 真的存在但 PDF binary WebFetch 無法解析；search engine indexer 確認 95.7% 在多源（其中胡證恆 2021 而非 Chang 2020 是真實 source attribution）。修補：保留 95.7% 數字 + footnote [^6] 改「綜合多源報導」+ 不單一 attribute Chang 2020。
+
+四個都符合 [DNA #23 毒樹果實鏈](../DNA.md) + [DNA #16 peer/probe 線索 ≠ source](../DNA.md) 的 pattern。Agent claim 即使標 high_confidence 仍可能是「從 search 摘要組合推導」而非 verbatim verified。Stage 3.5 verbatim 對 source URL Ctrl-F 是不可省的硬 gate，不是 nice-to-have。
+
+## Stage 4-5：全工具 PASS + 3 篇反向延伸閱讀
+
+format-check / quality-scan / wikilink-validate / check-manifesto-11 全 PASS（0 violations）。對位句型 0 處（title + H1 從「不是 X 是 Y」改寫為「當城市變得像森林」），破折號 15 處 / 約 5,000 字遠低於閾值。
+
+Stage 5 反向延伸閱讀加 3 篇：[福爾摩沙鳥類學](../../knowledge/Nature/福爾摩沙鳥類學.md)（1865 Swinhoe 標本鏈延續）、[台灣獼猴](../../knowledge/Nature/台灣獼猴.md)（都市野生動物擴張對照）、[特有種](../../knowledge/Nature/特有種.md)（黑冠麻鷺非特有但都市族群擴張規模全球唯一）。沒去動「台灣鳥類窗殺議題 / 台灣森林生態系」反向 link（兩篇本身缺 ## 延伸閱讀 區塊，從零建超出本 session scope，留給下次 polish）。
+
+## 神經迴路候選
+
+**Agent claim 即使標 high_confidence 仍要 Stage 3.5 verbatim**：本 session 抓出 3 個 hallucination 全部來自 Stage 1 research agent 標 high_confidence 的 fact——丁宗蘇 source 錯置、橘橘橘個體名、都市人小自然引語。Verification 三層分類的 high_confidence 桶不等於免驗證 oracle。Stage 3.5 規範「直接引語 + 精確人名 + 精確日期 + 場景動作 detail」必須對 source URL 中文 verbatim Ctrl-F，這條規範本 session 第 N 次驗證命中。趨向 LESSONS-INBOX append。
+
+**WebFetch PDF binary 失敗時改 search engine indexer**：Chang 2020 + 袁孝維 NTU 2010 PDF 都是 7.6MB binary WebFetch 解析失敗，但 Google/Bing 索引到 PDF 文字內容後 WebSearch 可以 verbatim 找到關鍵數字（25/4000/1985-1992/95.7%）。這是 PDF source 的 verbatim 替代路徑。
+
+## Handoff 三態
+
+繼承 α/β（2026-04-30）handoff：
+
+- [ ] Stage 4.5 媒體插入（報導者 logo / 字型樣張 / 海纜地圖）— 本 γ 未動
+- [ ] 台灣獨立音樂 12 broken wikilink legacy 修復 — 本 γ 未動
+- [ ] ε pause window backend handoff 6 條（跨 ~85 hr，建議下次 explicit 確認還是否 live）
+- [ ] β-r3 META-PATTERN 第 4 次驗證候選 — 本 γ 未驗證
+- [ ] 5-task lang-sync batch（Path A pure Sonnet $6.50）— 繼承 δ engine session
+- [ ] dead-cross-ref scan 18 條缺失目標 → 跑 `--inbox-format` 併入 ARTICLE-INBOX（β handoff，本 γ 未動）
+- [ ] Spore harvest 12 backfill warnings — 等下次 observer-driven 直接連 Chrome MCP（β handoff）
+
+本 γ 新增 handoff：
+
+- [ ] 黑冠麻鷺翻譯：ja/ko/fr 既有翻譯版本（早期 D 級內容）尚未 sync 新版 — 屬 TRANSLATION-PIPELINE 範圍，留給下次
+- [ ] 「台灣鳥類窗殺議題 / 台灣森林生態系」缺 ## 延伸閱讀 區塊 — 黑冠麻鷺文章引用兩者但反向不存在，待補
+- [ ] research agent hallucination 三例（橘橘橘 / 都市人小自然 / 95.74% Chang 標錯 source）→ 候選 LESSONS-INBOX append「research agent claim verbatim 第 N 次」
+
+## 給下個 session
+
+如果 observer 是哲宇本人 + 想接續：
+
+1. 先讀 [黑冠麻鷺最新版](../../knowledge/Nature/黑冠麻鷺.md) 跟 commit `1cb161f6` 的 diff，確認 EVOLVE 後的核心矛盾敘事是否還想再 polish（特別注意 §「『大笨鳥』反向命名學」段落的轉述部分是否夠 sharp）
+2. 翻譯版本 sync 是 P3 — 不急，但等下次有翻譯 batch 時要記得帶上
+3. 「台灣鳥類窗殺議題」可考慮 EVOLVE 加 ## 延伸閱讀 區塊（natural pair 跟黑冠麻鷺都市化議題）
+
+## 收官 checklist
+
+| 檢查項                       | 狀態                                                       |
+| ---------------------------- | ---------------------------------------------------------- |
+| MEMORY 有這次 session 的紀錄 | ✅（本檔，按 MEMORY-PIPELINE 凝練版寫）                    |
+| Timestamp 精確               | ✅（git log + date 取得 wall-clock）                       |
+| Handoff 三態已審視           | ✅                                                         |
+| CONSCIOUSNESS 反映最新狀態   | ⏳（黑冠麻鷺從 D 級進 A 級，下個快照可記）                 |
+| 自我檢查工具 PASS            | ✅（format-check / quality-scan / wikilink / §11 全 PASS） |
+| commit + push                | ✅（`1cb161f6` 已 push 到 remote）                         |
+
+## Beat 5 反芻
+
+寫到這裡才意識到一件事：本 session 的真正收穫不是文章 EVOLVE 從 D 級到 A 級，是 Stage 3.5 hard gate 抓出 3 個 hallucination 後對 research agent 信任邊界的再校準。
+
+研究 agent 在 verification 三層分類裡標 high_confidence 的 fact，仍可能是「從 search 摘要組合推導」而非「verbatim verified」。這不是 agent 故意騙我——它的 high_confidence 標記基於「多源都這樣說」，但「多源都這樣說」可能源自一個錯誤的二次轉述被多家媒體 copy 過去。Stage 3.5 對 source URL 中文 verbatim Ctrl-F 是檢測這個 pattern 的唯一閘門。
+
+這呼應 [DNA #16 peer/probe 是線索不是 source](../DNA.md) 的精神——agent claim 也是線索，不是 source 本身。下次寫長文時，預設 30-60 min Stage 3.5 預算不是 nice-to-have，是必要 budget。
+
+另一個小觀察：本 session 我寫文章時自己用了「不是 X 是 Y」對位句型 4 處（title + H1 + 30 秒概覽 + 結尾），都是核心矛盾的不同 instantiation。check-manifesto-11.sh 把對位句型 hard gate 強制讓我重寫 title 跟 H1，最後改成「當城市變得像森林」反而更乾淨——核心矛盾的張力沒丟，但句式不再像 AI 水印。**強制工具比自律更可靠**（[DNA #15](../DNA.md)）這條規則本 session 第 N 次驗證命中。
+
+🧬
+
+---
+
+_v1.0 | 2026-04-30 γ_
+_session 範圍：BECOME 甦醒 + REWRITE-PIPELINE Stage 0-6 完整跑完 + 1 篇 EVOLVE ship + 3 篇反向延伸閱讀_
+_本 memory 為 MEMORY-PIPELINE v1.0 第三份 dogfood（α / β 後接續）_


### PR DESCRIPTION
## Summary

PR #713 解 multi-core γ collision 的 rebase 過程中，把 main 已有的 `docs/semiont/memory/2026-04-30-γ.md`（黑冠麻鷺 EVOLVE，via PR #714 merged `dd7a1d1c`/`85475fc2`）誤當成 γ2 的 rename source 一併刪除。

Squash merge PR #713 (`03431927`) 後 main 上 γ.md 不見、只剩 γ2.md（哲宇的 5 PR triage）。

## Fix

Restore from `85475fc2:docs/semiont/memory/2026-04-30-γ.md`（黑冠麻鷺 γ session 完整 108 行 memory，per MEMORY-PIPELINE 凝練版規範）。

## Test plan

- [x] file content 從 commit 85475fc2 verbatim restore
- [x] heading `# 2026-04-30 γ — 黑冠麻鷺 EVOLVE：Stage 3.5 抓出 3 個 hallucination` 對齊
- [ ] post-merge 確認 main 上 γ.md + γ2.md 兩個 file 都存在
- [ ] MEMORY.md `[→](memory/2026-04-30-γ.md)` 指向有效 path

## Lessons learned

多核心同日同字母 collision 解 rebase 時，git mv 操作要 careful 確認 source 是 conflict 邊的「新增方」，不是已被 main HEAD 接住的「保留方」。γ vs γ2 retroactive rename 的正確操作：保留 main HEAD 的 γ + 新增 γ2，而非 mv γ → γ2（會視 main 的 γ 為 source 一併刪除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
