### PR TITLE
🧬 [semiont] heal: dashboard donut bug v2 — explicit circumference

### DIFF
--- a/src/templates/dashboard.template.astro
+++ b/src/templates/dashboard.template.astro
@@ -1290,9 +1290,15 @@ const isEn = lang === 'en';
       bars.querySelectorAll('.donut-fill').forEach((el) => {
         const target = el.getAttribute('data-target');
         requestAnimationFrame(() => {
-          // Fix: at 100%, use "100 0" (no gap) to avoid stroke-linecap round artifact
-          el.style.strokeDasharray =
-            parseFloat(target) >= 100 ? '100 0' : target + ', 100';
+          // Fix v2: explicit circumference + drop threshold to ≥99 (round-cap visual overlap starts before 100%)
+          // Circle r=15.9 → circumference = 2π × 15.9 ≈ 99.9
+          const t = parseFloat(target);
+          if (t >= 99) {
+            el.style.strokeDasharray = '99.9 0';
+          } else {
+            const len = (t / 100) * 99.9;
+            el.style.strokeDasharray = len.toFixed(2) + ' 99.9';
+          }
         });
       });
     });
@@ -1401,9 +1407,15 @@ const isEn = lang === 'en';
       bars.querySelectorAll('.donut-fill').forEach((el) => {
         const target = el.getAttribute('data-target');
         requestAnimationFrame(() => {
-          // Fix: at 100%, use "100 0" (no gap) to avoid stroke-linecap round artifact
-          el.style.strokeDasharray =
-            parseFloat(target) >= 100 ? '100 0' : target + ', 100';
+          // Fix v2: explicit circumference + drop threshold to ≥99 (round-cap visual overlap starts before 100%)
+          // Circle r=15.9 → circumference = 2π × 15.9 ≈ 99.9
+          const t = parseFloat(target);
+          if (t >= 99) {
+            el.style.strokeDasharray = '99.9 0';
+          } else {
+            const len = (t / 100) * 99.9;
+            el.style.strokeDasharray = len.toFixed(2) + ' 99.9';
+          }
         });
       });
     });
@@ -1490,9 +1502,15 @@ const isEn = lang === 'en';
       overview.querySelectorAll('.donut-fill').forEach((el) => {
         const target = el.getAttribute('data-target');
         requestAnimationFrame(() => {
-          // Fix: at 100%, use "100 0" (no gap) to avoid stroke-linecap round artifact
-          el.style.strokeDasharray =
-            parseFloat(target) >= 100 ? '100 0' : target + ', 100';
+          // Fix v2: explicit circumference + drop threshold to ≥99 (round-cap visual overlap starts before 100%)
+          // Circle r=15.9 → circumference = 2π × 15.9 ≈ 99.9
+          const t = parseFloat(target);
+          if (t >= 99) {
+            el.style.strokeDasharray = '99.9 0';
+          } else {
+            const len = (t / 100) * 99.9;
+            el.style.strokeDasharray = len.toFixed(2) + ' 99.9';
+          }
         });
       });
     });


### PR DESCRIPTION
v1 fix only handled exact 100%. v2 uses explicit circumference (99.9) + lowers threshold to ≥99% to handle the round-cap visual overlap zone.