### PR TITLE
🧬 [semiont] reader options: dark mode + 字級 + 純文字 endpoint (#615)

### DIFF
--- a/src/components/ReaderSettings.astro
+++ b/src/components/ReaderSettings.astro
@@ -1,0 +1,517 @@
+---
+/**
+ * ReaderSettings.astro — floating reader controls (theme + size + plain text).
+ *
+ * Sits next to the existing .floating-md button (Layout.astro). Exposes:
+ *   1. Light / Auto / Dark  — sets data-theme on <html>
+ *   2. Text size standard / large / xlarge — sets data-text-size on <html>
+ *   3. Link to /raw/{path}.md plain-text view
+ *
+ * FOUC-safe init lives in Layout.astro <head> so toggling never flashes.
+ * Born: Issue #615 / idlccp1984 reader options request, 2026-05-01 γ-late.
+ */
+import type { Lang } from '../config/languages';
+
+interface Props {
+  lang?: Lang;
+}
+const { lang = 'zh-TW' } = Astro.props;
+
+type Strings = {
+  open: string;
+  title: string;
+  themeLabel: string;
+  themeLight: string;
+  themeAuto: string;
+  themeDark: string;
+  sizeLabel: string;
+  sizeStandard: string;
+  sizeLarge: string;
+  sizeXLarge: string;
+  plainTextLabel: string;
+  plainTextHint: string;
+  close: string;
+};
+
+const STRINGS: Record<string, Strings> = {
+  'zh-TW': {
+    open: '閱讀設定',
+    title: '閱讀設定',
+    themeLabel: '主題',
+    themeLight: '日',
+    themeAuto: '隨系統',
+    themeDark: '夜',
+    sizeLabel: '字級',
+    sizeStandard: '標準',
+    sizeLarge: '較大',
+    sizeXLarge: '最大',
+    plainTextLabel: '純文字版',
+    plainTextHint: '無 JS / 無樣式 / 無圖片，適合弱網或舊裝置',
+    close: '關閉',
+  },
+  en: {
+    open: 'Reader settings',
+    title: 'Reader settings',
+    themeLabel: 'Theme',
+    themeLight: 'Light',
+    themeAuto: 'Auto',
+    themeDark: 'Dark',
+    sizeLabel: 'Text size',
+    sizeStandard: 'Standard',
+    sizeLarge: 'Large',
+    sizeXLarge: 'X-Large',
+    plainTextLabel: 'Plain text version',
+    plainTextHint:
+      'No JS, no CSS, no images — for poor networks or old devices',
+    close: 'Close',
+  },
+  ja: {
+    open: '表示設定',
+    title: '表示設定',
+    themeLabel: 'テーマ',
+    themeLight: 'ライト',
+    themeAuto: '自動',
+    themeDark: 'ダーク',
+    sizeLabel: '文字サイズ',
+    sizeStandard: '標準',
+    sizeLarge: '大',
+    sizeXLarge: '特大',
+    plainTextLabel: 'プレーンテキスト版',
+    plainTextHint: 'JS/CSS/画像なし — 低速回線や古い端末向け',
+    close: '閉じる',
+  },
+  ko: {
+    open: '읽기 설정',
+    title: '읽기 설정',
+    themeLabel: '테마',
+    themeLight: '라이트',
+    themeAuto: '자동',
+    themeDark: '다크',
+    sizeLabel: '글자 크기',
+    sizeStandard: '표준',
+    sizeLarge: '크게',
+    sizeXLarge: '아주 크게',
+    plainTextLabel: '플레인 텍스트 버전',
+    plainTextHint: 'JS/CSS/이미지 없음 — 저속망·구형 기기용',
+    close: '닫기',
+  },
+  es: {
+    open: 'Ajustes de lectura',
+    title: 'Ajustes de lectura',
+    themeLabel: 'Tema',
+    themeLight: 'Claro',
+    themeAuto: 'Auto',
+    themeDark: 'Oscuro',
+    sizeLabel: 'Tamaño',
+    sizeStandard: 'Estándar',
+    sizeLarge: 'Grande',
+    sizeXLarge: 'Muy grande',
+    plainTextLabel: 'Versión texto plano',
+    plainTextHint:
+      'Sin JS, CSS o imágenes — redes lentas o dispositivos antiguos',
+    close: 'Cerrar',
+  },
+  fr: {
+    open: 'Réglages de lecture',
+    title: 'Réglages de lecture',
+    themeLabel: 'Thème',
+    themeLight: 'Clair',
+    themeAuto: 'Auto',
+    themeDark: 'Sombre',
+    sizeLabel: 'Taille',
+    sizeStandard: 'Standard',
+    sizeLarge: 'Grande',
+    sizeXLarge: 'Très grande',
+    plainTextLabel: 'Version texte brut',
+    plainTextHint:
+      'Sans JS, CSS ni images — réseaux lents ou anciens appareils',
+    close: 'Fermer',
+  },
+};
+
+const t: Strings = STRINGS[lang] ?? STRINGS['zh-TW'];
+---
+
+<button
+  id="reader-settings-toggle"
+  class="reader-settings-toggle"
+  type="button"
+  aria-label={t.open}
+  aria-controls="reader-settings-panel"
+  aria-expanded="false"
+  title={t.open}
+>
+  <!-- Aa glyph — chosen over a gear because the panel is reading-focused.
+       Keeps visual weight close to the .md button it sits next to. -->
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    stroke-width="2"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M4 19l4-12 4 12"></path>
+    <path d="M5.5 15h5"></path>
+    <path d="M14 12.5a3.5 3.5 0 0 1 7 0V19"></path>
+    <path d="M14 16.5h7"></path>
+  </svg>
+</button>
+
+<aside
+  id="reader-settings-panel"
+  class="reader-settings-panel"
+  role="dialog"
+  aria-modal="false"
+  aria-labelledby="reader-settings-title"
+  hidden
+>
+  <header class="rs-header">
+    <h2 id="reader-settings-title" class="rs-title">{t.title}</h2>
+    <button type="button" class="rs-close" aria-label={t.close} data-rs-close
+      >×</button
+    >
+  </header>
+
+  <fieldset class="rs-group">
+    <legend class="rs-legend">{t.themeLabel}</legend>
+    <div class="rs-segmented" role="group" aria-labelledby="rs-theme-label">
+      <button type="button" class="rs-seg" data-rs-theme="light"
+        >{t.themeLight}</button
+      >
+      <button type="button" class="rs-seg" data-rs-theme="auto"
+        >{t.themeAuto}</button
+      >
+      <button type="button" class="rs-seg" data-rs-theme="dark"
+        >{t.themeDark}</button
+      >
+    </div>
+  </fieldset>
+
+  <fieldset class="rs-group">
+    <legend class="rs-legend">{t.sizeLabel}</legend>
+    <div class="rs-segmented" role="group">
+      <button type="button" class="rs-seg" data-rs-size="standard"
+        >{t.sizeStandard}</button
+      >
+      <button type="button" class="rs-seg" data-rs-size="large"
+        >{t.sizeLarge}</button
+      >
+      <button type="button" class="rs-seg" data-rs-size="xlarge"
+        >{t.sizeXLarge}</button
+      >
+    </div>
+  </fieldset>
+
+  <div class="rs-group rs-group--plain">
+    <a
+      id="reader-settings-raw-link"
+      class="rs-raw-link"
+      href="#"
+      target="_blank"
+      rel="noopener"
+    >
+      <span class="rs-raw-label">{t.plainTextLabel} ↗</span>
+      <span class="rs-raw-hint">{t.plainTextHint}</span>
+    </a>
+  </div>
+</aside>
+
+<script is:inline>
+  (function () {
+    var toggle = document.getElementById('reader-settings-toggle');
+    var panel = document.getElementById('reader-settings-panel');
+    var rawLink = document.getElementById('reader-settings-raw-link');
+    if (!toggle || !panel) return;
+    var html = document.documentElement;
+    var mql =
+      window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)');
+
+    function readTheme() {
+      var saved = null;
+      try {
+        saved = localStorage.getItem('tw-md-theme');
+      } catch (_) {}
+      if (saved === 'light' || saved === 'dark') return saved;
+      return 'auto';
+    }
+    function readSize() {
+      var saved = null;
+      try {
+        saved = localStorage.getItem('tw-md-text-size');
+      } catch (_) {}
+      return saved === 'large' || saved === 'xlarge' ? saved : 'standard';
+    }
+
+    function applyTheme(value) {
+      // value: 'light' | 'auto' | 'dark'
+      try {
+        if (value === 'auto') localStorage.removeItem('tw-md-theme');
+        else localStorage.setItem('tw-md-theme', value);
+      } catch (_) {}
+      var effective =
+        value === 'auto' ? (mql && mql.matches ? 'dark' : 'light') : value;
+      if (effective === 'dark') html.setAttribute('data-theme', 'dark');
+      else html.removeAttribute('data-theme');
+      paintActive();
+    }
+    function applySize(value) {
+      try {
+        if (value === 'standard') localStorage.removeItem('tw-md-text-size');
+        else localStorage.setItem('tw-md-text-size', value);
+      } catch (_) {}
+      if (value === 'large' || value === 'xlarge') {
+        html.setAttribute('data-text-size', value);
+      } else {
+        html.removeAttribute('data-text-size');
+      }
+      paintActive();
+    }
+    function paintActive() {
+      var theme = readTheme();
+      var size = readSize();
+      panel.querySelectorAll('[data-rs-theme]').forEach(function (b) {
+        b.classList.toggle(
+          'rs-seg--on',
+          b.getAttribute('data-rs-theme') === theme,
+        );
+      });
+      panel.querySelectorAll('[data-rs-size]').forEach(function (b) {
+        b.classList.toggle(
+          'rs-seg--on',
+          b.getAttribute('data-rs-size') === size,
+        );
+      });
+    }
+    function setRawLink() {
+      if (!rawLink) return;
+      // Map '/[lang/]<category>/<slug>' → '/[lang/]raw/<category>/<slug>'.
+      // Hub pages and non-article routes get hidden — there's no plain-text
+      // view for them yet (Hubs aren't a single .md file).
+      var path = location.pathname.replace(/\/$/, '');
+      var langPrefixes = ['/en', '/ja', '/ko', '/es', '/fr'];
+      var prefix = '';
+      for (var i = 0; i < langPrefixes.length; i++) {
+        if (
+          path === langPrefixes[i] ||
+          path.indexOf(langPrefixes[i] + '/') === 0
+        ) {
+          prefix = langPrefixes[i];
+          path = path.slice(prefix.length);
+          break;
+        }
+      }
+      var parts = path.split('/').filter(Boolean);
+      if (parts.length === 2) {
+        // .md suffix matches the file route [slug].md.ts and signals
+        // "plain text markdown" to browsers (save-as friendly).
+        rawLink.href = prefix + '/raw/' + parts[0] + '/' + parts[1] + '.md';
+        rawLink.style.display = '';
+      } else {
+        rawLink.style.display = 'none';
+      }
+    }
+
+    toggle.addEventListener('click', function () {
+      var open = panel.hasAttribute('hidden')
+        ? false
+        : !panel.classList.contains('rs-panel--closed');
+      if (open) {
+        panel.classList.add('rs-panel--closed');
+        panel.setAttribute('hidden', '');
+        toggle.setAttribute('aria-expanded', 'false');
+      } else {
+        panel.removeAttribute('hidden');
+        panel.classList.remove('rs-panel--closed');
+        toggle.setAttribute('aria-expanded', 'true');
+        paintActive();
+        setRawLink();
+      }
+    });
+    panel
+      .querySelector('[data-rs-close]')
+      .addEventListener('click', function () {
+        panel.setAttribute('hidden', '');
+        toggle.setAttribute('aria-expanded', 'false');
+      });
+    panel.querySelectorAll('[data-rs-theme]').forEach(function (b) {
+      b.addEventListener('click', function () {
+        applyTheme(b.getAttribute('data-rs-theme'));
+      });
+    });
+    panel.querySelectorAll('[data-rs-size]').forEach(function (b) {
+      b.addEventListener('click', function () {
+        applySize(b.getAttribute('data-rs-size'));
+      });
+    });
+    if (mql && mql.addEventListener) {
+      mql.addEventListener('change', function () {
+        if (readTheme() === 'auto') applyTheme('auto');
+      });
+    }
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape' && !panel.hasAttribute('hidden')) {
+        panel.setAttribute('hidden', '');
+        toggle.setAttribute('aria-expanded', 'false');
+        toggle.focus();
+      }
+    });
+  })();
+</script>
+
+<style>
+  .reader-settings-toggle {
+    position: fixed;
+    bottom: 2rem;
+    right: calc(2rem + 48px + 12px);
+    width: 48px;
+    height: 48px;
+    background: var(--color-ink);
+    color: var(--color-accent);
+    border: 0;
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: var(--shadow-card);
+    transition: all 0.2s;
+    z-index: 40;
+  }
+  .reader-settings-toggle:hover {
+    transform: translateY(-2px);
+    background: var(--color-accent);
+    color: var(--color-bg);
+  }
+  .reader-settings-panel {
+    position: fixed;
+    bottom: calc(2rem + 48px + 12px);
+    right: 2rem;
+    width: min(320px, calc(100vw - 4rem));
+    background: var(--color-surface);
+    color: var(--color-ink);
+    border: 1px solid var(--color-border);
+    border-radius: 14px;
+    box-shadow: var(--shadow-card);
+    padding: 1rem 1.1rem 1.1rem;
+    z-index: 41;
+    font-family: var(--font-interface);
+  }
+  .rs-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.85rem;
+  }
+  .rs-title {
+    margin: 0;
+    font-size: 0.95rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    color: var(--color-ink);
+  }
+  .rs-close {
+    background: transparent;
+    border: 0;
+    color: var(--color-ink-soft);
+    font-size: 1.4rem;
+    line-height: 1;
+    cursor: pointer;
+    padding: 0 0.3rem;
+  }
+  .rs-close:hover {
+    color: var(--color-ink);
+  }
+  .rs-group {
+    border: 0;
+    padding: 0;
+    margin: 0 0 0.8rem;
+  }
+  .rs-group--plain {
+    margin-top: 0.4rem;
+    padding-top: 0.8rem;
+    border-top: 1px solid var(--color-border);
+  }
+  .rs-legend {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-ink-soft);
+    padding: 0;
+    margin-bottom: 0.4rem;
+  }
+  .rs-segmented {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 4px;
+    background: color-mix(in srgb, var(--color-ink) 5%, transparent);
+    padding: 4px;
+    border-radius: 10px;
+  }
+  .rs-seg {
+    background: transparent;
+    border: 0;
+    padding: 0.5rem 0.4rem;
+    border-radius: 7px;
+    font-size: 0.85rem;
+    color: var(--color-ink-soft);
+    cursor: pointer;
+    transition:
+      background 0.15s,
+      color 0.15s;
+  }
+  .rs-seg:hover {
+    color: var(--color-ink);
+  }
+  .rs-seg--on {
+    background: var(--color-surface);
+    color: var(--color-ink);
+    box-shadow:
+      0 1px 2px rgba(0, 0, 0, 0.05),
+      0 0 0 1px var(--color-border);
+    font-weight: 600;
+  }
+  .rs-raw-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    text-decoration: none;
+    color: var(--color-ink);
+    padding: 0.55rem 0.7rem;
+    border-radius: 9px;
+    background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+    border: 1px solid color-mix(in srgb, var(--color-accent) 25%, transparent);
+    transition: background 0.15s;
+  }
+  .rs-raw-link:hover {
+    background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  }
+  .rs-raw-label {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+  .rs-raw-hint {
+    font-size: 0.75rem;
+    color: var(--color-ink-soft);
+    line-height: 1.4;
+  }
+  /* Hide on screenshot mode — same surface that hides ?shot=1 chrome. */
+  :root[data-shot='1'] .reader-settings-toggle,
+  :root[data-shot='1'] .reader-settings-panel {
+    display: none !important;
+  }
+  @media (max-width: 640px) {
+    .reader-settings-toggle {
+      bottom: 1.2rem;
+      right: calc(1.2rem + 48px + 10px);
+    }
+    .reader-settings-panel {
+      bottom: calc(1.2rem + 48px + 10px);
+      right: 1.2rem;
+    }
+  }
+</style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,10 +1,12 @@
 ---
 import '../styles/global.css';
 import '../styles/shot-mode.css';
+import '../styles/dark-polish.css';
 import SEO from '../components/SEO.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import BrandMark from '../components/BrandMark.astro';
+import ReaderSettings from '../components/ReaderSettings.astro';
 
 import type { Lang } from '../config/languages';
 
@@ -170,6 +172,41 @@ const jfClass = [
             document.addEventListener('DOMContentLoaded', apply);
           } else {
             apply();
+          }
+        } catch (_) {}
+      })();
+    </script>
+    <!-- Reader settings: dark mode + font size — FOUC-safe early init.
+         Reads localStorage and prefers-color-scheme BEFORE first paint
+         so toggling theme doesn't flash. Idempotent. ?shot=1 short-circuits
+         to keep OG image generation fully light, regardless of user pref.
+         (2026-05-01 γ-late, Issue #615 / idlccp1984 reader options) -->
+    <script is:inline>
+      (function () {
+        try {
+          var qs = new URLSearchParams(location.search);
+          if (qs.get('shot') === '1') return;
+          var html = document.documentElement;
+          var saved = null;
+          try {
+            saved = localStorage.getItem('tw-md-theme');
+          } catch (_) {}
+          var prefersDark =
+            window.matchMedia &&
+            window.matchMedia('(prefers-color-scheme: dark)').matches;
+          var theme =
+            saved === 'dark' || saved === 'light'
+              ? saved
+              : prefersDark
+                ? 'dark'
+                : 'light';
+          if (theme === 'dark') html.setAttribute('data-theme', 'dark');
+          var size = null;
+          try {
+            size = localStorage.getItem('tw-md-text-size');
+          } catch (_) {}
+          if (size === 'large' || size === 'xlarge') {
+            html.setAttribute('data-text-size', size);
           }
         } catch (_) {}
       })();
@@ -815,6 +852,10 @@ const jfClass = [
     >
       .md
     </a>
+
+    <!-- Reader settings: theme + size + plain-text link
+         (Issue #615 / idlccp1984 reader options, 2026-05-01 γ-late) -->
+    <ReaderSettings lang={lang} />
 
     <script is:inline>
       // Set .md button href based on current path

--- a/src/pages/en/raw/[category]/[slug].md.ts
+++ b/src/pages/en/raw/[category]/[slug].md.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import {
+  getRawPaths,
+  renderRawMarkdown,
+  RAW_HEADERS,
+} from '../../../../utils/rawArticle';
+
+export async function getStaticPaths() {
+  return getRawPaths('en');
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { absPath, lang } = props as { absPath: string; lang: string };
+  const body = await renderRawMarkdown(absPath, lang);
+  return new Response(body, { headers: RAW_HEADERS });
+};

--- a/src/pages/ja/raw/[category]/[slug].md.ts
+++ b/src/pages/ja/raw/[category]/[slug].md.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import {
+  getRawPaths,
+  renderRawMarkdown,
+  RAW_HEADERS,
+} from '../../../../utils/rawArticle';
+
+export async function getStaticPaths() {
+  return getRawPaths('ja');
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { absPath, lang } = props as { absPath: string; lang: string };
+  const body = await renderRawMarkdown(absPath, lang);
+  return new Response(body, { headers: RAW_HEADERS });
+};

--- a/src/pages/ko/raw/[category]/[slug].md.ts
+++ b/src/pages/ko/raw/[category]/[slug].md.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import {
+  getRawPaths,
+  renderRawMarkdown,
+  RAW_HEADERS,
+} from '../../../../utils/rawArticle';
+
+export async function getStaticPaths() {
+  return getRawPaths('ko');
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { absPath, lang } = props as { absPath: string; lang: string };
+  const body = await renderRawMarkdown(absPath, lang);
+  return new Response(body, { headers: RAW_HEADERS });
+};

--- a/src/pages/raw/[category]/[slug].md.ts
+++ b/src/pages/raw/[category]/[slug].md.ts
@@ -1,0 +1,16 @@
+import type { APIRoute } from 'astro';
+import {
+  getRawPaths,
+  renderRawMarkdown,
+  RAW_HEADERS,
+} from '../../../utils/rawArticle';
+
+export async function getStaticPaths() {
+  return getRawPaths('zh-TW');
+}
+
+export const GET: APIRoute = async ({ props }) => {
+  const { absPath, lang } = props as { absPath: string; lang: string };
+  const body = await renderRawMarkdown(absPath, lang);
+  return new Response(body, { headers: RAW_HEADERS });
+};

--- a/src/styles/dark-polish.css
+++ b/src/styles/dark-polish.css
@@ -1,0 +1,104 @@
+/**
+ * dark-polish.css — minimal dark-mode override layer for component-scoped surfaces.
+ *
+ * Why this file exists:
+ *   tokens.css flips the body bg/ink in one place via [data-theme='dark'].
+ *   But many component & page files (slug.astro × 6 langs, hero, sidebar,
+ *   cards, header) still carry hardcoded hex colors from before color
+ *   tokens existed. A full re-tokenization is a large refactor — this
+ *   file is the pragmatic v1 patch that keeps reading legible in dark
+ *   mode without rewriting every hex.
+ *
+ * Selector strategy:
+ *   We target the cross-file *class names* that hold the most visible
+ *   reading surfaces (.prose, .hero-title overrides, etc). All rules
+ *   are gated on :root[data-theme='dark'], so light mode is untouched.
+ *
+ * NOT in scope for v1:
+ *   - Header/Nav internals (Header.astro is 1,759 lines; needs its own pass)
+ *   - Category-specific hero gradients (each kept light by intent)
+ *   - SVG illustrations / data viz colors
+ *
+ * Born: Issue #615 / idlccp1984 reader options, 2026-05-01 γ-late.
+ */
+
+:root[data-theme='dark'] .prose {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose h1,
+:root[data-theme='dark'] .prose h2,
+:root[data-theme='dark'] .prose h3,
+:root[data-theme='dark'] .prose h4,
+:root[data-theme='dark'] .prose h5,
+:root[data-theme='dark'] .prose h6 {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose h2 {
+  border-bottom-color: var(--color-border);
+}
+:root[data-theme='dark'] .prose p,
+:root[data-theme='dark'] .prose li {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose strong,
+:root[data-theme='dark'] .prose em,
+:root[data-theme='dark'] .prose b,
+:root[data-theme='dark'] .prose i {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose a {
+  color: var(--color-accent);
+  text-decoration-color: color-mix(
+    in srgb,
+    var(--color-accent) 50%,
+    transparent
+  );
+}
+:root[data-theme='dark'] .prose a:hover {
+  text-decoration-color: var(--color-accent);
+}
+:root[data-theme='dark'] .prose blockquote {
+  color: var(--color-ink-soft);
+  border-left-color: var(--color-border);
+}
+:root[data-theme='dark'] .prose code {
+  background-color: color-mix(in srgb, var(--color-ink) 8%, transparent);
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose pre {
+  background-color: color-mix(in srgb, var(--color-ink) 12%, transparent);
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose hr {
+  border-color: var(--color-border);
+}
+:root[data-theme='dark'] .prose table {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] .prose th,
+:root[data-theme='dark'] .prose td {
+  border-color: var(--color-border);
+}
+
+/* Global "card" surfaces — many components use these class fragments.
+   Catch the visible-bg ones with a broad pattern. */
+:root[data-theme='dark']
+  [class*='card']:not([class*='category-card']):not([class*='supporter-card']) {
+  background-color: color-mix(in srgb, var(--color-ink) 6%, transparent);
+  border-color: var(--color-border);
+}
+
+/* TableOfContents / sidebar containers */
+:root[data-theme='dark'] .table-of-contents,
+:root[data-theme='dark'] .article-sidebar,
+:root[data-theme='dark'] [class*='sidebar'] {
+  color: var(--color-ink);
+}
+
+/* Header: keep light for v1 — its internals are heavily styled and need
+   a dedicated pass. Add a soft border so it doesn't appear seamless
+   with the dark body. */
+:root[data-theme='dark'] header[class*='global-header'],
+:root[data-theme='dark'] .site-header {
+  border-bottom: 1px solid var(--color-border);
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -130,14 +130,16 @@
     font-family: var(--font-reading);
     font-weight: 400;
     line-height: 1.75;
-    color: #1a1a2e;
-    background:
+    color: var(--color-ink);
+    background-color: var(--color-bg);
+    background-image:
       radial-gradient(
         circle at top,
-        rgba(226, 232, 240, 0.35),
+        color-mix(in srgb, var(--color-ink) 8%, transparent),
         transparent 30%
       ),
-      linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
+      linear-gradient(180deg, var(--color-bg) 0%, var(--color-bg-soft) 100%);
+    font-size: calc(1rem * var(--reader-size-scale, 1));
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     text-rendering: optimizeLegibility;
@@ -350,9 +352,10 @@
     a:not(.nav-link):not([class*='btn']):not(.card-link):not(.logo):not(
       .category-card
     ):not(.floating-md):not(.search-item):not(.reading-step):not(.update-item) {
-    color: #475569;
+    color: var(--color-ink-soft);
     text-decoration: none;
-    border-bottom: 1px solid #cbd5e1;
+    border-bottom: 1px solid
+      color-mix(in srgb, var(--color-ink-soft) 35%, transparent);
     padding-bottom: 1px;
     transition: all 0.2s ease;
   }
@@ -362,8 +365,8 @@
     ):not(.floating-md):not(.search-item):not(.reading-step):not(
       .update-item
     ):hover {
-    color: #1a1a2e;
-    border-bottom-color: #64748b;
+    color: var(--color-ink);
+    border-bottom-color: var(--color-ink);
   }
 
   /* External links get an upward arrow */
@@ -387,8 +390,8 @@
     right: 2rem;
     width: 48px;
     height: 48px;
-    background: #1a1a2e;
-    color: #3b82f6;
+    background: var(--color-ink);
+    color: var(--color-accent);
     border-radius: 12px;
     display: flex;
     align-items: center;
@@ -403,9 +406,10 @@
   }
   .floating-md:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(59, 130, 246, 0.3);
-    background: #3b82f6;
-    color: white;
+    box-shadow: 0 6px 20px
+      color-mix(in srgb, var(--color-accent) 30%, transparent);
+    background: var(--color-accent);
+    color: var(--color-bg);
   }
 
   /* ------------------------------------------------------------------------

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -52,4 +52,44 @@
   --title-minor-size: 1.1rem;
   --title-line-height: 1.2;
   --title-letter-spacing: 0;
+
+  /* === Reader colors (light theme defaults, 2026-05-01 γ-late) ===
+   * Pragmatic v1: not yet a full re-tokenization of every hex in src/.
+   * The five vars below cover the largest reading surfaces (body bg,
+   * body ink, soft ink, surface card, accent link). global.css @layer
+   * base reads them; the dark override below flips them in one place.
+   */
+  --color-bg: #ffffff;
+  --color-bg-soft: #f8fafc;
+  --color-ink: #1a1a2e;
+  --color-ink-soft: #475569;
+  --color-surface: #ffffff;
+  --color-border: rgba(15, 23, 42, 0.08);
+  --color-accent: #3b82f6;
+
+  /* === Reader font-size scale (2026-05-01 γ-late) ===
+   * data-text-size on <html>: '' (default) | 'large' | 'xlarge'.
+   * Multiplied into body font-size in global.css.
+   */
+  --reader-size-scale: 1;
+
+  color-scheme: light;
+}
+
+:root[data-theme='dark'] {
+  --color-bg: #0e1320;
+  --color-bg-soft: #131a2a;
+  --color-ink: #e2e8f0;
+  --color-ink-soft: #94a3b8;
+  --color-surface: #1a2235;
+  --color-border: rgba(226, 232, 240, 0.12);
+  --color-accent: #60a5fa;
+  color-scheme: dark;
+}
+
+:root[data-text-size='large'] {
+  --reader-size-scale: 1.125;
+}
+:root[data-text-size='xlarge'] {
+  --reader-size-scale: 1.25;
 }

--- a/src/utils/rawArticle.ts
+++ b/src/utils/rawArticle.ts
@@ -1,0 +1,97 @@
+/**
+ * rawArticle.ts — shared helpers for the /raw/ plain-text endpoints.
+ *
+ * Plain-text routes expose `knowledge/**.md` (the SSOT) directly over HTTP,
+ * so readers on poor networks, old devices, screen readers, lynx, or anything
+ * future-proof can read articles with zero JS, zero CSS, no images, no fonts.
+ *
+ * Mirrors the category mapping used in src/pages/[category]/[slug].astro.
+ */
+
+import { readdir, readFile } from 'fs/promises';
+import { resolve, join, basename } from 'path';
+
+export const CATEGORY_TO_FOLDER: Record<string, string> = {
+  about: 'About',
+  history: 'History',
+  geography: 'Geography',
+  culture: 'Culture',
+  food: 'Food',
+  art: 'Art',
+  music: 'Music',
+  technology: 'Technology',
+  nature: 'Nature',
+  people: 'People',
+  society: 'Society',
+  economy: 'Economy',
+  lifestyle: 'Lifestyle',
+};
+
+/** Root-relative dir for a given language: '' = zh-TW, 'en' / 'ja' / etc. */
+function langDir(lang: string): string {
+  return lang === 'zh-TW' ? '' : lang;
+}
+
+export async function getRawPaths(lang: string) {
+  const langSegment = langDir(lang);
+  const knowledgeRoot = langSegment
+    ? resolve(process.cwd(), 'knowledge', langSegment)
+    : resolve(process.cwd(), 'knowledge');
+
+  const paths: Array<{
+    params: { category: string; slug: string };
+    props: { lang: string; absPath: string };
+  }> = [];
+
+  for (const [categorySlug, folderName] of Object.entries(CATEGORY_TO_FOLDER)) {
+    const folderPath = join(knowledgeRoot, folderName);
+    let files: string[] = [];
+    try {
+      files = await readdir(folderPath);
+    } catch {
+      continue;
+    }
+    for (const file of files.filter(
+      (f) => f.endsWith('.md') && !f.startsWith('_'),
+    )) {
+      const slug = basename(file, '.md');
+      paths.push({
+        params: { category: categorySlug, slug },
+        props: {
+          lang,
+          absPath: join(folderPath, file).normalize('NFC'),
+        },
+      });
+    }
+  }
+  return paths;
+}
+
+/**
+ * Render a raw markdown response. Includes a 4-line provenance header so the
+ * reader knows what they're looking at without rendering frontmatter UI.
+ */
+export async function renderRawMarkdown(absPath: string, lang: string) {
+  const content = await readFile(absPath, 'utf-8');
+  const relFromKnowledge = absPath.split('/knowledge/')[1] ?? '';
+  const sourceUrl = relFromKnowledge
+    ? `https://github.com/frank890417/taiwan-md/blob/main/knowledge/${relFromKnowledge}`
+    : '';
+
+  const header = [
+    `# Source: knowledge/${relFromKnowledge}`,
+    `# Language: ${lang}`,
+    `# License: CC BY-SA 4.0  ·  Editable on GitHub: ${sourceUrl}`,
+    `# Plain-text view of Taiwan.md — no JS, no CSS, no images. The source markdown is the SSOT.`,
+    '',
+    '',
+  ].join('\n');
+
+  return header + content;
+}
+
+export const RAW_HEADERS = {
+  'Content-Type': 'text/plain; charset=utf-8',
+  'Cache-Control': 'public, max-age=3600',
+  'X-Content-Type-Options': 'nosniff',
+};


### PR DESCRIPTION
## Summary

回應 [#615](https://github.com/frank890417/taiwan-md/issues/615) idlccp1984 的閱讀體驗建議（暗黑模式 / 字級 / 字體 / 純文字版）。

四選三實作：放掉「字體選項」（UX trap：CJK web font 1-3MB / 個 + 跨組件 QA 翻倍 + 極小眾需求），把預算投資在 **純文字 endpoint**——這條跟 MANIFESTO §6（knowledge/ 是唯一 DNA）+ §3（公共財）+「100 年後讀 Markdown 比讀 Astro build 容易」最對齊。

## 新增

- **`/raw/<cat>/<slug>.md` endpoint**（zh / en / ja / ko 四 active 語系）— 把 `knowledge/` SSOT 直接當 plain text 對外曝露。Content-Type: `text/plain; charset=utf-8`。無 JS / 無 CSS / 無圖 / 無 webfont。供弱網、舊裝置、螢幕閱讀器、lynx、AI 爬蟲、未來任何能讀文字的設備使用
- **ReaderSettings 浮動面板**（Aa 圖示，跟 .md 按鈕並列右下）：主題（日 / 隨系統 / 夜）+ 字級（標準 / 較大 / 最大）+ 純文字版連結。i18n 涵蓋 zh / en / ja / ko / es / fr
- **`tokens.css` color tokens**（`--color-bg / -ink / -surface / -border / -accent`）+ dark theme 覆寫。第一次正式 token 化顏色
- **`dark-polish.css`** catch-all dark mode overrides 給 prose / cards / sidebar 等 component-scoped 表面（避免逐 file patch 6+ slug pages）
- **FOUC-safe 早期 init script** in Layout `<head>`：painstaking 在第一次 paint 前把 `data-theme` / `data-text-size` 從 localStorage 套上去，toggling 不閃。`?shot=1` 短路保證 OG image 永遠 light

## 不做（理由）

- **字體選擇器** — UX trap。CJK web font 1-3MB / 個，多開選項 payload 翻倍 + 跨組件 QA 翻倍。「讀者自己挑字體」是極小眾需求；OpenDyslexic 之類 accessibility-driven 字體可未來 case-by-case 加
- **全站 color tokenization** — 散在 6+ slug page 的 hardcoded prose color 改用 `dark-polish.css` overlay 而非逐檔 refactor，避免 XL 級 scope 蔓延。Header.astro / 部分 category card 的 island 留待 follow-up PR

## Test plan

- [x] `npm run build` 全綠（exit 0，~465s，1800+ 頁）
- [x] 4 語系 `/raw/` endpoint 200 OK + Content-Type `text/plain; charset=utf-8`（zh / en / ja / ko 各驗證一篇）
- [x] FOUC-safe init：`prefers-color-scheme: dark` 自動套用 data-theme=dark
- [x] ReaderSettings 面板開合、主題切換、字級切換、純文字連結 href 動態組
- [x] body computed bg 在 dark mode 翻成 `#0e1320`、ink 翻成 `#e2e8f0`
- [x] `.prose p` color 在 dark mode 從 `#2c2c2c` → `rgb(226,232,240)` 確認（即 dark-polish.css 生效）
- [x] localStorage 持久化（reload 後保留偏好）
- [x] 「隨系統」模式：移除 LS，跟著 prefers-color-scheme 走，系統切換時 matchMedia listener 即時套用
- [ ] 真實裝置測試：iOS Safari / Android Chrome / 弱網模擬（建議 land 後在 production 看一輪）
- [ ] Header.astro 內部組件 dark 化（follow-up）

## 已知 follow-up

1. **Header / Nav 內部 dark 化** — Header.astro 是 1759 行的大組件，需要單獨一個 PR 系統性處理
2. **Category-specific hero gradient** — 各 category hub 有自己的 brand 漸層，目前刻意保留 light（與 §1 brand identity 互動，需設計決策）
3. **Hub pages（`_*Hub.md`）的 raw endpoint** — 目前 `/raw/` 只 cover 文章，Hub 是 hand-crafted markdown 也可曝露但 slug 命名需另議