### PR TITLE
🔧 [ci] fix CI failures — Node 22 for i18n-smoke + 60min build timeout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     # 2026-04-22 β post-mortem: run 24782448133 `npx playwright install --with-deps`
-    # silent hang 6 小時才被 default 360 min timeout 殺掉。加 30 分上限避免重演。
-    timeout-minutes: 35
+    # silent hang 6 小時才被 default 360 min timeout 殺掉。加上限避免重演。
+    # 2026-05-02 γ: 35 → 60 — article volume grew (641 zh × 6 langs ≈ 3800 pages)
+    # 加 OG generation，到 2411/2520 才被 35 min timeout 砍。
+    # If this hits 60 again, profile build (likely OG generation tail).
+    timeout-minutes: 60
     env:
       # 防 apt-get 互動 prompt（Playwright --with-deps 會呼叫 sudo apt-get）
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/i18n-smoke-test.yml
+++ b/.github/workflows/i18n-smoke-test.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

Two distinct CI failures fixed:

**1. i18n Smoke Test failing immediately on `npm run build`**
```
Node.js v20.20.2 is not supported by Astro!
Please upgrade Node.js to a supported version: ">=22.12.0"
```
Workflow used Node 20 while `deploy.yml` already uses Node 22. Bumped to match.

**2. Deploy build hits 35-min timeout mid-page-generation**
Last cancelled run was at page 2411/2520 when killed. Article volume grew significantly (641 zh × 6 langs ≈ 3800 pages, plus OG image generation). Bumped `timeout-minutes` from 35 → 60.

If 60 also gets hit, profile the build (the OG generation tail is the most likely bottleneck — chrome-headless-shell + npm run dev orphans were visible in cleanup).

## Test plan

- [ ] After merge, next push to main should complete deploy within 60 min
- [ ] i18n Smoke Test should now pass `npm run build` (assuming no genuine build errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)