### PR TITLE
🧬 [造橋鋪路] OG cache rename sync — fix 40 min build slowdown

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -104,6 +104,15 @@ jobs:
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 5
         run: npx --no-install playwright install chromium
+      # 2026-05-03 cross-lang-baseline post-mortem: PR #797 rename 902 lang files
+      # 到 en canonical slug (per URL convention 2026-04-12)。OG cache file 用 lang
+      # URL slug 為 path → outputPath 變 → 全 cache miss → 重 render ~4500 images
+      # = 40 min build slowdown (5/2 build 21 min → 5/3 build 60 min timeout)。
+      # Fix: OG generation 前先掃 git log rename history，把對應 cache file 從
+      # 舊 slug path mv 到新 slug path。原本要重 render 的 ~900 file 只要 mv 即可。
+      - name: Sync OG cache for renamed articles
+        timeout-minutes: 2
+        run: node scripts/tools/og-rename-sync.mjs --since '30 days ago'
       - name: Generate OG images (incremental via ?shot=1)
         run: |
           set -o pipefail

--- a/scripts/tools/og-rename-sync.mjs
+++ b/scripts/tools/og-rename-sync.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * og-rename-sync.mjs — 同步 OG cache file 對應 git rename，避免 cache miss 全 regen
+ *
+ * 背景（2026-05-03）：PR #797 cross-lang baseline rename 902 lang files 到 en
+ * canonical slug (per URL convention 2026-04-12)。OG cache file 用 lang URL slug
+ * 為 path（{lang}/{cat}/{urlSlug}.jpg），rename 後 outputPath 變 → cache miss →
+ * 全 regen ~4500 images = 40 min build slowdown。
+ *
+ * Fix: 在 OG generation 前跑此 script，掃 git log rename history，把對應 OG
+ * cache file 從舊 path mv 到新 path。
+ *
+ * Strategy:
+ * 1. git log -M --name-status --diff-filter=R 抓最近 N commits 的 rename
+ * 2. 過濾 knowledge/{lang}/Cat/file.md 的 lang file rename
+ * 3. 計算對應 OG path（lang URL slug = file basename without .md）
+ * 4. mv public/og-images/{lang}/{cat_slug}/{old_slug}.jpg → {new_slug}.jpg
+ *
+ * Usage:
+ *   node scripts/tools/og-rename-sync.mjs                     # default since 30 days
+ *   node scripts/tools/og-rename-sync.mjs --since '7 days ago'
+ *   node scripts/tools/og-rename-sync.mjs --dry-run
+ */
+
+import { execSync } from 'node:child_process';
+import { existsSync, statSync, renameSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { LANGUAGES } from '../../src/config/languages.mjs';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const REPO = join(__dirname, '../..');
+const OG_DIR = join(REPO, 'public/og-images');
+
+const args = process.argv.slice(2);
+const dryRun = args.includes('--dry-run');
+const sinceIdx = args.indexOf('--since');
+const since = sinceIdx >= 0 ? args[sinceIdx + 1] : '30 days ago';
+
+const CATEGORY_FOLDER_TO_SLUG = {
+  About: 'about',
+  History: 'history',
+  Geography: 'geography',
+  Culture: 'culture',
+  Food: 'food',
+  Art: 'art',
+  Music: 'music',
+  Technology: 'technology',
+  Nature: 'nature',
+  People: 'people',
+  Society: 'society',
+  Economy: 'economy',
+  Lifestyle: 'lifestyle',
+  Resources: 'resources',
+  Language: 'language',
+};
+
+// Derive non-default enabled lang codes from LANGUAGES_REGISTRY
+// (avoid hardcode array — DNA #20 architecture-as-data)
+const ENABLED_LANGS = new Set(
+  LANGUAGES.filter((l) => l.enabled && !l.isDefault).map((l) => l.code),
+);
+
+function gitRenames() {
+  // -M for rename detection, --diff-filter=R only renames, --name-status R000 old new
+  const cmd = `git log -M --name-status --diff-filter=R --pretty=format: --since='${since}' -- knowledge/`;
+  let out = '';
+  try {
+    out = execSync(cmd, { cwd: REPO, encoding: 'utf-8' });
+  } catch (e) {
+    console.error(`git log failed: ${e.message}`);
+    return [];
+  }
+
+  const renames = [];
+  for (const line of out.split('\n')) {
+    if (!line.startsWith('R')) continue;
+    // Format: R100\tknowledge/ja/Music/ktv.md\tknowledge/ja/Music/ktv-culture.md
+    const parts = line.split('\t');
+    if (parts.length < 3) continue;
+    const [, oldPath, newPath] = parts;
+
+    // Parse: knowledge/{lang}/{Category}/{slug}.md
+    const oldMatch = oldPath.match(/^knowledge\/([^/]+)\/([^/]+)\/(.+)\.md$/);
+    const newMatch = newPath.match(/^knowledge\/([^/]+)\/([^/]+)\/(.+)\.md$/);
+    if (!oldMatch || !newMatch) continue;
+
+    const [, oldLang, oldCat, oldSlug] = oldMatch;
+    const [, newLang, newCat, newSlug] = newMatch;
+
+    // Only handle non-zh lang renames within same lang+category
+    if (!ENABLED_LANGS.has(oldLang)) continue;
+    if (oldLang !== newLang) continue;
+    if (oldCat !== newCat) continue;
+    if (oldSlug === newSlug) continue;
+
+    renames.push({ lang: oldLang, cat: oldCat, oldSlug, newSlug });
+  }
+  return renames;
+}
+
+function ogPathFor(lang, cat, slug) {
+  const catSlug = CATEGORY_FOLDER_TO_SLUG[cat] || cat.toLowerCase();
+  return join(OG_DIR, lang, catSlug, `${slug}.jpg`);
+}
+
+function main() {
+  if (!existsSync(OG_DIR)) {
+    console.log(`OG_DIR not found: ${OG_DIR} — skipping (no cache to sync)`);
+    return 0;
+  }
+
+  const renames = gitRenames();
+  console.log(`📋 git log rename detection (since '${since}'):`);
+  console.log(`   ${renames.length} lang file renames found`);
+
+  if (renames.length === 0) {
+    console.log('✅ Nothing to sync.');
+    return 0;
+  }
+
+  // Dedup: most recent rename wins (latest oldSlug→newSlug for given lang/cat/slug)
+  // git log iterates newest first; first occurrence per (lang,cat,oldSlug) wins
+  const seen = new Set();
+  const dedupedRenames = [];
+  for (const r of renames) {
+    const key = `${r.lang}/${r.cat}/${r.oldSlug}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    dedupedRenames.push(r);
+  }
+
+  let applied = 0;
+  let skipped_no_old = 0;
+  let skipped_target_exists = 0;
+  let failed = 0;
+
+  for (const r of dedupedRenames) {
+    const oldJpg = ogPathFor(r.lang, r.cat, r.oldSlug);
+    const newJpg = ogPathFor(r.lang, r.cat, r.newSlug);
+
+    if (!existsSync(oldJpg)) {
+      skipped_no_old++;
+      continue;
+    }
+    if (existsSync(newJpg)) {
+      // Target already correct — old jpg is stale leftover, can delete or leave
+      skipped_target_exists++;
+      continue;
+    }
+
+    if (dryRun) {
+      console.log(
+        `  [dry-run] mv ${oldJpg.replace(REPO + '/', '')} → ${newJpg.replace(REPO + '/', '')}`,
+      );
+      applied++;
+      continue;
+    }
+
+    try {
+      renameSync(oldJpg, newJpg);
+      applied++;
+    } catch (e) {
+      console.error(`  ❌ mv failed ${oldJpg} → ${newJpg}: ${e.message}`);
+      failed++;
+    }
+  }
+
+  console.log(`\n📊 Summary:`);
+  console.log(`   Renames detected (deduped): ${dedupedRenames.length}`);
+  console.log(`   ✅ Applied (mv old→new):     ${applied}`);
+  console.log(`   ⏭️  Skipped (no old jpg):     ${skipped_no_old}`);
+  console.log(`   ⏭️  Skipped (target exists):  ${skipped_target_exists}`);
+  console.log(`   ❌ Failed:                    ${failed}`);
+
+  if (dryRun) {
+    console.log(`\n(dry-run; pass without --dry-run to apply)`);
+  }
+
+  return failed > 0 ? 1 : 0;
+}
+
+process.exit(main());


### PR DESCRIPTION
## Summary

哲宇「上一個 CI/CD 超過一小時 timeout」+「剛剛明明就不用全部 og cache 重新 render，但還是重新了，所以才那麼慢」push — root cause 找到 + 造橋鋪路修補。

## Root cause（哲宇直覺對了）

5/3 PR #797 cross-lang baseline rename 902 lang files 到 en canonical slug（per URL convention 2026-04-12）。OG cache file 用 lang URL slug 為 path：

- 之前：`public/og-images/ja/music/ktv.jpg` ✅ cache hit
- 5/3 後：file rename 成 `knowledge/ja/Music/ktv-culture.md`
- OG outputPath 改成 `public/og-images/ja/music/ktv-culture.jpg`
- Cache 找不到 → 重 render → **902 × 5 lang ≈ 4500 regen × 0.5s = 40 min**

## Build duration trend

| Date | OG step | Total | Status |
|------|---------|-------|--------|
| 5/2 success | 9s (incremental) | 21 min | ✅ |
| 5/3 timeout | **2409s (40 min)** | 60 min | ❌ timeout |

## Fix: `scripts/tools/og-rename-sync.mjs`（新）

OG generation 前先掃 git log rename history，把對應 OG cache file 從舊 path mv 到新 path。原本要重 render 的 ~900 files 改成 mv（毫秒 vs 分鐘）。

```bash
node scripts/tools/og-rename-sync.mjs --since '30 days ago'
```

`ENABLED_LANGS` 從 `LANGUAGES_REGISTRY` derive (DNA #20 architecture-as-data，pre-commit hook 強制檢查)。

## deploy.yml integration

加 step 在 Playwright install 之後、OG generation 之前。下次 deploy 預期：

- 902 file rename → mv 902 jpg ≈ 1-2 sec
- OG generation incremental ~9s 而不是 40 min
- Build 從 60 min timeout 回 ~21 min

## 造橋鋪路意義

「rename 大批 lang file」反覆出現場景（cross-lang slug consistency / 主題重命名 / 新貢獻者整理）。修補不是「下次更小心」是儀器化（DNA #15 反覆浮現要儀器化第 N+4 次）。

og-rename-sync.mjs 加進 deploy.yml 後，未來任何 rename 自動處理，build 永遠 incremental。

## Test plan

- [x] Local dry-run: 908 renames detected from past 7 days
- [x] git log -M rename detection works
- [x] Pre-commit hook hardcoded lang array 檢查通過
- [ ] CI deploy 跑完看 build 時間恢復 ~21 min
- [ ] OG step 從 40 min 降回 ~10 sec

🤖 Generated with [Claude Code](https://claude.com/claude-code)