### PR TITLE
🧬 [造橋鋪路] v2: og-rename-sync touch jpg mtime + deploy timeout 60 → 120

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,11 @@ jobs:
     # silent hang 6 小時才被 default 360 min timeout 殺掉。加上限避免重演。
     # 2026-05-02 γ: 35 → 60 — article volume grew (641 zh × 6 langs ≈ 3800 pages)
     # 加 OG generation，到 2411/2520 才被 35 min timeout 砍。
-    # If this hits 60 again, profile build (likely OG generation tail).
-    timeout-minutes: 60
+    # 2026-05-03 cross-lang-baseline: 60 → 120 — PR #797 rename 902 lang files
+    # cache miss 全 regen ~4500 OG images = 40 min OG step + 20 min Build = 60 min hit。
+    # og-rename-sync.mjs (PR #805) + jpg mtime touch (PR #806) 修補後預期回 ~21 min，
+    # 但 timeout cushion 加倍給穩定性緩衝（避免再撞 cache miss 場景 timeout 又 cancel）。
+    timeout-minutes: 120
     env:
       # 防 apt-get 互動 prompt（Playwright --with-deps 會呼叫 sudo apt-get）
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,7 +116,33 @@ jobs:
       - name: Sync OG cache for renamed articles
         timeout-minutes: 2
         run: node scripts/tools/og-rename-sync.mjs --since '30 days ago'
+      # OG generation skip optimization (2026-05-03)：detect if any content/template
+      # change since last commit; if not, skip the entire dev-server-boot + Playwright
+      # launch (~30-60s saved on memory/diary-only PRs to main).
+      - name: Detect OG-relevant changes
+        id: og-changes
+        run: |
+          # Check if any md content or OG template changed since last commit
+          # (HEAD~1 to HEAD on main) — else cache is already correct, no regen needed.
+          CHANGED=$(git diff --name-only HEAD~1 HEAD -- 'knowledge/**/*.md' \
+            'src/pages/[category]/[slug].astro' \
+            'src/pages/**/[category]/[slug].astro' \
+            'src/components/ArticleHero.astro' \
+            'src/layouts/Layout.astro' \
+            'src/styles/shot-mode.css' 2>/dev/null | head -1)
+          if [ -n "$CHANGED" ]; then
+            echo "needed=true" >> $GITHUB_OUTPUT
+            echo "✓ Content/template change detected — running OG generation"
+          else
+            echo "needed=false" >> $GITHUB_OUTPUT
+            echo "⏭️  No OG-relevant change — skipping dev server boot + Playwright launch (saves ~30-60s)"
+          fi
       - name: Generate OG images (incremental via ?shot=1)
+        if: steps.og-changes.outputs.needed == 'true'
+        # 4-core ubuntu-latest free runner: OG_WORKERS=4 (default) optimal.
+        # Set explicit env for clarity + future runner upgrade tuning.
+        env:
+          OG_WORKERS: 4
         run: |
           set -o pipefail
           # 背景啟 Astro dev server（產圖來源頁面）

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -4,6 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main]
+    # 2026-05-03 cross-lang-baseline post-mortem: PR #797 1435 file change 撞
+    # GitHub Actions「Argument list too long」shell limit。PR review 只對
+    # CONTENT / ENGINEERING change 有意義 — 純 docs/ memory/ diary/ reports/
+    # PR 跳過避免 false-fail + 加速 CI。
+    paths:
+      - 'knowledge/**'
+      - 'src/**'
+      - 'scripts/**'
+      - 'astro.config.mjs'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/**'
 
 permissions:
   contents: read

--- a/scripts/tools/og-rename-sync.mjs
+++ b/scripts/tools/og-rename-sync.mjs
@@ -23,7 +23,7 @@
  */
 
 import { execSync } from 'node:child_process';
-import { existsSync, statSync, renameSync } from 'node:fs';
+import { existsSync, statSync, renameSync, utimesSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { LANGUAGES } from '../../src/config/languages.mjs';
@@ -160,6 +160,13 @@ function main() {
 
     try {
       renameSync(oldJpg, newJpg);
+      // Touch jpg mtime to "now" so OG generator's incremental check
+      // (entry.mtimeMs > jpgMtime) sees it as fresh — md mtime is the rename
+      // commit time (set by git-restore-mtime-action), older than now.
+      // Without this, mv preserves old jpg mtime and 902 jpg are still
+      // judged stale → full regen 40 min.
+      const now = new Date();
+      utimesSync(newJpg, now, now);
       applied++;
     } catch (e) {
       console.error(`  ❌ mv failed ${oldJpg} → ${newJpg}: ${e.message}`);


### PR DESCRIPTION
## Summary

哲宇 push「上一個 CI/CD 超過一小時 timeout」+「剛剛明明就不用全部 og cache 重新 render」+「你看看還有什麼可以完整優化 然後一起 merge，檢查整個 ci/cd 的效率與步驟」— 整 CI/CD 全 cycle 優化。

## 5/2 baseline timing breakdown

| Step | Time | % |
|------|------|---|
| Build (astro SSG 2520 pages) | 1107s (18.5 min) | 89% |
| Generate OG (incremental cache hit) | 9s | 1% |
| Install Playwright system deps | 20s | 2% |
| All other | ~30s | 3% |
| **TOTAL** | **1246s (21 min)** | 100% |

## 5 個整合優化

### 1. v2 og-rename-sync.mjs `utimesSync` jpg mtime touch

v1（PR #805）mv 不更新 jpg mtime → git-restore-mtime 把 md mtime 還原成 rename commit time → mtime check 仍判 stale → 全 regen。v2 加 `utimesSync(newJpg, now, now)` 把 jpg mtime 推到 mv 當下，確保 > md mtime。

### 2. deploy.yml timeout 60 → 120 min cushion

post-mortem stack：
- 5/2 success: 21 min
- 5/3 PR #797 timeout: 60 min（4500 cache miss 全 regen）
- 修補後預期 ~21 min，但 cushion 加倍給穩定性緩衝

### 3. pr-review.yml paths filter

PR review 之前對所有 PR 跑（含純 docs/memory/diary）→ 撞「Argument list too long」shell limit fail（PR #797 1435 file 暴露）。加 paths filter 限縮到 content/engineering：

```yaml
paths:
  - 'knowledge/**'
  - 'src/**'
  - 'scripts/**'
  - 'astro.config.mjs'
  - 'package.json'
  - 'package-lock.json'
  - '.github/workflows/**'
```

純 docs/memory/diary/reports PR 自動跳過 → 30-60s saved per PR + 0 false-fail。

### 4. deploy.yml OG generation skip-when-clean

OG step 即使 cache hit 也要 boot dev server + launch Playwright (~30-60s)。加 git diff detect step：HEAD~1 vs HEAD 沒任何 md/template 變動 → skip OG step 完全。對 docs-only commit 推 main 救 30-60s。

### 5. OG_WORKERS env explicit

ubuntu-latest free runner = 4 CPU 核，目前 OG_WORKERS=4 default 已最優。設成 explicit env 為將來 runner upgrade（larger / arm64 / self-hosted）tuning 留 hook。

## Cumulative cache state（PR #805 deploy 揭露）

`Sync OG cache for renamed articles` v1 在 cancelled run 報告：
- 900 renames detected ✓
- 0 applied (mv)
- 890 skipped (no old jpg) — cache 已被前幾輪 cancelled deploys 污染

意義：v1 邏輯沒 bug，但 cache 殘缺。本次 deploy 跑完規模 regen 一次 + save cache，下次 deploy v1 + v2 才能展現效益。

## 期望

- 本次 deploy: 60-90 min（full regen 一次 + save cache，120 min cushion 內）
- 下次 deploy（任何 rename 場景）: ~21 min（v1 + v2 完整 cycle）
- Memory/diary-only PR：跳過 pr-review job + 跳過 OG step (~60s saved)

## 沒做的優化（trade-off 不值）

- Larger runner（ubuntu-latest-large）— 需 GitHub Team/Enterprise，open-source 不可用
- Astro experimental flags — 沒有對 SSG performance 顯著的 flag；2520 pages × 7s = inherent SSG cost
- node_modules cache（vs npm cache）— `npm ci` 已 6s，存儲成本 vs 收益不值

## Test plan

- [x] YAML lint pass on deploy.yml + pr-review.yml
- [x] Local script test: `og-rename-sync.mjs --dry-run` works
- [ ] CI deploy 完成（full regen 一次 + save cache）
- [ ] 後續 PR 驗證 ~21 min build 恢復
- [ ] Memory/diary-only PR 跳過 pr-review job 驗證

🤖 Generated with [Claude Code](https://claude.com/claude-code)