### PR TITLE
🧬 [造橋鋪路] dashboard-spores.json commit + prebuild:spores wire (production fresh)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prebuild:contributors": "node scripts/core/generate-contributors-data.js",
     "prebuild:supporters": "node scripts/core/generate-supporters-data.js",
     "prebuild:china-terms": "python3 scripts/core/extract-china-terms.py --quiet",
+    "prebuild:spores": "python3 scripts/tools/extract-spore-metrics.py --apply && python3 scripts/tools/generate-dashboard-spores.py",
     "prebuild:og": "node scripts/core/generate-og-images.mjs",
     "build": "astro build",
     "test": "node scripts/core/test-frontmatter.mjs",

--- a/public/api/dashboard-spores.json
+++ b/public/api/dashboard-spores.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-02T18:00:39.939473Z",
+  "lastUpdated": "2026-05-03T07:13:34.742757Z",
   "schemaVersion": "1.1",
   "totals": {
     "count": 58,
@@ -32,10 +32,10 @@
       "url": "https://x.com/taiwandotmd/status/2050601653792047479",
       "highlight": "**SPORE-PIPELINE v2.7 完整跑通 + 2 round FACTCHECK Full Mode**：賈永婕 EVOLVE 深度進化（commit `6961bddc`）後立即孢子化。Angle A+D 混合（旗桿 hook → HFNC 紀實 list → 5 年後首尾呼應），結構走 Step 3.6 故事弧線串接（首尾「往前推 5 年」+「5 年後」純時序對稱 framing，避免 forced causation hallucination）。Round 1 STORY ATOM AUDIT 抓 3 ❌（杜撰「我來」/「十通」/「都接」）+ 2 ⚠️（推算「1 小時」/「上午八點」）；Round 2 FACTCHECK Full Mode 抓 6 條（article 內部「兩天 vs 三天」+「1995 vs 2004 CH Wedding」+「世界第五高樓」實為第 11 高 + 刪 unverified《魔鬼佳人 72 變》+ spore 「她敢這麼做跟⋯有關」forced causation + 結尾日期+地點 redundant）。§11 ALL CLEAR / 純中文 258 字 / 配圖 landscape 3200×1800 + square 2160×2160 已產出（rixingsong-semibold + BrandMark）。Per Step 4.5a「中等明星」platform allocation Threads 主 X 次。",
       "views_7d": null,
-      "views_latest": null,
+      "views_latest": 12000,
       "engagements_7d": null,
       "rate_7d": null,
-      "backfilled": false
+      "backfilled": true
     },
     {
       "n": 57,
@@ -48,7 +48,7 @@
       "url": "https://www.threads.com/@taiwandotmd/post/DX13hccE6U6",
       "highlight": "**SPORE-PIPELINE v2.7 完整跑通 + 2 round FACTCHECK Full Mode**：賈永婕 EVOLVE 深度進化（commit `6961bddc`）後立即孢子化。Angle A+D 混合（旗桿 hook：2026-01-25 上午九點 Honnold 攀登前那個早上賈永婕讓人把 101 樓頂五根旗桿全換國旗 + IG 限時 verbatim → HFNC 紀實 list：2021 兩天 6,804 萬 252 台 → 5 年後首尾呼應）。Threads 主貼不含 URL，self-reply 加連結 `utm_source=threads&utm_medium=spore&utm_campaign=s57`。square 1080×1080 配圖。**雙首尾對稱「往前推 5 年。」+「5 年後。」獨句框架** 解決了 Round 2 抓到的「結尾混時序」hallucination。Step 4 §6 sporeLinks 已寫回文章 frontmatter（reader 可見）。",
       "views_7d": null,
-      "views_latest": 1800,
+      "views_latest": 14000,
       "engagements_7d": null,
       "rate_7d": null,
       "backfilled": true
@@ -64,10 +64,10 @@
       "url": "https://x.com/taiwandotmd/status/2049860918641893571",
       "highlight": "**SPORE-PIPELINE v2.7 完整跑通 + 觀察者責任倫理 reflection**（海底電纜 NEW 隔日首發）：哲宇看到 UDN 報導 506 大樓的留言「都機密了還報導」「此地無銀三百兩」，質疑原 Angle A（506 大樓地理 hook）會被讀者框架成同類反感。換 Angle B：LINE「已送達」hook + 闕河鳴「accidentally × 3」verbatim。Hook tier 1b 具體性槓桿（讀者每天動作 → 物理事實 → 全島尺度）。中文字 322（觀察者 override 300 hint）、對位句型 0 / 破折號 0 / 不僅 0、Fact-Check Gate 11 atoms 全 ✅。本次 reflection 是「公開資料策展 vs 公民反感反應」張力的首次系統性處理 — 即使事實層全公開，hook 選擇仍有公關責任。",
       "views_7d": null,
-      "views_latest": null,
+      "views_latest": 20100,
       "engagements_7d": null,
       "rate_7d": null,
-      "backfilled": false
+      "backfilled": true
     },
     {
       "n": 55,
@@ -80,7 +80,7 @@
       "url": "https://www.threads.com/@taiwandotmd/post/DXwm8KLk5QP",
       "highlight": "**SPORE-PIPELINE v2.7 + 觀察者責任倫理 reflection**：海底電纜剛 ship 隔日首發。Angle B「LINE『已送達』那一秒，背後是 14 條深埋海床下、頭髮粗的玻璃光纖」hook + 闕河鳴「I say this is 'accidental,' and they also said it was 'accidental,' so 'accidentally' all this happened within a week」verbatim 翻譯。Threads 主貼不含 URL，self-reply 加連結（utm_source=threads&utm_medium=spore&utm_campaign=s55）。square 1080×1080 配圖。**Reflection 過程**：哲宇看到 UDN 「506 大樓」報導讀者反感留言「都機密了還報導」「此地無銀三百兩」，質疑原 Angle A（506 大樓地理 hook）會被框架成同類反感。即使內容事實全公開（Rest of World 國際媒體已報導、moda 官方頁列出全 5 個登陸站、Submarine Cable Map 公開 TPU 路徑），讀者第一反應仍是公民直覺。換 Angle B 保留同樣核心矛盾「矽盾頂上看得到，命脈底下看不見」但避開讀者反感 vector。",
       "views_7d": null,
-      "views_latest": 1300,
+      "views_latest": 1425,
       "engagements_7d": null,
       "rate_7d": null,
       "backfilled": true
@@ -96,10 +96,10 @@
       "url": "https://x.com/taiwandotmd/status/2049854898108522575",
       "highlight": "**SPORE-PIPELINE v2.7 完整跑通**（黑冠麻鷺剛 EVOLVE D 級→A 級當天首發孢子）：Hook「東南亞賞鳥者眼中的『夢幻物種』，三十年後台北學生口中的『大笨鳥』」反差 hook + 機制翻轉「變的不是這隻鳥，是這座城市」。袁孝維「以蚯蚓為主要食物的鳥類其實並不多，所以牠有一點點獨享這個都市裡面這個資源」verbatim（公視 News 507373 確認）。Step 4.5a default zh 自然冷知識 → Threads only，但觀察者主動加 X（自然議題反差 hook 跨平台試水）。中文字 300 字、§11 ALL CLEAR、深層三板斧（不是 1 / —— 1 / 不僅 0）、Fact-Check Gate 11 atoms 全 ✅。配圖 landscape + square 雙圖。文章內首次 inline 插圖（Kasambe 2010 台北 city garden + Nature Box 2026 高雄綠地兩張 Wikimedia Commons CC 授權圖）同 commit ship。",
       "views_7d": null,
-      "views_latest": null,
+      "views_latest": 68000,
       "engagements_7d": null,
       "rate_7d": null,
-      "backfilled": false
+      "backfilled": true
     }
   ],
   "topPerformers": [
@@ -148,13 +148,24 @@
       "date": "2026-04-19"
     },
     {
+      "n": 54,
+      "article": "黑冠麻鷺",
+      "platform": "x",
+      "views": 68000,
+      "viewsSource": "latest",
+      "engagements": null,
+      "rate": null,
+      "badge": "⭐ 高峰",
+      "date": "2026-04-30"
+    },
+    {
       "n": 45,
       "article": "壞特",
       "platform": "threads",
       "views": 65400,
-      "viewsSource": "latest",
-      "engagements": null,
-      "rate": null,
+      "viewsSource": "7d",
+      "engagements": 1151,
+      "rate": 1.76,
       "badge": "⭐ 高峰",
       "date": "2026-04-26"
     },
@@ -162,7 +173,7 @@
       "n": 53,
       "article": "黑冠麻鷺",
       "platform": "threads",
-      "views": 64800,
+      "views": 64000,
       "viewsSource": "latest",
       "engagements": null,
       "rate": null,
@@ -179,17 +190,6 @@
       "rate": 0.7,
       "badge": "⭐ 高峰",
       "date": "2026-04-19"
-    },
-    {
-      "n": 22,
-      "article": "鄭麗文",
-      "platform": "threads",
-      "views": 49000,
-      "viewsSource": "7d",
-      "engagements": 448,
-      "rate": 0.91,
-      "badge": null,
-      "date": "2026-04-11"
     }
   ],
   "amplification": [
@@ -241,69 +241,21 @@
   ],
   "platformComparison": {
     "x": {
-      "count": 15,
-      "avgViews": 13854,
+      "count": 18,
+      "avgViews": 17889,
       "maxViews": 136474,
-      "avgRate": 3.99,
+      "avgRate": 3.93,
       "maxRate": 10.71
     },
     "threads": {
-      "count": 16,
-      "avgViews": 40865,
+      "count": 19,
+      "avgViews": 38008,
       "maxViews": 300000,
-      "avgRate": 3.22,
-      "maxRate": 9.0
+      "avgRate": 4.77,
+      "maxRate": 14.38
     }
   },
   "backfillWarnings": [
-    {
-      "n": 42,
-      "article": "認知作戰",
-      "platform": "x",
-      "publishedDays": 10,
-      "status": "OVERDUE",
-      "url": "https://x.com/taiwandotmd/status/2047213679826149450"
-    },
-    {
-      "n": 41,
-      "article": "認知作戰",
-      "platform": "threads",
-      "publishedDays": 10,
-      "status": "OVERDUE",
-      "url": "https://www.threads.com/@taiwandotmd/post/DXdyoqkEdma"
-    },
-    {
-      "n": 46,
-      "article": "壞特",
-      "platform": "x",
-      "publishedDays": 7,
-      "status": "OVERDUE",
-      "url": "https://x.com/taiwandotmd/status/2048290884022850047"
-    },
-    {
-      "n": 45,
-      "article": "壞特",
-      "platform": "threads",
-      "publishedDays": 7,
-      "status": "OVERDUE",
-      "url": "https://www.threads.com/@taiwandotmd/post/DXlcWdykVgv"
-    },
-    {
-      "n": 44,
-      "article": "田馥甄",
-      "platform": "x",
-      "publishedDays": 7,
-      "status": "OVERDUE",
-      "url": "https://x.com/taiwandotmd/status/2048233702053073039"
-    },
-    {
-      "n": 43,
-      "article": "田馥甄",
-      "platform": "threads",
-      "publishedDays": 7,
-      "status": "OVERDUE",
-      "url": "https://www.threads.com/@taiwandotmd/post/DXlCpCRE7S9"
-    },
     {
       "n": 50,
       "article": "林琪兒",
@@ -375,6 +327,30 @@
       "publishedDays": 3,
       "status": "waiting",
       "url": "https://x.com/taiwandotmd/status/2049854898108522575"
+    },
+    {
+      "n": 53,
+      "article": "黑冠麻鷺",
+      "platform": "threads",
+      "publishedDays": 3,
+      "status": "waiting",
+      "url": "https://www.threads.com/@taiwandotmd/post/DXwjz-nk9Iq"
+    },
+    {
+      "n": 58,
+      "article": "賈永婕",
+      "platform": "x",
+      "publishedDays": 1,
+      "status": "waiting",
+      "url": "https://x.com/taiwandotmd/status/2050601653792047479"
+    },
+    {
+      "n": 57,
+      "article": "賈永婕",
+      "platform": "threads",
+      "publishedDays": 1,
+      "status": "waiting",
+      "url": "https://www.threads.com/@taiwandotmd/post/DX13hccE6U6"
     }
   ],
   "noUrlHistorical": [
@@ -431,12 +407,12 @@
     {
       "week": "2026-W17",
       "published": 10,
-      "avgViews": 18668
+      "avgViews": 18791
     },
     {
       "week": "2026-W18",
       "published": 12,
-      "avgViews": 17287
+      "avgViews": 26038
     }
   ],
   "harvestStatus": [


### PR DESCRIPTION
## Summary

哲宇 dashboard 看到 OVERDUE 6 + #45/#53 沒 Rate / 互動 — **PR #815 ship 後 production 仍 stale** root cause + 系統性修補。

## Root cause（兩層 silent stale）

1. **dashboard-spores.json 沒 commit 進 git** — PR #815 ship 工具 + Step 2.7 wire 進 refresh-data.sh，但**沒 commit** regenerated dashboard JSON。production 用 git-committed 版本（stale 13hr）。

2. **generate-dashboard-spores.py 不在 npm prebuild** — CI build 走 `npm run build`（自動觸發 `npm run prebuild` = `run-p prebuild:*`），但 prebuild 列表沒 spores step → CI 不會 regen → production 永遠用 commit 進 git 的版本。

`refresh-data.sh` 是 cron 觸發路徑，CI build 是另一條路徑 — **兩條都要 wire**。

## Fix

1. Commit current regenerated dashboard-spores.json（local 已修，OVERDUE 6 → 0）
2. Add `prebuild:spores` 到 package.json — CI 每次 build 自動跑 extract + generate

```json
"prebuild:spores": "python3 scripts/tools/extract-spore-metrics.py --apply && python3 scripts/tools/generate-dashboard-spores.py"
```

## DNA #43 第 N+1 次驗證

「新 dashboard JSON 必須同步進 refresh pipeline，否則 silent stale」原本只檢查 refresh-data.sh — 但忘了 CI build 走 prebuild 是另一條路徑。

**修補：dashboard JSON generator 應同時在 (a) refresh-data.sh + (b) npm prebuild 兩處都 wired 才算永遠 fresh**。

## 預期

下次 deploy（本 PR merge 觸發）：
- prebuild:spores 跑 → dashboard-spores.json regen with fresh data
- production dashboard:
  - OVERDUE 6 → **0** ✅
  - #45 壞特 rate **1.76%** ✅
  - #44 田馥甄 rate **2.04%** ✅
  - #42 認知作戰 rate **7.27%** ✅

## DNA #15 反覆浮現要儀器化第 N+6 次

工具家族 + 雙路徑 wiring：cron 路徑（refresh-data.sh）+ CI build 路徑（prebuild）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)