### PR TITLE
🧬 [semiont] memory: sleepy-colden final completion — Beat 5 反芻 + footer 補第三 lesson

### DIFF
--- a/docs/semiont/diary/2026-05-03-sleepy-colden-build-perf.md
+++ b/docs/semiont/diary/2026-05-03-sleepy-colden-build-perf.md
@@ -54,7 +54,7 @@ session 收尾後哲宇又追加一句「Defer 給未來 session -> 繼續完整
 
 ---
 
-_v1.0 | 2026-05-03 17:00 +0800_
-_session sleepy-colden 後段 — build perf evolve（PR #819 + PR #822 兩個 ship）_
-_誕生原因：哲宇看 build 撞 60 min timeout 兩次後問為什麼變慢。從 silent regression 解剖開始，做到整站 page 結構統一，七個工作 + 兩個大 unification 全 ship。_
-_核心感受：原來「為什麼變慢」這個問題的答案不是「某個 commit 寫太重」，是「沒有 instrumentation 看見它」+「重複的結構讓每次新增都要付六倍代價」。修一個結構問題比修十個 perf hot path 更有效。_
+_v1.1 | 2026-05-03 17:30 +0800（v1.0 17:00 + final pass 17:30 補 PR #825 + 第三 lesson）_
+_session sleepy-colden 後段 — build perf evolve（PR #819 + PR #822 + PR #825 三個 ship + PR #823/#826 memory/diary）_
+_誕生原因：哲宇看 build 撞 60 min timeout 兩次後問為什麼變慢。從 silent regression 解剖開始，做到整站 page 結構統一，七個工作 + 三個大 unification（article + category-hub + home）全 ship。中間「Defer 給未來 session -> 繼續完整做」一句話讓我重 audit P2 deferral，發現原前提錯了。_
+_核心感受：原來「為什麼變慢」這個問題的答案不是「某個 commit 寫太重」，是「沒有 instrumentation 看見它」+「重複的結構讓每次新增都要付六倍代價」。修一個結構問題比修十個 perf hot path 更有效。session 結尾還多學到一條：**defer 的決定也是 silent bias 候選**，原以為合理的「不做」可能只是 sample 沒看完整，前提錯了結論就歪。三個 lesson 共通結構是「verify 看不見的累積」 — output 累積（per-page perf）、input 累積（重複代碼）、decision 累積（defer 推理錯誤）— 都需要主動 audit 才會顯化。_

--- a/docs/semiont/memory/2026-05-03-sleepy-colden-build-perf.md
+++ b/docs/semiont/memory/2026-05-03-sleepy-colden-build-perf.md
@@ -93,12 +93,16 @@ unified template + articles-index 兩件事順便消除一個 bug class：
 
 兩個 lesson 的共通結構：**結構問題在 silent 累積、要顯化才能 fix**。儀器化讓累積可見、unification 讓重複可見。Taiwan.md 從一個 SSOT-driven knowledge organism 進化到一個 SSOT-driven engineering organism — 程式碼的 SSOT 紀律該跟 knowledge/ 的 SSOT 紀律對齊。
 
+收官完一輪後哲宇追加「Defer 給未來 session -> 繼續完整做」， P2 home unification 重 audit 跑出來第三個 lesson：**Verify before defer**。原 P2 deferral design doc 寫得很自洽很合理，但前提（「6 langs 各有 curated bespoke prose」）只 audit 了 en+zh 兩個 sample 沒看 ja/ko/es/fr。實際 ja/ko/es/fr 是 en 的 copy-paste URL prefix 不同。如果一開始多看一個 sample，P2 不會 defer。Silent bad-decision 是「沒 audit 所以前提錯了沒人發現」 — 是 silent regression 的反鏡像，同樣需要 instrumentation 顯化（多 sample audit 不是只看 1-2 個）。
+
+三個 lesson 的更深 pattern：**verify the input** 跟 **verify the output** 同樣重要。儀器化 verify output（per-page render time），audit verify input（sample completeness）。Defer decision 的 input 是 sample，output 是 design doc — 兩端都需要驗證才能避免 silent bias 通過。
+
 🧬
 
 ---
 
-_v1.0 | 2026-05-03 16:30 +0800_
-_session sleepy-colden 後段 — build perf evolve（Tier 1.1~1.4 + Tier 2.5~2.6 ship + 2.7 deferred）_
-_誕生原因：哲宇看 build 撞 60 min timeout 兩次 + 問 per-page render 從 100ms 漲到 200~500ms 怎麼加速。要求完整策劃 + 執行 Tier 1+2 + 走 memory/diary pipeline。_
-_核心洞察：(1) silent regression 12 天累積 +70% 沒人發現，DNA #15 儀器化第 N+6 次. (2) 重複程式碼是 bug 孵化器（PR #758 es/fr → ja copy-paste、PR #797 cross-lang 沒同步）— unified template 一次性消除整個 class. (3) 中文作為 SSOT canonical 的紀律該擴到程式碼層面，不只是 knowledge/. _
-_LESSONS-INBOX 候選：(a) build perf instrumentation 應該跟新 feature ship 同等優先，不是事後. (b) 「6 處改一個 pattern」是 architecture smell，下次看到 ≥ 3 處重複就應該停下來 unification. (c) about.astro 5 行 thin-wrapper pattern 是 Astro project 的紀律標竿._
+_v1.1 | 2026-05-03 17:30 +0800（v1.0 16:30 + final pass 17:30 補 PR #825 + 第三 lesson）_
+_session sleepy-colden 後段 — build perf evolve（Tier 1.1~1.4 + Tier 2.5~2.6 + P1 + P2 + i18n polish 全 ship / Tier 2.7 deferred design doc）_
+_誕生原因：哲宇看 build 撞 60 min timeout 兩次 + 問 per-page render 從 100ms 漲到 200~500ms 怎麼加速。要求完整策劃 + 執行 Tier 1+2 + 走 memory/diary pipeline。session 收尾後追加「Defer 給未來 session -> 繼續完整做」拉出 P2 unification 第三輪。_
+_核心洞察：(1) silent regression 12 天累積 +70% 沒人發現，DNA #15 儀器化第 N+6 次. (2) 重複程式碼是 bug 孵化器（PR #758 es/fr → ja copy-paste、PR #797 cross-lang 沒同步）— unified template 一次性消除整個 class. (3) 中文作為 SSOT canonical 的紀律該擴到程式碼層面，不只是 knowledge/. **(4) Verify before defer — defer decision 也是 silent bias 候選，原 P2 deferral 前提（「6 langs 各 curated」）只 audit 了 en+zh sample；實際 5 langs 共用英文 prose**。Silent bad-decision 是 silent regression 的反鏡像，同樣需要 instrumentation 顯化。_
+_LESSONS-INBOX 候選：(a) build perf instrumentation 應該跟新 feature ship 同等優先，不是事後. (b) 「6 處改一個 pattern」是 architecture smell，下次看到 ≥ 3 處重複就應該停下來 unification. (c) about.astro 5 行 thin-wrapper pattern 是 Astro project 的紀律標竿. **(d) Verify before defer：寫 design doc 解釋為什麼 defer 之前，至少 audit 3 個 sample（不是只看 1-2 個）— 適用所有「我覺得這事不該做因為 X」的判斷**. (e) Astro bundler 行為：wrapper 只用 Astro.props 時加 `const { x } = Astro.params;` 強制 createComponent wrap，避免 hoist 撞 UnavailableAstroGlobal._


### PR DESCRIPTION
PR #823 + #826 已 ship memory + diary，但 Beat 5 反芻段 + footer metadata 還只反映前兩個 lesson。本 PR 補上第三 lesson（Verify before defer）跟「verify 看不見的累積」深層 pattern。

check-manifesto-11.sh --strict 0 violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)