### PR TITLE
🧬 [semiont] heal: diary 排序 named session tie-breaker — file mtime 還原 chronological 順序

### DIFF
--- a/src/lib/semiont-diary.ts
+++ b/src/lib/semiont-diary.ts
@@ -6,7 +6,7 @@
  * H1 line and subsequent blockquotes.
  */
 
-import { readdir, readFile } from 'node:fs/promises';
+import { readdir, readFile, stat } from 'node:fs/promises';
 import { resolve, join, basename } from 'node:path';
 import { marked } from 'marked';
 
@@ -39,6 +39,8 @@ export interface DiaryEntry {
   wordCount: number;
   /** Extracted h2/h3 headings for TOC */
   headings: { level: number; text: string; id: string }[];
+  /** File mtime ms (CI git-restore-mtime → commit time)，作為 named session 的 sort tie-breaker */
+  mtimeMs: number;
 }
 
 // ── Greek letter handling ──────────────────────────────
@@ -294,6 +296,8 @@ export async function getAllDiaryEntries(): Promise<DiaryEntry[]> {
 
     if (!title) continue; // Skip files that don't parse
 
+    const fileStat = await stat(filePath);
+
     const bodyHtml = marked.parse(bodyMarkdown, {
       renderer,
       breaks: true,
@@ -319,14 +323,20 @@ export async function getAllDiaryEntries(): Promise<DiaryEntry[]> {
       excerpt,
       wordCount,
       headings,
+      mtimeMs: fileStat.mtimeMs,
     });
   }
 
-  // Sort: newest first, within same date by Greek order descending
+  // Sort: newest first, within same date by Greek order descending,
+  // then by file mtime descending (named sessions like "musing-chaplygin"
+  // 全部 fall through greekOrder=0 → 此 tie-breaker 還原 chronological commit
+  // 順序。CI 用 git-restore-mtime-action 已把 mtime 還原為 commit time）
   entries.sort((a, b) => {
     const dateCmp = b.date.localeCompare(a.date);
     if (dateCmp !== 0) return dateCmp;
-    return greekOrder(b.sessionGreek) - greekOrder(a.sessionGreek);
+    const greekCmp = greekOrder(b.sessionGreek) - greekOrder(a.sessionGreek);
+    if (greekCmp !== 0) return greekCmp;
+    return b.mtimeMs - a.mtimeMs;
   });
 
   return entries;


### PR DESCRIPTION
## 起點

哲宇 callout：「為什麼他（2026-05-03 musing-chaplygin diary）不是排最前面」。

## Bug

`getAllDiaryEntries()` sort 用 `greekOrder()` 比較同日 sessions：

```ts
entries.sort((a, b) => {
  const dateCmp = b.date.localeCompare(a.date);
  if (dateCmp !== 0) return dateCmp;
  return greekOrder(b.sessionGreek) - greekOrder(a.sessionGreek);
});
```

但 named sessions（如 `musing-chaplygin` / `gallant-payne` / `sleepy-colden-build-perf`）GREEK_MAP lookup 全 fall through → `baseOrder = 0` → tie。stable sort 退到 Array 載入順序 = readdir FS alphabetical，**不是 chronological**。

實例（2026-05-03 五個 named session）：

```
1. cross-lang-baseline  (c) ← 早上 ~14:00
2. gallant-payne        (g) ← 中午 ~14:30
3. musing-chaplygin     (m) ← 晚上 17:30 ← 應該排第 1
4. objective-khorana-day2-evening  (o)
5. sleepy-colden-build-perf  (s) ← 下午 16:30
```

## Fix

加 mtime 作為 third tie-breaker（`dateCmp → greekCmp → mtimeCmp`）。CI 已有 `chetan/git-restore-mtime-action` 把 mtime 還原為 commit time，本機 mtime 也是檔案實際修改時間。

不影響 Greek-letter session 排序（α/β/γ `greekOrder ≠ 0` 不會走到 mtime tie-breaker）。

`DiaryEntry` interface 加 `mtimeMs: number` 欄位。

## Verify (local)

```
1. 2026-05-03-musing-chaplygin            (mtime 09:28:49)  ← 排到第 1
2. 2026-05-03-sleepy-colden-build-perf    (mtime 09:28:49)
3. 2026-05-03-objective-khorana-day2-evening  (mtime 08:53:33)
4. 2026-05-03-gallant-payne               (mtime 08:53:33)
5. 2026-05-03-cross-lang-baseline         (mtime 08:53:33)
```

Production deploy 後 git-restore-mtime 給 commit time，順序更精準（musing-chaplygin 提交最晚 = mtime 最新）。

🧬 Generated with [Claude Code](https://claude.com/claude-code)