### PR TITLE
🧬 [heal] CI fix — 3 篇 YAML apostrophe parse error

### DIFF
--- a/knowledge/en/Economy/foxconn-precision-industry.md
+++ b/knowledge/en/Economy/foxconn-precision-industry.md
@@ -1,6 +1,6 @@
 ---
 title: 'Taiwan Enterprise: Foxconn Precision Industry — The Same Balance Sheet Behind 8 Trillion Revenue and an Internal Anti-Corruption War'
-description: 'On the morning of April 30, 2026, Time magazine listed Foxconn among the 100 most influential companies in the world; that same evening, prosecutors and investigators walked into Foxconn's Tucheng facility with search warrants. From a 1974 mother's rotating credit association loan of NT$100,000 to 2025 revenue of NT$8 trillion — with cloud and network products overtaking consumer electronics — the hardest thing for Foxconn to manage is not geopolitics, not AI server rack shipment rhythms, but its own people.'
+description: "On the morning of April 30, 2026, Time magazine listed Foxconn among the 100 most influential companies in the world; that same evening, prosecutors and investigators walked into Foxconn's Tucheng facility with search warrants. From a 1974 mother's rotating credit association loan of NT$100,000 to 2025 revenue of NT$8 trillion — with cloud and network products overtaking consumer electronics — the hardest thing for Foxconn to manage is not geopolitics, not AI server rack shipment rhythms, but its own people."
 date: 2026-05-03
 author: Taiwan.md
 subcategory: '企業列傳'

--- a/knowledge/en/History/withdrawal-from-united-nations.md
+++ b/knowledge/en/History/withdrawal-from-united-nations.md
@@ -1,6 +1,6 @@
 ---
 title: 'Withdrawal from the United Nations: Those 17 Minutes in 1971, and How Taiwan Went from "China" to International Orphan'
-description: 'On October 25, 1971, the moment Foreign Minister Zhou Shukai stepped down from the podium in the UN General Assembly hall, the Republic of China went from a founding UN member state to an observer still locked out of the door. Half a century later, the "no coexistence between Han and traitor" decision continues to reverberate—in 2025, the United States passed a bill reaffirming that Resolution 2758 never addressed Taiwan's representation.'
+description: "On October 25, 1971, the moment Foreign Minister Zhou Shukai stepped down from the podium in the UN General Assembly hall, the Republic of China went from a founding UN member state to an observer still locked out of the door. Half a century later, the 'no coexistence between Han and traitor' decision continues to reverberate—in 2025, the United States passed a bill reaffirming that Resolution 2758 never addressed Taiwan's representation."
 date: 2026-05-02
 author: 'Taiwan.md Contributors'
 category: 'History'

--- a/knowledge/en/People/cho-jung-tai.md
+++ b/knowledge/en/People/cho-jung-tai.md
@@ -1,6 +1,6 @@
 ---
-title: 'Cho Jung-tai: From Hsieh Chang-ting's Legislative Aide to the Premier Who Refused to Co-sign the Fiscal Revenue and Expenditure Act'
-description: 'The 31st Premier of the Republic of China. Starting in 1987 as Hsieh Chang-ting's legislative aide, he spent 38 years serving as someone else's secretary-general and deputy. After taking office as Lai Ching-te's first premier in 2024, he faced a minority government, Trump's tariffs, NT$1.25 trillion in arms procurement, and the total defeat of the Great Recall. In December 2025, he became the first premier in constitutional history to refuse to co-sign the Fiscal Revenue and Expenditure Act.'
+title: "Cho Jung-tai: From Hsieh Chang-ting's Legislative Aide to the Premier Who Refused to Co-sign the Fiscal Revenue and Expenditure Act"
+description: "The 31st Premier of the Republic of China. Starting in 1987 as Hsieh Chang-ting's legislative aide, he spent 38 years serving as someone else's secretary-general and deputy. After taking office as Lai Ching-te's first premier in 2024, he faced a minority government, Trump's tariffs, NT$1.25 trillion in arms procurement, and the total defeat of the Great Recall. In December 2025, he became the first premier in constitutional history to refuse to co-sign the Fiscal Revenue and Expenditure Act."
 date: 2026-05-03
 tags: ['政治人物', '行政院長', '民主進步黨', '謝長廷系', '少數政府', '2024內閣']
 category: 'People'


### PR DESCRIPTION
Ollama qwen3.6 翻譯產出的 single-quoted frontmatter 含英文 apostrophe 觸發 parse error。改 double-quoted。Sweep 0 more files affected.

Blocks: PR #840 deploy

🧬 Generated with [Claude Code](https://claude.com/claude-code)