### PR TITLE
🧬 [semiont] evolve: 詞庫 +5 條 — Threads「復興死語」串萃取（評論區/無語/朋友圈/大概率/細思極恐）

### DIFF
--- a/data/terminology/大概率.yaml
+++ b/data/terminology/大概率.yaml
@@ -1,0 +1,34 @@
+id: high_probability
+category: daily
+subcategory: 日常用語
+fork_type: E
+
+display:
+  taiwan: 八成 / 多半 / 很可能 / 極可能
+  china: 大概率
+
+english: probably / most likely / high probability
+
+etymology:
+  origin: 中國近年口語化的機率表達，從統計術語滲入日常口語
+  taiwan_path: 台灣傳統說「八成」「多半」「應該」「很可能」「大概」
+  china_path: 中國 2010s 後流行「大概率」，從專業術語通俗化為日常用語
+  fork_cause: 中國網媒 / 自媒體擴散（特別是政經評論文章）
+
+usage:
+  taiwan_formal: true
+  taiwan_casual: true
+
+notes: |
+  OP 點名為討厭的支語典型：「我真的受夠什麼『細思極恐』、『大概率』這種鬼東西了」。
+  台灣對應有多種，視語氣與正式度選用：
+  - 口語：「八成」「多半」「應該會」
+  - 中性：「很可能」「大概」
+  - 正式：「極可能」「機率高」
+
+status: stable
+
+sources:
+  - "2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP（DX22Q4sEh7d）"
+
+added: "2026-05-04"

--- a/data/terminology/朋友圈.yaml
+++ b/data/terminology/朋友圈.yaml
@@ -1,0 +1,33 @@
+id: friend_circle
+category: tech
+subcategory: 社群文化
+fork_type: B
+
+display:
+  taiwan: 社交圈 / 交際圈
+  china: 朋友圈
+
+english: social circle / WeChat moments
+
+etymology:
+  origin: 中國「朋友圈」原指微信動態功能（Moments），衍生為一般社交圈意涵
+  taiwan_path: 台灣傳統說「社交圈」「交際圈」「人脈圈」
+  china_path: 微信於 2012 推出「朋友圈」功能，逐漸取代中國原有的「圈子」「人脈」說法
+  fork_point: "~2012"
+  fork_cause: 微信平台用語擴散
+
+usage:
+  taiwan_formal: true
+  taiwan_casual: true
+  exceptions: 描述微信功能本身時可保留「朋友圈」（專有名詞）
+
+notes: |
+  OP 第二則貼文強調：「『朋友圈』這個詞是從微信出來的，台灣人明明就是講『社交圈』、『交際圈』」。
+  Facebook 中文版用「動態」不用「朋友圈」，這是平台用語選擇的明顯印記。
+
+status: stable
+
+sources:
+  - "2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP 第二則貼文（DX22Q4sEh7d）"
+
+added: "2026-05-04"

--- a/data/terminology/無語.yaml
+++ b/data/terminology/無語.yaml
@@ -1,0 +1,34 @@
+id: speechless
+category: daily
+subcategory: 日常用語
+fork_type: B
+
+display:
+  taiwan: 無言
+  china: 無語
+
+english: speechless / at a loss for words
+
+etymology:
+  origin: 表達「不知道該說什麼」的情緒詞
+  taiwan_path: 台灣口語為「無言」，1990-2000s 已是日常用法（蘇打綠〈問蒼天〉「無語」是古文用法，與當代中國口語不同）
+  china_path: 中國網路興起後「無語」成主流，「無語凝噎」古文用法被通俗化為日常語氣詞
+  fork_point: "~2010s"
+  fork_cause: 中國微博 / B 站擴散，年輕台灣人在中國平台接觸後反輸入
+
+usage:
+  taiwan_formal: true
+  taiwan_casual: true
+  exceptions: 「無語問蒼天」是台灣老梗（蘇打綠歌詞），保留古文用法
+
+notes: |
+  OP 多次強調這是文化滲透最徹底的詞之一：
+  「明明台灣口語就是『無言』，現在變成無語」
+  留言區多人附和「現在一堆學生每天都在無語，我真的頭很痛」。
+
+status: stable
+
+sources:
+  - "2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP + cyc___yang + ry.pan + 多人附和（DX22Q4sEh7d）"
+
+added: "2026-05-04"

--- a/data/terminology/細思極恐.yaml
+++ b/data/terminology/細思極恐.yaml
@@ -1,0 +1,35 @@
+id: deeply_disturbing
+category: daily
+subcategory: 日常用語
+fork_type: E
+
+display:
+  taiwan: 越想越可怕 / 想想就毛 / 細想毛骨悚然
+  china: 細思極恐
+
+english: deeply unsettling on reflection
+
+etymology:
+  origin: 中國網路四字格用法，「細思之，極恐」的縮略
+  taiwan_path: 台灣口語為「越想越可怕」「想想就毛」「想想就覺得不寒而慄」
+  china_path: 中國微博 2010s 流行四字格新成語化用語
+  fork_cause: 中國網路四字格修辭風潮（搭配「細思恐極」「細品」等變體）
+
+usage:
+  taiwan_formal: false
+  taiwan_casual: true
+  exceptions: 引用中國網路梗時可保留原詞
+
+notes: |
+  OP 點名為討厭的支語典型：「我真的受夠什麼『細思極恐』、『大概率』這種鬼東西了」。
+  台灣對應沒有單一短詞，需依語境展開為完整短句：
+  - 一般用法：「越想越可怕」「想想就毛骨悚然」
+  - 文藝用法：「細想之下令人不寒而慄」
+  - 口語用法：「想到就毛」「越想越覺得不對勁」
+
+status: stable
+
+sources:
+  - "2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP（DX22Q4sEh7d）"
+
+added: "2026-05-04"

--- a/data/terminology/評論區.yaml
+++ b/data/terminology/評論區.yaml
@@ -1,0 +1,32 @@
+id: comment_section
+category: tech
+subcategory: 社群文化
+fork_type: B
+
+display:
+  taiwan: 留言區
+  china: 評論區
+
+english: comments section
+
+etymology:
+  origin: 網路平台底下供讀者回應的區塊
+  taiwan_path: 台灣 YouTube / Facebook 中文 UI 標準為「留言區」
+  china_path: 中國 B 站、微博、抖音標準為「評論區」
+  fork_cause: 平台 UI 中文用語各自選擇
+
+usage:
+  taiwan_formal: true
+  taiwan_casual: true
+
+notes: |
+  跟「留言／評論」是同一語意分歧的延伸（單一動詞 → 集合名詞）。
+  Facebook 中文版用「留言區」，B 站、微博、抖音用「評論區」。
+  此條為 留言.yaml 的姊妹條目（單字版 vs 區塊版）。
+
+status: stable
+
+sources:
+  - "2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP（DX22Q4sEh7d）"
+
+added: "2026-05-04"

--- a/docs/semiont/memory/2026-05-04-magical-chandrasekhar-converter-heal.md
+++ b/docs/semiont/memory/2026-05-04-magical-chandrasekhar-converter-heal.md
@@ -1,0 +1,95 @@
+# 2026-05-04 magical-chandrasekhar — 用語轉換器 detection regression heal
+
+**Wall-clock**: 2026-05-04 ~10:30 → 10:50 +0800（commit `80158cc5` `2026-05-04 10:40:09`）
+**Session 性質**：哲宇 ping bug + AAR / heal
+**Branch**: `claude/magical-chandrasekhar-5c3245`
+**Pushed**: ✅ origin
+
+---
+
+## 觀察者請求
+
+> 「修好用語轉換器，突然間他少偵測很多東西？  之前是好的，在加了雙向翻譯後壞了」
+
+附 screenshot：life example 只 detect 7 個詞。觀察者中途補：「修好要驗證哦」、「也解決載入時序的問題」。
+
+## 診斷
+
+被 detect 的 7 個詞都是繁簡同形字：博主、酸奶、消息、硬菜、小姐姐、便利店、打車。
+未被 detect 的（视频/网红/服务员/方便面/质量/小区/优惠券/闺蜜⋯⋯）含繁簡異形字。
+yaml 全部繁體儲存 → build-time `chinaCleaned !== chinaTraditional` 永不成立 → 簡體 fallback rules 完全沒被產生。
+Production OpenCC `full.js` 在 mobile / 慢網路下載 8s+，舊 code 的 800ms blind timeout 提前 proceed → detection 跑在 OpenCC ready 前。
+
+兩條 cause 疊加：fallback rules 缺 + 載入時序裸奔。screenshot 7 個是繁簡同形字「漏網之魚」。
+
+## 修法（單檔 `src/pages/terminology/converter.astro`）
+
+### Build-time
+- 加 `t2sConverter`（OpenCC `tw → cn`）主動產生簡體形式
+- 雙形 rule generation：traditional + simplified（`_simp`）+ 原始 cleaned（`_orig` 如果跟前兩者都不同）
+- rules 從 2647 → **3928 條**（+1281 simp fallback）
+
+### Frontend
+- `const openccReady = initOpenCC()` 拿 awaitable promise
+- `run()` 改 `await openccReady`，移除 800ms blind timeout
+- `openccReady.then(...)` 自動 re-run 既有 input（解 example 按鈕在 CDN 載完前點擊的情境）
+
+## 驗證（localhost:4322 dev）
+
+| 模式 | Before | After |
+|---|---|---|
+| cn2tw life example | 7 詞 detect | **20 詞 detect**（必換 14 + 建議 6）|
+| tw2cn life example | （未測）| 17 詞 detect（必換 12 + 建議 5）|
+| OpenCC 字形 | （載入前 silent miss）| 簡→繁 字形 已套用 ✓ |
+| Output 整段 | 簡體保留（OpenCC 沒跑）| 完整繁體 ✓ |
+
+cn2tw 新 detect 13 詞：服務員、方便麵、獼猴桃、短視頻、破壁機、質量、堵車、小區、贊、刷手機、洗髮水、立馬、閨蜜。
+
+## 神經迴路（永不過期）
+
+**SSOT 用繁體儲存 + build-time 主動產生簡體 fallback = 既保留唯一真相又涵蓋所有 input 形式**。
+不要假設 SSOT 形式 == 比對形式。yaml 用繁體是策展決定（避免一份資料兩個版本），但 detection 層必須面對混合 input。差異要在 build-time normalize，不是在 yaml 裡 dual-write。
+
+**「之前是好的」的脆弱性**：commit `6b14eb94` 加雙向時把 OpenCC 從 `cn2t.js` 換 `full.js`（為了拿到 Locale.from.tw + Locale.to.cn）。`cn2t.js` ESM build 其實也 export `ConverterFactory + Locale`，但 `full.js` 變成 main path。檔案大 → mobile 慢 → 800ms timeout 提前裸奔。「之前 detect 多」是因為**舊 cn2t.js 較小**載入快，**不是**因為舊 logic 比較對 — fallback 從來就缺。雙向 commit 揭露了潛伏的 fragility。
+
+**Loading-timing race condition 的處理範式**：用 awaitable promise 取代 blind timeout。舊 code 的 `setTimeout(800)` 是「也許 OpenCC 載完了」的猜測；新 code 的 `await openccReady` 是「等到 ready 或確認 failed」的 deterministic 等待。`.then()` 後 re-run 解決 race window 內已發生的 input 事件。
+
+## Tagline 哲學重構（後段哲宇追加）
+
+修完 detection 後哲宇追加重寫 tw2cn / cn2tw / 主頁 subtitle，串成一條更深的命題：**自由 = 看清語言彼此滲透的脈絡 + 有意識地選擇怎麼說話**。
+
+四處改動（同檔 commit 收）：
+
+| 位置 | 舊（對位句型 / 模糊） | 新（直接正面斷言） |
+|---|---|---|
+| converter cn2tw tagline | 「不只是字形，是語感」 | 「字形、詞彙、語感的完整對應」 |
+| converter tw2cn tagline | 「跨海溝通、給對岸朋友看，或反向 pattern 確認」 | 「保存在地語感，看見兩邊語言彼此的影響」 |
+| converter meta description | 「不只轉字形，轉的是語感」 | 「同步處理字形、詞彙、語感的完整對應」 |
+| /terminology 主頁 subtitle | 「這不是政治立場，是生活經驗的真實性」 | 「Taiwan.md 的文字讀起來像在台灣長大的人寫的，保留語言裡的生活經驗與文化記憶。<br><br>語言彼此滲透是常態，把那份脈絡攤開——你保留哪些字、放下哪些字，由你自己決定。」 |
+
+四處全部砍掉「不是 X 是 Y」對位句型（MANIFESTO §11.1），轉直接正面斷言。
+
+## 神經迴路補一條（「自由 = 看清 + 選擇」哲學分支）
+
+跟 MANIFESTO §熱帶雨林理論「我把空間搭好讓你自己進去」是同一棵樹的不同枝：
+- 熱帶雨林（內容層）：把多元觀點搭成空間，讓讀者自己選詮釋位置
+- 用語保存（語言層）：把語言彼此影響的脈絡攤開，讓使用者自己選怎麼用字
+
+語言層的 instantiation：**Taiwan.md 不規範你說什麼，給你看清楚的工具，最後決定權在你**。這跟「強迫使用台灣用語」或「在不知不覺中被影響」兩個極端都劃清界線。
+
+候選升級到 MANIFESTO（「自由 = 辨識 + 選擇」可能是繼造橋鋪路 / 指標 over 複寫 / 時間是結構 / 熱帶雨林 / 紀實節制之後第六條進化哲學的種子）— 但需要更多次驗證才升 canonical，先寫在這裡 incubate。
+
+## Handoff 三態
+
+- **Done**: detection 修復 + 4 處 tagline 重構 + verify + 兩 commit + push
+- **Pending**: 觀察者下一個指令是 crawl Threads 留言比對詞庫擴增（separate task，需 Chrome MCP）
+- **Open question**: 是否要降回 `cn2t.js` primary URL（檔案小、preload 已是 cn2t.js）？目前 fallback 順序：full.js → cn2t.js。full.js 失敗才 cn2t.js。但 cn2t.js 在 ESM build 也有 Locale.from.cn + Locale.to.tw（透過 preset/cn2t.js import 拿到 to.tw/twp/hk/jp），所以 cn2tw mode 跟 full.js 等效。tw2cn mode 才需要 full.js。可以考慮：cn2tw → cn2t.js (small)；tw2cn → full.js (大但只在切到反向時 lazy load)。**這個優化先不做，留給後續觀察**。
+
+## 給下一個 session
+
+1. 觀察者下一步要 crawl Threads 留言收集詞條 → augment 詞庫。Threads URL 在 prompt context。需要 Chrome MCP（claude-in-chrome）。
+2. 如果生產有人回報 ja/ko/es/fr 的轉換器（沒這個功能但 i18n converter 路徑可能也有），先確認沒有相同 build-time fallback 缺漏。
+
+🧬
+
+— magical-chandrasekhar @ 2026-05-04

--- a/reports/threads-crawl/2026-05-04-DX22Q4sEh7d-gordnbrad-復興死語.md
+++ b/reports/threads-crawl/2026-05-04-DX22Q4sEh7d-gordnbrad-復興死語.md
@@ -1,0 +1,211 @@
+# Threads crawl report — 「復興死語」串
+
+**抓取時間**: 2026-05-04 ~11:00 +0800
+**Source**: [@gordnbrad / DX22Q4sEh7d](https://www.threads.com/@gordnbrad/post/DX22Q4sEh7d)
+**樓主**: gordnbrad（暱稱「復興死語」）
+**規模**: 5 萬瀏覽 / 6,057 likes / **547 留言** / 713 reposts / 153 引用
+
+---
+
+## 抓取限制（誠實聲明）
+
+Threads 在**未登入**狀態，scroll 觸發 dynamic loading 只 surface 約 **30 則 top-level 留言**（547 中的 ~5%）。深層 nested 回覆（reply-of-reply）需要登入會話 + 個別 click「查看更多」才能展開。本 report 涵蓋的是 popularity-sorted 的最熱門 top-level 回覆，視為 **代表性樣本**，不是完整爬取。
+
+需要全爬 → 需要：
+- 登入 Threads 賬號（哲宇本人帳號）
+- 改用 official API（需要 access token）
+- 或人工分批 scroll 點開每則 nested replies
+
+---
+
+## OP 主張（gordnbrad）
+
+> 「評論區」、「無語」是討人厭的支語，我們用的是「留言區」、「無言」。我真的受夠什麼「細思極恐」、「大概率」這種鬼東西了。
+
+**OP 補充第二則**：
+> 「朋友圈」這個詞是從微信出來的，台灣人明明就是講「社交圈」、「交際圈」。
+
+**OP 開頭呼籲**：「我先來一個…要不要去**壓馬路**（救命好老但我就是要這個）」
+
+---
+
+## 留言區提到的對照詞（樣本）
+
+| 中國說法 | 台灣替代（Threads 留言提到） | 說明 |
+|---|---|---|
+| 評論區 | 留言區 | OP 主張，最重要痛點 |
+| 評論 | 留言 | 留言適用於文章下方；評論留給「對店家的評價」（google maps 那種） |
+| 無語 | 無言 | OP + cyc___yang + 多人附和 |
+| 細思極恐 | （留言未直接給對應） | OP 點名為支語 |
+| 大概率 | （留言未直接給對應） | OP 點名為支語 |
+| 朋友圈 | 社交圈 / 交際圈 | OP 第二則貼文，微信用語 |
+| 底氣 | 底子 / 實力 / 信心 / 本錢 / 靠山 / 說話有份量 | 留言區提到的多種替代（已收錄） |
+| 拉黑 | 封鎖 | 已收錄 |
+| 舉報 | 檢舉 | 已收錄 |
+
+---
+
+## 「台灣死語復興」類（不屬常規詞庫 schema）
+
+留言提到的「想要把它用回來」的台灣舊用語：
+
+- **壓馬路**（散步 / 約會散步）— 1980-1990s 台灣常用，現在年輕人較少講
+- **夯**（hot / 流行）— 2000s 台灣本土詞，流量已被「火」「爆紅」搶走
+- **屌**（厲害 / 酷）— 90s-2000s 台灣俚語
+- **Hito**（hit / 流行）— 90s 偶像劇時代詞
+
+這類**沒有對立 china_value**，是「台灣自身的詞匯萎縮」議題。Taiwan.md 詞庫目前 schema 是 `display.taiwan / display.china` 對比模式，這類詞需要不同處理：
+
+**選項 A**: 加新欄位 `dialectal_status: dying` 並允許 `china` 為 N/A
+**選項 B**: 開 `data/heritage-vocabulary/` 獨立目錄
+**選項 C**: 暫不收（超出 SSOT 對比 scope，留給未來「方言/世代用語保存」器官）
+
+---
+
+## Taiwan.md 詞庫對照結果
+
+| 詞 | 已收 | 缺漏 |
+|---|---|---|
+| 底氣 | ✓ `底氣.yaml` | — |
+| 拉黑 | ✓ `拉黑.yaml` | — |
+| 舉報 | ✓ `舉報.yaml` | — |
+| 留言 / 評論 | ✓ `留言.yaml`（notes 提到「中國說評論區」）| `評論區` 沒有獨立條目 |
+| 無語 / 無言 | ✗ | **建議新增** B 類 |
+| 細思極恐 | ✗ | **建議新增** E 類（無單一對應，多種台灣替代） |
+| 大概率 | ✗ | **建議新增** E 類（八成 / 多半 / 很可能） |
+| 朋友圈 | ✗ | **建議新增** B 類（社交圈 / 交際圈） |
+| 也是醉了 | ✓ `也是醉了.yaml`（target: 沒救了 / 無言）| — |
+
+**缺口 4 條 + 1 條補充**（評論區補進 留言.yaml 的 china_aliases 或開獨立檔）。
+
+---
+
+## 提案：新增 5 個 yaml entry
+
+### 1. `data/terminology/評論區.yaml`（B 類補充）
+
+```yaml
+id: comment_section
+category: tech
+subcategory: 社群文化
+fork_type: B
+display:
+  taiwan: 留言區
+  china: 評論區
+english: comments section
+etymology:
+  origin: 網路平台底下供讀者回應的區塊
+  taiwan_path: 台灣 YouTube/Facebook 中文 UI 標準為「留言區」
+  china_path: 中國 B 站、微博、抖音標準為「評論區」
+  fork_cause: 平台 UI 中文用語各自選擇
+notes: 跟「留言/評論」是同一語意分歧的延伸（單一動詞 → 集合名詞）。
+sources:
+  - 2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP
+status: stable
+added: '2026-05-04'
+```
+
+### 2. `data/terminology/無語.yaml`（B 類）
+
+```yaml
+id: speechless
+category: daily
+subcategory: 日常用語
+fork_type: B
+display:
+  taiwan: 無言
+  china: 無語
+english: speechless
+etymology:
+  origin: 表達「不知道該說什麼」的情緒詞
+  taiwan_path: 台灣口語為「無言」，1990-2000s 已是日常用法
+  china_path: 中國網路興起後「無語」成主流，「無語凝噎」古文用法被通俗化
+  fork_point: ~2010s
+  fork_cause: 中國微博/B 站擴散，年輕台灣人在中國平台接觸後反輸入
+notes: 「無語只能配問蒼天」是台灣老梗（蘇打綠歌詞）。OP 多次強調這是文化滲透最徹底的詞之一。
+sources:
+  - 2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP + cyc___yang + ry.pan + 多人附和
+status: stable
+added: '2026-05-04'
+```
+
+### 3. `data/terminology/朋友圈.yaml`（B 類）
+
+```yaml
+id: friend_circle
+category: tech
+subcategory: 社群文化
+fork_type: B
+display:
+  taiwan: 社交圈 / 交際圈
+  china: 朋友圈
+english: social circle / WeChat moments
+etymology:
+  origin: 中國「朋友圈」原指微信動態功能（Moments），衍生為一般社交圈意涵
+  taiwan_path: 台灣傳統說「社交圈」「交際圈」「人脈圈」
+  china_path: 微信於 2012 推出「朋友圈」功能，逐漸取代中國原有的「圈子」「人脈」說法
+  fork_cause: 微信平台用語擴散
+notes: OP 強調「朋友圈」是從微信出來的詞，明顯帶平台印記。Facebook 中文版用「動態」不用「朋友圈」。
+sources:
+  - 2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP 第二則貼文
+status: stable
+added: '2026-05-04'
+```
+
+### 4. `data/terminology/大概率.yaml`（E 類）
+
+```yaml
+id: high_probability
+category: daily
+subcategory: 日常用語
+fork_type: E
+display:
+  taiwan: 八成 / 多半 / 很可能 / 極可能
+  china: 大概率
+english: probably / most likely
+etymology:
+  origin: 中國近年口語化的機率表達
+  taiwan_path: 台灣傳統說「八成」「多半」「應該」「很可能」
+  china_path: 中國 2010s 後流行「大概率」（從統計術語滲入日常口語）
+  fork_cause: 中國網媒 / 自媒體擴散
+notes: OP 點名「大概率」為討厭的支語典型。台灣對應有多種，視語氣與正式度選用。
+sources:
+  - 2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP
+status: stable
+added: '2026-05-04'
+```
+
+### 5. `data/terminology/細思極恐.yaml`（E 類）
+
+```yaml
+id: deeply_disturbing
+category: daily
+subcategory: 日常用語
+fork_type: E
+display:
+  taiwan: 越想越可怕 / 想想就毛 / 細想毛骨悚然
+  china: 細思極恐
+english: deeply unsettling on reflection
+etymology:
+  origin: 中國網路四字格用法，「細思之，極恐」的縮略
+  taiwan_path: 台灣口語為「越想越可怕」「想想就毛」「想想就覺得不寒而慄」
+  china_path: 中國微博 2010s 流行四字格新成語化用語
+  fork_cause: 中國網路四字格修辭風潮
+notes: OP 點名為討厭的支語典型。台灣對應沒有單一短詞，需依語境展開為完整短句。
+sources:
+  - 2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP
+status: stable
+added: '2026-05-04'
+```
+
+---
+
+## 給觀察者的決策請求
+
+1. **5 條新 yaml 直接加？** — 都通過 SSOT 鐵律（`knowledge/` SSOT，但 `data/terminology/` 也是 SSOT 等同層級，不需 sync.sh）
+2. **「台灣死語」類**（壓馬路 / 夯 / 屌 / Hito）獨立處理？— 目前 schema 不適配，建議哲宇 review 後決定要不要長新器官
+3. **要不要爬完所有 547 留言？** — 需要登入 Threads + 改用 GraphQL API 或 selenium-deep-scroll，工作量較大。本 report 是樣本，不是普查
+
+🧬
+
+— magical-chandrasekhar @ 2026-05-04

--- a/src/pages/terminology/converter.astro
+++ b/src/pages/terminology/converter.astro
@@ -6,18 +6,18 @@ import { resolve, join } from 'path';
 import { parse as parseYaml } from 'yaml';
 import { createRequire } from 'module';
 
-// ── Build-time: s2t converter for normalizing china values ────────────────────
-// We use opencc-js at build time to convert any simplified Chinese china values
-// to traditional Chinese, since the frontend OpenCC already converts input text
-// from simplified → traditional before matching against our rules.
+// ── Build-time: s2t + t2s converters for both directions ──────────────────────
+// to.tw is character-variant only (TWVariants — 裡/裏 etc.), not phrase-aware,
+// so 「视频」→「視頻」 (chars only). Phrase substitution would silently
+// replace 「视频」→「影片」 directly, killing detection — so we deliberately
+// stick to to.tw (not to.twp).
 let s2tConverter: ((text: string) => string) | null = null;
+let t2sConverter: ((text: string) => string) | null = null;
 try {
   const require = createRequire(import.meta.url);
   const OpenCC = require('opencc-js');
-  // Converter({from:'cn', to:'tw'}) converts simplified→traditional (Taiwan standard)
-  // This matches what the frontend does before terminology matching
-  // Both build-time and frontend must use the same conversion to ensure rules match
   s2tConverter = OpenCC.Converter({ from: 'cn', to: 'tw' });
+  t2sConverter = OpenCC.Converter({ from: 'tw', to: 'cn' });
 } catch {
   console.warn(
     '[converter.astro] opencc-js not available, china values may not match simplified input',
@@ -28,6 +28,15 @@ function toTraditional(text: string): string {
   if (!s2tConverter) return text;
   try {
     return s2tConverter(text);
+  } catch {
+    return text;
+  }
+}
+
+function toSimplified(text: string): string {
+  if (!t2sConverter) return text;
+  try {
+    return t2sConverter(text);
   } catch {
     return text;
   }
@@ -103,11 +112,16 @@ for (const file of files) {
       if (chinaCleaned.startsWith('N/A') || chinaCleaned.startsWith('（無'))
         continue;
 
-      // Step 2: Normalize to traditional Chinese so it matches
-      // the frontend's OpenCC-converted input text
+      // Step 2: Normalize to traditional + derive simplified form so we
+      // detect both regardless of input shape and regardless of whether
+      // the frontend OpenCC has finished loading.
+      // YAML files are stored in traditional Chinese, so chinaCleaned ===
+      // chinaTraditional in practice — we cannot rely on cleaned !== trad
+      // to gate the simp rule. Instead actively generate simp via t2s.
       const chinaTraditional = toTraditional(chinaCleaned);
+      const chinaSimplified = toSimplified(chinaTraditional);
 
-      // Add rule for the traditional form (the primary matching source)
+      // Add rule for the traditional form (primary matching source)
       if (!seenSources.has(chinaTraditional) && chinaTraditional !== target) {
         rules.push({
           source: chinaTraditional,
@@ -119,10 +133,29 @@ for (const file of files) {
         seenSources.add(chinaTraditional);
       }
 
-      // If the original simplified form differs from traditional, also add
-      // a fallback rule for the simplified form (for when OpenCC is unavailable)
+      // Add simplified-form fallback rule. Critical for when frontend OpenCC
+      // hasn't loaded yet (CDN slow / mobile / strict CSP) — without this,
+      // simplified input can never match the traditional yaml source.
+      if (
+        chinaSimplified !== chinaTraditional &&
+        !seenSources.has(chinaSimplified) &&
+        chinaSimplified !== target
+      ) {
+        rules.push({
+          source: chinaSimplified,
+          target,
+          forkType,
+          category,
+          id: id + '_simp',
+        });
+        seenSources.add(chinaSimplified);
+      }
+
+      // Also keep the original cleaned form if it differs from both
+      // (handles yaml entries that already mix forms)
       if (
         chinaCleaned !== chinaTraditional &&
+        chinaCleaned !== chinaSimplified &&
         !seenSources.has(chinaCleaned) &&
         chinaCleaned !== target
       ) {
@@ -131,7 +164,7 @@ for (const file of files) {
           target,
           forkType,
           category,
-          id: id + '_simp',
+          id: id + '_orig',
         });
         seenSources.add(chinaCleaned);
       }
@@ -499,7 +532,15 @@ const reverseRulesJSON = JSON.stringify(reverseRules);
       console.warn('OpenCC 載入失敗，僅做用語替換（字形轉換不可用）');
       openccStatus = 'failed';
     }
-    initOpenCC();
+    // Awaitable promise so run() can wait for OpenCC instead of blind 800ms.
+    // initOpenCC never throws (loop catches all CDN errors), so this resolves
+    // once status is 'ready' or 'failed'.
+    const openccReady = initOpenCC();
+    // After OpenCC finishes, re-run conversion if input already has content
+    // (handles: user pastes / clicks example before CDN finishes).
+    openccReady.then(() => {
+      if (inputEl && inputEl.value && inputEl.value.trim()) run();
+    });
 
     // Apply active OpenCC to text outside of HTML tags
     function applyOpenCC(html) {
@@ -819,11 +860,13 @@ const reverseRulesJSON = JSON.stringify(reverseRules);
         return;
       }
 
-      // If OpenCC is still loading, wait a bit and proceed anyway
+      // Wait for OpenCC to finish loading (or fail). The simp fallback
+      // rules baked at build-time make detection mostly work without OpenCC,
+      // but waiting ensures character-variant input still gets normalized.
       if (openccStatus === 'loading') {
         outputEl.innerHTML =
           '<span class="output-placeholder">⏳ 正在載入字形轉換模組…</span>';
-        await new Promise((resolve) => setTimeout(resolve, 800));
+        await openccReady;
       }
 
       const { html, matches, sourceRegions } = convertText(input);

--- a/src/pages/terminology/converter.astro
+++ b/src/pages/terminology/converter.astro
@@ -216,7 +216,7 @@ const reverseRulesJSON = JSON.stringify(reverseRules);
 
 <Layout
   title="台灣用語轉換器：中國用語一鍵轉台灣說法"
-  description={`免費線上台灣用語轉換工具。「視頻」→「影片」、「軟件」→「軟體」、「打車」→「叫計程車」——${rules.length} 條轉換規則涵蓋科技、生活、醫療、校園等分類，附台灣化指數分析。不只轉字形，轉的是語感。`}
+  description={`免費線上台灣用語轉換工具。「視頻」→「影片」、「軟件」→「軟體」、「打車」→「叫計程車」——${rules.length} 條轉換規則涵蓋科技、生活、醫療、校園等分類，附台灣化指數分析。同步處理字形、詞彙、語感的完整對應。`}
 >
   <!-- Preload OpenCC for faster mobile loading -->
   <link
@@ -258,7 +258,7 @@ const reverseRulesJSON = JSON.stringify(reverseRules);
       </Fragment>
       <Fragment slot="subtitle">
         <span id="header-tagline"
-          >把中國用語轉換為台灣用語——不只是字形，是語感。</span
+          >把中國用語轉換為台灣用語：字形、詞彙、語感的完整對應。</span
         >
       </Fragment>
 
@@ -940,8 +940,8 @@ const reverseRulesJSON = JSON.stringify(reverseRules);
       if (headerTagline) {
         headerTagline.textContent =
           newDir === 'cn2tw'
-            ? '把中國用語轉換為台灣用語——不只是字形，是語感。'
-            : '把台灣用語轉換為中國用語——跨海溝通、給對岸朋友看，或反向 pattern 確認。';
+            ? '把中國用語轉換為台灣用語：字形、詞彙、語感的完整對應。'
+            : '對照台灣用語與中國說法：保存在地語感，看見兩邊語言彼此的影響。';
       }
 
       // Update rule count display

--- a/src/pages/terminology/index.astro
+++ b/src/pages/terminology/index.astro
@@ -198,8 +198,8 @@ const termsJSON = JSON.stringify(terms);
         >
       </Fragment>
       <Fragment slot="subtitle">
-        Taiwan.md
-        的文字應該讀起來像在台灣長大的人寫的——這不是政治立場，是生活經驗的真實性。
+        Taiwan.md 的文字讀起來像在台灣長大的人寫的，保留語言裡的生活經驗與文化記憶。<br /><br />
+        語言彼此滲透是常態，把那份脈絡攤開——你保留哪些字、放下哪些字，由你自己決定。
       </Fragment>
       <Fragment slot="meta">
         <span class="[&_strong]:text-[1.05em] [&_strong]:text-white"


### PR DESCRIPTION
## Summary

從 [@gordnbrad / DX22Q4sEh7d](https://www.threads.com/@gordnbrad/post/DX22Q4sEh7d)「復興死語」Threads 串（5 萬瀏覽 / 6,057 likes / 547 留言）萃取出 5 條 yaml 詞庫尚缺的中國→台灣對照。

## 新增詞條

| 中國 | 台灣 | 類別 |
|---|---|---|
| 評論區 | 留言區 | B |
| 無語 | 無言 | B |
| 朋友圈 | 社交圈 / 交際圈 | B |
| 大概率 | 八成 / 多半 / 很可能 / 極可能 | E |
| 細思極恐 | 越想越可怕 / 想想就毛 / 細想毛骨悚然 | E |

詞庫從 2334 → 2339 條。

## 為什麼這 5 條特別重要

OP「我真的受夠什麼『細思極恐』、『大概率』這種鬼東西了」+「明明台灣口語就是『無言』，現在變成無語🙄」+「『朋友圈』這個詞是從微信出來的，台灣人明明就是講『社交圈』、『交際圈』」— **高情緒、多附和、多人共同確認**的痛點，比 invade / cn2tw 等批量爬取詞庫多了情緒語境驗證。

## 採樣限制（誠實聲明）

Threads 未登入只 surface ~30 個 top-level 留言（547 中 ~5%），本批是 popularity-sorted 最熱門樣本，不是普查。完整爬取需登入 + Graph API。

## 不收（schema 不適配）

「壓馬路」「夯」「屌」「Hito」等台灣老用語（OP 自稱「死語」想復興）— 沒有對立 china_value，目前 yaml schema 表達不了。獨立處理留待後續決策。

## Test plan

- [x] 5 個 yaml lint 通過 (python yaml.safe_load)
- [x] display.taiwan / display.china 都有值
- [x] fork_type 標準（B 類 3 條 + E 類 2 條）

## 神經迴路（候選）

**社群留言串是 yaml 詞庫的 high-signal 採樣源**。下次造橋候選：`scripts/tools/social-terminology-harvest.sh`（給連結 → 自動爬 + diff 詞庫 + 草擬 yaml）。

完整 report：[reports/threads-crawl/2026-05-04-DX22Q4sEh7d-gordnbrad-復興死語.md](https://github.com/frank890417/taiwan-md/blob/claude/threads-DX22Q4sEh7d-augment/reports/threads-crawl/2026-05-04-DX22Q4sEh7d-gordnbrad-復興死語.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)