### PR TITLE
🧬 [造橋鋪路] build perf: Astro 6.0.5→6.2.1 + concurrency=4 + ARM CI runner

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,11 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # 2026-05-04: ubuntu-latest → ubuntu-24.04-arm. Free for public repos
+    # (4 vCPU / 16 GB), and arm64 is reported 1.3-1.7× faster on Node + Sharp
+    # workloads. Playwright Chromium binary supports linux/arm64 since 1.40.
+    # If perf regresses, revert to ubuntu-latest in a hotfix.
+    runs-on: ubuntu-24.04-arm
     # 2026-04-22 β post-mortem: run 24782448133 `npx playwright install --with-deps`
     # silent hang 6 小時才被 default 360 min timeout 殺掉。加上限避免重演。
     # 2026-05-02 γ: 35 → 60 — article volume grew (641 zh × 6 langs ≈ 3800 pages)
@@ -29,6 +33,10 @@ jobs:
     env:
       # 防 apt-get 互動 prompt（Playwright --with-deps 會呼叫 sudo apt-get）
       DEBIAN_FRONTEND: noninteractive
+      # 2026-05-04: bump heap to 12 GB. Default 4 GB has been close to the
+      # ceiling at 4,393 pages × 6 langs (max RSS ~3.4 GB observed locally).
+      # Headroom prevents GC thrashing as content grows.
+      NODE_OPTIONS: --max-old-space-size=12288
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -217,10 +217,40 @@ export default defineConfig({
     '/fr/culture/new-religions-and-spirituality':
       '/fr/culture/religion-and-temple-culture/',
   },
+  // 2026-05-04: build perf tuning. Page render is 93% of build time
+  // (363s render / 391s wall, baseline 4,331 pages). concurrency 1 → 4
+  // is the highest-ROI lever; details in reports/research/astro-build-speed-2026-05-04.md.
+  build: {
+    concurrency: 4,
+    inlineStylesheets: 'auto',
+  },
   markdown: {
+    // Explicit lang allowlist. Knowledge corpus uses bare ``` fences almost
+    // exclusively (1 named lang in src/content), so capping the loaded grammar
+    // bundle to common ones keeps Shiki startup small without breaking pages.
     shikiConfig: {
       theme: 'github-light',
       wrap: true,
+      langs: [
+        'ts',
+        'tsx',
+        'js',
+        'jsx',
+        'astro',
+        'bash',
+        'sh',
+        'md',
+        'json',
+        'yaml',
+        'html',
+        'css',
+        'python',
+        'go',
+        'rust',
+        'sql',
+        'diff',
+        'plaintext',
+      ],
     },
     remarkPlugins: [remarkWikilinks],
     rehypePlugins: [
@@ -232,5 +262,29 @@ export default defineConfig({
   },
   vite: {
     plugins: [tailwindcss()],
+    build: {
+      target: 'es2022',
+      minify: 'esbuild',
+      cssCodeSplit: true,
+      chunkSizeWarningLimit: 10000,
+      rollupOptions: {
+        output: {
+          // For huge SSG (4k+ pages) Rollup spends measurable time computing
+          // chunk splits when the per-route bundle is tiny. Forcing one-chunk
+          // output is faster on this scale (per bitdoze 339k-page case study).
+          manualChunks: undefined,
+        },
+      },
+    },
+    esbuild: {
+      target: 'es2022',
+      minifyIdentifiers: false,
+      minifySyntax: true,
+      minifyWhitespace: true,
+    },
+    optimizeDeps: { force: false },
   },
+  // experimental.queuedRendering tested 2026-05-04 — local wallclock unchanged,
+  // peak RSS 1.7 GB → 4.3 GB (poolSize: 1000 over-allocates for diverse pages).
+  // Skipping until upstream tunes pool sizing for content-heavy SSG.
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@astrojs/rss": "^4.0.17",
         "@astrojs/sitemap": "^3.7.1",
         "@tailwindcss/vite": "^4.2.2",
-        "astro": "^6.0.5",
+        "astro": "^6.2.1",
         "gray-matter": "^4.0.3",
         "marked": "^17.0.4",
         "minisearch": "^7.2.0",
@@ -35,22 +35,28 @@
       }
     },
     "node_modules/@astrojs/compiler": {
-      "version": "3.0.1",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/compiler/-/compiler-4.0.0.tgz",
+      "integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
       "license": "MIT"
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.8.0",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.9.0.tgz",
+      "integrity": "sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==",
       "license": "MIT",
       "dependencies": {
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@astrojs/markdown-remark": {
-      "version": "7.0.0",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-remark/-/markdown-remark-7.1.1.tgz",
+      "integrity": "sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/prism": "4.0.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/prism": "4.0.1",
         "github-slugger": "^2.0.0",
         "hast-util-from-html": "^2.0.3",
         "hast-util-to-text": "^4.0.2",
@@ -62,6 +68,7 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-smartypants": "^3.0.2",
+        "retext-smartypants": "^6.2.0",
         "shiki": "^4.0.0",
         "smol-toml": "^1.6.0",
         "unified": "^11.0.5",
@@ -72,13 +79,15 @@
       }
     },
     "node_modules/@astrojs/prism": {
-      "version": "4.0.0",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/prism/-/prism-4.0.1.tgz",
+      "integrity": "sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==",
       "license": "MIT",
       "dependencies": {
         "prismjs": "^1.30.0"
       },
       "engines": {
-        "node": "^20.19.1 || >=22.12.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/rss": {
@@ -102,15 +111,16 @@
       }
     },
     "node_modules/@astrojs/telemetry": {
-      "version": "3.3.0",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@astrojs/telemetry/-/telemetry-3.3.1.tgz",
+      "integrity": "sha512-7fcIxXS9J4ls5tr8b3ww9rbAIz2+HrhNJYZdkAhhB4za/I5IZ/60g+Bs8q7zwG0tOIZfNB4JWhVJ1Qkl/OrNCw==",
       "license": "MIT",
       "dependencies": {
-        "ci-info": "^4.2.0",
-        "debug": "^4.4.0",
+        "ci-info": "^4.4.0",
         "dlv": "^1.1.3",
         "dset": "^3.1.4",
-        "is-docker": "^3.0.0",
-        "is-wsl": "^3.1.0",
+        "is-docker": "^4.0.0",
+        "is-wsl": "^3.1.1",
         "which-pm-runs": "^1.1.0"
       },
       "engines": {
@@ -1465,6 +1475,8 @@
     },
     "node_modules/@shikijs/core": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/primitive": "4.0.2",
@@ -1479,6 +1491,8 @@
     },
     "node_modules/@shikijs/engine-javascript": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.0.2",
@@ -1491,6 +1505,8 @@
     },
     "node_modules/@shikijs/engine-oniguruma": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.0.2",
@@ -1502,6 +1518,8 @@
     },
     "node_modules/@shikijs/langs": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.0.2"
@@ -1512,6 +1530,8 @@
     },
     "node_modules/@shikijs/primitive": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.0.2",
@@ -1524,6 +1544,8 @@
     },
     "node_modules/@shikijs/themes": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/types": "4.0.2"
@@ -1534,6 +1556,8 @@
     },
     "node_modules/@shikijs/types": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -1545,6 +1569,8 @@
     },
     "node_modules/@shikijs/vscode-textmate": {
       "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
@@ -1805,7 +1831,9 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -1831,10 +1859,14 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/nlcst": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/nlcst/-/nlcst-2.0.3.tgz",
+      "integrity": "sha512-vSYNSDe6Ix3q+6Z7ri9lyWqgGhJTmzRjZRqyq15N0Z/1/UnVsno9G/N40NBijoYx2seFDIl0+B2mgAb9mezUCA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -1906,6 +1938,8 @@
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -1916,7 +1950,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -1931,6 +1967,8 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -1942,6 +1980,8 @@
     },
     "node_modules/array-iterate": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/array-iterate/-/array-iterate-2.0.1.tgz",
+      "integrity": "sha512-I1jXZMjAgCMmxT4qxXfPXa6SthSoE8h6gkSI9BGGNv8mP8G/v0blc+qFnZu6K42vTOiuME596QaLO0TP3Lk0xg==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -1949,15 +1989,17 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.0.5",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.2.1.tgz",
+      "integrity": "sha512-3g1sYNly+QAkuO5ErNEQBYvsxorNDSCUNIeStBs+kcXGchvKQl1Q9EuDNOvSg010XLlHJFLVFZs9LV18Jjp4Hg==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/compiler": "^3.0.0",
-        "@astrojs/internal-helpers": "0.8.0",
-        "@astrojs/markdown-remark": "7.0.0",
-        "@astrojs/telemetry": "3.3.0",
+        "@astrojs/compiler": "^4.0.0",
+        "@astrojs/internal-helpers": "0.9.0",
+        "@astrojs/markdown-remark": "7.1.1",
+        "@astrojs/telemetry": "3.3.1",
         "@capsizecss/unpack": "^4.0.0",
-        "@clack/prompts": "^1.0.1",
+        "@clack/prompts": "^1.1.0",
         "@oslojs/encoding": "^1.1.0",
         "@rollup/pluginutils": "^5.3.0",
         "aria-query": "^5.3.2",
@@ -1968,7 +2010,6 @@
         "cookie": "^1.1.1",
         "devalue": "^5.6.3",
         "diff": "^8.0.3",
-        "dlv": "^1.1.3",
         "dset": "^3.1.4",
         "es-module-lexer": "^2.0.0",
         "esbuild": "^0.27.3",
@@ -1987,22 +2028,22 @@
         "p-queue": "^9.1.0",
         "package-manager-detector": "^1.6.0",
         "piccolore": "^0.1.3",
-        "picomatch": "^4.0.3",
+        "picomatch": "^4.0.4",
         "rehype": "^13.0.2",
         "semver": "^7.7.4",
-        "shiki": "^4.0.0",
+        "shiki": "^4.0.2",
         "smol-toml": "^1.6.0",
-        "svgo": "^4.0.0",
-        "tinyclip": "^0.1.6",
-        "tinyexec": "^1.0.2",
+        "svgo": "^4.0.1",
+        "tinyclip": "^0.1.12",
+        "tinyexec": "^1.0.4",
         "tinyglobby": "^0.2.15",
         "tsconfck": "^3.1.6",
         "ultrahtml": "^1.6.0",
         "unifont": "~0.7.4",
         "unist-util-visit": "^5.1.0",
-        "unstorage": "^1.17.4",
+        "unstorage": "^1.17.5",
         "vfile": "^6.0.3",
-        "vite": "^7.3.1",
+        "vite": "^7.3.2",
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
@@ -2012,7 +2053,7 @@
         "astro": "bin/astro.mjs"
       },
       "engines": {
-        "node": "^20.19.1 || >=22.12.0",
+        "node": ">=22.12.0",
         "npm": ">=9.6.5",
         "pnpm": ">=7.1.0"
       },
@@ -2053,6 +2094,8 @@
     },
     "node_modules/character-entities": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -2087,6 +2130,8 @@
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -2100,6 +2145,8 @@
     },
     "node_modules/ci-info": {
       "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "funding": [
         {
           "type": "github",
@@ -2192,7 +2239,9 @@
       }
     },
     "node_modules/cookie-es": {
-      "version": "1.2.2",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/cookie-es/-/cookie-es-1.2.3.tgz",
+      "integrity": "sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==",
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -2235,6 +2284,8 @@
     },
     "node_modules/crossws": {
       "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.3.5.tgz",
+      "integrity": "sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==",
       "license": "MIT",
       "dependencies": {
         "uncrypto": "^0.1.3"
@@ -2304,6 +2355,8 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -2319,6 +2372,8 @@
     },
     "node_modules/decode-named-character-reference": {
       "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
       "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -2329,7 +2384,9 @@
       }
     },
     "node_modules/defu": {
-      "version": "6.1.4",
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
+      "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
     "node_modules/dequal": {
@@ -2374,6 +2431,8 @@
     },
     "node_modules/dlv": {
       "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "license": "MIT"
     },
     "node_modules/dom-serializer": {
@@ -2435,6 +2494,8 @@
     },
     "node_modules/dset": {
       "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/dset/-/dset-3.1.4.tgz",
+      "integrity": "sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -2528,6 +2589,8 @@
     },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -2668,6 +2731,8 @@
     },
     "node_modules/github-slugger": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz",
+      "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
     "node_modules/graceful-fs": {
@@ -2708,12 +2773,14 @@
       }
     },
     "node_modules/h3": {
-      "version": "1.15.6",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
+      "integrity": "sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==",
       "license": "MIT",
       "dependencies": {
-        "cookie-es": "^1.2.2",
+        "cookie-es": "^1.2.3",
         "crossws": "^0.3.5",
-        "defu": "^6.1.4",
+        "defu": "^6.1.6",
         "destr": "^2.0.5",
         "iron-webcrypto": "^1.2.1",
         "node-mock-http": "^1.0.4",
@@ -2780,6 +2847,8 @@
     },
     "node_modules/hast-util-raw": {
       "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2824,6 +2893,8 @@
     },
     "node_modules/hast-util-to-parse5": {
       "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2841,6 +2912,8 @@
     },
     "node_modules/hast-util-to-text": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/hast-util-to-text/-/hast-util-to-text-4.0.2.tgz",
+      "integrity": "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -2913,6 +2986,8 @@
     },
     "node_modules/iron-webcrypto": {
       "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iron-webcrypto/-/iron-webcrypto-1.2.1.tgz",
+      "integrity": "sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/brc-dd"
@@ -2965,13 +3040,15 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-4.0.0.tgz",
+      "integrity": "sha512-LHE+wROyG/Y/0ZnbktRCoTix2c1RhgWaZraMZ8o1Q7zCh0VSrICJQO5oqIIISrcSBtrXv0o233w1IYwsWCjTzA==",
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3012,6 +3089,8 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -3021,6 +3100,21 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3038,6 +3132,8 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -3070,6 +3166,8 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3435,6 +3533,8 @@
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3442,7 +3542,9 @@
       }
     },
     "node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -3466,6 +3568,8 @@
     },
     "node_modules/markdown-table": {
       "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -3484,6 +3588,8 @@
     },
     "node_modules/mdast-util-definitions": {
       "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-definitions/-/mdast-util-definitions-6.0.0.tgz",
+      "integrity": "sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3497,6 +3603,8 @@
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3511,6 +3619,8 @@
     },
     "node_modules/mdast-util-from-markdown": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3533,6 +3643,8 @@
     },
     "node_modules/mdast-util-gfm": {
       "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
       "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^2.0.0",
@@ -3550,6 +3662,8 @@
     },
     "node_modules/mdast-util-gfm-autolink-literal": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3565,6 +3679,8 @@
     },
     "node_modules/mdast-util-gfm-footnote": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3580,6 +3696,8 @@
     },
     "node_modules/mdast-util-gfm-strikethrough": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3593,6 +3711,8 @@
     },
     "node_modules/mdast-util-gfm-table": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3608,6 +3728,8 @@
     },
     "node_modules/mdast-util-gfm-task-list-item": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3622,6 +3744,8 @@
     },
     "node_modules/mdast-util-phrasing": {
       "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3653,6 +3777,8 @@
     },
     "node_modules/mdast-util-to-markdown": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -3672,6 +3798,8 @@
     },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
@@ -3760,6 +3888,8 @@
     },
     "node_modules/micromark": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3793,6 +3923,8 @@
     },
     "node_modules/micromark-core-commonmark": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3825,6 +3957,8 @@
     },
     "node_modules/micromark-extension-gfm": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
       "license": "MIT",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^2.0.0",
@@ -3843,6 +3977,8 @@
     },
     "node_modules/micromark-extension-gfm-autolink-literal": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
       "license": "MIT",
       "dependencies": {
         "micromark-util-character": "^2.0.0",
@@ -3857,6 +3993,8 @@
     },
     "node_modules/micromark-extension-gfm-footnote": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -3875,6 +4013,8 @@
     },
     "node_modules/micromark-extension-gfm-strikethrough": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -3891,6 +4031,8 @@
     },
     "node_modules/micromark-extension-gfm-table": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -3906,6 +4048,8 @@
     },
     "node_modules/micromark-extension-gfm-tagfilter": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
       "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
@@ -3917,6 +4061,8 @@
     },
     "node_modules/micromark-extension-gfm-task-list-item": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
       "license": "MIT",
       "dependencies": {
         "devlop": "^1.0.0",
@@ -3941,6 +4087,8 @@
     },
     "node_modules/micromark-factory-destination": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3960,6 +4108,8 @@
     },
     "node_modules/micromark-factory-label": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3980,6 +4130,8 @@
     },
     "node_modules/micromark-factory-space": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3998,6 +4150,8 @@
     },
     "node_modules/micromark-factory-title": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4018,6 +4172,8 @@
     },
     "node_modules/micromark-factory-whitespace": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4056,6 +4212,8 @@
     },
     "node_modules/micromark-util-chunked": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4073,6 +4231,8 @@
     },
     "node_modules/micromark-util-classify-character": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4092,6 +4252,8 @@
     },
     "node_modules/micromark-util-combine-extensions": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4110,6 +4272,8 @@
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4127,6 +4291,8 @@
     },
     "node_modules/micromark-util-decode-string": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4161,6 +4327,8 @@
     },
     "node_modules/micromark-util-html-tag-name": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4175,6 +4343,8 @@
     },
     "node_modules/micromark-util-normalize-identifier": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4192,6 +4362,8 @@
     },
     "node_modules/micromark-util-resolve-all": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4228,6 +4400,8 @@
     },
     "node_modules/micromark-util-subtokenize": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -4302,6 +4476,8 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4329,6 +4505,8 @@
     },
     "node_modules/nlcst-to-string": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/nlcst-to-string/-/nlcst-to-string-4.0.0.tgz",
+      "integrity": "sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0"
@@ -4344,10 +4522,14 @@
     },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
+      "integrity": "sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==",
       "license": "MIT"
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4438,14 +4620,18 @@
       }
     },
     "node_modules/oniguruma-parser": {
-      "version": "0.12.1",
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
       "license": "MIT"
     },
     "node_modules/oniguruma-to-es": {
-      "version": "4.3.5",
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
       "license": "MIT",
       "dependencies": {
-        "oniguruma-parser": "^0.12.1",
+        "oniguruma-parser": "^0.12.2",
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
@@ -4538,6 +4724,8 @@
     },
     "node_modules/parse-latin": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
+      "integrity": "sha512-mhHgobPPua5kZ98EF4HWiH167JWBfl4pvAIXXdbaVohtK7a6YBOy56kvhCqduqyo/f3yrHFWmqmiMg/BkBkYYQ==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -4596,7 +4784,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4754,6 +4944,8 @@
     },
     "node_modules/prismjs": {
       "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.30.0.tgz",
+      "integrity": "sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4769,6 +4961,8 @@
     },
     "node_modules/radix3": {
       "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
+      "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
     },
     "node_modules/read-package-json-fast": {
@@ -4787,6 +4981,8 @@
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 20.19.0"
@@ -4798,6 +4994,8 @@
     },
     "node_modules/regex": {
       "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -4805,6 +5003,8 @@
     },
     "node_modules/regex-recursion": {
       "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
       "license": "MIT",
       "dependencies": {
         "regex-utilities": "^2.3.0"
@@ -4812,6 +5012,8 @@
     },
     "node_modules/regex-utilities": {
       "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
       "license": "MIT"
     },
     "node_modules/rehype": {
@@ -4861,6 +5063,8 @@
     },
     "node_modules/rehype-raw": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4887,6 +5091,8 @@
     },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4903,6 +5109,8 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4917,6 +5125,8 @@
     },
     "node_modules/remark-rehype": {
       "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
@@ -4932,6 +5142,8 @@
     },
     "node_modules/remark-smartypants": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/remark-smartypants/-/remark-smartypants-3.0.2.tgz",
+      "integrity": "sha512-ILTWeOriIluwEvPjv67v7Blgrcx+LZOkAUVtKI3putuhlZm84FnqDORNXPPm+HY3NdZOMhyDwZ1E+eZB/Df5dA==",
       "license": "MIT",
       "dependencies": {
         "retext": "^9.0.0",
@@ -4945,6 +5157,8 @@
     },
     "node_modules/remark-stringify": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
@@ -4995,6 +5209,8 @@
     },
     "node_modules/retext": {
       "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/retext/-/retext-9.0.0.tgz",
+      "integrity": "sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -5009,6 +5225,8 @@
     },
     "node_modules/retext-latin": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-latin/-/retext-latin-4.0.0.tgz",
+      "integrity": "sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -5022,6 +5240,8 @@
     },
     "node_modules/retext-smartypants": {
       "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/retext-smartypants/-/retext-smartypants-6.2.0.tgz",
+      "integrity": "sha512-kk0jOU7+zGv//kfjXEBjdIryL1Acl4i9XNkHxtM7Tm5lFiCog576fjNC9hjoR7LTKQ0DsPWy09JummSsH1uqfQ==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -5035,6 +5255,8 @@
     },
     "node_modules/retext-stringify": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/retext-stringify/-/retext-stringify-4.0.0.tgz",
+      "integrity": "sha512-rtfN/0o8kL1e+78+uxPTqu1Klt0yPzKuQ2BfWwwfgIUSayyzxpM1PJzkKt4V8803uB9qSy32MvI7Xep9khTpiA==",
       "license": "MIT",
       "dependencies": {
         "@types/nlcst": "^2.0.0",
@@ -5221,6 +5443,8 @@
     },
     "node_modules/shiki": {
       "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/core": "4.0.2",
@@ -5288,7 +5512,9 @@
       }
     },
     "node_modules/smol-toml": {
-      "version": "1.6.0",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">= 18"
@@ -5529,6 +5755,8 @@
     },
     "node_modules/uncrypto": {
       "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/uncrypto/-/uncrypto-0.1.3.tgz",
+      "integrity": "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -5563,6 +5791,8 @@
     },
     "node_modules/unist-util-find-after": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-find-after/-/unist-util-find-after-5.0.0.tgz",
+      "integrity": "sha512-amQa0Ep2m6hE2g72AugUItjbuM8X8cGQnFoHk0pGfrFeT9GZhzN5SW8nRsiGKK7Aif4CrACPENkA6P/Lw6fHGQ==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5586,6 +5816,8 @@
     },
     "node_modules/unist-util-modify-children": {
       "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-modify-children/-/unist-util-modify-children-4.0.0.tgz",
+      "integrity": "sha512-+tdN5fGNddvsQdIzUF3Xx82CU9sMM+fA0dLgR9vOmT0oPT2jH+P1nd5lSqfCfXAw+93NhcXNY2qqvTUtE4cQkw==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5609,6 +5841,8 @@
     },
     "node_modules/unist-util-remove-position": {
       "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-remove-position/-/unist-util-remove-position-5.0.0.tgz",
+      "integrity": "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
@@ -5645,6 +5879,8 @@
     },
     "node_modules/unist-util-visit-children": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-children/-/unist-util-visit-children-3.0.0.tgz",
+      "integrity": "sha512-RgmdTfSBOg04sdPcpTSD1jzoNBjt9a80/ZCzp5cI9n1qPzLZWF9YdvWGN2zmTumP1HWhXKdUWexjy/Wy/lJ7tA==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
@@ -5667,14 +5903,16 @@
       }
     },
     "node_modules/unstorage": {
-      "version": "1.17.4",
+      "version": "1.17.5",
+      "resolved": "https://registry.npmjs.org/unstorage/-/unstorage-1.17.5.tgz",
+      "integrity": "sha512-0i3iqvRfx29hkNntHyQvJTpf5W9dQ9ZadSoRU8+xVlhVtT7jAX57fazYO9EHvcRCfBCyi5YRya7XCDOsbTgkPg==",
       "license": "MIT",
       "dependencies": {
         "anymatch": "^3.1.3",
         "chokidar": "^5.0.0",
         "destr": "^2.0.5",
-        "h3": "^1.15.5",
-        "lru-cache": "^11.2.0",
+        "h3": "^1.15.10",
+        "lru-cache": "^11.2.7",
         "node-fetch-native": "^1.6.7",
         "ofetch": "^1.5.1",
         "ufo": "^1.6.3"
@@ -5797,7 +6035,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",
@@ -5911,6 +6151,8 @@
     },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
+      "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@astrojs/rss": "^4.0.17",
     "@astrojs/sitemap": "^3.7.1",
     "@tailwindcss/vite": "^4.2.2",
-    "astro": "^6.0.5",
+    "astro": "^6.2.1",
     "gray-matter": "^4.0.3",
     "marked": "^17.0.4",
     "minisearch": "^7.2.0",

--- a/reports/build-perf-experiment/baseline.txt
+++ b/reports/build-perf-experiment/baseline.txt
@@ -1,0 +1,23 @@
+# Build perf experiment — local M-series, 2026-05-04
+# Cold cache between every run (rm -rf dist .astro node_modules/.astro)
+
+| Run                                              | Wallclock | Max RSS | Pages |
+|--------------------------------------------------|-----------|---------|-------|
+| Astro 6.0.5 baseline (cold OS, first ever)        |   391.00s | 1.94 GB | 4,331 |
+| Astro 6.0.5 baseline (re-run, OS cache warm)      |   356.20s | 3.40 GB | 4,331 |
+| Astro 6.0.5 + Tier 1 config                       |   357.09s | 1.70 GB | 4,331 |
+| Astro 6.2.1 + Tier 1 + experimental.queuedRendering | 364.22s | 4.32 GB | 4,331 |
+| Astro 6.2.1 + Tier 1 (final, shipped)             |   361.52s | 3.95 GB | 4,331 |
+
+Conclusion (local): wallclock effectively unchanged (within OS-cache noise of ~35s).
+queuedRendering caused +0.9 GB peak RSS without speed gain → dropped.
+
+Real wins are CI-side and unmeasurable locally:
+  - ubuntu-24.04-arm: 1.3-1.7× faster on Node + Sharp + Playwright (per GitHub blog)
+  - NODE_OPTIONS heap headroom: prevents OOM as content grows past current 4,393 pages
+  - build.concurrency: 4: I/O parallelism on 4-core CI runner
+
+CI baseline (before this PR, 7-day avg from public/api/dashboard-build-perf.json):
+  1029s (17 min)
+
+Will compare to post-merge CI run.

--- a/reports/research/astro-build-speed-2026-05-04.md
+++ b/reports/research/astro-build-speed-2026-05-04.md
@@ -1,0 +1,787 @@
+# Astro Build Speed Optimization — Deep Research (late 2025 / early 2026)
+
+Target context: Astro 6.0.5, 100% SSG, ~2,750 pages × 6 languages = ~16,000+ pages, 35MB markdown, 65MB public, ~17 min builds on `ubuntu-latest`, per-page render regressed 98ms → 167ms over 12 days.
+
+---
+
+## 1. Astro 5 Content Layer API vs Legacy Collections
+
+### State of the art
+
+The Content Layer API is **mandatory** in Astro 6 — legacy collections (`type: 'content'`, `type: 'data'`) were fully removed. The migration helper `legacy.collectionsBackwardsCompat` is a temporary shim, not a long-term path. (Astro 6 upgrade guide.)
+
+Officially reported deltas vs the legacy API:
+
+- **Up to 5× faster Markdown builds**
+- **Up to 2× faster MDX builds**
+- **25–50% lower memory** during build
+- "Suitable for tens of thousands of content entries" — explicit in the docs (legacy was documented as choking past ~5–10k).
+
+Source: Astro 5 release notes; Content Layer Deep Dive blog; `docs.astro.build/en/guides/content-collections/`.
+
+### `glob()` vs `file()` loaders
+
+- `glob({ pattern, base, generateId })` — directory of files (md/mdx/json/yaml/toml). This is the workhorse for filesystem-backed collections and is what backs the legacy backward-compat path under the hood.
+- `file()` — a single JSON/YAML/TOML file containing many entries. Cheaper than `glob()` for "many small entries in one file" because there is one fs read and one parse, no per-file overhead.
+- Custom inline loader (an async function that returns an array) — useful when you already shell out / git-log / etc. and want to push the result into the data store once.
+
+Decision rule for the Taiwan.md case (35MB markdown across thousands of files, 6 languages):
+
+- `glob()` is correct for the per-language markdown. **Do not** read files with `fs.readFile + gray-matter` inside `getStaticPaths` — that bypasses the data store entirely (no caching, no incremental, paid every build).
+- For derived/aggregate data (e.g. "all article slugs by language"), prefer building it once in a custom loader that writes into the data store, then `getCollection()` in pages — the data store is cached at `node_modules/.astro/data-store.json` and survives between builds when you cache that directory in CI.
+
+### Schema validation cost
+
+- Zod 4 is the default in Astro 6 (import `z` from `astro/zod`, not `astro:content` — that re-export is deprecated).
+- Validation is per-entry, at load time into the data store, **not** at page render time. So with the data store cached, schema cost is amortized across builds.
+- Heavy `z.refine()` / `z.transform()` on every entry **is** measurable on warm caches because the data store re-validates on load. Keep schemas declarative; push expensive transforms into a loader that writes the post-transform shape into the store.
+
+### `livePreview` / live content collections
+
+- Stable in Astro 6 (the experimental flag was removed). Live collections fetch on every request — they are the wrong tool for SSG and **will** murder build time if used at the page level. They're for SSR/hybrid endpoints only. Stick to build-time collections for SSG.
+
+### Migration cost
+
+- `getEntryBySlug()` / `getDataEntryById()` → `getEntry()`
+- `entry.slug` → `entry.id` (and configure `generateId` if you need slug-style ids)
+- `entry.render()` → `render(entry)` import from `astro:content`
+- Move config from `src/content/config.ts` → `src/content.config.ts`
+- Replace any `Astro.glob()` (removed in 6) with `import.meta.glob()` or `getCollection()`
+
+---
+
+## 2. Astro 6 Release Notes — Performance-Relevant Changes Since 5.0
+
+### Astro 6.0 (March 10, 2026)
+
+- **Vite 7** required (Environment API). Dev server and build now share code paths. Astro `dev` runs the production runtime (workerd / Bun / Node) directly — fewer dev/prod drift bugs but no direct build-time win in itself.
+- **Shiki 4** (highlighting), **Zod 4** (schemas).
+- **Node 22.12+ required**, Node 18/20 dropped. Polyfills removed → smaller, faster runtime.
+- **Experimental Rust compiler** (`@astrojs/compiler-rs`, flag: `experimental.rustCompiler`). Reported up to 100× faster compile phase in early benchmarks. Defaults Go compiler in 6, will become default in 7.
+- **Queued rendering** (experimental): two-pass tree-walk + linear render instead of recursion. ~2× rendering speed in early benchmarks. See §16.
+- **CSP, Fonts, live collections** all stabilized (flag removed).
+- **`Astro.glob()` removed**. Replace with `import.meta.glob()` or `getCollection()`. This is a forced cleanup that often *helps* perf because Astro.glob synchronously evaluated all matched modules at request time — `import.meta.glob({ eager: false })` lets you defer.
+- **Trailing-slash policy on endpoints, percent-encoded filenames, numeric `getStaticPaths` params** — all removed. Mostly correctness fixes.
+- **Image pipeline**: SVG → raster supported, default Sharp service crops by default, never upscales. Responsive images use hash classes + `data-*` instead of inline styles (CSP-safe).
+
+### Astro 6.1
+
+- **`.astro` SSR rendering up to 2× faster** (the queued-rendering work landing in stable paths).
+- **`createShikiHighlighter` is now cached by options** instead of being re-created. Material if you have many code blocks across pages.
+- **Dev-server dependency-crawl caching** (small).
+- **Codec-specific Sharp defaults** via `image.service.config` — set JPEG/WebP/AVIF/PNG quality once globally instead of per `<Image>`.
+
+### Astro 6.2
+
+- **Rust compiler stabilizing** — slated as default in Astro 7.
+- **SVG optimizer is now pluggable** (any `SvgOptimizer` impl, not only SVGO). On a site with many inline SVG components this matters; SVGO can be CPU-heavy.
+- **`compressHTML: "jsx"`** — strips multi-line indented text but preserves `<pre>`. Faster than the default whitespace-collapse on JSX-y output.
+- **Experimental JSON logger** — useful for parsing build phases (see §11).
+
+### Deprecated / removed (Astro 6)
+
+- `Astro.glob`, `emitESMImage`, `<ViewTransitions />` (use `<ClientRouter />`), `astro:ssr-manifest`, legacy collections, `app.render()` old signature, CommonJS configs (`.cjs`/`.cts`), `prefetch.with`, `handleForms` prop, `astro:schema`.
+- Experimental flags removed/promoted: `csp`, `fonts`, `liveContentCollections`, `preserveScriptOrder`, `staticImportMetaEnv`, `headingIdCompat`.
+
+---
+
+## 3. Vite 7 Optimizations
+
+### `optimizeDeps`
+
+- In Astro 6, Astro pre-warms a curated dep list. Adding heavy non-Astro deps used during build to `vite.optimizeDeps.include` can cut cold-start time.
+- `optimizeDeps.force: false` is the right default — `true` invalidates the dep cache every build.
+
+### `build.rollupOptions.output.manualChunks`
+
+- Counter-intuitive: for SSG-heavy sites, `manualChunks: undefined` is often **faster** than carefully partitioned chunks because Rollup doesn't have to compute splits for thousands of page entries. The bitdoze 339k-page case study explicitly recommends `manualChunks: undefined`.
+- Object-form `manualChunks` is removed in Vite 8 (Astro 7 territory). Function-form is deprecated. Investing in clever chunking now is a forward-incompatibility trap.
+
+### Other rollup knobs
+
+```js
+rollupOptions: {
+  maxParallelFileOps: cpus().length * 3,  // higher than the rollup default 20
+  output: {
+    manualChunks: undefined,
+    generatedCode: { preset: 'es2022' },
+  },
+}
+```
+
+### esbuild settings
+
+```js
+vite: {
+  esbuild: {
+    target: 'es2022',
+    minifyIdentifiers: false,   // identifier minification is slow vs gain
+    minifySyntax: true,
+    minifyWhitespace: true,
+  },
+  build: {
+    target: 'es2022',
+    minify: 'esbuild',          // not 'terser' — terser is 5–10× slower
+    chunkSizeWarningLimit: 10000,
+  },
+}
+```
+
+### `cssCodeSplit`
+
+- Default `true` is correct for SSG: each page references only the CSS it needs.
+- `cssCodeSplit: false` collapses to a single CSS file — fewer asset emit calls but bigger payload per page. Only worth it if asset emit is your bottleneck (rare).
+
+### `assetsInlineLimit`
+
+- Default 4096 bytes. Lowering it (e.g., 1024) reduces the number of bytes inlined into HTML and pushes assets to separate files; that means more files written but smaller HTML — trade against your CDN's edge cost.
+- The `build.inlineStylesheets: 'auto'` flag in Astro is gated by this Vite limit.
+
+### Vite 8 / Rolldown horizon
+
+- Vite 8 (Astro 7) replaces Rollup with Rolldown. Reported 10–30× faster bundling on real codebases. Plan migration paths now (avoid `manualChunks` object form, avoid CommonJS plugins).
+
+---
+
+## 4. Markdown / MDX Rendering
+
+### Shiki vs Prism vs Expressive Code
+
+- Astro 6 ships Shiki 4 by default. Prism is still supported (`markdown.syntaxHighlight: 'prism'`) but actively de-prioritized.
+- **Expressive Code** is the heaviest of the three — it builds an annotated AST per code block. Beautiful output, slowest. If you see code-block render time dominate the per-page profile, Expressive Code is the first suspect.
+- Shiki ≈ 2–4× faster than Expressive Code on equivalent code blocks.
+- Prism is fastest but client-only and lower fidelity — only relevant if perf is desperate.
+
+### Shiki performance levers
+
+```js
+// astro.config
+markdown: {
+  shikiConfig: {
+    themes: { light: 'github-light', dark: 'github-dark' }, // 1 or 2 themes max
+    langs: ['ts','js','astro','bash','md','json','yaml'],   // explicit langs only
+    // do NOT pass the entire bundled lang set
+  }
+}
+```
+
+Astro 6.1 fix: `createShikiHighlighter` is now cached by options, so the same highlighter is reused across pages. Earlier versions instantiated a new highlighter per code block in some paths — a major source of the regression you saw if you upgraded mid-window.
+
+Lever: when a page has zero code blocks, ensure Shiki is not invoked. The remark pipeline currently runs the Shiki highlighter as a hook regardless; you can short-circuit it with a custom `transformers` no-op or by using `astro-fence-skipper` style patterns. Verify with `--cpu-prof`.
+
+### `transformers` and `cssVariablesTheme`
+
+- Each transformer runs per code block per build. A Twoslash transformer alone can add 5–20s on a docs site.
+- `cssVariablesTheme` cost is negligible — it's a static post-process.
+
+### Switching parsers
+
+- **swc / Bun's native md parser**: not a drop-in for Astro because Astro's pipeline depends on unified/remark/rehype AST. Custom parser swap requires reimplementing `markdown.render()`.
+- For 95% of cases, the right move is *not* swapping parsers but pruning remark/rehype plugins and Shiki langs.
+
+### Remark / rehype plugin overhead
+
+- AST traversal cost is roughly linear in node count × plugin count.
+- Common offenders: `rehype-pretty-code` (overlaps with Shiki — pick one), `remark-toc` on huge docs, custom plugins doing fs reads per node.
+- Internal optimization flag exists for MDX: `markdown.optimize: true` (already default for plain `.md` in Astro 5+). Confirm MDX side is on. Starlight's docs got ~40% faster with this enabled.
+
+### "No code blocks" optimization
+
+- A scan-once pre-check: for each entry, set a frontmatter or computed boolean `hasCode` and pass a custom `remarkPlugins` array conditionally. This is a project-level escape hatch — Astro doesn't ship it.
+
+---
+
+## 5. `getStaticPaths` Bottlenecks
+
+### Antipatterns to look for
+
+1. **Direct `readFile` + `gray-matter` inside `getStaticPaths`** — the most common cause of "98ms → 167ms" regressions. Every page render re-reads + re-parses sibling files because the result isn't cached anywhere.
+2. **API calls in nested components**, not in `getStaticPaths` itself. `getStaticPaths` runs once; the page component runs *N* times. An async fetch in a component called from each page = N API calls. The AntStack 30→5min case study attributes ~24 of the 25 minutes saved to this single fix.
+3. **Synchronous `git log` shell-outs per page** for "lastUpdated" timestamps — measure with `--verbose`. Shell startup alone is 10–30ms × 16k pages = 4+ minutes.
+4. **Large JSON read per page** — the file is read once but allocated N times if you `JSON.parse` inside `getStaticPaths` for each route.
+
+### The `knowledge/` direct-read pattern
+
+If Taiwan.md uses `readFile('knowledge/...')` + `matter()` directly:
+
+- This bypasses the data store. No caching between builds.
+- Every full rebuild re-parses 35MB of markdown from scratch.
+- Recommended migration: define a `glob({ pattern: '**/*.md', base: './knowledge' })` collection. Astro's data store will cache the parsed frontmatter+body keyed by file mtime. Cache `node_modules/.astro` in CI for cross-run reuse.
+
+### Module-level cache pattern (if you can't migrate)
+
+```ts
+// shared/articleCache.ts
+let cache: Map<string, Article> | null = null;
+
+export async function getAllArticles() {
+  if (cache) return cache;
+  cache = new Map();
+  const files = await fg('knowledge/**/*.md');
+  await Promise.all(files.map(async f => {
+    const raw = await fs.readFile(f, 'utf8');
+    const parsed = matter(raw);
+    cache!.set(f, parsed);
+  }));
+  return cache;
+}
+```
+
+This survives within a single build (process-level memo). It does NOT survive across builds — for that, you need the data store.
+
+### Numeric param removal
+
+Astro 6 disallows numeric values in `params` returned by `getStaticPaths()`. Coerce to strings (`String(id)`).
+
+---
+
+## 6. Parallel Rendering
+
+### Built-in `build.concurrency`
+
+```js
+// astro.config.mjs
+export default defineConfig({
+  build: {
+    concurrency: 4,  // default 1; tune empirically
+  },
+});
+```
+
+- Added in Astro 4.16, still in 6.x.
+- Astro core team's official caveat: "Use only when other attempts to reduce overall rendering time are insufficient." This is honest — JS is single-threaded; concurrency here is I/O parallelism, not CPU parallelism, so it helps when pages are blocked on `fetch()` or `fs` reads.
+- Empirical guidance from case studies: 2–6 sweet spot. 4 was optimal on a 12-core machine in the bitdoze case study. Higher values increase memory pressure and GC pauses.
+- Memory cost scales linearly. With `concurrency: 8` and a 167ms-per-page render footprint, expect ~2–4GB headroom.
+
+### Known issues
+
+- Astro 5+ broke the "run two `astro build` processes in parallel folders" workaround due to a race on `node_modules/.astro/data-store.json.tmp` rename (issue #12992, closed "not planned"). If you used the per-language parallel-build strategy in Astro 4, it stopped working. Workarounds:
+  - Different `cacheDir` per worker: `--cacheDir ./.astro-cache-en`
+  - Different `outDir` per worker, then merge.
+  - Containerize each language into its own Docker build, merge `dist/` afterwards.
+
+### Worker pools for `getStaticPaths`
+
+Not natively supported. The static build is single-process by design. Workarounds are external: pre-compute the route table in a parallel script, write to disk, have `getStaticPaths` `JSON.parse` the result.
+
+### Multi-process (the per-language pattern)
+
+Still the best lever for a 6-language site. Architecture:
+
+```yaml
+# .github/workflows/build.yml
+jobs:
+  build-en:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: pnpm install
+      - run: ASTRO_LANG=en pnpm build  # builds only /en/* via i18n filter
+      - uses: actions/upload-artifact@v5
+        with: { name: dist-en, path: dist }
+  build-zh:
+    # ...identical, ASTRO_LANG=zh
+  merge:
+    needs: [build-en, build-zh, ...]
+    steps:
+      - uses: actions/download-artifact@v5
+      - run: rsync -a dist-*/. dist/
+```
+
+Real-world report: 14k-page site went from ~4min → <2min with per-language parallel jobs.
+
+This requires the build to be aware of `ASTRO_LANG` — exclude other locales from `getStaticPaths` when set. Cleaner than running multiple processes in the same folder (which will race the data store).
+
+---
+
+## 7. Incremental Builds
+
+### Native Astro
+
+Astro does **not** ship full incremental SSG. The history:
+
+- `experimental.contentCollectionCache` (Astro 3.5–4.x) — the famous 92% bundling-step speedup on Astro Docs (133s → 10.46s, end-to-end 4:58 → ~1:00). **Removed in Astro 5** because of correctness bugs (stale content after edits, image ENOENT).
+- The Content Layer **data store** (`node_modules/.astro/data-store.json`) replaces the old cache philosophically. It caches the parsed entries between builds, but **page rendering is still done from scratch every build**. So you save the parse phase (significant for 35MB markdown), not the render phase.
+- `experimental.routeCaching` is for on-demand-rendered routes only — irrelevant for 100% SSG.
+
+### Third-party
+
+- `@jcayzac/astro-build-cache` — npm package that snapshots `dist/` and skips pages whose content hash matches. Works but invasive; verify it handles your i18n routing.
+- `@astrojs/db` + custom diff — heavy; not worth it for static content.
+
+### Hash-based skipping (DIY)
+
+Pattern that works in CI:
+
+```bash
+# Step 1: compute current content hash
+HASH=$(find knowledge src/content -type f | sort | xargs sha256sum | sha256sum | cut -d' ' -f1)
+
+# Step 2: try to download a previous dist+manifest matching the hash from R2/S3
+curl -fsSL "$CDN/dist-${HASH}.tar.zst" | tar -xI zstd -C dist/ && exit 0
+
+# Step 3: full build, then upload
+pnpm build
+tar -cI 'zstd -19' -f dist.tar.zst dist/
+aws s3 cp dist.tar.zst "s3://bucket/dist-${HASH}.tar.zst"
+```
+
+This gives you "if nothing changed, 0-second build" — not true incremental but functionally equivalent for content-only pushes.
+
+### Cloudflare Pages / Netlify build cache
+
+- **Cloudflare Pages**: Settings → Build → Build cache → Enable. Caches the working directory between builds, including `node_modules/.astro`. 10GB project quota, LRU eviction. Known issue: framework auto-detection sometimes resets, defeating the cache. Manually re-set Astro preset after each settings change.
+- **Netlify**: Caches `node_modules` automatically. Add `.astro` to the cached set via `netlify-plugin-cache` or `netlify.toml`'s `[build.environment]`.
+
+### Diff-based partial rebuild
+
+Possible but custom. Determine which files changed since last build, derive the affected route slugs, build only those routes (`astro build --route /en/foo`-style flags don't exist; you'd patch `getStaticPaths` to filter to the affected set), then rsync the partial output over the previous full `dist/`.
+
+---
+
+## 8. Image Pipeline
+
+### Sharp vs Squoosh
+
+- **Sharp** is default in Astro 6. Native bindings (libvips). 5–10× faster than Squoosh on equivalent ops.
+- **Squoosh** is WASM, portable to environments without native binaries (StackBlitz, some serverless).
+- For GitHub Actions ubuntu-latest: always Sharp. Ensure it's installed (sometimes silently falls back).
+
+### `astro:assets` and skipping it
+
+- For `<Image>` components, the build runs Sharp on every referenced image. With 65MB of public assets this could matter — but `public/` images are NOT processed by `astro:assets`; they're copied as-is. Only images imported via `import img from './x.jpg'` and used in `<Image>` go through Sharp.
+- `passthroughImageService()` was supposed to skip optimization but has a known regression in 5.15+ where WebP conversion still runs (issue #14721). Use a plain `<img>` tag or `image.service: { entrypoint: 'astro/assets/services/noop' }` if you really want zero processing.
+
+### Codec choice
+
+- **AVIF** encodes 5–10× slower than JPEG. For batch SSG it's fine if you do it once and cache. For incremental builds, the cache hit rate drops.
+- **WebP** is the workhorse: ~97% browser support, encodes ~2× JPEG.
+- Astro 6.1 lets you set defaults globally:
+  ```js
+  image: {
+    service: {
+      entrypoint: 'astro/assets/services/sharp',
+      config: {
+        webp: { quality: 80 },
+        avif: { quality: 65, effort: 4 },  // effort 0-9; lower = faster encode
+        jpeg: { quality: 82, mozjpeg: true },
+      }
+    }
+  }
+  ```
+  `avif.effort: 4` is a reasonable build-time tradeoff (default is 4, max 9).
+
+### Caching images across CI runs
+
+```yaml
+- uses: actions/cache@v4
+  with:
+    path: node_modules/.astro
+    key: astro-${{ hashFiles('src/content/**', 'src/assets/**', 'public/**') }}
+    restore-keys: astro-
+```
+
+`node_modules/.astro` contains the Sharp output cache, the data store, and OG image cache. The Daniel Wulff benchmark: 10+ minutes → ~30 seconds on cache hit.
+
+---
+
+## 9. CI/CD-Specific Levers
+
+### Runner sizing
+
+Free `ubuntu-latest` is 4 vCPU / 16 GB RAM (as of 2026). Going to a larger runner is the easiest win:
+
+| Runner | Cores | RAM | Notes |
+|---|---|---|---|
+| `ubuntu-latest` (free) | 4 | 16 GB | Standard |
+| `ubuntu-24.04-arm` (free for public) | 4 | 16 GB | ~37% cheaper for private; faster for many node workloads |
+| `ubuntu-latest-8-core` | 8 | 32 GB | Paid; ~2× faster on parallelizable work |
+| `ubuntu-latest-16-core` | 16 | 64 GB | Diminishing returns past concurrency=6 |
+
+**ARM runners**: free for public repos. Native arm64 Node + Sharp work well. Some npm packages still ship x86-only binaries — check your `pnpm install` succeeds. Reported 30+ min → ~4 min on ARM in some cases, but this is for arm-friendly workloads (Node + Sharp qualify).
+
+For Taiwan.md (public repo, Node + Sharp): **`ubuntu-24.04-arm` is the obvious first move**. Free, faster, lower contention.
+
+### Package manager
+
+| Manager | Install speed | Astro support |
+|---|---|---|
+| `npm ci` | baseline | works |
+| `pnpm install --frozen-lockfile` | 2–3× faster | first-class |
+| `bun install` | 12× faster than npm, 3.6× faster than pnpm | works; experimental for build runtime |
+
+For 6-language Taiwan.md: pnpm is the safest "fast enough" choice. Bun install + Node build is a valid hybrid.
+
+### `actions/cache` patterns
+
+```yaml
+- uses: pnpm/action-setup@v4
+  with: { version: 9, run_install: false }
+
+- uses: actions/setup-node@v4
+  with:
+    node-version: 22
+    cache: 'pnpm'  # caches the pnpm store
+
+- name: Cache Astro build artifacts
+  uses: actions/cache@v4
+  with:
+    path: |
+      node_modules/.astro
+      .astro
+    key: astro-build-${{ runner.os }}-${{ hashFiles('src/content/**','src/assets/**','public/**','astro.config.*') }}
+    restore-keys: astro-build-${{ runner.os }}-
+```
+
+**Don't** cache `node_modules/` itself with pnpm — the store is what matters; the symlinked `node_modules` is recreated quickly.
+
+### Turborepo remote cache
+
+Overkill for a single-package site. Worth it if Taiwan.md becomes a monorepo with shared tooling.
+
+### `withastro/action`
+
+The official action does set up package-manager-aware caching by default and caches `node_modules/.astro`. Fine for GitHub Pages deploys; for CF Pages / Netlify you'd write your own workflow anyway.
+
+---
+
+## 10. Bun / Node Versions
+
+### Node 22 vs Node 24
+
+- Node 22 LTS is current minimum for Astro 6.
+- Node 24 ships Maglev tier improvements; reported ~5–10% faster on JS-heavy workloads.
+- For SSG builds the gain is real but small; Node 22.x is the safe default unless you're chasing every percent.
+
+### `--max-old-space-size`
+
+```bash
+NODE_OPTIONS="--max-old-space-size=8192" pnpm build
+```
+
+Sizing guide:
+- < 1k pages: 4096
+- 1k–10k pages: 8192
+- 10k+ pages (Taiwan.md is here): 12288–16384
+
+GitHub `ubuntu-latest` has 16 GB RAM; `--max-old-space-size=12288` leaves enough for Sharp's native heap.
+
+### Bun as runtime
+
+```bash
+bun run --bun astro build
+```
+
+- Faster process startup, faster file I/O (zlib parallelization).
+- Astro's render pipeline is JS, single-threaded — Bun won't speed up rendering itself.
+- Heavy markdown / Sharp work is dominant in your build; Bun helps install + cold start, modest help on render. Realistic upper bound: 10–25% faster end-to-end vs Node 22 on SSG.
+- Caveat: occasional plugin compat issues. Test with `--bun` flag first.
+
+---
+
+## 11. Profiling — Where the 17 Minutes Actually Goes
+
+### `astro build --verbose`
+
+- Surfaces Vite phase boundaries: dep optimization → SSR build → page render → asset emit → sitemap.
+- Look for the line `[build] X pages built in Y.Yy` — this is render-only, excluding Vite's bundling.
+- The Vite "bundling" step (which on Astro Docs went 133s → 10.46s with caching) is usually 30–60% of total time on content-heavy sites.
+
+### `--debug`
+
+- Verbose plugin-by-plugin timing. Noisy but uncovers slow remark/rehype plugins immediately.
+
+### `ASTRO_TELEMETRY_DISABLED=1`
+
+- Removes a network call at end of build. Doesn't affect total time meaningfully but cleans logs.
+
+### Node CPU profiling
+
+```bash
+NODE_OPTIONS="--cpu-prof --cpu-prof-dir=./profiles --max-old-space-size=12288" pnpm build
+```
+
+- Produces `.cpuprofile` files. Open in Chrome DevTools → Performance → Load profile.
+- For Taiwan.md's 98→167ms regression: this will tell you in 30 seconds whether the regression is in Shiki, in remark plugins, in fs reads, or in component render.
+
+### Vite `--profile`
+
+- Enabled via `VITE_PROFILE=1`. Useful for the bundling phase specifically.
+
+### Identifying which phase dominates
+
+Common breakdown on a 16k-page Astro site:
+
+| Phase | Typical share | Symptoms |
+|---|---|---|
+| Dep optimize | 5–10% | First build only; cached |
+| Content load + parse | 10–30% | grows with markdown size; data store helps |
+| **Page render (Astro)** | **30–60%** | grows with N pages × per-page cost; this is your regression |
+| Asset emit (Sharp/CSS) | 10–25% | grows with image count |
+| Sitemap | 1–10% | spikes on huge sites |
+| HTML compress | 1–5% | trivial unless `compressHTML: 'jsx'` is wrong |
+
+For 17 min ≈ 1020s and 16k pages: 167ms × 16k = 2670s of nominal render, which means concurrency is already happening (effective 1.5–2 pages in parallel). A 98ms baseline × 16k = 1568s — so the regression is ~18 min of build time alone, making the "12-day regression" the entire story.
+
+### Astro 6.2 JSON logger
+
+```js
+experimental: { logger: { type: 'json' } }
+```
+
+Enables structured logs you can pipe to `jq` to extract per-phase timings.
+
+---
+
+## 12. Sitemap / Integration Overhead
+
+### `@astrojs/sitemap`
+
+- Default chunk size 45,000 entries → splits to multiple sitemaps + index. 16k entries fits in one — no chunking benefit.
+- The `serialize(item)` hook runs for every URL. Inside, common antipatterns:
+  - Reading the source file from disk to compute lastmod (synchronous on every URL = N fs reads).
+  - Hitting an API for changefreq.
+- Recommended pattern: precompute lastmod into the data store via the loader; have `serialize` look up an in-memory map, not disk.
+
+### Alternative: write your own sitemap
+
+For 16k URLs, a custom sitemap script reading from `getCollection()` and writing one file is ~1 second. The integration's overhead can be 10–60s if `serialize` does fs work.
+
+---
+
+## 13. Common Antipatterns (Likely Suspects for Your 98→167ms Regression)
+
+1. **Synchronous `fs.readFileSync` / `gray-matter` per page** — re-reads adjacent articles for navigation. Add a process-level memo or migrate to a content collection.
+2. **`execSync('git log -1 ...')` per page** — for "lastUpdated" timestamps. Shell startup × 16k = many minutes. Cache once at build start, look up in memory.
+3. **Schema validation with `.refine()` doing fs reads** — Zod runs on every entry load. Refines run again. Expensive refines on 5k entries × 6 languages = 30k validations.
+4. **Large remark plugin doing AST traversal twice** — some plugins traverse on `tree` and again in a `transformer` closure. Profile first.
+5. **`Astro.glob` (now removed)** — replaced by `import.meta.glob`. If a hidden compat layer is still globbing eagerly, that's a regression vector.
+6. **MDX without `markdown.optimize: true`** — the internal optimizer is opt-in for MDX; default in `.md`. Confirm.
+7. **Expressive Code with multiple themes** — each theme = full re-tokenize per code block.
+8. **Unused Shiki languages loaded** — every entry in `langs: [...]` ships its TextMate grammar. Cap to languages you actually use.
+9. **Image components iterating in `getStaticPaths`** — Sharp work multiplied by route count.
+10. **CSP `experimental.csp` enabled** with hash mode — runs a hash over every script/style at build time. Now stable in 6 (no more flag), but the cost is real on huge sites.
+
+---
+
+## 14. Large-Site Case Studies
+
+### `docs.astro.build` itself
+
+- ~2,500 pages. Used as the canonical benchmark.
+- Content caching (when it existed in Astro 4): bundling 133s → 10.46s, total 4:58 → 1:00.
+- Now uses Content Layer data store + CI cache — similar effective speedup.
+
+### TanStack docs
+
+- Astro + Starlight. Reports leaning hard on `markdown.optimize: true`, minimal client JS, prefetch off.
+
+### Vercel docs
+
+- Hybrid (not pure Astro). Use ISR aggressively. Not a directly applicable model but illustrates "render most pages on demand, cache forever" as an alternative to "build all upfront."
+
+### blog.cloudflare.com
+
+- Migrated to Astro 5 from Next 14. Reported full build 2hr → 14min for 8k posts. Stack: Astro 5 + Content Layer + Cloudflare Pages build cache + R2 image origin (NOT `astro:assets` for content images — they're served from R2 directly with signed URLs).
+- Lesson: for content-heavy sites, push image processing **out** of the build to a separate pipeline (ImgIX, Cloudinary, or R2 + Cloudflare Image Resizing).
+
+### Notion-as-CMS sites
+
+- Use a custom loader that fetches Notion at build time, with `node_modules/.astro` data store as the cache. Webhook-driven rebuilds (LimeCuda pattern): conditional GraphQL/Notion query for "modified since last build," only update changed entries in the store, then full Astro build with the warm cache. Reported 30min → ~2min on content-only updates.
+
+### Bitdoze (339,340 pages)
+
+- 35 → 127 pages/sec via:
+  - `compressHTML: false`
+  - `manualChunks: undefined`
+  - `target: 'es2022'`, `minify: 'esbuild'`
+  - `concurrency: 4` (12-core machine)
+  - `maxParallelFileOps: cpus * 3`
+  - `NODE_OPTIONS=--max-old-space-size=16384`
+  - Aggressive fetch-level cache for any external API
+  - Hardware: AMD 5900X (25% over Xeon E5-1650v3)
+
+---
+
+## 15. Newer Experimental Features — Do Any Affect Build Time?
+
+| Flag | Astro 6 status | Build-time impact |
+|---|---|---|
+| `experimental.fonts` | **stable** (now `fonts` config) | Slight cost: downloads + subsets fonts at build. Subset narrowly (`unicodeRange`) for non-Latin (Taiwan.md: zh-Hant subset) — full CJK glyph dump can be 10MB+. |
+| `experimental.actions` | stable | Server-only; no SSG cost. |
+| `experimental.csp` | **stable** (now `security.csp`) | Per-page hash computation. Measurable on 16k pages but seconds, not minutes. Disable if not needed. |
+| `experimental.contentIntellisense` | experimental | Generates types in `.astro/`. Build cost minimal; helps DX. |
+| `experimental.serverIslands` | stable | Hybrid only; SSG unaffected. |
+| `experimental.responsiveImages` | stable in 6 | Generates `srcset` at build. Meaningful per-image cost; cumulatively significant only if many `<Image>` per page. |
+| `experimental.queuedRendering` | experimental | **Worth trying.** Up to 2× render speed reported. May fix part of your 98→167ms regression. |
+| `experimental.rustCompiler` | experimental | Up to 100× faster compile phase. Compile (`.astro` → JS) is a small share of build for content-heavy sites, so end-to-end improvement is more like 5–15%. Worth piloting. |
+| `experimental.routeCaching` | experimental | On-demand only; SSG unaffected. |
+| `experimental.staticImportMetaEnv` | **stable** (default) | Removed; was a correctness fix. |
+
+### Recommended experimental cocktail for Taiwan.md
+
+```js
+experimental: {
+  queuedRendering: { enabled: true, poolSize: 1000 },
+  rustCompiler: true,
+}
+```
+
+Both have low blast radius. Disable individually if rendering looks off.
+
+---
+
+## 16. Configuration Knobs — The Full Knob Table
+
+```js
+// astro.config.mjs — opinionated config for 16k-page i18n SSG
+import { defineConfig } from 'astro/config';
+import { cpus } from 'node:os';
+
+export default defineConfig({
+  output: 'static',
+  trailingSlash: 'never',  // fewer redirects, smaller sitemap
+
+  build: {
+    format: 'directory',           // for clean URLs; 'file' is slightly faster + flatter
+    inlineStylesheets: 'auto',     // inline < 4kb stylesheets, external for the rest
+    concurrency: 4,                // tune 2/4/6 — measure
+    assets: '_astro',
+  },
+
+  prefetch: {
+    prefetchAll: false,            // don't pay client perf for every link
+    defaultStrategy: 'hover',
+  },
+
+  compressHTML: true,              // small CDN savings; disable only if profile shows it dominates
+
+  image: {
+    service: {
+      entrypoint: 'astro/assets/services/sharp',
+      config: {
+        webp:  { quality: 80 },
+        avif:  { quality: 65, effort: 4 },
+        jpeg:  { quality: 82, mozjpeg: true },
+      }
+    }
+  },
+
+  markdown: {
+    syntaxHighlight: 'shiki',
+    shikiConfig: {
+      themes: { light: 'github-light', dark: 'github-dark' },
+      langs: ['ts','js','astro','bash','md','json','yaml'],  // explicit allowlist
+    },
+    // remarkPlugins: [...]   // audit; remove what you don't use
+    // rehypePlugins: [...]
+  },
+
+  vite: {
+    build: {
+      target: 'es2022',
+      minify: 'esbuild',
+      cssCodeSplit: true,
+      chunkSizeWarningLimit: 10000,
+      assetsInlineLimit: 4096,
+      rollupOptions: {
+        maxParallelFileOps: cpus().length * 3,
+        output: {
+          manualChunks: undefined,
+          generatedCode: { preset: 'es2022' },
+        },
+      },
+    },
+    esbuild: {
+      target: 'es2022',
+      minifyIdentifiers: false,
+      minifySyntax: true,
+      minifyWhitespace: true,
+    },
+    optimizeDeps: { force: false },
+  },
+
+  experimental: {
+    queuedRendering: { enabled: true, poolSize: 1000 },
+    rustCompiler: true,
+  },
+});
+```
+
+### Knob sensitivity (rough order of impact for Taiwan.md)
+
+1. **`build.concurrency`** — 1 → 4 typically 1.5–2× speedup if I/O bound.
+2. **CI runner upgrade** — `ubuntu-latest` → `ubuntu-24.04-arm` or 8-core: 1.5–2× speedup, free or low cost.
+3. **`actions/cache` for `node_modules/.astro`** — 30s on cache hit vs full build, when content unchanged.
+4. **Shiki `langs` allowlist** — can shave seconds-to-minutes if currently loading default bundle.
+5. **Removing per-page `git log`** if present — minutes.
+6. **Migrating `knowledge/` to a Content Layer collection** — enables data store caching, cuts content-load phase 50–90%.
+7. **`experimental.queuedRendering`** — up to 2× page render.
+8. **`compressHTML: false`** — small but free if CDN compresses.
+9. **`manualChunks: undefined`** — depends; measure.
+10. **`max-old-space-size`** — prevents GC thrashing; the speedup is "build doesn't crash," not "build is faster."
+
+---
+
+## 17. Action Plan Summary (Optimization Order for Taiwan.md)
+
+Priority list, ordered by ROI / effort:
+
+1. **Profile first (1 hour).** `NODE_OPTIONS="--cpu-prof"`, run build, open in DevTools. Identify which phase regressed 98→167ms.
+2. **Switch CI to `ubuntu-24.04-arm`** (free, public repo). One-line YAML change. Expected: 1.3–1.7× speedup.
+3. **Cache `node_modules/.astro` in CI** (5-line YAML). Expected: warm builds <2 min.
+4. **Audit `knowledge/` reads.** If using direct `readFile` + `gray-matter`, migrate to `glob()` collection. Expected: content-load phase down 50–90%.
+5. **Audit Shiki config.** Pin `langs:` and `themes:`. Confirm 6.1+ for the highlighter cache fix.
+6. **Audit remark/rehype plugins.** Disable any not actively used. Profile with `--debug`.
+7. **Remove per-page `git log` shellouts** if present. Pre-compute once.
+8. **Set `build.concurrency: 4`.** Test 2/4/6.
+9. **Set `NODE_OPTIONS="--max-old-space-size=12288"`** in CI.
+10. **Try `experimental.queuedRendering`** + `experimental.rustCompiler`. Can always disable.
+11. **Per-language parallel matrix builds** (6 jobs, merge `dist/`). The big lever for a 6-language site. Expected: ~1/N total time minus overhead, so 17 min → ~3–5 min.
+12. **Hash-based "skip if no content changed"** wrapper outside Astro. For doc-only PRs, near-zero builds.
+
+Items 1–9 are reversible config; item 11 is structural. Land 1–9 first, measure, then decide on 11.
+
+---
+
+## Sources
+
+- [Astro 6.0 release notes](https://astro.build/blog/astro-6/)
+- [Astro 6.1 release notes](https://astro.build/blog/astro-610/)
+- [Astro 6.2 release notes](https://astro.build/blog/astro-620/)
+- [Upgrade to Astro v6](https://docs.astro.build/en/guides/upgrade-to/v6/)
+- [Astro Content Layer Deep Dive](https://astro.build/blog/content-layer-deep-dive/)
+- [Astro Content Collections docs](https://docs.astro.build/en/guides/content-collections/)
+- [Astro Configuration Reference](https://docs.astro.build/en/reference/configuration-reference/)
+- [Experimental Queued Rendering](https://docs.astro.build/en/reference/experimental-flags/queued-rendering/)
+- [Experimental Rust Compiler](https://docs.astro.build/en/reference/experimental-flags/rust-compiler/)
+- [Experimental Route Caching](https://docs.astro.build/en/reference/experimental-flags/route-caching/)
+- [Scaling Astro to 10,000+ Pages](https://astro.build/blog/experimental-static-build/)
+- [Bitdoze: 35→127 pages/sec case study](https://www.bitdoze.com/astro-ssg-build-optimization/)
+- [AntStack: 30→5min Astro build](https://medium.com/@antstack/how-we-cut-astro-build-time-from-30-minutes-to-5-minutes-83-faster-d7da73cde481)
+- [LimeCuda: incremental Astro builds via webhook](https://limecuda.com/blog/get-faster-build-times-for-content-updates-on-your-large-content-astro-site/)
+- [Markaicode: Astro build optimization](https://markaicode.com/optimize-astro-build-performance/)
+- [Walter Ra: Astro build caching in CI](https://walterra.dev/blog/2025-11-09-astro-build-caching)
+- [Daniel Wulff: cache Astro images across GH Actions](https://danielwulff.dev/blog/cache-astro-images-across-github-action-runs/)
+- [Astro parallel build broken issue #12992](https://github.com/withastro/astro/issues/12992)
+- [Astro getStaticPaths required reference](https://docs.astro.build/en/reference/errors/get-static-paths-required/)
+- [Astro: dev server slow as collections grow #10269](https://github.com/withastro/astro/issues/10269)
+- [Shiki best performance practices](https://shiki.style/guide/best-performance)
+- [Vite build options](https://vite.dev/config/build-options)
+- [Vite migration to v7](https://vite.dev/guide/migration)
+- [Vite 8 / Rolldown migration](https://byteiota.com/vite-8-rolldown-migration-guide-10-30x-faster-builds/)
+- [GitHub blog: arm64 hosted runners](https://github.blog/news-insights/product-news/arm64-on-github-actions-powering-faster-more-efficient-build-systems/)
+- [GitHub-hosted runners reference](https://docs.github.com/en/actions/reference/runners/github-hosted-runners)
+- [Cloudflare Pages build caching](https://developers.cloudflare.com/pages/configuration/build-caching/)
+- [Bun vs Node for Astro static builds](https://dev.to/lovestaco/bun-vs-node-for-astro-static-site-builds-4okk)
+- [Steve Fenton: Astro JS heap OOM in GH Actions](https://stevefenton.co.uk/blog/2023/07/astro-javascript-heap-out-of-memory/)
+- [Astro static asset gen perf PR #12922](https://github.com/withastro/astro/pull/12922)
+- [Astro slow rendering vs Solid issue #11454](https://github.com/withastro/astro/issues/11454)
+- [Astro sitemap integration docs](https://docs.astro.build/en/guides/integrations-guide/sitemap/)
+- [Astro image service reference](https://docs.astro.build/en/reference/image-service-reference/)
+- [Starlight CHANGELOG (perf for large sidebars)](https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md)
+- [Starlight build perf for large sidebars PR #2252](https://github.com/withastro/starlight/pull/2252)
+- [Push-Based: advanced Node CPU profiling](https://push-based.io/article/advanced-cpu-profiling-in-node-real-life-examples)
+- [Astro changelog mirror](https://astro-changelog.netlify.app/)
+- [What's new in Astro - April 2026](https://astro.build/blog/whats-new-april-2026/)
+- [What's new in Astro - March 2026](https://astro.build/blog/whats-new-march-2026/)


### PR DESCRIPTION
## Summary

Lay groundwork for sustained build-speed improvement as content grows past 4,393 pages × 6 langs. Conservative subset only; deeper levers (per-language matrix build, Content Layer migration) deferred to follow-up PRs.

## What changes

| Layer | Change | Why |
|---|---|---|
| Astro | 6.0.5 → 6.2.1 | Shiki highlighter cache (6.1), `.astro` SSR up to 2× faster (6.1), pluggable SVG optimizer (6.2), Vite 7 |
| Config | `build.concurrency: 4` | Lets the renderer overlap I/O across pages (default 1) |
| Config | Explicit `shikiConfig.langs` allowlist | Corpus uses bare ``` fences almost exclusively; capping the grammar bundle is safe and saves Shiki startup |
| Config | Vite tunings (`target: es2022`, `manualChunks: undefined`, esbuild minify) | Per the bitdoze 339k-page case study; less work for Rollup on 4k+ tiny route bundles |
| CI | `ubuntu-latest` → `ubuntu-24.04-arm` | Free for public repos, reported 1.3-1.7× faster on Node + Sharp + Playwright |
| CI | `NODE_OPTIONS=--max-old-space-size=12288` | Max RSS 3.4 GB observed locally, default ~4 GB heap is close to the ceiling as content grows |

## Tested + dropped

`experimental.queuedRendering` — local wallclock unchanged but peak RSS 1.7 → 4.3 GB. `poolSize: 1000` over-allocates for diverse-page SSG. Revisit when upstream tunes pool sizing.

## Local validation (cold cache, 4,331 pages, M2)

| Run | Wallclock | Max RSS |
|---|---|---|
| 6.0.5 baseline | 391.0s | 1.94 GB |
| 6.0.5 + Tier 1 config | 357.1s | 1.70 GB |
| 6.2.1 + Tier 1 + queuedRendering | 364.2s | 4.32 GB |
| **6.2.1 + Tier 1 (shipped)** | **361.5s** | **3.95 GB** |

Local M2 wallclock is a wash within OS-cache noise (~35s). Real wins are CI-side (ARM + concurrency on slower 4-core hardware + heap headroom) and only measurable post-merge.

## Output verification

Diffed `dist-baseline` (Astro 6.0.5 default config) vs `dist-tuned` (with full Tier 1) vs `dist-final` (post-upgrade).

- **HTML diff**: purely inline-script identifier minification (`const e=` → `const header=`) — semantically identical, slightly more readable in DevTools, +0.15-0.45% per page
- **CSS hash changes**: expected from rollup chunk-strategy change
- **JSON dashboard files**: regenerated each build (timestamps, build perf, contributors) — unrelated to config
- **Visible text + footnote rendering + TableOfContents + structural tags**: identical

User-confirmed acceptable since the difference is purely cosmetic minification style.

## CI baseline before this PR

- 7-day avg: **1029s (17 min)**
- 30-day avg: 1064s (17.7 min)
- Latest run: 719s (12 min)

(From `public/api/dashboard-build-perf.json`, scraped from GitHub Actions.)

## Deferred to follow-up PRs

- **Per-language matrix build** — biggest structural lever. Estimated 17 min → 3-5 min for a 6-lang site by spawning 6 parallel build jobs and merging `dist/`. Needs `ASTRO_LANG`-aware `getStaticPaths` in 6 `[category]/[slug].astro` wrappers.
- **Content Layer migration** — `[category]/[slug].astro` reads `knowledge/` directly via `readdir/readFile/gray-matter` and renders via `marked` rather than Astro's collection + render() pipeline. Migration would touch the 1,246-line article template; deferred per MANIFESTO §自主權邊界 (>50-file impact).

## References

- [reports/research/astro-build-speed-2026-05-04.md](reports/research/astro-build-speed-2026-05-04.md) — 787-line deep-dive, 39 sources
- [reports/build-perf-experiment/baseline.txt](reports/build-perf-experiment/baseline.txt) — measurement log

## Test plan

- [ ] CI build job completes successfully on `ubuntu-24.04-arm`
- [ ] Build wallclock decreases meaningfully from current 17 min average
- [ ] `dashboard-build-perf.json` updates show post-merge perf trend
- [ ] Production deploy serves identical pages to baseline
- [ ] No memory pressure during build (heap headroom prevents OOM)

🧬

🤖 Generated with [Claude Code](https://claude.com/claude-code)