### PR TITLE
🧬 [semiont] evolve: reader settings + dark mode 擴到 hub pages

### DIFF
--- a/src/components/HeadInlineScripts.astro
+++ b/src/components/HeadInlineScripts.astro
@@ -16,9 +16,15 @@
  */
 
 interface Props {
-  isArticlePage: boolean;
+  /**
+   * Whether this surface opts into the ReaderSettings panel +
+   * FOUC-safe theme init. Mirrors the same-named prop on Layout.
+   * Renamed from `isArticlePage` 2026-05-04 (zen-mendeleev) so the
+   * gate describes its rendered effect rather than the surface type.
+   */
+  readerSettings: boolean;
 }
-const { isArticlePage } = Astro.props;
+const { readerSettings } = Astro.props;
 ---
 
 <!-- shot-mode init: ?shot=1 啟動 OG/Spore 圖片生成模式
@@ -75,17 +81,20 @@ const { isArticlePage } = Astro.props;
 <!-- Reader settings FOUC-safe early init.
      讀 localStorage 設定在 first paint 前套用 data-theme / data-text-size，
      避免 toggling 閃。?shot=1 短路（OG image 永遠 light）。
-     window.__TW_MD_IS_ARTICLE gate：只在標準 article page 套用 dark theme，
-     hub / dashboard pages 仍 light（component layouts 假設 light bg）。
+     window.__TW_MD_READER_SETTINGS gate：只在 opt-in 的 surface 套 dark theme。
+     未 opt-in 的 surface（dashboard / home / etc）仍 light，因為 component
+     layouts 假設 light bg。
      2026-05-01 γ-late issue #615 / idlccp1984 reader options;
-     v1.1 fix 2026-05-02 γ-late after dark-on-dashboard regression。 -->
-<script is:inline define:vars={{ isArticlePage }}>
-  window.__TW_MD_IS_ARTICLE = !!isArticlePage;
+     v1.1 fix 2026-05-02 γ-late after dark-on-dashboard regression;
+     v1.2 2026-05-04 zen-mendeleev: rename gate to `readerSettings` prop
+     so any surface can opt in (hub pages 加入). -->
+<script is:inline define:vars={{ readerSettings }}>
+  window.__TW_MD_READER_SETTINGS = !!readerSettings;
 </script>
 <script is:inline>
   (function () {
     try {
-      if (!window.__TW_MD_IS_ARTICLE) return;
+      if (!window.__TW_MD_READER_SETTINGS) return;
       var qs = new URLSearchParams(location.search);
       if (qs.get('shot') === '1') return;
       var html = document.documentElement;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -25,6 +25,22 @@ interface Props {
   slug?: string;
   categorySlug?: string;
   noindex?: boolean;
+  /**
+   * Opt this surface into the floating ReaderSettings panel
+   * (light/auto/dark theme + text-size + plain-text link) and
+   * the FOUC-safe pre-paint theme init script.
+   *
+   * Contract for opting in: the surface MUST be dark-mode tested.
+   * Per-surface dark polish lives in `src/styles/dark-polish.css`
+   * scoped under the surface's <main class="..."> hook (e.g.
+   * `main.article-page`, `main.category-page`). Don't enable
+   * this on a surface that hasn't been visually audited dark —
+   * the panel will toggle data-theme on <html> globally and a
+   * surface without dark coverage will look broken.
+   *
+   * Default: false. Article + category-hub templates opt in.
+   */
+  readerSettings?: boolean;
 }
 
 const { lang = 'zh-TW' } = Astro.props;
@@ -43,6 +59,7 @@ const {
   slug,
   categorySlug: propCategorySlug,
   noindex,
+  readerSettings = false,
 } = Astro.props;
 
 // Search index now loaded via /api/search-index.json (fetch API)
@@ -59,15 +76,6 @@ const categorySlug =
   propCategorySlug?.toLowerCase() || category?.toLowerCase() || '';
 const currentPath = Astro.url.pathname.replace(/\/$/, '') || '/';
 const isHome = currentPath === '/' || currentPath === '/en';
-
-// Reader options (dark mode + ReaderSettings panel) only run on standard
-// category article pages — those are the only routes whose prose CSS is
-// dark-ready. Dashboard / home / bench / hub pages still have white-island
-// component layouts that look broken on a dark body, so we keep them
-// light until a dedicated dark-mode pass per surface lands.
-// Detection: only [category]/[slug].astro pages pass BOTH props.
-// (Hub pages pass category only; lifetree passes slug only; landings pass neither.)
-const isArticlePage = Boolean(category && slug);
 // justfont: only put the body font class on <body> to avoid rate-limit.
 // Other font classes go on specific elements (h1-h6, blockquote, nav, etc.)
 const jfClass = [
@@ -137,7 +145,7 @@ const jfClass = [
     <!-- Pre-paint inline scripts: shot-mode + reader-settings FOUC init.
          2026-05-03 sleepy-colden Tier 2.6: 抽到 src/components/HeadInlineScripts.astro
          讓 Layout 主結構乾淨。原本 ~150 行 inline 邏輯都在這裡。 -->
-    <HeadInlineScripts isArticlePage={isArticlePage} />
+    <HeadInlineScripts readerSettings={readerSettings} />
     <script
       is:inline
       async
@@ -797,9 +805,10 @@ const jfClass = [
 
     <!-- Reader settings: theme + size + plain-text link
          (Issue #615 / idlccp1984 reader options, 2026-05-01 γ-late)
-         v1.1 (2026-05-02 γ-late): only render on article pages — same
-         gate as the FOUC init script above. Other pages aren't dark-ready. -->
-    {isArticlePage && <ReaderSettings lang={lang} />}
+         v1.2 (2026-05-04 zen-mendeleev): gated by explicit `readerSettings`
+         prop on Layout. Surfaces opt in by passing readerSettings={true}
+         (and audit dark CSS in dark-polish.css before doing so). -->
+    {readerSettings && <ReaderSettings lang={lang} />}
 
     <script is:inline>
       // Set .md button href based on current path

--- a/src/styles/dark-polish.css
+++ b/src/styles/dark-polish.css
@@ -312,9 +312,7 @@
 :root[data-theme='dark'] main.article-page [class*='bg-[rgba(193,125,94'] {
   background-color: color-mix(in srgb, #c17d5e 14%, transparent);
 }
-:root[data-theme='dark']
-  main.article-page
-  [class*='border-[rgba(193,125,94'] {
+:root[data-theme='dark'] main.article-page [class*='border-[rgba(193,125,94'] {
   border-color: color-mix(in srgb, #c17d5e 30%, transparent);
 }
 
@@ -328,4 +326,160 @@
 :root[data-theme='dark'] .table-of-contents a:hover,
 :root[data-theme='dark'] .article-sidebar a:hover {
   color: var(--color-ink);
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Category hub overrides (main.category-page).
+ *
+ * Mirrors the article-page strategy above: the template
+ * (src/templates/category-hub.template.astro) uses Tailwind arbitrary
+ * values + scoped class selectors hard-wired to the slate palette
+ * (#1a1a2e / #334155 / #475569 / #64748b / #94a3b8 / #e2e8f0 / etc).
+ * Re-tokenizing the template is a large refactor; we patch at the
+ * class-attribute / leaf-class level instead so the hub template
+ * stays untouched.
+ *
+ * Born: 2026-05-04 zen-mendeleev — observer asked for reader settings
+ * (text-size + dark mode) on hub pages parallel to article pages.
+ * Layout.astro now exposes a `readerSettings` prop; hub opts in;
+ * this block is the per-surface dark polish that opt-in requires.
+ * ────────────────────────────────────────────────────────────────── */
+
+/* Page background — hub doesn't paint its own bg, it inherits from
+ * <body>, which tokens.css already flips. The header strip uses a
+ * category-color tint var and keeps its accent in dark (intentional;
+ * matches how the article-page hero band stays accent-tinted). */
+
+/* Slate-text Tailwind arbitrary classes throughout the hub chrome
+ * (breadcrumb, header meta, sidebar nav, subcategory nav, results
+ * count, etc) → primary ink */
+:root[data-theme='dark'] main.category-page [class*='text-[#1a1a2e]'],
+:root[data-theme='dark'] main.category-page [class*='text-[#1e293b]'],
+:root[data-theme='dark'] main.category-page [class*='text-[#334155]'] {
+  color: var(--color-ink);
+}
+
+/* Muted-slate utilities → ink-soft */
+:root[data-theme='dark'] main.category-page [class*='text-[#475569]'],
+:root[data-theme='dark'] main.category-page [class*='text-[#64748b]'],
+:root[data-theme='dark'] main.category-page [class*='text-[#6b7280]'],
+:root[data-theme='dark'] main.category-page [class*='text-[#94a3b8]'],
+:root[data-theme='dark'] main.category-page [class*='text-[#9ca3af]'] {
+  color: var(--color-ink-soft);
+}
+
+/* White / pale-slate panel backgrounds (hub essay card, mobile
+ * subcategory chips, article-count chip) → dark surface tokens */
+:root[data-theme='dark'] main.category-page [class~='bg-white'],
+:root[data-theme='dark'] main.category-page [class*='bg-[#f8fafc]'],
+:root[data-theme='dark'] main.category-page [class*='bg-[#f1f5f9]'] {
+  background-color: var(--color-surface);
+}
+
+/* Pale-slate borders → token border */
+:root[data-theme='dark'] main.category-page [class*='border-[#e2e8f0]'] {
+  border-color: var(--color-border);
+}
+
+/* Hub essay prose — scoped class survives Astro hashing because we
+ * use the leaf class name. Specificity wins over the scoped rule
+ * via the extra :root[data-theme='dark'] qualifier. */
+:root[data-theme='dark'] main.category-page .hub-prose,
+:root[data-theme='dark'] main.category-page .hub-prose p,
+:root[data-theme='dark'] main.category-page .hub-prose li,
+:root[data-theme='dark'] main.category-page .hub-prose strong,
+:root[data-theme='dark'] main.category-page .hub-prose em {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] main.category-page .hub-prose h2,
+:root[data-theme='dark'] main.category-page .hub-prose h3 {
+  color: var(--color-ink);
+  border-bottom-color: var(--color-border);
+}
+:root[data-theme='dark'] main.category-page .hub-prose a {
+  color: var(--color-ink);
+  border-bottom-color: var(--color-ink-soft);
+}
+:root[data-theme='dark'] main.category-page .hub-prose a:hover {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+/* Topic-pill (wikilinks resolved to article links) — keep accent
+ * tint but rebuild on the dark bg so the chip stays a chip */
+:root[data-theme='dark'] main.category-page .hub-prose a.topic-pill {
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 35%, transparent);
+  color: var(--color-accent);
+}
+:root[data-theme='dark'] main.category-page .hub-prose a.topic-pill:hover {
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
+}
+:root[data-theme='dark'] main.category-page .hub-prose blockquote {
+  color: var(--color-ink-soft);
+  background: linear-gradient(
+    to right,
+    color-mix(in srgb, var(--color-ink) 8%, transparent),
+    color-mix(in srgb, var(--color-ink) 2%, transparent)
+  );
+}
+:root[data-theme='dark'] main.category-page .hub-prose blockquote.pull-quote {
+  color: var(--color-ink);
+  background: none;
+}
+:root[data-theme='dark'] main.category-page .hub-prose code {
+  background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] main.category-page .hub-prose pre {
+  background: color-mix(in srgb, var(--color-ink) 12%, transparent);
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] main.category-page .hub-prose th,
+:root[data-theme='dark'] main.category-page .hub-prose td {
+  color: var(--color-ink);
+  border-color: color-mix(in srgb, var(--color-ink) 28%, transparent);
+}
+:root[data-theme='dark'] main.category-page .hub-prose th {
+  background: color-mix(in srgb, var(--color-ink) 6%, transparent);
+}
+:root[data-theme='dark'] main.category-page .hub-prose em:not(.topic-pill) {
+  color: var(--color-ink-soft);
+}
+
+/* Article list rows — title #1e293b → ink, desc/time → ink-soft.
+ * #16a34a (citations green) reads fine on dark, leave intact. */
+:root[data-theme='dark'] main.category-page .row-title {
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] main.category-page .row-desc,
+:root[data-theme='dark'] main.category-page .row-time,
+:root[data-theme='dark'] main.category-page .no-results {
+  color: var(--color-ink-soft);
+}
+:root[data-theme='dark'] main.category-page .article-row {
+  border-bottom-color: var(--color-border);
+}
+:root[data-theme='dark'] main.category-page .article-row:hover {
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+}
+:root[data-theme='dark'] main.category-page .article-row.is-featured {
+  background: color-mix(in srgb, var(--color-accent) 4%, transparent);
+}
+
+/* Subcategory side-nav active state — uses var(--categoryColor) so
+ * the rgba(45,80,22,…) hardcoded fallback bleeds through on dark.
+ * Re-paint with a token-mix so the active chip reads as accent
+ * regardless of the per-category color. */
+:root[data-theme='dark'] main.category-page .subcat-nav-link.active {
+  background-color: color-mix(in srgb, var(--color-accent) 12%, transparent);
+}
+
+/* Filter input — pale border + slate placeholder vanish on dark */
+:root[data-theme='dark'] main.category-page input#articleFilter {
+  background: var(--color-surface);
+  border-color: var(--color-border);
+  color: var(--color-ink);
+}
+:root[data-theme='dark'] main.category-page input#articleFilter::placeholder {
+  color: var(--color-ink-soft);
 }

--- a/src/templates/article.template.astro
+++ b/src/templates/article.template.astro
@@ -326,6 +326,7 @@ const encodedTitle = encodeURIComponent(title);
   category={categoryInfo.name}
   slug={slug}
   categorySlug={category}
+  readerSettings
 >
   <!-- Reading progress bar -->
   <div class="reading-progress" id="reading-progress" aria-hidden="true"></div>

--- a/src/templates/category-hub.template.astro
+++ b/src/templates/category-hub.template.astro
@@ -281,6 +281,7 @@ const otherCategories = categories
   title={`${categoryInfo.name} - Taiwan.md`}
   description={`${categoryInfo.description} - 台灣知識庫`}
   category={categoryInfo.name}
+  readerSettings
 >
   <!--
     Phase 6 partial migration — [category]/index.astro (zh-TW)


### PR DESCRIPTION
## Summary

- Hub `/[category]` 頁面現在跟 article 頁一樣有閱讀設定面板（主題切換／字級／純文字版）+ dark mode 完整覆蓋。
- `Layout.astro` 新 `readerSettings: boolean` prop（預設 false，contract 寫在 prop comment）— 把原本 `isArticlePage = category && slug` 的隱式 magic 拆成顯式 opt-in。未來任何 surface 想加閱讀設定 = 一行 `readerSettings`，並在 `dark-polish.css` 補上 `main.{class}-page` 區塊。
- API 命名遵循 `feedback_api_naming_effect_not_context`：prop 名描述 rendered effect（reader controls available）而非 surface type（is article page）。

## 動到的檔案

- `src/layouts/Layout.astro` — 新 prop + doc 寫 opt-in contract
- `src/components/HeadInlineScripts.astro` — prop + window var rename (`__TW_MD_IS_ARTICLE` → `__TW_MD_READER_SETTINGS`)
- `src/templates/article.template.astro` — 加 `readerSettings`（顯式化既有行為）
- `src/templates/category-hub.template.astro` — 加 `readerSettings`（新 opt-in，6 langs 同時生效）
- `src/styles/dark-polish.css` — 加 `main.category-page` 整段覆蓋（Tailwind 任意值 + scoped class 雙策略，跟現有 `main.article-page` 區塊對稱）

## Test plan

- [x] Hub `/history` 在 light mode 正常渲染（reader-settings 浮鈕出現在右下）
- [x] Hub `/history` 在 dark mode 正常渲染（body bg `#050505`、hub-prose `#f1f5f9`、header-hook `#cbd5e1`、article-row 標題/描述/badge 都有對應 dark token）
- [x] 字級 standard → xlarge 從 `<html>` font-size 16px → 23.6px，套用到 row 標題 + hub-prose
- [x] Article page 無 regression（main.article-page class 完整、閱讀設定面板還在、dark prose 還是讀得通）
- [x] 0 console errors
- [ ] 6 langs 隨機抽樣再過一次（en/ja/ko/es/fr 共用同 template，理論上自動帶上）

🤖 Generated with [Claude Code](https://claude.com/claude-code)