### PR TITLE
🧬 文章內文標題 → jinxuanlatte-semibold (weight 600)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -190,6 +190,24 @@ const jfClass = [
         'jf-jinxuanlatte',
       ]);
       _jf.push(['_setFont', 'jf-jinxuanlatte-regular', 'weight', 400]);
+      // jinxuanlatte-semibold (weight 600) for article + hub body headings
+      // (.prose h2-h6). 2026-05-04 user 把更多 jinxuanlatte 變體加進 project
+      // 65854 (book/regular/medium/semibold/bold) — 此處挑 semibold 給內文
+      // 標題視覺重量。alias 同 jf-jinxuanlatte，browser 依 font-weight 600
+      // 自動 match 到此變體（regular weight 400 仍給內文）。
+      _jf.push([
+        '_setFont',
+        'jf-jinxuanlatte-semibold',
+        'css',
+        '.prose h1, .prose h2, .prose h3, .prose h4, .prose h5, .prose h6',
+      ]);
+      _jf.push([
+        '_setFont',
+        'jf-jinxuanlatte-semibold',
+        'alias',
+        'jf-jinxuanlatte',
+      ]);
+      _jf.push(['_setFont', 'jf-jinxuanlatte-semibold', 'weight', 600]);
       _jf.push([
         '_setFont',
         'jf-lanyanghei-extrabold',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -493,6 +493,10 @@ html.jf-active .hero-title {
 html.jf-active .prose :is(h1, h2, h3, h4, h5, h6) {
   font-family:
     'jf-jinxuanlatte', 'Noto Sans TC', 'Source Han Sans TC', sans-serif;
+  /* Browser font-weight 600 matches the jinxuanlatte-semibold @font-face
+     registered in Layout.astro (alias 'jf-jinxuanlatte', weight 600).
+     Body 內文 keeps weight 400 (regular). 2026-05-04. */
+  font-weight: 600;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
## Why

Project 65854 新增 jinxuanlatte 多 weight 變體後（user 提供新 production snippet：book/regular/medium/semibold/bold），把 .prose 內文標題升到 semibold (weight 600) — 視覺重量明顯、字族統一。

## Changes

1. `Layout.astro`: 新增 `jf-jinxuanlatte-semibold` SDK 註冊（selector `.prose h1-h6`，alias `jf-jinxuanlatte`，weight 600）
2. `global.css`: `.prose` heading rule 加 `font-weight: 600`

## Test

- [x] `/` home → both jinxuanlatte@400 + @600 loaded
- [x] `/food/蚵仔煎/` → API drop jinxuanlatte (known long-article issue)，fallback Noto Sans TC weight 600，跟內文同 family，比 lanyanghei 一致 ✓
- [x] 內文 weight 400 不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)