### PR TITLE
🧬 article-health SSOT Phases 3-7 — full migration (frontmatter_title / prose_health / footnote / wikilink / format / image / pre-commit shadow)

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -92,6 +92,20 @@ fi
 # 檢查器：scripts/tools/check-cjk-punct.py
 # 智慧排除：fenced code / inline code / URL / HTML attr / 1,800 等 intra-number
 # 修法：python3 scripts/tools/check-cjk-punct.py --fix <file> （自動轉換）
+# ═══ article-health SSOT shadow run（2026-05-04 Phase 7 新增）═══
+# 8 個 plugin 統一入口跑 staged zh-TW knowledge .md，warn-only 不擋 commit.
+# Phase 8+ 觀察 30 天再考慮 promote 成 hard gate（取代下面這些 legacy 步驟）.
+# 詳見 reports/article-health-ssot-design-2026-05-04.md.
+if [ -n "$staged_md" ]; then
+  if ! python3 scripts/tools/article-health.py --staged --profile=pre-commit --quiet 2>/dev/null; then
+    # SSOT 偵測到的 hard violation — INFORMATIONAL 顯示，不擋 commit
+    echo ""
+    echo "ℹ️  SSOT (article-health) 報告 hard violation — 此階段為 shadow run，"
+    echo "   仍會由下方 legacy 檢查正式 gate。要看明細："
+    echo "   python3 scripts/tools/article-health.py --staged --profile=pre-commit"
+  fi
+fi
+
 if [ -n "$staged_md" ]; then
   if ! python3 scripts/tools/check-cjk-punct.py --staged --quiet; then
     echo ""

--- a/scripts/tools/article-health.config.toml
+++ b/scripts/tools/article-health.config.toml
@@ -3,62 +3,59 @@
 # 設計提案：reports/article-health-ssot-design-2026-05-04.md
 # Canonical 寫作品質規則：docs/editorial/EDITORIAL.md
 #
-# Phase 1（this commit）：infrastructure 進場，registry 是空的，所以 profile
-# 跑出來都是 0 violations。Phase 2+ 會逐個 migrate plugin 進來，每個 commit
-# 觀察既有行為不變。
+# Phases 1-7 shipped 2026-05-04. 8 plugins registered:
+#   cjk-punct / frontmatter-title / prose-health / footnote-format /
+#   footnote-density / wikilink-target / format-structure / image-health
 
 [meta]
 version = 1
 canonical_doc = "docs/editorial/EDITORIAL.md"
-phase = "1-infrastructure"
+phase = "7-pre-commit-wired"
 
 # ── Per-check severity / options ─────────────────────────────────────────────
-# 留空（[]）— Phase 1 沒有 plugin 需要 config。Phase 2 開始會逐個加。
-
-# Phase 2 will add:
-# [checks.cjk-punct]
-# severity = "hard"
-# options = { skip_protected_regions = true }
-
-# Phase 3 will add:
-# [checks.frontmatter-title-format]
-# severity = "warn"
-# [checks.frontmatter-title-halfwidth-punct]
-# severity = "hard"
+# Plugin defaults are set in each module (DEFAULT_SEVERITY). Override here.
+# (No overrides currently — plugin defaults are appropriate.)
 
 # ── Stage profiles ───────────────────────────────────────────────────────────
 
 [profiles.pre-commit]
-# pre-commit hook 用：擋 commit 的 hard checks
-checks = []  # Phase 2+ 會填
+# Pre-commit hook gate. HARD violations block; WARN reported but allowed.
+# Matches legacy inline-check severity model so .husky/pre-commit can flip.
+checks = [
+  "cjk-punct",
+  "frontmatter-title",
+  "footnote-format",
+  "wikilink-target",
+  "format-structure",
+]
 fail_on = "hard"
 
 [profiles."rewrite-stage-3"]
-# REWRITE-PIPELINE Stage 3 (Verify): quality-scan ≤ 3 budget
-checks = []
+# REWRITE-PIPELINE Stage 3 (Verify): quality-scan ≤ 3 budget.
+checks = ["prose-health"]
 fail_on = "score-budget"
 
 [profiles."rewrite-stage-3-5"]
-# Stage 3.5 FactCheck
-checks = []
+# Stage 3.5 FactCheck — citation health.
+checks = ["footnote-format", "footnote-density"]
 fail_on = "hard"
 
 [profiles."rewrite-stage-4"]
-# Stage 4 Format
-checks = []
+# Stage 4 Format.
+checks = ["format-structure", "wikilink-target", "cjk-punct"]
 fail_on = "hard"
 
 [profiles."rewrite-stage-4-5"]
-# Stage 4.5 Media
-checks = []
+# Stage 4.5 Media.
+checks = ["image-health"]
 fail_on = "hard"
 
 [profiles.release-pr]
-# 全跑、嚴格
+# 全跑、嚴格 (both HARD and WARN trigger fail).
 checks = "*"
 fail_on = "warn"
 
 [profiles.dashboard]
-# 全跑、不擋、JSON output
+# 全跑、不擋、JSON output for site dashboards.
 checks = "*"
 fail_on = "never"

--- a/scripts/tools/lib/article_health/checks/footnote_density.py
+++ b/scripts/tools/lib/article_health/checks/footnote_density.py
@@ -1,0 +1,72 @@
+"""footnote_density — citation density grading (A-F).
+
+Migrated from `scripts/tools/footnote-scan.sh` grade calculation.
+
+Grade rules (matches shell):
+  A: ≥3 footnotes AND density ≤300 (1 fn per ≤300 words)
+  B: ≥1 footnote (lower density / count)
+  C: ≥3 URLs (no formal footnotes but has external sources)
+  D: ≥1 URL  (minimal sourcing)
+  F: zero footnotes, zero URLs (citation desert)
+
+Severity: WARN (informational health metric, not block-grade).
+For PR-level enforcement use prose_health's citation-desert check.
+"""
+
+from __future__ import annotations
+import re
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "footnote-density"
+DIMENSION = "citation"
+DEFAULT_SEVERITY = Severity.WARN
+EDITORIAL_REF = "footnote-scan.sh A-F grading"
+APPLIES_TO = ["*"]
+
+_RE_DEF = re.compile(r"^\[\^[0-9a-zA-Z_-]+\]:", re.MULTILINE)
+
+
+def _word_count(body: str) -> int:
+    return len(body.split())
+
+
+def _grade(fn_count: int, url_count: int, density: int | None) -> str:
+    if fn_count >= 3 and density is not None and density <= 300:
+        return "A"
+    if fn_count >= 1:
+        return "B"
+    if url_count >= 3:
+        return "C"
+    if url_count >= 1:
+        return "D"
+    return "F"
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    body = target.body
+    fn_count = len(_RE_DEF.findall(body))
+    url_count = body.count("http")
+    words = _word_count(body)
+    density = words // fn_count if fn_count > 0 else None
+    grade = _grade(fn_count, url_count, density)
+
+    if grade in ("A", "B"):
+        return  # healthy — no violation
+
+    if grade == "C":
+        msg = f"腳註等級 C：無正式腳註但有 {url_count} 個 inline URL"
+    elif grade == "D":
+        msg = f"腳註等級 D：僅 {url_count} 個 URL，無正式腳註"
+    else:  # F
+        msg = "腳註等級 F：引用荒漠（零腳註、零 URL）"
+
+    yield Violation(
+        check=CHECK_NAME,
+        severity=DEFAULT_SEVERITY,
+        message=msg,
+        editorial_ref=EDITORIAL_REF,
+        fix_suggestion=grade,  # surfaces grade letter for dashboard JSON
+    )

--- a/scripts/tools/lib/article_health/checks/footnote_format.py
+++ b/scripts/tools/lib/article_health/checks/footnote_format.py
@@ -1,0 +1,50 @@
+"""footnote_format — canonical footnote definition format.
+
+Migrated from `scripts/tools/footnote-format-fix.py` + the inline regex
+in `.husky/pre-commit:78-95`.
+
+Canonical: `[^N]: [Title](URL) — desc{10+ chars}`
+
+Hard error: definitions that don't match canonical format. Fix supported
+via `--fix` (best-effort transformation of common malformed shapes).
+
+Editorial reference: pre-commit footnote format gate (originally added
+2026-04-14 η session, lifted to SSOT 2026-05-04).
+"""
+
+from __future__ import annotations
+import re
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "footnote-format"
+DIMENSION = "citation"
+DEFAULT_SEVERITY = Severity.HARD
+EDITORIAL_REF = ".husky/pre-commit footnote format gate"
+APPLIES_TO = ["*"]  # all langs
+
+# Canonical: [^id]: [Title](https://...) — description (≥10 chars)
+_RE_CANONICAL = re.compile(
+    r"^\[\^[0-9a-zA-Z_-]+\]:\s*\[.+?\]\(https?://\S+\)\s+[—-]\s*.{10,}$"
+)
+_RE_DEF_LINE = re.compile(r"^\[\^[0-9a-zA-Z_-]+\]:")
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    for line_num, line in enumerate(target.body.splitlines(), start=1):
+        if not _RE_DEF_LINE.match(line):
+            continue
+        if _RE_CANONICAL.match(line):
+            continue
+        yield Violation(
+            check=CHECK_NAME,
+            severity=DEFAULT_SEVERITY,
+            message=(
+                "腳註格式不合規範：應為 `[^N]: [Title](URL) — description (≥10 chars)`"
+            ),
+            line=line_num,
+            snippet=line[:100],
+            editorial_ref=EDITORIAL_REF,
+        )

--- a/scripts/tools/lib/article_health/checks/format_structure.py
+++ b/scripts/tools/lib/article_health/checks/format_structure.py
@@ -35,8 +35,11 @@ _RE_FURTHER_READING = re.compile(
     r"^(?:##\s*延伸閱讀|\*\*延伸閱讀\*\*\s*[：:])", re.MULTILINE
 )
 _RE_REFERENCES_H2 = re.compile(r"^##\s*參考資料", re.MULTILINE)
+# Accept both:
+#   > **30 秒概覽**: 內文       (colon outside bold)
+#   > **30 秒概覽：** 內文       (colon inside bold — common in real articles)
 _RE_OVERVIEW_BLOCKQUOTE = re.compile(
-    r"^>\s*\*\*30\s*秒概覽\*\*", re.MULTILINE
+    r"^>\s*\*\*30\s*秒概覽[：:]?\*\*", re.MULTILINE
 )
 _RE_LIST_WIKILINK = re.compile(
     r"^(?:\s*[-*+]\s+)\[\[", re.MULTILINE

--- a/scripts/tools/lib/article_health/checks/format_structure.py
+++ b/scripts/tools/lib/article_health/checks/format_structure.py
@@ -1,0 +1,112 @@
+"""format_structure — markdown structure / format validation.
+
+Migrated from `scripts/tools/format-check.sh` (7 dimensions). Covers the
+ones that are pure single-file checks. Cross-link reverse-link analysis
+(dim 7) is deferred — it requires reading multiple articles and is in
+practice a Stage 5 manual review.
+
+Dimensions ported:
+  1. 延伸閱讀 section presence — WARN
+  2. ## 參考資料 H2 presence — WARN (when footnotes exist)
+  4. broken inline `[link](url)` (no http/https) — WARN
+  5. `[[wikilink]]` 殘留 in list items — HARD (Astro doesn't render)
+  6. 30 秒概覽 blockquote presence — WARN
+
+Deferred:
+  3. footnote format (handled by `footnote_format` plugin)
+  7. reverse link analysis (cross-article — separate plugin Phase 6b)
+"""
+
+from __future__ import annotations
+import re
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "format-structure"
+DIMENSION = "structure"
+DEFAULT_SEVERITY = Severity.WARN
+EDITORIAL_REF = "format-check.sh + EDITORIAL.md §三"
+APPLIES_TO = ["zh-TW"]
+
+# 延伸閱讀 markers (canonical accepted): `## 延伸閱讀` or `**延伸閱讀**：`
+_RE_FURTHER_READING = re.compile(
+    r"^(?:##\s*延伸閱讀|\*\*延伸閱讀\*\*\s*[：:])", re.MULTILINE
+)
+_RE_REFERENCES_H2 = re.compile(r"^##\s*參考資料", re.MULTILINE)
+_RE_OVERVIEW_BLOCKQUOTE = re.compile(
+    r"^>\s*\*\*30\s*秒概覽\*\*", re.MULTILINE
+)
+_RE_LIST_WIKILINK = re.compile(
+    r"^(?:\s*[-*+]\s+)\[\[", re.MULTILINE
+)
+_RE_FOOTNOTE_REF_USE = re.compile(r"\[\^[0-9a-zA-Z_-]+\](?!:)")
+_RE_FOOTNOTE_DEF = re.compile(r"^\[\^[0-9a-zA-Z_-]+\]:", re.MULTILINE)
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    body = target.body
+    has_overview = bool(_RE_OVERVIEW_BLOCKQUOTE.search(body))
+    has_further = bool(_RE_FURTHER_READING.search(body))
+    has_refs_h2 = bool(_RE_REFERENCES_H2.search(body))
+    has_fn_uses = bool(_RE_FOOTNOTE_REF_USE.search(body))
+    has_fn_defs = bool(_RE_FOOTNOTE_DEF.search(body))
+
+    # 1. 30 秒概覽 missing
+    if not has_overview:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message="缺 `> **30 秒概覽**:` blockquote (EDITORIAL §30 秒概覽)",
+            editorial_ref="EDITORIAL.md §30 秒概覽",
+        )
+
+    # 2. 延伸閱讀 missing (only flag for substantive articles)
+    if not has_further and len(body) > 1500:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message="缺延伸閱讀 section (`## 延伸閱讀` 或 `**延伸閱讀**:`)",
+            editorial_ref="EDITORIAL.md §三",
+        )
+
+    # 3. 參考資料 H2 missing despite footnotes used / defined
+    if (has_fn_uses or has_fn_defs) and not has_refs_h2:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message="使用了腳註但缺 `## 參考資料` H2",
+            editorial_ref="EDITORIAL.md §citation",
+        )
+
+    # 4. List items containing raw [[wikilink]] (HARD — Astro won't render)
+    for m in _RE_LIST_WIKILINK.finditer(body):
+        line_no = body.count("\n", 0, m.start()) + 1
+        line_start = body.rfind("\n", 0, m.start()) + 1
+        line_end = body.find("\n", m.start())
+        if line_end == -1:
+            line_end = len(body)
+        snippet = body[line_start:line_end].strip()[:80]
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.HARD,
+            message=(
+                "列表項目中有 `[[wikilink]]` 殘留 — Astro 不會渲染，"
+                "請改 `[文字](/category/slug)`"
+            ),
+            line=line_no,
+            snippet=snippet,
+            editorial_ref="EDITORIAL.md §wikilink",
+        )
+
+    # 5. Footnote ref count vs def count parity
+    use_count = len(_RE_FOOTNOTE_REF_USE.findall(body))
+    def_count = len(_RE_FOOTNOTE_DEF.findall(body))
+    if use_count > 0 and def_count == 0:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.HARD,
+            message=f"使用了 {use_count} 個腳註 ref `[^N]` 但無 `[^N]:` 定義",
+            editorial_ref="EDITORIAL.md §citation",
+        )

--- a/scripts/tools/lib/article_health/checks/frontmatter_title.py
+++ b/scripts/tools/lib/article_health/checks/frontmatter_title.py
@@ -1,0 +1,144 @@
+"""frontmatter_title — title format checks.
+
+Migrated from `scripts/core/test-frontmatter.mjs::checkTitleFormat`
+(2026-05-04 SSOT Phase 3).
+
+Canonical: docs/editorial/EDITORIAL.md §Title 五原則 + §半形標點禁用
+
+Yields multiple violations (different severities) from a single check:
+  - HARD: half-width punct in CJK title context (silent rendering issue)
+  - WARN: vague adjective in title (per EDITORIAL §原則 3)
+  - WARN: title length > 35 effective chars (EDITORIAL recommends ≤ 30)
+  - WARN (People only): missing colon sandwich (per EDITORIAL §原則 5)
+  - WARN (People only): post-colon part < 8 weight (per EDITORIAL §原則 4)
+
+Translations (en/ja/ko/es/fr) follow source-lang conventions — APPLIES_TO=zh-TW.
+"""
+
+from __future__ import annotations
+import re
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "frontmatter-title"
+DIMENSION = "frontmatter"
+DEFAULT_SEVERITY = Severity.WARN  # most checks are warn; HARD ones override per-violation
+EDITORIAL_REF = "EDITORIAL.md §Title 五原則"
+APPLIES_TO = ["zh-TW"]
+
+# Per EDITORIAL §原則 3 canonical 禁用清單. 「神話 / 不朽 / 永恆」等
+# 沒列在這裡的詞可能是文章本身的 subject (如《原住民神話》、《不朽記憶》).
+# 擴充先讀 docs/editorial/EDITORIAL.md §原則 3.
+TITLE_VAGUE_ADJECTIVES: list[str] = [
+    "傳奇",
+    "偉大",
+    "優秀",
+    "最強",
+    "國民",
+    "天后",
+]
+
+CJK_RE = re.compile(r"[一-鿿㐀-䶿]")
+
+# Half-width punctuation in CJK title context — HARD violations.
+# Mirror of `cjk_punct` plugin's title-side patterns. Both sides require CJK
+# (or right-side digit for the comma/colon variants) to avoid false positives
+# on English citation text.
+_HALFWIDTH_PUNCT: list[tuple[re.Pattern, str, str]] = [
+    (re.compile(r"(?<=[一-鿿㐀-䶿]),(?=[一-鿿㐀-䶿]|[0-9])"), ",", "，"),
+    (re.compile(r"(?<=[一-鿿㐀-䶿]):(?=[一-鿿㐀-䶿]|[0-9])"), ":", "："),
+    (re.compile(r"(?<=[一-鿿㐀-䶿]);(?=[一-鿿㐀-䶿])"), ";", "；"),
+    (re.compile(r"(?<=[一-鿿㐀-䶿])\?(?=[一-鿿㐀-䶿])"), "?", "？"),
+    (re.compile(r"(?<=[一-鿿㐀-䶿])!(?=[一-鿿㐀-䶿])"), "!", "！"),
+]
+
+
+def _effective_length(s: str) -> float:
+    """CJK chars count as 1, others as 0.5 (matches the .mjs original)."""
+    n = 0.0
+    for ch in s:
+        n += 1.0 if CJK_RE.match(ch) else 0.5
+    return n
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    title = target.frontmatter.get("title")
+    if not isinstance(title, str) or not title.strip():
+        return
+
+    # 1. Half-width punct in title (HARD — silent rendering issue)
+    for pattern, half, full in _HALFWIDTH_PUNCT:
+        for m in pattern.finditer(title):
+            yield Violation(
+                check=CHECK_NAME,
+                severity=Severity.HARD,
+                message=(
+                    f"title 含半形「{half}」(中文段落應用「{full}」)"
+                    f" — 建議跑 `python3 scripts/tools/article-health.py --check=cjk-punct --fix`"
+                ),
+                snippet=title,
+                fix_suggestion=full,
+                editorial_ref="EDITORIAL.md §半形標點禁用",
+            )
+
+    # 2. Vague adjectives (WARN)
+    for adj in TITLE_VAGUE_ADJECTIVES:
+        if adj in title:
+            yield Violation(
+                check=CHECK_NAME,
+                severity=Severity.WARN,
+                message=(
+                    f"title 含空泛形容詞「{adj}」"
+                    f" (EDITORIAL §原則 3 禁止「傳奇/偉大/最強/國民」等空泛詞)"
+                ),
+                snippet=title,
+                editorial_ref="EDITORIAL.md §原則 3",
+            )
+
+    # 3. People category: colon sandwich (WARN)
+    if target.category == "People":
+        has_colon = ":" in title or "：" in title
+        if not has_colon:
+            yield Violation(
+                check=CHECK_NAME,
+                severity=Severity.WARN,
+                message=(
+                    "People title 缺冒號三明治結構"
+                    " (EDITORIAL §原則 5「人名：代表性弧線」格式必填)"
+                ),
+                snippet=title,
+                editorial_ref="EDITORIAL.md §原則 5",
+            )
+        else:
+            m = re.match(r"^[^:：]+[:：]\s*(.+)$", title)
+            if m:
+                after = m.group(1).strip()
+                weight = _effective_length(after)
+                if weight < 8:
+                    yield Violation(
+                        check=CHECK_NAME,
+                        severity=Severity.WARN,
+                        message=(
+                            f"People title 冒號後敘述太短"
+                            f" (\"{after}\", weight {weight:.1f} < 8)"
+                            " — 副標應能單獨成立 (EDITORIAL §原則 4)"
+                        ),
+                        snippet=title,
+                        editorial_ref="EDITORIAL.md §原則 4",
+                    )
+
+    # 4. Length sanity (WARN) — recommend ≤ 30, hard cap at 35.
+    length = _effective_length(title)
+    if length > 35:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message=(
+                f"title 過長 (effective length {length:.1f} > 35)"
+                " — EDITORIAL 建議 ≤ 30"
+            ),
+            snippet=title,
+            editorial_ref="EDITORIAL.md §Title 五原則",
+        )

--- a/scripts/tools/lib/article_health/checks/image_health.py
+++ b/scripts/tools/lib/article_health/checks/image_health.py
@@ -1,0 +1,118 @@
+"""image_health — article image references + frontmatter coherence.
+
+Migrated from `scripts/tools/article-image-health.sh` (REWRITE-PIPELINE
+Stage 4.5f hard gate per DNA #30).
+
+Dimensions:
+  1. inline `![alt](path)` references — `path` must exist on disk
+  2. frontmatter `image:` — file must exist
+  3. external hot-link detection — http/https URLs not under
+     `/article-images/` or `https://upload.wikimedia.org/...`
+     (canonical CC sources allowed)
+  4. ## 圖片來源 section presence (when CC images used)
+
+Severity: HARD for missing files / hot-links, WARN for missing 圖片來源 section.
+"""
+
+from __future__ import annotations
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "image-health"
+DIMENSION = "media"
+DEFAULT_SEVERITY = Severity.HARD
+EDITORIAL_REF = "REWRITE-PIPELINE Stage 4.5f / DNA #30"
+APPLIES_TO = ["*"]
+
+# Markdown image syntax: ![alt](src)
+_RE_INLINE_IMAGE = re.compile(r"!\[([^\]]*)\]\(([^)\n]+)\)")
+_RE_IMAGE_SOURCES_H2 = re.compile(r"^##\s*圖片來源", re.MULTILINE)
+
+
+def _is_local_path(src: str) -> bool:
+    """Local image: starts with / or article-images/ or no scheme."""
+    return not src.startswith(("http://", "https://"))
+
+
+def _is_allowed_external(src: str) -> bool:
+    """Allow Wikimedia / commons (canonical CC sources)."""
+    allowed_prefixes = (
+        "https://upload.wikimedia.org/",
+        "https://commons.wikimedia.org/",
+    )
+    return src.startswith(allowed_prefixes)
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    body = target.body
+    repo_root = Path.cwd()
+    public_root = repo_root / "public"
+
+    # 1. inline image references
+    for m in _RE_INLINE_IMAGE.finditer(body):
+        alt, src = m.group(1), m.group(2).strip()
+        line_no = body.count("\n", 0, m.start()) + 1
+        if not _is_local_path(src):
+            if not _is_allowed_external(src):
+                yield Violation(
+                    check=CHECK_NAME,
+                    severity=Severity.HARD,
+                    message=(
+                        "外部圖片熱連結 — 圖片應 cache 到 public/article-images/"
+                        " 並改 src=`/article-images/...`"
+                    ),
+                    line=line_no,
+                    snippet=src[:80],
+                    editorial_ref=EDITORIAL_REF,
+                )
+            continue
+        # Local: validate file exists (relative to public/ for absolute paths)
+        if src.startswith("/"):
+            local = public_root / src.lstrip("/")
+        else:
+            local = target.path.parent / src
+        if not local.exists():
+            yield Violation(
+                check=CHECK_NAME,
+                severity=Severity.HARD,
+                message=f"圖片檔不存在: {src}",
+                line=line_no,
+                snippet=src[:80],
+                editorial_ref=EDITORIAL_REF,
+            )
+
+    # 2. frontmatter image
+    fm_image = target.frontmatter.get("image")
+    if isinstance(fm_image, str) and fm_image.strip():
+        src = fm_image.strip()
+        if _is_local_path(src):
+            local = public_root / src.lstrip("/")
+            if not local.exists():
+                yield Violation(
+                    check=CHECK_NAME,
+                    severity=Severity.HARD,
+                    message=f"frontmatter image 檔不存在: {src}",
+                    snippet=src[:80],
+                    editorial_ref=EDITORIAL_REF,
+                )
+
+    # 3. ## 圖片來源 section when frontmatter image with attribution exists
+    has_attribution = (
+        target.frontmatter.get("imageCredit")
+        or target.frontmatter.get("imageLicense")
+        or target.frontmatter.get("imageSource")
+    )
+    if has_attribution and not _RE_IMAGE_SOURCES_H2.search(body):
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message=(
+                "frontmatter 有 imageCredit/imageLicense/imageSource 但缺 "
+                "`## 圖片來源` section (CC 圖片需 cite 來源)"
+            ),
+            editorial_ref=EDITORIAL_REF,
+        )

--- a/scripts/tools/lib/article_health/checks/prose_health.py
+++ b/scripts/tools/lib/article_health/checks/prose_health.py
@@ -1,0 +1,411 @@
+"""prose_health — consolidated prose quality checks.
+
+Migrated from `scripts/tools/quality-scan.sh` (16 dims) +
+`scripts/tools/check-manifesto-11.sh` (3 tiers) into a single SSOT plugin.
+
+Canonical:
+  - quality-scan: docs/editorial/EDITORIAL.md §quality-scan 偵測指標
+  - manifesto-11: docs/semiont/MANIFESTO.md §11 書寫節制
+
+Ports the most actionable dimensions:
+
+quality-scan dims:
+  1. bullet density           7. repeated bullet blocks    13. (THIN — deferred)
+  2. year count               8. plastic phrases (5 variants + extras)
+  3. URL count               8b. em-dash overuse
+  4. hollow words             9. textbook opening
+  5. (prose lines — deferred) 10. formulaic ending
+  6. lastHumanReview          11. template H2
+                             12. (LIST-DUMP — deferred)
+                             14. (QUALITY-DECAY — deferred)
+                             15. (CHINA-TERM — deferred to terminology plugin)
+                             16. citation desert
+
+manifesto-11 tiers:
+  Tier 1: 11 「不是X是Y」 對位句型 variants + em-dash density
+  Tier 2: 30+ AI 抽象 metaphor 詞 (warn ≥ 2 occurrences total)
+  Tier 3: 17 AI ritual 語 (warn ≥ 1 occurrence)
+
+Total score budget: ≤ 3 = pass (per QUALITY-CHECKLIST §四 + REWRITE-PIPELINE).
+A "score" violation is yielded with the running total — the runner can
+gate on this via profile.fail_on = "score-budget".
+
+Deferred to Phase 4b (need more structural parsing):
+  - LIST-DUMP: bullet ratio per file half
+  - THIN: prose lines per H2 section
+  - QUALITY-DECAY: prose ratio front vs back
+  - CHINA-TERM: requires data/terminology TSV files (separate plugin)
+"""
+
+from __future__ import annotations
+import re
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "prose-health"
+DIMENSION = "prose-quality"
+DEFAULT_SEVERITY = Severity.WARN
+EDITORIAL_REF = "EDITORIAL.md §quality-scan + MANIFESTO.md §11"
+APPLIES_TO = ["zh-TW"]
+
+
+# ── Plastic phrases (quality-scan §8) ────────────────────────────────────────
+_RE_PLASTIC = re.compile(
+    r"不僅.{0,8}更是|不只.{0,8}也是|不是.{0,8}而是|"
+    r"展現了.{0,8}的精神|展現.{0,8}的決心|體現了.{0,8}的精神|"
+    r"扮演著.{0,10}角色|發揮著.{0,10}作用|見證了.{0,10}的歷程|"
+    r"彰顯了|承載著.{0,10}的|不僅僅是.{0,10}更是|"
+    r"既是.{0,8}也是.{0,8}更是|成為.{0,8}的重要.{0,6}|"
+    r"為.{0,10}注入.{0,8}活力|為.{0,10}奠定.{0,8}基礎|"
+    r"在.{0,10}上扮演.{0,8}角色|為.{0,10}提供了.{0,8}動力|"
+    r"開啟了.{0,8}的新篇章|翻開.{0,8}的新頁|書寫.{0,8}的篇章|"
+    r"譜寫.{0,8}的華章|綻放.{0,8}的光芒|閃耀.{0,8}的光輝"
+)
+
+# ── Hollow words (quality-scan §4) ───────────────────────────────────────────
+_RE_HOLLOW = re.compile(
+    r"重要的|顯著的|豐富的|完整的|多元的|"
+    r"積極|蓬勃發展|逐步|逐漸|不斷|持續|"
+    r"日益|進一步|全面|深入|大力|有效|顯著|穩步"
+)
+
+# ── Em-dash (manifesto-11 [9-10] / quality-scan §8b) ─────────────────────────
+_RE_EMDASH = re.compile(r"——")
+
+# ── Manifesto §11 Tier 1: 不是X是Y 對位句型 11 變體 ─────────────────────────
+# Tightened versions of patterns from check-manifesto-11.sh
+_TIER1_PATTERNS = [
+    re.compile(r"不是.{0,30}[，,]\s*而是"),  # cross-comma
+    re.compile(r"這不是.{0,15}是"),
+    re.compile(r"不只是.{0,15}是"),
+    re.compile(r"不再是.{0,15}是"),
+    re.compile(r"不僅.{0,15}更是"),
+    re.compile(r"不只.{0,15}也是"),
+    re.compile(r"不是.{0,8}而是"),
+    re.compile(r"不僅僅是.{0,10}更是"),
+    re.compile(r"既是.{0,8}也是.{0,8}更是"),
+    re.compile(r"從.{2,15}到.{2,15}[，,]\s*從.{2,15}到"),
+    re.compile(r"與其說.{0,15}不如說"),
+]
+
+# ── Manifesto §11 Tier 2: AI 抽象 metaphor 詞 ────────────────────────────────
+_TIER2_WORDS = [
+    "重量", "縮影", "軌跡", "弧線", "DNA", "基因",
+    "土壤", "養分", "血液", "縫隙", "皺褶", "肌理", "織就",
+    "指紋", "神經末梢", "肌肉記憶", "基底", "底色",
+    "張力", "光譜", "鏡子", "承載著", "形塑", "鬆動",
+    "展演", "召喚", "凝視", "直面", "直擊",
+    "鋪陳", "醞釀", "沈澱",
+]
+
+# ── Manifesto §11 Tier 3: AI ritual 語 ───────────────────────────────────────
+_TIER3_PHRASES = [
+    "在這個意義上", "從某種意義上", "就此而言", "換言之",
+    "值得我們深思", "值得我們反思", "拭目以待", "不容忽視",
+    "不可或缺", "不可磨滅", "影響深遠", "歷久彌新",
+    "並非偶然", "耐人尋味", "不言而喻", "不可言說", "無以名狀",
+]
+
+# ── Textbook opening (quality-scan §9) ───────────────────────────────────────
+_RE_TEXTBOOK_OPENING = re.compile(
+    r"^(台灣的.{2,20}是|.{2,10}是台灣.{2,20}|"
+    r"作為.{2,15}[，,]\s*台灣|"
+    r"在.{2,10}(方面|領域)[，,]\s*台灣|"
+    r"台灣.{2,6}(擁有|具有|位於|以其))"
+)
+
+# ── Formulaic ending (quality-scan §10) ──────────────────────────────────────
+_RE_FORMULAIC_ENDING = re.compile(
+    r"總之|綜上所述|展望未來|總結來說|總的來說|未來展望|"
+    r"隨著.{2,20}的(發展|推進|深化)|將繼續|值得期待"
+)
+
+# ── Template H2 (quality-scan §11) ───────────────────────────────────────────
+_RE_TEMPLATE_H2 = re.compile(
+    r"^(歷史(背景|沿革|發展)?|發展歷程|歷史脈絡|"
+    r"現況(與|及)?|現狀|當前|"
+    r"未來(展望|發展|趨勢)|結語|總結|"
+    r"挑戰與展望|挑戰與機遇|影響與意義|"
+    r"特色(與|及)?|重要性|"
+    r"國際(比較|影響|地位))$"
+)
+
+
+def _count_year_mentions(body: str) -> int:
+    """4-digit years in 1600-2099 range, excluding `date:` lines."""
+    n = 0
+    for line in body.splitlines():
+        if "date:" in line:
+            continue
+        n += len(re.findall(r"\b(?:1[6-9]\d{2}|20[0-2]\d)\b", line))
+    return n
+
+
+def _count_urls(body: str) -> int:
+    return body.count("http")
+
+
+def _count_repeated_bullets(body: str) -> int:
+    """Max consecutive `- **` bullet block length."""
+    max_run = 0
+    cur = 0
+    for line in body.splitlines():
+        if line.startswith("- **"):
+            cur += 1
+            if cur > max_run:
+                max_run = cur
+        else:
+            cur = 0
+    return max_run
+
+
+def _count_bullet_lines(body: str) -> tuple[int, int]:
+    """Returns (bullet_lines, total_lines). Bullet = `- **` style."""
+    total = body.count("\n") + 1
+    bullets = sum(1 for line in body.splitlines() if line.startswith("- **"))
+    return bullets, total
+
+
+def _detect_textbook_opening(body: str) -> bool:
+    """First 2 non-empty non-heading lines after frontmatter."""
+    seen_lines = 0
+    for line in body.splitlines():
+        if not line.strip():
+            continue
+        if line.startswith("#"):
+            continue
+        if _RE_TEXTBOOK_OPENING.search(line):
+            return True
+        seen_lines += 1
+        if seen_lines >= 2:
+            break
+    return False
+
+
+def _detect_formulaic_ending(body: str) -> bool:
+    """Last 5 non-bullet non-heading non-link lines."""
+    eligible = [
+        line for line in body.splitlines()
+        if line.strip()
+        and not line.startswith("#")
+        and not line.startswith("-")
+        and "http" not in line
+    ]
+    tail = eligible[-5:] if eligible else []
+    text = "\n".join(tail)
+    return bool(_RE_FORMULAIC_ENDING.search(text))
+
+
+def _count_template_h2(body: str) -> int:
+    n = 0
+    for line in body.splitlines():
+        if line.startswith("## "):
+            heading = line[3:].strip()
+            if _RE_TEMPLATE_H2.match(heading):
+                n += 1
+    return n
+
+
+def _count_footnote_defs(body: str) -> int:
+    return sum(
+        1
+        for line in body.splitlines()
+        if re.match(r"^\[\^[0-9a-zA-Z_-]+\]:", line)
+    )
+
+
+def _word_count(body: str) -> int:
+    """Rough whitespace-tokenized count after frontmatter (CJK 1 char = 1 word).
+
+    Matches `wc -w` semantics of the shell script for parity.
+    """
+    return len(body.split())
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    """Yield prose-health violations + a final score-summary violation.
+
+    Skips if file is too short (lines < 20) or has no frontmatter (matches
+    quality-scan.sh::scan_file early-exit semantics).
+    """
+    body = target.body
+    line_count = body.count("\n") + 1
+    if line_count < 20:
+        return
+    if not target.frontmatter:
+        # Hub / private docs without frontmatter — quality-scan skips these
+        return
+
+    score = 0
+    reasons: list[str] = []
+
+    # Use body without protected regions for pattern detection so code
+    # blocks / link URLs don't trigger false positives.
+    text_for_patterns = target.body_without_protected()
+
+    # ── 1. Bullet density ──
+    bullets, total = _count_bullet_lines(body)
+    if total > 0:
+        ratio = bullets * 100 // total
+        if ratio > 30:
+            score += 3
+            reasons.append(f"bullet密度{ratio}%")
+        elif ratio > 20:
+            score += 1
+            reasons.append(f"bullet密度{ratio}%")
+
+    # ── 2. Year count ──
+    years = _count_year_mentions(body)
+    if years < 2:
+        score += 3
+        reasons.append(f"年份僅{years}個")
+    elif years < 5:
+        score += 1
+        reasons.append(f"年份{years}個")
+
+    # ── 3. URL count ──
+    urls = _count_urls(body)
+    if urls == 0:
+        score += 3
+        reasons.append("無URL來源")
+    elif urls < 3:
+        score += 1
+        reasons.append(f"僅{urls}個URL")
+
+    # ── 4. Hollow words ──
+    hollow_n = len(_RE_HOLLOW.findall(text_for_patterns))
+    if hollow_n > 15:
+        score += 3
+        reasons.append(f"空洞詞{hollow_n}個")
+    elif hollow_n > 8:
+        score += 2
+        reasons.append(f"空洞詞{hollow_n}個")
+    elif hollow_n > 4:
+        score += 1
+        reasons.append(f"空洞詞{hollow_n}個")
+
+    # ── 6. lastHumanReview ──
+    if target.frontmatter.get("lastHumanReview") is False:
+        score += 1
+        reasons.append("未人工審核")
+
+    # ── 7. Repeated bullet blocks ──
+    max_run = _count_repeated_bullets(body)
+    if max_run >= 6:
+        score += 2
+        reasons.append(f"連續bullet{max_run}行")
+    elif max_run >= 4:
+        score += 1
+        reasons.append(f"連續bullet{max_run}行")
+
+    # ── 8. Plastic phrases ──
+    plastic_n = len(_RE_PLASTIC.findall(text_for_patterns))
+    if plastic_n > 8:
+        score += 4
+        reasons.append(f"塑膠句{plastic_n}個")
+    elif plastic_n > 4:
+        score += 3
+        reasons.append(f"塑膠句{plastic_n}個")
+    elif plastic_n > 2:
+        score += 2
+        reasons.append(f"塑膠句{plastic_n}個")
+    elif plastic_n >= 1:
+        score += 1
+        reasons.append(f"塑膠句{plastic_n}個")
+
+    # ── 8b. Em-dash overuse ──
+    dash_n = len(_RE_EMDASH.findall(text_for_patterns))
+    if dash_n > 15:
+        score += 3
+        reasons.append(f"破折號{dash_n}個")
+    elif dash_n > 8:
+        score += 2
+        reasons.append(f"破折號{dash_n}個")
+    elif dash_n > 4:
+        score += 1
+        reasons.append(f"破折號{dash_n}個")
+
+    # ── 9. Textbook opening ──
+    if _detect_textbook_opening(body):
+        score += 2
+        reasons.append("教科書開場")
+
+    # ── 10. Formulaic ending ──
+    if _detect_formulaic_ending(body):
+        score += 2
+        reasons.append("套路結尾")
+
+    # ── 11. Template H2 ──
+    template_h2 = _count_template_h2(body)
+    if template_h2 >= 4:
+        score += 3
+        reasons.append(f"萬用H2×{template_h2}")
+    elif template_h2 >= 3:
+        score += 2
+        reasons.append(f"萬用H2×{template_h2}")
+    elif template_h2 >= 2:
+        score += 1
+        reasons.append(f"萬用H2×{template_h2}")
+
+    # ── 16. Citation desert ──
+    fn_defs = _count_footnote_defs(body)
+    word_count = _word_count(body)
+    if fn_defs == 0:
+        if word_count > 500:
+            if urls == 0:
+                score += 4
+                reasons.append("引用荒漠(零腳註零URL)")
+            else:
+                score += 2
+                reasons.append("引用荒漠(零腳註)")
+        elif word_count > 200:
+            score += 1
+            reasons.append("無腳註")
+
+    # ── Manifesto §11 Tier 1: 對位句型 ──
+    tier1_total = 0
+    for pat in _TIER1_PATTERNS:
+        matches = list(pat.finditer(text_for_patterns))
+        if matches:
+            tier1_total += len(matches)
+            for m in matches:
+                yield Violation(
+                    check=CHECK_NAME,
+                    severity=Severity.WARN,
+                    message=f"對位句型 (§11 Tier 1): {m.group(0)[:30]}…",
+                    snippet=m.group(0)[:80],
+                    editorial_ref="MANIFESTO.md §11 Tier 1",
+                )
+
+    # ── Manifesto §11 Tier 2: AI metaphor ──
+    tier2_total = sum(text_for_patterns.count(w) for w in _TIER2_WORDS)
+    if tier2_total >= 2:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message=f"AI 抽象 metaphor 密度 (§11 Tier 2): 累計 {tier2_total} 處",
+            editorial_ref="MANIFESTO.md §11 Tier 2",
+        )
+
+    # ── Manifesto §11 Tier 3: ritual 語 ──
+    tier3_total = sum(text_for_patterns.count(p) for p in _TIER3_PHRASES)
+    if tier3_total >= 1:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message=f"AI ritual 句 (§11 Tier 3): 累計 {tier3_total} 處",
+            editorial_ref="MANIFESTO.md §11 Tier 3",
+        )
+
+    # ── Final score summary as a single violation ──
+    # The runner can gate on score via profile.fail_on = "score-budget".
+    if score > 0:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.WARN,
+            message=f"prose-health score: {score} (≤ 3 = pass) — {'; '.join(reasons)}",
+            editorial_ref=EDITORIAL_REF,
+            fix_suggestion=str(score),  # used by score-budget gating
+        )

--- a/scripts/tools/lib/article_health/checks/wikilink_target.py
+++ b/scripts/tools/lib/article_health/checks/wikilink_target.py
@@ -1,0 +1,80 @@
+"""wikilink_target — verify [[X]] / [[X|Y]] targets resolve to real articles.
+
+Migrated from `scripts/tools/wikilink-validate.sh` (HARD pre-commit gate
+since 2026-04-04).
+
+Resolution rule: target name must equal the basename (without .md) of an
+existing zh-TW article under `knowledge/{Category}/`.
+"""
+
+from __future__ import annotations
+import os
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "wikilink-target"
+DIMENSION = "structure"
+DEFAULT_SEVERITY = Severity.HARD
+EDITORIAL_REF = "wikilink-validate.sh"
+APPLIES_TO = ["*"]
+
+_RE_WIKILINK = re.compile(r"\[\[([^\]|\n]+?)(?:\|[^\]\n]+)?\]\]")
+
+# Directories to scan for valid article slugs (zh-TW only — translations
+# share the source slug, not target).
+_LANG_DIRS_SKIP = {"en", "ja", "ko", "es", "fr"}
+_KNOWLEDGE_ROOT = Path("knowledge")
+
+
+def _existing_slugs() -> set[str]:
+    """Cache: scan knowledge/ once per process for valid zh-TW article slugs."""
+    cached = getattr(_existing_slugs, "_cache", None)
+    if cached is not None:
+        return cached
+    slugs: set[str] = set()
+    if _KNOWLEDGE_ROOT.exists():
+        for entry in _KNOWLEDGE_ROOT.iterdir():
+            if not entry.is_dir() or entry.name in _LANG_DIRS_SKIP:
+                continue
+            for md in entry.glob("*.md"):
+                if md.name.startswith("_"):
+                    continue
+                slugs.add(md.stem)
+    _existing_slugs._cache = slugs  # type: ignore[attr-defined]
+    return slugs
+
+
+def _reset_cache() -> None:
+    """Test helper — invalidate the slug cache."""
+    if hasattr(_existing_slugs, "_cache"):
+        delattr(_existing_slugs, "_cache")
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    body = target.body
+    slugs = _existing_slugs()
+    seen_at: dict[str, int] = {}  # dedup per (target, line) so re-uses count once
+    for m in _RE_WIKILINK.finditer(body):
+        link = m.group(1).strip()
+        if not link:
+            continue
+        if link in slugs:
+            continue
+        # Compute line number
+        line = body.count("\n", 0, m.start()) + 1
+        key = f"{link}@{line}"
+        if key in seen_at:
+            continue
+        seen_at[key] = 1
+        yield Violation(
+            check=CHECK_NAME,
+            severity=DEFAULT_SEVERITY,
+            message=f"wikilink 目標不存在：[[{link}]]",
+            line=line,
+            snippet=m.group(0)[:80],
+            editorial_ref=EDITORIAL_REF,
+        )

--- a/scripts/tools/lib/article_health/runner.py
+++ b/scripts/tools/lib/article_health/runner.py
@@ -98,13 +98,15 @@ def run_checks(
         violations: list[Violation] = []
         try:
             for v in mod.check(target, options):
-                # Plugin can yield violations with their own severity
-                # but the runner has the final say (per profile/config).
-                # If plugin's severity is INFO and runner says HARD, runner wins.
-                if v.severity == Severity.INFO and resolved_severity != Severity.INFO:
-                    # Don't escalate INFO unless plugin asked
-                    pass
-                else:
+                # Severity precedence (per design 2026-05-04 SSOT Phase 3):
+                # 1. Plugin-yielded severity that DIFFERS from the plugin's
+                #    DEFAULT_SEVERITY → authoritative. Lets a single check
+                #    yield mixed HARD/WARN violations (e.g. frontmatter-title:
+                #    halfwidth punct = HARD, vague adjective = WARN).
+                # 2. If plugin yielded the default, profile/config can
+                #    override it (resolved_severity).
+                # 3. Plugin's DEFAULT_SEVERITY → fallback (already in v).
+                if v.severity == mod.DEFAULT_SEVERITY:
                     v.severity = resolved_severity
                 violations.append(v)
         except Exception as e:

--- a/tests/article_health/test_footnote.py
+++ b/tests/article_health/test_footnote.py
@@ -1,0 +1,143 @@
+"""Tests for footnote_format + footnote_density plugins (Phase 5)."""
+
+import textwrap
+from pathlib import Path
+
+from lib.article_health import registry
+from lib.article_health.checks import footnote_density, footnote_format
+from lib.article_health.loader import load_target
+from lib.article_health.types import Severity
+
+
+def _write(tmp_path: Path, body: str, name: str = "x.md") -> Path:
+    f = tmp_path / "knowledge" / "Nature" / name
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        f"---\ntitle: x\ndescription: y\ndate: 2026-05-04\ntags: [t]\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return f
+
+
+# ════════════════════════════════════════════════════════════════════════
+# footnote-format
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_canonical_footnote_no_violation(tmp_path):
+    body = "段落[^1]\n\n[^1]: [Source Title](https://example.com) — description text\n"
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_format.check(target, {}))
+    assert violations == []
+
+
+def test_missing_url_flagged(tmp_path):
+    body = "段落[^1]\n\n[^1]: just plain text without link or url\n"
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_format.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.HARD
+
+
+def test_missing_dash_separator_flagged(tmp_path):
+    body = "段落[^1]\n\n[^1]: [Title](https://example.com) — short\n"
+    # description < 10 chars
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_format.check(target, {}))
+    assert len(violations) == 1
+
+
+def test_short_description_flagged(tmp_path):
+    body = "段落[^1]\n\n[^1]: [Title](https://example.com) — 9chars\n"
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_format.check(target, {}))
+    assert len(violations) == 1
+
+
+def test_multiple_violations(tmp_path):
+    body = (
+        "段落[^1][^2][^3]\n\n"
+        "[^1]: [Title](https://example.com) — proper desc enough chars\n"
+        "[^2]: just plain text bad\n"
+        "[^3]: another bad one\n"
+    )
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_format.check(target, {}))
+    assert len(violations) == 2
+
+
+def test_format_plugin_metadata():
+    assert footnote_format.CHECK_NAME == "footnote-format"
+    assert footnote_format.DEFAULT_SEVERITY == Severity.HARD
+
+
+# ════════════════════════════════════════════════════════════════════════
+# footnote-density grading
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_grade_a_high_density(tmp_path):
+    body = textwrap.dedent(
+        """\
+        短文 內容。
+
+        [^1]: [src](https://e.com) — desc enough chars
+        [^2]: [src2](https://e.com) — desc enough chars2
+        [^3]: [src3](https://e.com) — desc enough chars3
+        """
+    )
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_density.check(target, {}))
+    # Grade A → no violation yielded
+    assert violations == []
+
+
+def test_grade_b_few_footnotes(tmp_path):
+    body = textwrap.dedent(
+        """\
+        段落內容比較長，但腳註只有一個。
+
+        [^1]: [src](https://e.com) — desc enough chars
+        """
+    ) + "\n".join(["延伸"] * 100)  # inflate word count → density > 300
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_density.check(target, {}))
+    # B grade → no violation
+    assert violations == []
+
+
+def test_grade_c_only_inline_urls(tmp_path):
+    body = "段落 https://a.com 段落 https://b.com 段落 https://c.com 又一段"
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_density.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].fix_suggestion == "C"
+
+
+def test_grade_d_one_url(tmp_path):
+    body = "段落 https://only.com 結束"
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_density.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].fix_suggestion == "D"
+
+
+def test_grade_f_naked(tmp_path):
+    body = "純文字段落沒有任何引用 沒有 URL"
+    target = load_target(_write(tmp_path, body))
+    violations = list(footnote_density.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].fix_suggestion == "F"
+    assert "引用荒漠" in violations[0].message
+
+
+def test_density_plugin_metadata():
+    assert footnote_density.CHECK_NAME == "footnote-density"
+    assert footnote_density.DEFAULT_SEVERITY == Severity.WARN
+
+
+def test_both_plugins_registered():
+    registry.reset_registry()
+    found = registry.discover_checks()
+    assert "footnote-format" in found
+    assert "footnote-density" in found

--- a/tests/article_health/test_frontmatter_title.py
+++ b/tests/article_health/test_frontmatter_title.py
@@ -1,0 +1,219 @@
+"""Tests for frontmatter_title plugin (SSOT Phase 3).
+
+Mirror of `scripts/core/test-frontmatter.mjs::checkTitleFormat` behavior
+plus precedence semantics (per-violation severity > profile override).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from lib.article_health import registry
+from lib.article_health.checks import frontmatter_title
+from lib.article_health.loader import load_target
+from lib.article_health.types import Severity
+
+
+def _make_article(
+    tmp_path: Path,
+    title: str,
+    category: str = "Nature",
+    lang_dir: str = "",
+    description: str = "desc",
+) -> Path:
+    if lang_dir:
+        d = tmp_path / "knowledge" / lang_dir / category
+    else:
+        d = tmp_path / "knowledge" / category
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "test.md"
+    f.write_text(
+        f"---\ntitle: '{title}'\ndescription: '{description}'\n---\n\nbody.\n",
+        encoding="utf-8",
+    )
+    return f
+
+
+def _check(tmp_path: Path, title: str, category: str = "Nature", lang_dir: str = ""):
+    f = _make_article(tmp_path, title, category, lang_dir)
+    target = load_target(f)
+    return list(frontmatter_title.check(target, {}))
+
+
+# ════════════════════════════════════════════════════════════════════════
+# HARD: half-width punct in CJK title
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_halfwidth_colon_between_cjk_is_hard(tmp_path):
+    violations = _check(tmp_path, "黃魚鴞:六公里溪流養一對")
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    assert len(hard) >= 1
+    assert any("：" in (v.fix_suggestion or "") for v in hard)
+
+
+def test_halfwidth_comma_cjk_to_digit_is_hard(tmp_path):
+    """`對,1800` (CJK→digit) — HARD violation."""
+    violations = _check(tmp_path, "六公里養一對,1800 公尺")
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    assert len(hard) >= 1
+    assert any("，" in (v.fix_suggestion or "") for v in hard)
+
+
+def test_intra_number_comma_not_flagged(tmp_path):
+    """`1,800` digit-comma-digit not flagged — both sides digits."""
+    violations = _check(tmp_path, "海拔 1,800 公尺烏心石")
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    assert hard == []
+
+
+def test_english_comma_not_flagged(tmp_path):
+    violations = _check(tmp_path, "Sun, Y. H. monograph")
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    assert hard == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# WARN: vague adjectives (EDITORIAL §原則 3)
+# ════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("adj", ["傳奇", "偉大", "優秀", "最強", "國民", "天后"])
+def test_vague_adjective_is_warn(tmp_path, adj):
+    violations = _check(tmp_path, f"{adj}的故事和台灣味道")
+    warns = [v for v in violations if v.severity == Severity.WARN and adj in v.message]
+    assert len(warns) == 1
+
+
+def test_unlisted_word_not_flagged(tmp_path):
+    """『神話』『不朽』不在 canonical 清單，不算 vague adjective."""
+    violations = _check(tmp_path, "原住民神話之夜歌與祭典", category="Culture")
+    vague_warns = [v for v in violations if "空泛形容詞" in v.message]
+    assert vague_warns == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# WARN: People colon-sandwich (EDITORIAL §原則 5)
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_people_without_colon_warns(tmp_path):
+    violations = _check(tmp_path, "周杰倫", category="People")
+    warns = [v for v in violations if "冒號三明治" in v.message]
+    assert len(warns) == 1
+
+
+def test_people_with_colon_and_long_subtitle_passes(tmp_path):
+    title = "周杰倫：從 4 in Love 隔壁練團室到不能說的祕密的二十五年"
+    violations = _check(tmp_path, title, category="People")
+    # Should not warn about colon sandwich or short subtitle
+    relevant = [
+        v for v in violations
+        if "冒號三明治" in v.message or "敘述太短" in v.message
+    ]
+    assert relevant == []
+
+
+def test_people_short_subtitle_warns(tmp_path):
+    """副標 weight < 8 — `太短` warn."""
+    violations = _check(tmp_path, "周杰倫：歌手", category="People")
+    warns = [v for v in violations if "太短" in v.message]
+    assert len(warns) == 1
+
+
+def test_non_people_without_colon_no_colon_warn(tmp_path):
+    """Nature article without colon shouldn't trigger People-only rule."""
+    violations = _check(tmp_path, "黃魚鴞", category="Nature")
+    warns = [v for v in violations if "冒號三明治" in v.message]
+    assert warns == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# WARN: title length
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_long_title_warns(tmp_path):
+    # > 35 effective chars: each CJK = 1, so 36 CJK chars triggers
+    long_title = "黃魚鴞甲乙丙丁戊己庚辛壬癸子丑寅卯辰巳午未申酉戌亥東南西北春夏秋冬山水火木"
+    violations = _check(tmp_path, long_title)
+    warns = [v for v in violations if "過長" in v.message]
+    assert len(warns) == 1, f"len={len(long_title)}, weight should be > 35, got {len(warns)} warns"
+
+
+def test_normal_title_passes_length(tmp_path):
+    violations = _check(tmp_path, "黃魚鴞：六公里溪流養一對的夜行猛禽")
+    warns = [v for v in violations if "過長" in v.message]
+    assert warns == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Lang filter: APPLIES_TO=zh-TW
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_translation_files_skipped_at_runner_level(tmp_path):
+    """Translations don't run this plugin (APPLIES_TO filter at runner)."""
+    from lib.article_health import config as cfg_mod
+    from lib.article_health.runner import run_checks
+
+    f = _make_article(tmp_path, "Some English Title!", lang_dir="en")
+    target = load_target(f)
+    cfg = cfg_mod.Config()
+    report = run_checks(target, cfg, check_name="frontmatter-title")
+    # Plugin not selected for en lang
+    assert report.results == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Per-violation severity precedence (Phase 3 runner change)
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_mixed_severities_in_one_check(tmp_path):
+    """A title with BOTH halfwidth punct AND vague adjective should yield
+    one HARD + one WARN violation."""
+    violations = _check(tmp_path, "傳奇:故事與台灣")
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    warn = [v for v in violations if v.severity == Severity.WARN]
+    assert len(hard) >= 1  # halfwidth :
+    assert len(warn) >= 1  # 傳奇 vague adj
+
+
+def test_runner_preserves_per_violation_hard(tmp_path):
+    """Even with profile override default→warn, plugin's HARD violations
+    stay HARD."""
+    from lib.article_health import config as cfg_mod
+    from lib.article_health.runner import run_checks
+
+    f = _make_article(tmp_path, "黃魚鴞:六公里")
+    target = load_target(f)
+    cfg = cfg_mod.Config()
+    cfg.profiles["test"] = cfg_mod.ProfileConfig(
+        name="test",
+        checks=["frontmatter-title"],
+        severity_overrides={"frontmatter-title": Severity.WARN},
+    )
+    report = run_checks(target, cfg, profile_name="test")
+    # halfwidth punct violation must STILL be HARD even with profile WARN override
+    hard_violations = [v for r in report.results for v in r.violations if v.severity == Severity.HARD]
+    assert len(hard_violations) >= 1, "halfwidth punct HARD must survive profile override"
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Plugin metadata
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_plugin_metadata():
+    assert frontmatter_title.CHECK_NAME == "frontmatter-title"
+    assert frontmatter_title.DEFAULT_SEVERITY == Severity.WARN
+    assert "Title" in frontmatter_title.EDITORIAL_REF
+    assert "zh-TW" in frontmatter_title.APPLIES_TO
+    assert callable(frontmatter_title.check)
+
+
+def test_plugin_registered():
+    registry.reset_registry()
+    found = registry.discover_checks()
+    assert "frontmatter-title" in found, list(found.keys())

--- a/tests/article_health/test_frontmatter_title_parity.py
+++ b/tests/article_health/test_frontmatter_title_parity.py
@@ -1,0 +1,171 @@
+"""Parity tests — Python plugin must agree with JS test-frontmatter.mjs.
+
+During Phase 3, we ship the Python plugin alongside the existing JS
+checkTitleFormat in `scripts/core/test-frontmatter.mjs`. Both must behave
+identically for representative inputs so Phase 7 cleanup can safely rip
+the JS.
+
+This test launches the JS validator in --strict mode against a temp
+knowledge/ tree containing canonical fixture titles, captures the
+violations, and compares the violation count to the Python plugin's
+count over the same titles.
+"""
+
+import json
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lib.article_health.checks import frontmatter_title
+from lib.article_health.loader import load_target
+from lib.article_health.types import Severity
+
+
+# Canonical fixtures: (title, category, expected_hard_count, expected_warn_count, label)
+FIXTURES = [
+    # Halfwidth punct → HARD
+    ("黃魚鴞:六公里溪流養一對,1,800 公尺烏心石", "Nature", 2, 0, "halfwidth-colon-comma"),
+    ("台灣黑熊", "People", 0, 1, "people-no-colon"),
+    ("傳奇:故事與台灣味道", "Food", 1, 1, "vague-adj+halfwidth"),
+    ("黃魚鴞：六公里溪流養一對的夜行猛禽", "Nature", 0, 0, "clean-zh-tw"),
+    ("周杰倫", "People", 0, 1, "people-no-colon-bare"),
+    (
+        "周杰倫：從 4 in Love 隔壁練團室到不能說的祕密的二十五年",
+        "People",
+        0,
+        0,
+        "people-good-colon-sandwich",
+    ),
+    ("周杰倫：歌手", "People", 0, 1, "people-short-subtitle"),
+    (
+        "黃魚鴞甲乙丙丁戊己庚辛壬癸子丑寅卯辰巳午未申酉戌亥東南西北春夏秋冬山水火木",
+        "Nature",
+        0,
+        1,
+        "title-too-long",
+    ),
+]
+
+
+def _check_via_python(title: str, category: str, tmp_path: Path):
+    """Run the Python plugin and return (hard_count, warn_count)."""
+    d = tmp_path / "knowledge" / category
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "py.md"
+    f.write_text(
+        f"---\ntitle: '{title}'\ndescription: 'desc'\n---\nbody.\n",
+        encoding="utf-8",
+    )
+    target = load_target(f)
+    violations = list(frontmatter_title.check(target, {}))
+    hard = sum(1 for v in violations if v.severity == Severity.HARD)
+    warn = sum(1 for v in violations if v.severity == Severity.WARN)
+    return hard, warn
+
+
+def _check_via_js(title: str, category: str, tmp_path: Path) -> tuple[int, int]:
+    """Run scripts/core/test-frontmatter.mjs in --strict mode against a
+    minimal knowledge tree and parse its stdout.
+
+    Returns (hard_count, warn_count) where:
+      - hard_count = errors related to this title from JS output
+      - warn_count = warnings related to this title from JS output
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    # Set up minimal knowledge tree in tmp_path
+    knowledge = tmp_path / "knowledge"
+    knowledge.mkdir(exist_ok=True)
+    cat_dir = knowledge / category
+    cat_dir.mkdir(exist_ok=True)
+    test_md = cat_dir / "js-fixture.md"
+    test_md.write_text(
+        textwrap.dedent(
+            f"""\
+            ---
+            title: '{title.replace("'", "\\'")}'
+            description: 'fixture description with anchor 2026 and number 100'
+            date: 2026-05-04
+            tags: ['test']
+            category: {category}
+            ---
+
+            body.
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    js_script = repo_root / "scripts" / "core" / "test-frontmatter.mjs"
+    if not js_script.exists():
+        pytest.skip(f"JS validator not found at {js_script}")
+
+    proc = subprocess.run(
+        ["node", str(js_script)],
+        cwd=str(tmp_path),
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    out = proc.stdout + proc.stderr
+
+    js_label = f"{category}/js-fixture.md"
+    title_relevant = [
+        line for line in out.splitlines()
+        if js_label in line and "title" in line
+    ]
+    # JS test-frontmatter outputs title-format checks as either errors
+    # (halfwidth punct) or warnings (others). Distinguish by keywords:
+    hard_keywords = ["title 含半形"]
+    hard = sum(
+        1 for line in title_relevant if any(k in line for k in hard_keywords)
+    )
+    warn = len(title_relevant) - hard
+    return hard, warn
+
+
+@pytest.mark.parametrize(
+    "title,category,expected_hard,expected_warn,label", FIXTURES
+)
+def test_python_plugin_matches_expected(
+    tmp_path, title, category, expected_hard, expected_warn, label
+):
+    """Python plugin's count matches the fixture's expected counts."""
+    py_hard, py_warn = _check_via_python(title, category, tmp_path)
+    assert py_hard == expected_hard, (
+        f"[{label}] Python hard={py_hard}, expected {expected_hard}; title={title!r}"
+    )
+    assert py_warn == expected_warn, (
+        f"[{label}] Python warn={py_warn}, expected {expected_warn}; title={title!r}"
+    )
+
+
+@pytest.mark.parametrize(
+    "title,category,expected_hard,expected_warn,label", FIXTURES
+)
+def test_js_validator_agrees_with_python(
+    tmp_path, title, category, expected_hard, expected_warn, label
+):
+    """Cross-check: the legacy JS validator agrees with our Python plugin
+    on every fixture. If this fails, drift has happened — fix one or
+    the other before merging."""
+    py_hard, py_warn = _check_via_python(title, category, tmp_path)
+    # Reset tmp dir between python and JS runs to avoid sharing state
+    import shutil
+
+    tmp_path_js = tmp_path / "_js_run"
+    tmp_path_js.mkdir(exist_ok=True)
+    js_hard, js_warn = _check_via_js(title, category, tmp_path_js)
+
+    assert py_hard == js_hard, (
+        f"[{label}] DRIFT: Python hard={py_hard}, JS hard={js_hard}; "
+        f"title={title!r}, expected={expected_hard}"
+    )
+    # JS output may include extra warnings unrelated to title (e.g. missing
+    # subcategory). We assert AT LEAST as many title-related warnings as
+    # the python count. Strict equality is brittle here.
+    assert js_warn >= py_warn, (
+        f"[{label}] JS warn={js_warn} < Python warn={py_warn}; "
+        f"title={title!r}"
+    )

--- a/tests/article_health/test_phase6.py
+++ b/tests/article_health/test_phase6.py
@@ -1,0 +1,264 @@
+"""Tests for Phase 6 plugins: wikilink_target / format_structure / image_health."""
+
+import textwrap
+from pathlib import Path
+
+from lib.article_health import registry
+from lib.article_health.checks import (
+    format_structure,
+    image_health,
+    wikilink_target,
+)
+from lib.article_health.loader import load_target
+from lib.article_health.types import Severity
+
+
+def _write_article(tmp_path: Path, body: str, frontmatter_extra: str = "") -> Path:
+    f = tmp_path / "knowledge" / "Nature" / "test.md"
+    f.parent.mkdir(parents=True, exist_ok=True)
+    fm = (
+        "title: x\ndescription: y\ndate: 2026-05-04\ntags: [t]\ncategory: Nature\n"
+        + frontmatter_extra
+    )
+    f.write_text(f"---\n{fm}---\n\n{body}\n", encoding="utf-8")
+    return f
+
+
+# ════════════════════════════════════════════════════════════════════════
+# wikilink_target
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_wikilink_resolves(tmp_path, monkeypatch):
+    """[[X]] → if 'knowledge/<cat>/X.md' exists, no violation."""
+    monkeypatch.chdir(tmp_path)
+    # Create the target article
+    target_md = tmp_path / "knowledge" / "Nature" / "黃魚鴞.md"
+    target_md.parent.mkdir(parents=True)
+    target_md.write_text("---\ntitle: t\n---\nbody\n", encoding="utf-8")
+    # Reset slug cache so it picks up the test file
+    wikilink_target._reset_cache()
+    body = "段落引用 [[黃魚鴞]] 結束"
+    src = _write_article(tmp_path, body)
+    target = load_target(src)
+    violations = list(wikilink_target.check(target, {}))
+    assert violations == []
+
+
+def test_wikilink_target_missing_flagged(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    wikilink_target._reset_cache()
+    body = "段落 [[不存在的目標]] 後面"
+    src = _write_article(tmp_path, body)
+    target = load_target(src)
+    violations = list(wikilink_target.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.HARD
+    assert "不存在" in violations[0].message
+
+
+def test_wikilink_with_alias(tmp_path, monkeypatch):
+    """[[X|顯示文字]] — target X must resolve."""
+    monkeypatch.chdir(tmp_path)
+    target_md = tmp_path / "knowledge" / "Nature" / "黑熊.md"
+    target_md.parent.mkdir(parents=True)
+    target_md.write_text("---\ntitle: t\n---\nbody\n", encoding="utf-8")
+    wikilink_target._reset_cache()
+    body = "段落 [[黑熊|台灣黑熊]] 引用"
+    src = _write_article(tmp_path, body)
+    target = load_target(src)
+    violations = list(wikilink_target.check(target, {}))
+    assert violations == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# format_structure
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_overview_blockquote_missing_warn(tmp_path):
+    body = textwrap.dedent(
+        """\
+        ## 開頭段落
+
+        正文
+        """
+    )
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(format_structure.check(target, {}))
+    assert any("30 秒概覽" in v.message for v in violations)
+
+
+def test_overview_blockquote_present_passes(tmp_path):
+    body = textwrap.dedent(
+        """\
+        > **30 秒概覽**: 文章主旨
+
+        ## 開頭
+
+        正文
+        """
+    )
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(format_structure.check(target, {}))
+    overview_warns = [v for v in violations if "30 秒概覽" in v.message]
+    assert overview_warns == []
+
+
+def test_list_wikilink_residual_hard(tmp_path):
+    body = textwrap.dedent(
+        """\
+        > **30 秒概覽**: x
+
+        ## 段落
+
+        - [[殘留 wikilink]]
+        - 正常 bullet
+        """
+    )
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(format_structure.check(target, {}))
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    assert any("[[wikilink]]" in v.message for v in hard)
+
+
+def test_footnote_use_without_def_hard(tmp_path):
+    body = textwrap.dedent(
+        """\
+        > **30 秒概覽**: x
+
+        段落使用[^1]但沒定義。
+        """
+    )
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(format_structure.check(target, {}))
+    hard = [v for v in violations if v.severity == Severity.HARD]
+    assert any("無 `[^N]:` 定義" in v.message for v in hard)
+
+
+def test_references_h2_required_when_footnotes_used(tmp_path):
+    body = textwrap.dedent(
+        """\
+        > **30 秒概覽**: x
+
+        正文[^1]。
+
+        [^1]: [Source](https://e.com) — desc enough chars
+        """
+    )
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(format_structure.check(target, {}))
+    refs_warns = [v for v in violations if "參考資料" in v.message]
+    assert len(refs_warns) == 1
+
+
+def test_complete_structure_passes(tmp_path):
+    body = textwrap.dedent(
+        """\
+        > **30 秒概覽**: 文章主旨
+
+        ## 段落
+
+        正文[^1]。
+
+        ## 延伸閱讀
+
+        - [文章 A](/cat/a)
+
+        ## 參考資料
+
+        [^1]: [src](https://e.com) — desc enough chars
+        """
+    ) + "\n".join(["延伸"] * 50)
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(format_structure.check(target, {}))
+    # No structural issues expected
+    assert violations == [], [v.message for v in violations]
+
+
+# ════════════════════════════════════════════════════════════════════════
+# image_health
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_inline_image_missing_file_hard(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = "![alt](/article-images/nature/missing.jpg) 段落"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(image_health.check(target, {}))
+    assert any("不存在" in v.message for v in violations)
+
+
+def test_inline_image_existing_file_passes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "public" / "article-images" / "nature" / "owl.jpg"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(b"fake")
+    body = "![alt](/article-images/nature/owl.jpg) 段落"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(image_health.check(target, {}))
+    assert violations == []
+
+
+def test_external_hotlink_flagged(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = "![alt](https://example.com/external.jpg) 段落"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(image_health.check(target, {}))
+    assert any("熱連結" in v.message for v in violations)
+
+
+def test_wikimedia_external_allowed(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = "![alt](https://upload.wikimedia.org/file.jpg) 段落"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(image_health.check(target, {}))
+    # Allowed canonical CC source — no hot-link violation
+    hot_warns = [v for v in violations if "熱連結" in v.message]
+    assert hot_warns == []
+
+
+def test_frontmatter_image_missing_hard(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    body = "段落"
+    target = load_target(
+        _write_article(
+            tmp_path, body, frontmatter_extra="image: '/article-images/missing.jpg'\n"
+        )
+    )
+    violations = list(image_health.check(target, {}))
+    assert any("frontmatter image" in v.message for v in violations)
+
+
+def test_attribution_without_section_warn(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    img = tmp_path / "public" / "article-images" / "owl.jpg"
+    img.parent.mkdir(parents=True)
+    img.write_bytes(b"fake")
+    body = "段落"
+    target = load_target(
+        _write_article(
+            tmp_path,
+            body,
+            frontmatter_extra=(
+                "image: '/article-images/owl.jpg'\n"
+                "imageCredit: 'gailhampshire'\n"
+                "imageLicense: 'CC BY 2.0'\n"
+            ),
+        )
+    )
+    violations = list(image_health.check(target, {}))
+    assert any("圖片來源" in v.message for v in violations)
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Plugin registration
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_phase6_plugins_registered():
+    registry.reset_registry()
+    found = registry.discover_checks()
+    assert "wikilink-target" in found
+    assert "format-structure" in found
+    assert "image-health" in found

--- a/tests/article_health/test_prose_health.py
+++ b/tests/article_health/test_prose_health.py
@@ -1,0 +1,332 @@
+"""Tests for prose_health plugin (Phase 4 — quality-scan + manifesto-11 consolidation)."""
+
+import textwrap
+from pathlib import Path
+
+import pytest
+
+from lib.article_health import registry
+from lib.article_health.checks import prose_health
+from lib.article_health.loader import load_target
+from lib.article_health.types import Severity
+
+
+def _make_article(
+    tmp_path: Path,
+    body: str,
+    title: str = "測試文章",
+    category: str = "Nature",
+    last_human_review: bool = True,
+    extra_frontmatter: str = "",
+) -> Path:
+    fm = (
+        f"title: '{title}'\n"
+        f"description: '描述 2026 anchor 1000'\n"
+        f"date: 2026-05-04\n"
+        f"tags: ['test']\n"
+        f"category: {category}\n"
+        f"lastHumanReview: {'true' if last_human_review else 'false'}\n"
+    ) + extra_frontmatter
+    d = tmp_path / "knowledge" / category
+    d.mkdir(parents=True, exist_ok=True)
+    f = d / "test.md"
+    f.write_text(f"---\n{fm}---\n\n{body}\n", encoding="utf-8")
+    return f
+
+
+def _check(tmp_path: Path, body: str, **kwargs) -> list:
+    f = _make_article(tmp_path, body, **kwargs)
+    target = load_target(f)
+    return list(prose_health.check(target, {}))
+
+
+def _score(violations) -> int:
+    """Extract numeric score from the score-summary violation."""
+    for v in violations:
+        if v.fix_suggestion and v.fix_suggestion.isdigit():
+            return int(v.fix_suggestion)
+    return 0
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Skip cases
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_short_file_skipped(tmp_path):
+    """File < 20 lines is skipped (matches quality-scan.sh early-exit)."""
+    f = tmp_path / "knowledge" / "Nature" / "stub.md"
+    f.parent.mkdir(parents=True)
+    f.write_text("---\ntitle: x\n---\n\nshort content\n", encoding="utf-8")
+    target = load_target(f)
+    violations = list(prose_health.check(target, {}))
+    assert violations == []
+
+
+def test_no_frontmatter_skipped(tmp_path):
+    f = tmp_path / "knowledge" / "Nature" / "x.md"
+    f.parent.mkdir(parents=True)
+    f.write_text("\n".join(["plain text"] * 30), encoding="utf-8")
+    target = load_target(f)
+    violations = list(prose_health.check(target, {}))
+    assert violations == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Quality-scan dimension parity
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_year_count_low_scores_3(tmp_path):
+    body = "\n".join(["這是一段散文，沒有任何年份提及"] * 22)
+    score = _score(_check(tmp_path, body))
+    assert score >= 3  # 缺乏年份 = +3
+
+
+def test_year_count_normal_low_score(tmp_path):
+    body = textwrap.dedent(
+        """\
+        這篇文章在 1916 年出版，記錄了 1994 年的事件。
+        2026 年我們重新看 1995 年的紀錄[^1]。
+        2024 年開始有更新研究。
+
+        ## H2
+
+        散文段落一段
+        散文段落二段
+        散文段落三段
+        散文段落四段
+
+        ## H3
+
+        散文1
+        散文2
+        散文3
+        散文4
+        散文5
+
+        [^1]: [來源](https://example.com) — desc 足夠長
+        """
+    )
+    score = _score(_check(tmp_path, body))
+    # 4+ years → no year penalty; URL=1 → +1; fn=1 → no citation desert
+    assert score < 3
+
+
+def test_no_url_scores_3(tmp_path):
+    body = "\n".join(["這是純散文段落 1916 年沒有任何 URL"] * 25)
+    score = _score(_check(tmp_path, body))
+    assert score >= 3  # 無URL = +3
+
+
+def test_hollow_words_high_count(tmp_path):
+    # ≥ 20 lines required (else early-exit). Need plenty of hollow density.
+    body = (
+        "這個產業蓬勃發展，逐步形成顯著的影響力，"
+        "持續日益成長，全面深入大力推動。"
+    )
+    body_multi = "\n".join([body] * 25)  # 25 lines, ~75 hollow word hits
+    body_multi += "\n\n散文 1916 年提及，1994 年確認[^1]。"
+    body_multi += "\n\n[^1]: [src](https://e.com) — desc enough length"
+    violations = _check(tmp_path, body_multi)
+    score = _score(violations)
+    # 75 hollow words is > 15 threshold → +3 score
+    assert score >= 1, f"hollow words should trigger score, got {score}"
+
+
+def test_plastic_phrase_detection(tmp_path):
+    body = textwrap.dedent(
+        """\
+        台灣不僅是亞洲最重要的，更是全球科技中心。
+        這展現了民主的精神，也體現了制度的決心。
+        從南到北，從東到西，這座島嶼承載著無數的故事。
+        台積電扮演著重要的角色，發揮著關鍵的作用。
+
+        參考 https://example.com 提及 1986 年成立[^1]。
+
+        ## H2 段落
+        正文1
+        正文2
+        正文3
+        正文4
+        正文5
+
+        [^1]: [Source](https://example.com) — long-enough description here
+        """
+    )
+    body = body * 2
+    violations = _check(tmp_path, body)
+    score = _score(violations)
+    # 4 plastic phrases × 2 = 8 → score +3 (3-4 range)
+    assert score >= 2
+
+
+def test_emdash_overuse(tmp_path):
+    body = "這段——文字——有很多——破折號——濫用了——又一次——\n" * 5
+    body += "\n".join(["正常一段散文 1916 年內容"] * 20)
+    body += "\n\n[^1]: [src](https://e.com) — desc enough characters"
+    score = _score(_check(tmp_path, body))
+    # 6×5 = 30 em-dashes → +3 dash penalty
+    assert score >= 3
+
+
+def test_textbook_opening_scores_2(tmp_path):
+    body = "台灣的半導體產業是亞洲重要的支柱。\n"
+    body += "\n".join(["延伸內容 1916 年起步"] * 25)
+    body += "\n\n[^1]: [src](https://e.com) — desc enough characters"
+    score = _score(_check(tmp_path, body))
+    assert score >= 2  # textbook opening = +2
+
+
+def test_formulaic_ending_scores_2(tmp_path):
+    body = "\n".join(["主文段落 1916 年內容"] * 22)
+    body += "\n\n總之，這是一個值得我們深思的議題。"
+    body += "\n\n[^1]: [src](https://e.com) — desc"
+    score = _score(_check(tmp_path, body))
+    assert score >= 2
+
+
+def test_template_h2_count(tmp_path):
+    body = textwrap.dedent(
+        """\
+        散文段落 1916 年起步引言
+
+        ## 歷史背景
+
+        段落
+
+        ## 現況
+
+        段落
+
+        ## 未來展望
+
+        段落
+
+        ## 挑戰與展望
+
+        段落
+        """
+    )
+    body += "\n".join(["延伸 2024 年內容"] * 12)
+    body += "\n\n[^1]: [src](https://e.com) — desc"
+    score = _score(_check(tmp_path, body))
+    assert score >= 3  # 4 template H2s = +3
+
+
+def test_citation_desert_long_no_footnote(tmp_path):
+    body = "\n".join(["長段散文 1916 年起點 2024 年現況"] * 50)
+    score = _score(_check(tmp_path, body))
+    # word count > 500, fn = 0, urls = 0 → +4 (extreme citation desert)
+    assert score >= 4
+
+
+def test_last_human_review_false_scores_1(tmp_path):
+    body = textwrap.dedent(
+        """\
+        正常散文 1916 年內容 2024 年[^1]。
+
+        ## 段落
+
+        正文1
+        正文2
+        正文3
+
+        [^1]: [Source](https://example.com) — desc enough chars
+        """
+    )
+    body += "\n".join(["延伸"] * 15)
+    score_with_review = _score(_check(tmp_path, body, last_human_review=True))
+    score_without = _score(_check(tmp_path, body, last_human_review=False))
+    assert score_without >= score_with_review + 1
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Manifesto §11 tier checks
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_tier1_dual_pattern_detected(tmp_path):
+    body = "這不是科技問題，而是制度問題。\n" * 5
+    body += "\n".join(["延伸 1916 年"] * 20)
+    body += "\n\n[^1]: [src](https://e.com) — desc"
+    violations = _check(tmp_path, body)
+    tier1 = [v for v in violations if "Tier 1" in (v.editorial_ref or "")]
+    assert len(tier1) >= 5
+
+
+def test_tier2_metaphor_density(tmp_path):
+    body = "這篇文章的軌跡承載著 DNA，鏡子般的張力，光譜的縮影。\n"
+    body += "\n".join(["散文 1916 年"] * 22)
+    body += "\n\n[^1]: [src](https://e.com) — desc"
+    violations = _check(tmp_path, body)
+    tier2 = [v for v in violations if "Tier 2" in (v.editorial_ref or "")]
+    assert len(tier2) == 1
+    # Should be ≥ 5 metaphor occurrences (test phrase has 軌跡 / 承載著 / DNA /
+    # 鏡子 / 張力 / 光譜 / 縮影 = 7 distinct words)
+    import re
+    m = re.search(r"累計 (\d+) 處", tier2[0].message)
+    assert m and int(m.group(1)) >= 5, tier2[0].message
+
+
+def test_tier3_ritual_phrases(tmp_path):
+    body = "在這個意義上，這個議題不容忽視，值得我們深思。\n"
+    body += "\n".join(["散文 1916 年"] * 22)
+    body += "\n\n[^1]: [src](https://e.com) — desc"
+    violations = _check(tmp_path, body)
+    tier3 = [v for v in violations if "Tier 3" in (v.editorial_ref or "")]
+    assert len(tier3) == 1
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Score budget
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_clean_article_passes_budget(tmp_path):
+    body = textwrap.dedent(
+        """\
+        1994 年的某一天，研究員在花蓮太魯閣的溪畔找到了一個巢[^1]。
+        2026 年 4 月，研究團隊在武陵的烏心石老樹洞裡找到全台最高巢位[^2]。
+        2024 年最新統計顯示族群在易危等級之間波動[^3]。
+
+        ## 砂卡礑那年
+
+        三十年前的研究是現在所有後續定位的起點。
+        孫元勳教授團隊持續追蹤了 91 個領域。
+        每對黃魚鴞需要 6.2 公里溪流維持領域。
+        天然林比例 44.6% 是維持族群的關鍵變數。
+
+        ## 武陵的新發現
+
+        最新的紀錄改寫了高度上限。
+        1,800 公尺的烏心石樹洞是台灣最高巢位。
+        雪霸國家公園推出 24 小時育雛直播。
+
+        [^1]: [Sun et al. 1997](https://example.com) — 砂卡礑首次定位巢位完整紀錄
+        [^2]: [公視 2026](https://example.com) — 武陵最高巢位記錄
+        [^3]: [紅皮書 2024](https://example.com) — 易危等級評估報告
+        """
+    )
+    score = _score(_check(tmp_path, body))
+    # Clean article should be ≤ 3 (canonical pass threshold)
+    assert score <= 3, f"clean article scored {score}, should be ≤ 3"
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Plugin metadata
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_plugin_metadata():
+    assert prose_health.CHECK_NAME == "prose-health"
+    assert prose_health.DEFAULT_SEVERITY == Severity.WARN
+    assert "MANIFESTO" in prose_health.EDITORIAL_REF
+    assert "zh-TW" in prose_health.APPLIES_TO
+    assert callable(prose_health.check)
+
+
+def test_plugin_registered():
+    registry.reset_registry()
+    found = registry.discover_checks()
+    assert "prose-health" in found, list(found.keys())


### PR DESCRIPTION
Continuation of [PR #862](https://github.com/frank890417/taiwan-md/pull/862) (Phases 1-2, MERGED). Re-targets to main after the Phase 1-2 base branch was deleted.

5 phases of the SSOT consolidation, each as its own commit. **133/133 tests pass.**

## Phases shipped

### Phase 3 — frontmatter_title (commit 722e7ee2c)
Migrates `checkTitleFormat` from `scripts/core/test-frontmatter.mjs` to Python plugin. **22 unit tests + 16 JS↔Python parity tests** ensure the JS legacy implementation and Python plugin agree on 8 canonical fixture titles.

### Phase 4 — prose_health (commit 7472d27d5)
**Eliminates the 3-way duplication audit P1 flagged.** Consolidates `quality-scan.sh` (16 dims) + `check-manifesto-11.sh` (Tier 1-3) + `review-pr.sh` L2. Score budget ≤ 3 = pass preserved. 19 tests.

### Phase 5 — footnote_format + footnote_density (commit 757204c20)
HARD `[^N]: [Title](URL) — desc{10+}` validation + WARN A-F citation grade. 13 tests.

### Phase 6 — wikilink + format + image (commit 4ee4aad65)
- `wikilink-target` (HARD) — `[[X]]` resolution
- `format-structure` (HARD+WARN) — 30秒概覽 / 延伸閱讀 / 參考資料 / list-wikilink
- `image-health` (HARD+WARN) — file existence / hot-link / Wikimedia allowed
16 tests.

### Phase 7 — pre-commit shadow run + config (commit 3e8bad0c5)
- 8 plugins fully wired into 7 stage profiles
- `.husky/pre-commit` runs SSOT as a SHADOW (informational, not gate-blocking) for 30-day observation window before promoting to hard gate.

## Statistics

| | Tests | Plugins |
|---|---|---|
| Phase 3 | +38 | +1 (frontmatter-title) |
| Phase 4 | +19 | +1 (prose-health) |
| Phase 5 | +13 | +2 (footnote-{format,density}) |
| Phase 6 | +16 | +3 (wikilink + format + image) |
| Phase 7 | 0 | wiring |
| **Total** | **86 added** (133 cumulative) | **+7 (8 cumulative)** |

## Test plan

- [x] `python3 -m pytest tests/article_health -q` → 133/133
- [x] `python3 scripts/tools/article-health.py --list-checks` → 8 plugins
- [x] `python3 scripts/tools/article-health.py knowledge/Nature/黃魚鴞.md --profile=pre-commit` → 0/0
- [x] `node scripts/core/test-frontmatter.mjs` → unchanged behavior
- [x] All 8 legacy shell scripts still callable (facade pattern preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)