### PR TITLE
🧬 article-health Phase 9 — deferred plugins (LIST-DUMP/THIN/QUALITY-DECAY/terminology/footnote-url/cross-reference)

### DIFF
--- a/scripts/tools/lib/article_health/checks/cross_reference.py
+++ b/scripts/tools/lib/article_health/checks/cross_reference.py
@@ -1,0 +1,107 @@
+"""cross_reference — bidirectional 延伸閱讀 / wikilink reciprocity.
+
+Migrated from `scripts/tools/cross-link.sh` (Stage 5 cross-link analysis).
+
+For each `[[X]]` or `延伸閱讀 - [Y](/cat/Y)` link in this article,
+check whether the TARGET article links back. Asymmetric links are flagged
+as INFO (not actionable warnings — context-dependent).
+
+This plugin reads MULTIPLE articles to compute reverse-link maps. To keep
+scan O(N) where N = articles, the inverse-index is built once per session
+and cached.
+"""
+
+from __future__ import annotations
+import re
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "cross-reference"
+DIMENSION = "structure"
+DEFAULT_SEVERITY = Severity.INFO  # informational — not block-grade
+EDITORIAL_REF = "cross-link.sh / EDITORIAL.md §wikilink"
+APPLIES_TO = ["zh-TW"]
+
+_RE_WIKILINK = re.compile(r"\[\[([^\]|\n]+?)(?:\|[^\]\n]+)?\]\]")
+_RE_MD_LINK_INTERNAL = re.compile(r"\]\(/([a-z]+)/([^)\n]+?)\)")
+
+_LANG_DIRS_SKIP = {"en", "ja", "ko", "es", "fr"}
+_KNOWLEDGE_ROOT = Path("knowledge")
+
+
+def _build_inverse_index() -> dict[str, set[str]]:
+    """target_slug → set of source_slugs that link to it.
+
+    Cached on first call per process. Tests can reset via _reset_cache().
+    """
+    cached = getattr(_build_inverse_index, "_cache", None)
+    if cached is not None:
+        return cached
+
+    inverse: dict[str, set[str]] = {}
+    if not _KNOWLEDGE_ROOT.exists():
+        _build_inverse_index._cache = inverse  # type: ignore[attr-defined]
+        return inverse
+
+    for entry in _KNOWLEDGE_ROOT.iterdir():
+        if not entry.is_dir() or entry.name in _LANG_DIRS_SKIP:
+            continue
+        for md in entry.glob("*.md"):
+            if md.name.startswith("_"):
+                continue
+            source = md.stem
+            try:
+                text = md.read_text(encoding="utf-8")
+            except Exception:
+                continue
+            for m in _RE_WIKILINK.finditer(text):
+                inverse.setdefault(m.group(1).strip(), set()).add(source)
+            for m in _RE_MD_LINK_INTERNAL.finditer(text):
+                inverse.setdefault(m.group(2).strip(), set()).add(source)
+
+    _build_inverse_index._cache = inverse  # type: ignore[attr-defined]
+    return inverse
+
+
+def _reset_cache() -> None:
+    if hasattr(_build_inverse_index, "_cache"):
+        delattr(_build_inverse_index, "_cache")
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    body = target.body
+    inverse = _build_inverse_index()
+    self_slug = target.slug
+
+    # Collect this article's outgoing links
+    outgoing: set[str] = set()
+    for m in _RE_WIKILINK.finditer(body):
+        outgoing.add(m.group(1).strip())
+    for m in _RE_MD_LINK_INTERNAL.finditer(body):
+        outgoing.add(m.group(2).strip())
+
+    if not outgoing:
+        return
+
+    # For each outgoing link, check if target links back.
+    # inverse[X] = set of source slugs that link TO X. So:
+    #   "self → X is symmetric" iff X is one of self's referrers
+    #   ⇔ X in inverse[self_slug]
+    referrers_of_self = inverse.get(self_slug, set())
+    for target_slug in outgoing:
+        if target_slug == self_slug:
+            continue
+        if target_slug in referrers_of_self:
+            continue  # symmetric — target links back to self
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.INFO,
+            message=(
+                f"單向連結到 [[{target_slug}]] — 對方未連回 (informational; "
+                "Stage 5 review 判斷該不該補)"
+            ),
+            editorial_ref=EDITORIAL_REF,
+        )

--- a/scripts/tools/lib/article_health/checks/footnote_url.py
+++ b/scripts/tools/lib/article_health/checks/footnote_url.py
@@ -1,0 +1,92 @@
+"""footnote_url — verify footnote URL reachability via HEAD.
+
+Migrated from `scripts/tools/check-footnote-urls.sh`.
+
+**Network-bound — disabled by default.** Enable per-run via:
+  python3 scripts/tools/article-health.py file.md --check=footnote-url
+  ARTICLE_HEALTH_NETWORK=1 python3 ...  (env var)
+  options.network=true (config)
+
+Reason: blind HEAD on every commit slows pre-commit by 10-30s and
+fails on flaky links. Best run as Stage 3.5 manual check or scheduled
+cron sweep, not as gate.
+
+Severity: WARN by default. 4xx/5xx surface as warnings (won't block PR).
+"""
+
+from __future__ import annotations
+import os
+import re
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "footnote-url"
+DIMENSION = "citation"
+DEFAULT_SEVERITY = Severity.WARN
+EDITORIAL_REF = "check-footnote-urls.sh"
+APPLIES_TO = ["*"]
+
+_RE_FOOTNOTE_URL = re.compile(
+    r"^\[\^[0-9a-zA-Z_-]+\]:\s*\[[^\]]+\]\((https?://[^)\s]+)\)",
+    re.MULTILINE,
+)
+
+
+def _network_enabled(config: dict[str, Any]) -> bool:
+    if os.environ.get("ARTICLE_HEALTH_NETWORK") == "1":
+        return True
+    return bool(config.get("network", False))
+
+
+def _check_url(url: str, timeout: float = 5.0) -> tuple[bool, int | None, str]:
+    """Returns (ok, status_code, message). ok = True if 2xx/3xx."""
+    try:
+        import urllib.request
+        import urllib.error
+
+        req = urllib.request.Request(url, method="HEAD")
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.status
+            return (200 <= status < 400, status, "")
+    except urllib.error.HTTPError as e:
+        # Some servers reject HEAD; retry GET with a small range
+        try:
+            req2 = urllib.request.Request(url, method="GET")
+            req2.add_header("Range", "bytes=0-0")
+            with urllib.request.urlopen(req2, timeout=timeout) as resp:
+                status = resp.status
+                return (200 <= status < 400, status, "")
+        except Exception as e2:
+            return (False, getattr(e, "code", None), f"{e}; retry: {e2}")
+    except urllib.error.URLError as e:
+        return (False, None, f"URLError: {e.reason}")
+    except Exception as e:
+        return (False, None, str(e))
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    if not _network_enabled(config):
+        return
+
+    body = target.body
+    seen: set[str] = set()
+    for m in _RE_FOOTNOTE_URL.finditer(body):
+        url = m.group(1).rstrip(",;:.")  # trim common trailing punct
+        if url in seen:
+            continue
+        seen.add(url)
+        line = body.count("\n", 0, m.start()) + 1
+        ok, status, msg = _check_url(url)
+        if ok:
+            continue
+        status_str = f"HTTP {status}" if status else (msg or "no response")
+        yield Violation(
+            check=CHECK_NAME,
+            severity=DEFAULT_SEVERITY,
+            message=f"腳註 URL 無法存取 ({status_str}): {url[:80]}",
+            line=line,
+            snippet=url,
+            editorial_ref=EDITORIAL_REF,
+        )

--- a/scripts/tools/lib/article_health/checks/prose_health.py
+++ b/scripts/tools/lib/article_health/checks/prose_health.py
@@ -216,6 +216,74 @@ def _count_footnote_defs(body: str) -> int:
     )
 
 
+def _is_hub_file(target: FileTarget) -> bool:
+    """Hub files (`_X Hub.md`) — relax structural penalties per quality-scan.sh."""
+    name = target.path.name
+    return name.startswith("_") and "Hub" in name
+
+
+def _bullet_ratios_split(body: str) -> tuple[int, int, int, int]:
+    """Front/back half bullet ratios. Returns (front_bullet, back_bullet,
+    front_total, back_total) — total = non-empty lines, bullet =
+    `- ` / `* ` / `N.`."""
+    lines = body.splitlines()
+    n = len(lines)
+    if n == 0:
+        return 0, 0, 0, 0
+    split = (n * 6) // 10  # quality-scan uses 60/40 split
+    front_bullet = back_bullet = front_total = back_total = 0
+    for i, line in enumerate(lines):
+        if not line.strip():
+            continue
+        is_bullet = bool(re.match(r"^(?:[-*]\s|\d+\.\s)", line))
+        if i < split:
+            front_total += 1
+            if is_bullet:
+                front_bullet += 1
+        else:
+            back_total += 1
+            if is_bullet:
+                back_bullet += 1
+    return front_bullet, back_bullet, front_total, back_total
+
+
+def _count_thin_blocks(body: str) -> int:
+    """H2 blocks with < 3 prose lines. Mirrors quality-scan.sh dim 13."""
+    thin = 0
+    in_block = False
+    prose = 0
+    for line in body.splitlines():
+        if line.startswith("## "):
+            if in_block and prose < 3:
+                thin += 1
+            in_block = True
+            prose = 0
+        elif in_block:
+            if line.strip() and not re.match(r"^(?:[#\-*|>]|\d+\.)", line):
+                prose += 1
+    if in_block and prose < 3:
+        thin += 1
+    return thin
+
+
+def _prose_ratios_split(body: str) -> tuple[int, int, int, int]:
+    """Front/back half prose ratios for QUALITY-DECAY detection."""
+    lines = body.splitlines()
+    n = len(lines)
+    split = (n * 6) // 10
+    fp = bp = fa = ba = 0
+    for i, line in enumerate(lines):
+        if i < split:
+            fa += 1
+            if line.strip() and not re.match(r"^(?:[#\-*|>]|\d+\.)", line):
+                fp += 1
+        else:
+            ba += 1
+            if line.strip() and not re.match(r"^(?:[#\-*|>]|\d+\.)", line):
+                bp += 1
+    return fp, bp, fa, ba
+
+
 def _word_count(body: str) -> int:
     """Rough whitespace-tokenized count after frontmatter (CJK 1 char = 1 word).
 
@@ -348,6 +416,56 @@ def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
     elif template_h2 >= 2:
         score += 1
         reasons.append(f"萬用H2×{template_h2}")
+
+    # ── 12. LIST-DUMP (back-half bullet density disproportionate to front) ──
+    is_hub = _is_hub_file(target)
+    front_b, back_b, front_t, back_t = _bullet_ratios_split(body)
+    if front_t > 0 and back_t > 0:
+        front_ratio = front_b * 100 // front_t
+        back_ratio = back_b * 100 // back_t
+        if is_hub:
+            # Hub pages naturally back-heavy index lists — relaxed
+            if back_ratio > 60 and back_ratio > front_ratio * 3:
+                score += 1
+                reasons.append(f"後段清單堆砌{back_ratio}%(Hub)")
+        else:
+            if back_ratio > 40 and back_ratio > front_ratio * 2:
+                score += 3
+                reasons.append(f"後段清單堆砌{back_ratio}%")
+            elif back_ratio > 30:
+                score += 2
+                reasons.append(f"後段清單堆砌{back_ratio}%")
+
+    # ── 13. THIN (H2 blocks with < 3 prose lines) ──
+    thin = _count_thin_blocks(body)
+    if is_hub:
+        if thin >= 4:
+            score += 1
+            reasons.append(f"稀薄段落×{thin}(Hub)")
+    else:
+        if thin >= 2:
+            score += 2
+            reasons.append(f"稀薄段落×{thin}")
+        elif thin >= 1:
+            score += 1
+            reasons.append(f"稀薄段落×{thin}")
+
+    # ── 14. QUALITY-DECAY (front prose ratio >> back prose ratio) ──
+    fp, bp, fa, ba = _prose_ratios_split(body)
+    if fa > 0 and ba > 0:
+        front_pr = fp * 100 // fa
+        back_pr = bp * 100 // ba
+        if is_hub:
+            if back_pr < front_pr // 4:
+                score += 1
+                reasons.append(f"品質衰退前{front_pr}%後{back_pr}%(Hub)")
+        elif front_pr > 0:
+            if back_pr < front_pr // 2:
+                score += 3
+                reasons.append(f"品質衰退前{front_pr}%後{back_pr}%")
+            elif back_pr < (front_pr * 7) // 10:
+                score += 1
+                reasons.append(f"品質衰退前{front_pr}%後{back_pr}%")
 
     # ── 16. Citation desert ──
     fn_defs = _count_footnote_defs(body)

--- a/scripts/tools/lib/article_health/checks/terminology.py
+++ b/scripts/tools/lib/article_health/checks/terminology.py
@@ -1,0 +1,105 @@
+"""terminology — China-term detection (audit O5 / quality-scan §15).
+
+Reads `data/terminology/.china-terms.detection.tsv` (auto-generated from
+data/terminology/*.yaml) and flags A-severity terms in body. B-severity
+terms are reported as INFO (potentially ambiguous, not penalized).
+
+Severity (per quality-scan.sh §15):
+  A: red — Taiwan-side prose should always swap (HARD)
+  B: yellow — context-dependent ambiguity (INFO)
+
+False-positive corrections via `.china-terms.false-positives.tsv` —
+e.g. `博客來` (Bookstore name) reduces `博客` count by N.
+
+Skipped if TSV files don't exist (graceful).
+"""
+
+from __future__ import annotations
+from pathlib import Path
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "terminology"
+DIMENSION = "language"
+DEFAULT_SEVERITY = Severity.HARD
+EDITORIAL_REF = "TERMINOLOGY.md + quality-scan §15"
+APPLIES_TO = ["zh-TW"]
+
+
+def _load_detection() -> list[tuple[str, str, str, str]]:
+    """Load (cterm, severity, taiwan, fork_type) tuples from TSV."""
+    path = Path("data/terminology/.china-terms.detection.tsv")
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        cterm = parts[0].strip()
+        severity = parts[1].strip()
+        taiwan = parts[2].strip() if len(parts) > 2 else ""
+        fork = parts[3].strip() if len(parts) > 3 else ""
+        if cterm and severity:
+            out.append((cterm, severity, taiwan, fork))
+    return out
+
+
+def _load_false_positives() -> dict[str, list[str]]:
+    """cterm → list of false-positive patterns."""
+    path = Path("data/terminology/.china-terms.false-positives.tsv")
+    if not path.exists():
+        return {}
+    fp: dict[str, list[str]] = {}
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split("\t")
+        if len(parts) < 2:
+            continue
+        cterm = parts[0].strip()
+        pattern = parts[1].strip()
+        if cterm and pattern:
+            fp.setdefault(cterm, []).append(pattern)
+    return fp
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    detection = _load_detection()
+    false_positives = _load_false_positives()
+    if not detection:
+        return
+
+    body = target.body
+    for cterm, severity, taiwan, _fork in detection:
+        count = body.count(cterm)
+        if count == 0:
+            continue
+        # Subtract false-positive matches
+        for fp_pat in false_positives.get(cterm, []):
+            count -= body.count(fp_pat)
+        if count <= 0:
+            continue
+
+        suggested = f"建議改用台灣用語：「{taiwan}」" if taiwan else ""
+        if severity == "A":
+            yield Violation(
+                check=CHECK_NAME,
+                severity=Severity.HARD,
+                message=f"中國用語「{cterm}」({count} 處) — {suggested}",
+                fix_suggestion=taiwan or None,
+                editorial_ref=EDITORIAL_REF,
+            )
+        elif severity == "B":
+            yield Violation(
+                check=CHECK_NAME,
+                severity=Severity.INFO,
+                message=(
+                    f"可能歧義「{cterm}」({count} 處) — {suggested}（語境決定）"
+                ),
+                editorial_ref=EDITORIAL_REF,
+            )

--- a/tests/article_health/test_phase9.py
+++ b/tests/article_health/test_phase9.py
@@ -1,0 +1,167 @@
+"""Phase 9 tests: terminology / footnote_url / cross_reference plugins."""
+
+from pathlib import Path
+
+import pytest
+
+from lib.article_health import registry
+from lib.article_health.checks import (
+    cross_reference,
+    footnote_url,
+    terminology,
+)
+from lib.article_health.loader import load_target
+from lib.article_health.types import Severity
+
+
+def _write_article(tmp_path: Path, body: str, name: str = "x.md") -> Path:
+    f = tmp_path / "knowledge" / "Nature" / name
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(
+        f"---\ntitle: x\ndescription: y\ndate: 2026-05-04\ntags: [t]\n---\n\n{body}",
+        encoding="utf-8",
+    )
+    return f
+
+
+# ════════════════════════════════════════════════════════════════════════
+# terminology plugin
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_terminology_no_tsv_skips(tmp_path, monkeypatch):
+    """Without TSV files, plugin yields nothing (graceful)."""
+    monkeypatch.chdir(tmp_path)
+    target = load_target(_write_article(tmp_path, "視頻 段落"))
+    violations = list(terminology.check(target, {}))
+    assert violations == []
+
+
+def test_terminology_severity_a_hard(tmp_path, monkeypatch):
+    """A-severity term yields HARD violation."""
+    monkeypatch.chdir(tmp_path)
+    tsv = tmp_path / "data" / "terminology" / ".china-terms.detection.tsv"
+    tsv.parent.mkdir(parents=True)
+    tsv.write_text(
+        "# header\n視頻\tA\t影片\tlexical\n", encoding="utf-8"
+    )
+    target = load_target(_write_article(tmp_path, "他在視頻中說了一些話"))
+    violations = list(terminology.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.HARD
+    assert violations[0].fix_suggestion == "影片"
+
+
+def test_terminology_severity_b_info(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    tsv = tmp_path / "data" / "terminology" / ".china-terms.detection.tsv"
+    tsv.parent.mkdir(parents=True)
+    tsv.write_text("人設\tB\t形象\tlexical\n", encoding="utf-8")
+    target = load_target(_write_article(tmp_path, "他的人設是這樣的"))
+    violations = list(terminology.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.INFO
+
+
+def test_terminology_false_positive_subtracts(tmp_path, monkeypatch):
+    """False-positive pattern subtracts from count."""
+    monkeypatch.chdir(tmp_path)
+    tsv_dir = tmp_path / "data" / "terminology"
+    tsv_dir.mkdir(parents=True)
+    (tsv_dir / ".china-terms.detection.tsv").write_text(
+        "博客\tA\t部落格\tlexical\n", encoding="utf-8"
+    )
+    (tsv_dir / ".china-terms.false-positives.tsv").write_text(
+        "博客\t博客來\n", encoding="utf-8"
+    )
+    # Article has 「博客來」 (FP) once and standalone 「博客」 zero times
+    body = "在博客來書店買了一本書"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(terminology.check(target, {}))
+    # 1 「博客」 (in 博客來) - 1 FP = 0 → no violation
+    assert violations == []
+
+
+# ════════════════════════════════════════════════════════════════════════
+# footnote-url plugin
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_footnote_url_default_skipped(tmp_path):
+    """Network-bound check skipped by default."""
+    body = "段落[^1]\n\n[^1]: [src](https://example.com) — desc enough chars"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(footnote_url.check(target, {}))
+    assert violations == []
+
+
+def test_footnote_url_enabled_via_config(tmp_path, monkeypatch):
+    """When config enables network, plugin attempts HEAD."""
+    body = "段落[^1]\n\n[^1]: [src](https://this-domain-does-not-exist-12345.invalid) — desc"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(footnote_url.check(target, {"network": True}))
+    # Invalid domain should yield a warning
+    assert len(violations) >= 1
+    assert violations[0].severity == Severity.WARN
+
+
+def test_footnote_url_env_var_enables(tmp_path, monkeypatch):
+    monkeypatch.setenv("ARTICLE_HEALTH_NETWORK", "1")
+    body = "段落[^1]\n\n[^1]: [src](https://this-bad-12345.invalid) — desc enough"
+    target = load_target(_write_article(tmp_path, body))
+    violations = list(footnote_url.check(target, {}))
+    assert len(violations) >= 1
+
+
+# ════════════════════════════════════════════════════════════════════════
+# cross-reference plugin
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_cross_ref_symmetric_passes(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cross_reference._reset_cache()
+    # A links to B, B links to A — symmetric
+    a = tmp_path / "knowledge" / "Nature" / "A.md"
+    a.parent.mkdir(parents=True)
+    a.write_text(
+        "---\ntitle: A\n---\n參考 [[B]] 結尾", encoding="utf-8"
+    )
+    b = tmp_path / "knowledge" / "Nature" / "B.md"
+    b.write_text(
+        "---\ntitle: B\n---\n參考 [[A]] 結尾", encoding="utf-8"
+    )
+    target = load_target(a)
+    violations = list(cross_reference.check(target, {}))
+    assert violations == []
+
+
+def test_cross_ref_asymmetric_info(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cross_reference._reset_cache()
+    # A links to B, B doesn't link back
+    a = tmp_path / "knowledge" / "Nature" / "A.md"
+    a.parent.mkdir(parents=True)
+    a.write_text(
+        "---\ntitle: A\n---\n參考 [[B]] 結尾", encoding="utf-8"
+    )
+    b = tmp_path / "knowledge" / "Nature" / "B.md"
+    b.write_text("---\ntitle: B\n---\n沒有連回", encoding="utf-8")
+    target = load_target(a)
+    violations = list(cross_reference.check(target, {}))
+    assert len(violations) == 1
+    assert violations[0].severity == Severity.INFO
+    assert "[[B]]" in violations[0].message
+
+
+# ════════════════════════════════════════════════════════════════════════
+# Plugin registration
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_phase9_plugins_registered():
+    registry.reset_registry()
+    found = registry.discover_checks()
+    assert "terminology" in found
+    assert "footnote-url" in found
+    assert "cross-reference" in found

--- a/tests/article_health/test_prose_health.py
+++ b/tests/article_health/test_prose_health.py
@@ -279,6 +279,56 @@ def test_tier3_ritual_phrases(tmp_path):
 
 
 # ════════════════════════════════════════════════════════════════════════
+# Phase 4b dims: LIST-DUMP / THIN / QUALITY-DECAY
+# ════════════════════════════════════════════════════════════════════════
+
+
+def test_list_dump_back_half_bullet_heavy(tmp_path):
+    """Back half bullet ratio > 40% AND > 2x front → +3 score."""
+    front = "\n".join([
+        "這是 1916 年的一段散文敘述",
+        "1994 年另一段研究發現",
+        "2024 年最近的紀錄",
+        "更多的散文敘述",
+    ] * 4)  # 16 lines, 0 bullets
+    back = "\n".join([
+        "- bullet item 1",
+        "- bullet item 2",
+        "- bullet item 3",
+        "- bullet item 4",
+    ] * 4)  # 16 lines, 100% bullets
+    body = front + "\n\n" + back
+    body += "\n\n[^1]: [src](https://e.com) — desc enough chars"
+    score = _score(_check(tmp_path, body))
+    assert score >= 2, f"LIST-DUMP should add ≥ +2 score, got {score}"
+
+
+def test_thin_blocks_detected(tmp_path):
+    body = textwrap.dedent(
+        """\
+        > **30 秒概覽**: x
+
+        ## 段落一
+
+        只有一行散文 1916 年。
+
+        ## 段落二
+
+        只有一行散文 1994 年。
+
+        ## 段落三
+
+        只有一行散文 2024 年。
+
+        [^1]: [src](https://e.com) — desc enough chars
+        """
+    ) + "\n".join(["延伸"] * 8)
+    score = _score(_check(tmp_path, body))
+    # 3 thin blocks → at minimum +1 score on top of other dims
+    assert score >= 2
+
+
+# ════════════════════════════════════════════════════════════════════════
 # Score budget
 # ════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Completes the Phase 4b deferred dimensions + adds 3 plugins flagged as future work in the SSOT design doc.

## What's in

### prose-health: +3 dimensions
- LIST-DUMP (#12): back-half bullet ratio > 40% AND > 2× front
- THIN (#13): H2 blocks with < 3 prose lines
- QUALITY-DECAY (#14): front prose ratio >> back ratio
- Hub pages get relaxed thresholds (preserves quality-scan.sh logic)

### New plugins
- **terminology** (CHINA-TERM dim #15): reads `data/terminology/.china-terms.detection.tsv`. A=HARD, B=INFO, false-positives subtract.
- **footnote-url**: HEAD reachability check. **Network-bound, opt-in only** (`--check=footnote-url` or `network=true` config or `ARTICLE_HEALTH_NETWORK=1` env). Avoids pre-commit slowdown.
- **cross-reference**: bidirectional 延伸閱讀 / wikilink reciprocity (Stage 5). INFO-level. Session-cached inverse-link index.

## Plugin registry: 8 → 11 plugins

cjk-punct / cross-reference / footnote-density / footnote-format / footnote-url / format-structure / frontmatter-title / image-health / prose-health / terminology / wikilink-target

## Test plan

- [x] `python3 -m pytest tests/article_health -q` → 147/147 (+12 from Phase 8)
- [x] `python3 scripts/tools/article-health.py --list-checks` → 11 plugins
- [x] `python3 scripts/tools/article-health.py knowledge/Nature/黃魚鴞.md` runs all 11 plugins; current article passes
- [x] Pre-commit hook unchanged (legacy gate canonical, SSOT shadow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)