### PR TITLE
fix(ui): resolve share icons overlapping with external link arrow

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -376,7 +376,9 @@
   main
     a[target='_blank']:not(.nav-link):not([class*='btn']):not(.card-link):not(
       .logo
-    ):not(.category-card):not(.floating-md):not(.contributor-card)::after {
+    ):not(.category-card):not(.floating-md):not(.contributor-card):not(
+      .no-external-icon
+    )::after {
     content: '↗';
     font-size: 0.8em;
     margin-left: 0.2em;

--- a/src/templates/article.template.astro
+++ b/src/templates/article.template.astro
@@ -653,7 +653,7 @@ const encodedTitle = encodeURIComponent(title);
               href={`https://twitter.com/intent/tweet?text=${encodedTitle}&url=${encodedUrl}`}
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full border-none bg-[rgba(26,60,52,0.06)] text-[#1a3c34] no-underline transition-[background,color] duration-200 hover:bg-[#1a3c34] hover:text-[#f8f1e9]"
+              class="no-external-icon inline-flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full border-none bg-[rgba(26,60,52,0.06)] text-[#1a3c34] no-underline transition-[background,color] duration-200 hover:bg-[#1a3c34] hover:text-[#f8f1e9]"
               aria-label={t('article.sidebar.shareX')}
             >
               <svg
@@ -670,7 +670,7 @@ const encodedTitle = encodeURIComponent(title);
               href={`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`}
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full border-none bg-[rgba(26,60,52,0.06)] text-[#1a3c34] no-underline transition-[background,color] duration-200 hover:bg-[#1a3c34] hover:text-[#f8f1e9]"
+              class="no-external-icon inline-flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full border-none bg-[rgba(26,60,52,0.06)] text-[#1a3c34] no-underline transition-[background,color] duration-200 hover:bg-[#1a3c34] hover:text-[#f8f1e9]"
               aria-label={t('article.sidebar.shareFacebook')}
             >
               <svg
@@ -687,7 +687,7 @@ const encodedTitle = encodeURIComponent(title);
               href={`https://social-plugins.line.me/lineit/share?url=${encodedUrl}`}
               target="_blank"
               rel="noopener noreferrer"
-              class="inline-flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full border-none bg-[rgba(26,60,52,0.06)] text-[#1a3c34] no-underline transition-[background,color] duration-200 hover:bg-[#1a3c34] hover:text-[#f8f1e9]"
+              class="no-external-icon inline-flex h-[34px] w-[34px] cursor-pointer items-center justify-center rounded-full border-none bg-[rgba(26,60,52,0.06)] text-[#1a3c34] no-underline transition-[background,color] duration-200 hover:bg-[#1a3c34] hover:text-[#f8f1e9]"
               aria-label={t('article.sidebar.shareLine')}
             >
               <svg


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修正文章底部分享圖示（X, Facebook, Line）與全域外部連結箭頭樣式衝突的問題。

在圓形分享按鈕中加入了 `no-external-icon` 類別，並在 `global.css` 中排除此類別的 `::after` 偽元素，以解決圖示右上方出現多餘「↗」箭頭導致的破版現象。

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）

## ✅ 自我檢查

- [x] 文章有完整的 frontmatter
- [x] `category` 用英文 + 對齊路徑
- [x] `author: 'Taiwan.md Contributors'`
- [x] `featured: false`
- [x] **腳註用 canonical 格式**
- [x] 內容有附上可查證的參考資料來源
- [x] 沒有抄襲或版權問題
- [x] 在本地 build 測試通過

## 🎨 如果動到樣式（非內容 PR 才需要）

- [x] 沒有 hardcode 新的 hex color
- [x] 優先 inline Tailwind 工具類
- [x] 沒有新增 `@layer components`、`@apply`、或 `@theme` bridge
- [x] 如果刪掉 class 的 markup，同一個 commit 也把對應 scoped rule 刪掉

## 📸 截圖（如果是視覺改動）

修復前：分享圖示右上角有「↗」符號，且圖示被壓縮/移位。
修復後：分享圖示恢復乾淨圓形，不再顯示外部連結箭頭。