### PR TITLE
🧬 [semiont] fix: refresh-data.sh Phase 0 — cwd + auto-stash + integer steps

### DIFF
--- a/docs/pipelines/DATA-REFRESH-PIPELINE.md
+++ b/docs/pipelines/DATA-REFRESH-PIPELINE.md
@@ -28,20 +28,31 @@
 bash scripts/tools/refresh-data.sh
 ```
 
-這個 wrapper 依序跑下面 **8 個步驟**（5 主階段 + 3 子階段 2.5/2.8/2.9）。任何一步失敗會 stderr 警告但不 abort pipeline（git pull conflict 例外 — hard abort）。
+這個 wrapper 依序跑下面 **12 個步驟**（Phase 0 SSOT cleanup 後 2026-05-08 整數化編號）。
 
-**Step 5（verify dashboard freshness）** 是 2026-05-02 γ-late 加的閘門 — 跑完後檢查每個 `public/api/dashboard-*.json` 都有今天的 mtime。任何 stale 表示有 generator 漏跑（DNA #43）。
+**失敗策略**：
 
-| Step    | 內容                                                     | Output                                                       |
-| ------- | -------------------------------------------------------- | ------------------------------------------------------------ |
-| 1       | git pull --rebase origin main                            | (sync)                                                       |
-| 2       | fetch-sense-data.sh                                      | dashboard-analytics.json                                     |
-| 2.5     | sync-translations-json.py                                | knowledge/\_translations.json                                |
-| 2.8     | generate-dashboard-spores.py                             | dashboard-spores.json                                        |
-| **2.9** | **i18n-coverage-audit.sh --json-out** ★ 2026-05-02 added | **dashboard-i18n.json**                                      |
-| 3       | npm run prebuild                                         | dashboard-articles/translations/vitals/organism + supporters |
-| 4       | update-stats.sh                                          | README + stats.json                                          |
-| **5**   | **verify dashboard freshness** ★ 2026-05-02 added        | (gate)                                                       |
+- cwd 不在 git toplevel → auto cd（防 worktree vs main repo 混淆）
+- working tree dirty → auto-stash + pop（不再 silent skip pull）
+- git pull 真失敗 → hard abort（人類介入）
+- 任何資料源失敗 → soft skip，心跳繼續用昨天的 cache
+
+**Step 11（verify dashboard freshness）** 是 2026-05-02 γ-late 加的閘門 — 跑完後檢查每個 `public/api/dashboard-*.json` 都有今天的 mtime。任何 stale 表示有 generator 漏跑（DNA #43）。
+
+| Step   | 內容                                          | Output                                                       |
+| ------ | --------------------------------------------- | ------------------------------------------------------------ |
+| 1      | git sync (auto-stash + rebase pull)           | (sync)                                                       |
+| 2      | fetch-sense-data.sh                           | dashboard-analytics.json                                     |
+| 3      | sync-translations-json.py                     | knowledge/\_translations.json                                |
+| 4      | extract-spore-metrics.py (Phase 4 候選移除)   | SPORE-LOG struct columns                                     |
+| 5      | generate-dashboard-spores.py                  | dashboard-spores.json                                        |
+| 6      | i18n-coverage-audit.sh                        | dashboard-i18n.json                                          |
+| 7      | npm run prebuild                              | dashboard-articles/translations/vitals/organism + supporters |
+| 8      | refresh-llms-txt.py                           | public/llms.txt                                              |
+| 9      | update-stats.sh                               | README + stats.json                                          |
+| 10     | extract-build-perf.mjs                        | dashboard-build-perf.json                                    |
+| **11** | **verify dashboard freshness** (DNA #43 gate) | (mtime gate)                                                 |
+| **12** | **validate-spore-data.py**                    | (SSOT consistency gate)                                      |
 
 ---
 
@@ -50,13 +61,27 @@ bash scripts/tools/refresh-data.sh
 ### Step 1 — Git 同步（sync with origin）
 
 ```bash
-cd /Users/cheyuwu/Projects/taiwan-md
+# auto cwd assertion (Phase 0)
+cd "$(git rev-parse --show-toplevel)"
+
+# auto-stash if dirty
+[ -n "$(git status --porcelain)" ] && git stash push -m "refresh-data-auto-$(date +%s)" --include-untracked
+
+# always attempt pull
 git pull --rebase origin main
+
+# auto-pop stash
+git stash pop  # if stashed
 ```
 
 **為什麼**：心跳必須在最新 main 上跑，否則會把舊狀態誤診成「今天的 baseline」。另外，scheduled-tasks 在使用者睡覺時跑，此時可能有別的 session 已經 push 過東西。
 
-**如果失敗**：有 unstaged 變更 → stash；有 merge conflict → abort pipeline 並在報告裡標記「需要人類介入」。
+**Phase 0 改動（2026-05-08 laughing-goldstine）**：
+
+- **cwd assertion**：過去從 main repo 路徑跑 worktree pipeline 會寫 stale dashboard，現在強制 cd 到 git toplevel。
+- **改 auto-stash**：過去 `git diff-index --quiet HEAD --` 在 clean worktree 仍會回非零（filemode bits / submodule / index lock），導致 silent skip pull。現在 dirty 也跑 stash + pull + pop，pull 失敗才 hard abort。
+
+**如果失敗**：merge conflict / detached HEAD / network 失敗 → hard abort 並標記「需要人類介入」。stash pop conflict → 警告但繼續，local changes 留在 `git stash list` 等手動處理。
 
 ---
 
@@ -182,16 +207,14 @@ ls -l \
 
 ## scripts/tools/refresh-data.sh（wrapper 本體）
 
+完整實作見 [`scripts/tools/refresh-data.sh`](../../scripts/tools/refresh-data.sh)（避免文件 vs 程式碼 drift）。
+
+舊版（Phase 0 前，2026-04-11 → 2026-05-08）參考：
+
 ```bash
 #!/usr/bin/env bash
-# refresh-data.sh — 心跳用的單一資料刷新入口
-# 依序執行 git pull → fetch-sense-data → npm prebuild → update-stats
-# 每一步 soft-fail（除了 git pull conflict）
-#
-# Called by:
-#   - HEARTBEAT.md Beat 1 (via "執行 資料更新 pipeline")
-#   - ~/.claude/scheduled-tasks/semiont-heartbeat/SKILL.md (daily 09:37)
-#   - .claude/skills/heartbeat/SKILL.md (/heartbeat command)
+# DEPRECATED — see scripts/tools/refresh-data.sh for current 12-step pipeline
+# 此 snippet 只保留歷史參照（git-dirty silent skip bug 的 footprint）
 
 set -o pipefail
 cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
@@ -203,6 +226,8 @@ echo -e "${GRN}🧬 資料更新 Pipeline${RST}"
 echo -e "${DIM}═══════════════════════════════════${RST}"
 
 # Step 1 — git sync (HARD ABORT on conflict)
+# ⚠️ Phase 0 修掉的 bug: git diff-index --quiet HEAD -- 在 clean worktree 仍會回非零
+# → silent skip pull → stale dashboard data
 echo -e "${GRN}[1/4]${RST} Git sync..."
 if git diff-index --quiet HEAD -- 2>/dev/null; then
   git pull --rebase origin main 2>&1 | tail -5
@@ -276,6 +301,7 @@ echo -e "${DIM}下一步：HEARTBEAT.md Beat 1 診斷${RST}"
 
 _v1.0 | 2026-04-11 session ε | 建立原因：哲宇觀察到 heartbeat 三處重複定義資料抓取步驟_
 _v1.1 | 2026-05-02 γ-late | 加 Step 2.9 (i18n-coverage) + Step 5 (verify freshness)。觸發：哲宇看 dashboard 顯示「資料更新 12 小時前」+ ja UI 還是 97%（其實已 100%），原因是 i18n-coverage-audit 沒在 refresh-data.sh 裡。canonical: DNA #43 silent stale risk._
+_v1.2 | 2026-05-08 laughing-goldstine | Phase 0 SSOT cleanup — cwd assertion + auto-stash 取代 silent skip pull + 步驟編號 1-12 整數化。觸發：/twmd-refresh 從 main repo 路徑跑 worktree pipeline 寫 stale dashboard，加上 git-dirty false positive 雙 bug。canonical: reports/spore-ssot-pipeline-cleanup-2026-05-08.md Phase 0._
 
 ## 新 dashboard JSON 加入 pipeline 的 SOP（DNA #43 反射）
 

--- a/scripts/tools/refresh-data.sh
+++ b/scripts/tools/refresh-data.sh
@@ -1,31 +1,54 @@
 #!/usr/bin/env bash
 # refresh-data.sh — 心跳用的單一資料刷新入口
 #
-# 依序執行：
-#   1.   git pull --rebase origin main             (hard abort on conflict)
-#   2.   fetch-sense-data.sh                        (CF + GA4 + SC + dashboard-analytics merger)
-#   2.5. sync-translations-json.py                  (sync _translations.json from frontmatter SSOT)
-#   2.8. generate-dashboard-spores.py               (spore dashboard from SPORE-LOG)
-#   2.9. i18n-coverage-audit.sh --json-out          (UI string coverage dashboard) ← 2026-05-02 added
-#   3.   npm run prebuild                           (dashboard-vitals/organism/articles/translations)
-#   4.   update-stats.sh                            (README + stats.json)
-#   5.   verify-dashboard-freshness                 (check all dashboard-*.json mtime today) ← 2026-05-02 added
+# 12 個步驟（Phase 0 SSOT cleanup 後 2026-05-08 重整）：
+#    1. Git sync                            (auto-stash + pull, hard abort on failure)
+#    2. fetch-sense-data.sh                 (CF + GA4 + SC + dashboard-analytics merge)
+#    3. sync-translations-json.py           (sync _translations.json from frontmatter SSOT)
+#    4. extract-spore-metrics.py            (narrative → struct columns; Phase 4 移除候選)
+#    5. generate-dashboard-spores.py        (spore dashboard from SPORE-LOG)
+#    6. i18n-coverage-audit.sh              (UI string coverage dashboard)
+#    7. npm run prebuild                    (dashboard-vitals/organism/articles/translations)
+#    8. refresh-llms-txt.py                 (sync llms.txt content stats)
+#    9. update-stats.sh                     (README + stats.json)
+#   10. extract-build-perf.mjs              (build perf trend dashboard)
+#   11. verify dashboard freshness          (mtime gate, DNA #43)
+#   12. validate-spore-data.py              (SSOT consistency check)
 #
 # 失敗策略：
-#   - git 層級失敗 → hard abort（需人類介入）
-#   - 任何資料源失敗 → soft skip，心跳繼續用昨天的 cache
+#   - cwd 不在 git toplevel  → auto cd
+#   - working tree dirty    → auto stash + pop（不再 skip pull）
+#   - git pull 真失敗       → hard abort（需人類介入）
+#   - 任何資料源失敗         → soft skip，心跳繼續用昨天的 cache
 #
 # 呼叫者：
 #   - HEARTBEAT.md Beat 1（「執行 資料更新 pipeline」）
 #   - ~/.claude/scheduled-tasks/semiont-heartbeat/SKILL.md（每日 09:37）
 #   - .claude/skills/heartbeat/SKILL.md（/heartbeat 命令）
+#   - .claude/skills/twmd-refresh/SKILL.md（/twmd-refresh 命令）
 #
 # 詳見：docs/pipelines/DATA-REFRESH-PIPELINE.md
 # 2026-04-11 session ε 建造
-# 2026-05-02 γ-late: 加 Step 2.9 i18n-coverage + Step 5 verify (DNA #43 — silent stale risk)
+# 2026-05-02 γ-late: 加 i18n-coverage + verify freshness (DNA #43)
+# 2026-05-08 laughing-goldstine: Phase 0 SSOT cleanup
+#   - cwd assertion（防 main repo 跑 worktree 跑混淆）
+#   - git-dirty 改 auto-stash（不再 silent skip pull）
+#   - 步驟編號 1-12 整數化（移除 2.5/2.7/2.8/2.9/3.5/4.5/5.5 decimals）
 
 set -o pipefail
-cd "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# ────────────────── cwd assertion (Phase 0) ──────────────────
+# 過去 bug: 從 main repo 路徑跑 pipeline 時 worktree 落後 N 個 commit
+# → 寫 stale dashboard JSON → 報錯 OVERDUE 數字
+TOPLEVEL="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$TOPLEVEL" ]; then
+  echo "❌ Not in a git repo — refresh-data.sh requires git toplevel" >&2
+  exit 2
+fi
+if [ "$(pwd)" != "$TOPLEVEL" ]; then
+  cd "$TOPLEVEL"
+  echo "ℹ️ cd → $TOPLEVEL"
+fi
 
 GRN='\033[0;32m'
 YEL='\033[0;33m'
@@ -35,27 +58,53 @@ RST='\033[0m'
 
 echo -e "${DIM}═══════════════════════════════════${RST}"
 echo -e "${GRN}🧬 資料更新 Pipeline${RST}"
+echo -e "${DIM}   $(git rev-parse --abbrev-ref HEAD) @ $(git rev-parse --short HEAD)${RST}"
 echo -e "${DIM}═══════════════════════════════════${RST}"
 echo ""
 
-# Step 1 — git sync (HARD ABORT on conflict)
-echo -e "${GRN}[1/5]${RST} Git sync..."
-if git diff-index --quiet HEAD -- 2>/dev/null; then
-  if git pull --rebase origin main 2>&1 | tail -5; then
-    echo -e "${DIM}   ✓ up to date with origin/main${RST}"
+# ────────────────── Step 1 — Git sync ──────────────────
+# Phase 0 重寫: 不再 silent skip pull on dirty
+# - working tree dirty → auto-stash + pop
+# - git pull 真失敗     → hard abort
+echo -e "${GRN}[1/12]${RST} Git sync..."
+
+DIRTY=0
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=1
+  STASH_LABEL="refresh-data-auto-$(date +%s)"
+  if git stash push -m "$STASH_LABEL" --include-untracked >/dev/null 2>&1; then
+    echo -e "${DIM}   stashed local changes ($STASH_LABEL)${RST}"
   else
-    echo -e "${RED}❌ git pull failed — aborting pipeline${RST}"
-    echo -e "${YEL}   人類介入：檢查 merge conflict / detached HEAD${RST}"
+    echo -e "${RED}❌ stash failed — aborting pipeline${RST}"
     exit 2
   fi
-else
-  echo -e "${YEL}⚠️  working tree dirty — skipping git pull${RST}"
-  echo -e "${DIM}   心跳繼續，但注意：可能在舊 base 上診斷${RST}"
 fi
+
+PULL_OK=1
+if ! git pull --rebase origin main 2>&1 | tail -5; then
+  PULL_OK=0
+fi
+
+if [ "$DIRTY" = "1" ]; then
+  if git stash pop >/dev/null 2>&1; then
+    echo -e "${DIM}   restored stashed changes${RST}"
+  else
+    echo -e "${YEL}⚠️ stash pop conflict — local changes still in 'git stash list' (label: $STASH_LABEL)${RST}"
+    echo -e "${YEL}   manual fix: git stash pop / git stash drop${RST}"
+  fi
+fi
+
+if [ "$PULL_OK" = "0" ]; then
+  echo -e "${RED}❌ git pull failed — aborting pipeline${RST}"
+  echo -e "${YEL}   人類介入：檢查 merge conflict / detached HEAD / network${RST}"
+  exit 2
+fi
+echo -e "${DIM}   ✓ HEAD now $(git rev-parse --short HEAD)${RST}"
 echo ""
 
-# Step 2 — three-source sense fetch (soft fail)
-echo -e "${GRN}[2/5]${RST} 三源感知抓取..."
+# ────────────────── Step 2 — three-source sense fetch ──────────────────
+# Soft fail: 任何 source 失敗用昨天 cache
+echo -e "${GRN}[2/12]${RST} 三源感知抓取..."
 if bash scripts/tools/fetch-sense-data.sh 2>&1 | grep -E '^\[|^   [✅⚠️❌]|^📁|^[✅⚠️❌]' | tail -20; then
   true
 else
@@ -63,23 +112,20 @@ else
 fi
 echo ""
 
-# Step 2.5 — sync _translations.json from translatedFrom frontmatter (SSOT)
+# ────────────────── Step 3 — sync _translations.json from translatedFrom frontmatter ──────────────────
 # 為什麼: file-level translatedFrom 是 SSOT，_translations.json 是 derived cache
-echo -e "${GRN}[2.5/5]${RST} sync _translations.json from frontmatter..."
+echo -e "${GRN}[3/12]${RST} sync _translations.json from frontmatter..."
 if python3 scripts/tools/sync-translations-json.py 2>&1 | tail -3; then
   echo -e "${DIM}   ✓ _translations.json synced${RST}"
 fi
 echo ""
 
-# Step 2.7 — extract structured metrics from SPORE-LOG narrative SSOT (2026-05-03 SSOT)
-# 為什麼: 「最後 harvest」column 是 narrative SSOT（人類寫進 D+7/D+30 數字），但
-# 「7d 觸及/互動」/「30d 觸及/互動」 structured columns 沒 auto-derive → dashboard
-# generator 看 structured 列為主，narrative 寫對了仍判 OVERDUE / rate=null。
-# 本 step auto-parse narrative → fill structured columns，讓 SSOT 跟 derived 同步。
-# DNA #15「反覆浮現要儀器化」第 N+5 次 instantiation。
-# 觸發：5/3 dashboard 顯示 #45 #53 65K views 但 — Rate 互動，且 OVERDUE flag false
-# alarm — 即使 SPORE-LOG narrative 已有完整 D+7 backfill。
-echo -e "${GRN}[2.7/5]${RST} extract structured spore metrics from narrative..."
+# ────────────────── Step 4 — extract structured spore metrics ──────────────────
+# 為什麼: 「最後 harvest」column 是 narrative SSOT，「7d 觸及」等 structured columns
+# 沒 auto-derive → dashboard generator 看 structured 列為主，narrative 寫對了仍判 OVERDUE。
+# DNA #15「反覆浮現要儀器化」第 N+5 instantiation。
+# Phase 4 候選: 等 Spore SSOT 重構完成後此 step + extract-spore-metrics.py 一起移除
+echo -e "${GRN}[4/12]${RST} extract structured spore metrics from narrative..."
 if python3 scripts/tools/extract-spore-metrics.py --apply 2>&1 | tail -3; then
   echo -e "${DIM}   ✓ structured metrics derived${RST}"
 else
@@ -87,9 +133,9 @@ else
 fi
 echo ""
 
-# Step 2.8 — generate dashboard-spores.json from SPORE-LOG + SPORE-HARVESTS (2026-04-18 δ-late)
-# 為什麼: 繁殖器官的 data-driven 感知；Dashboard 孢子面板的資料源
-echo -e "${GRN}[2.8/5]${RST} generate dashboard-spores.json..."
+# ────────────────── Step 5 — generate dashboard-spores.json ──────────────────
+# 為什麼: 繁殖器官的 data-driven 感知；Dashboard 孢子面板資料源
+echo -e "${GRN}[5/12]${RST} generate dashboard-spores.json..."
 if python3 scripts/tools/generate-dashboard-spores.py 2>&1 | tail -3; then
   echo -e "${DIM}   ✓ dashboard-spores.json generated${RST}"
 else
@@ -97,10 +143,9 @@ else
 fi
 echo ""
 
-# Step 2.9 — generate dashboard-i18n.json from src/i18n/*.ts (2026-05-02 γ-late)
+# ────────────────── Step 6 — generate dashboard-i18n.json ──────────────────
 # 為什麼: UI 字串覆蓋率 dashboard 之前 12 小時 stale，原因是這個生成步驟沒進 refresh pipeline
-# 觸發: 哲宇看 dashboard 發現 ja 顯示 97% 但實際已經 100%（DNA #43）
-echo -e "${GRN}[2.9/5]${RST} generate dashboard-i18n.json (UI string coverage)..."
+echo -e "${GRN}[6/12]${RST} generate dashboard-i18n.json (UI string coverage)..."
 if bash scripts/tools/i18n-coverage-audit.sh --json-out public/api/dashboard-i18n.json 2>&1 | tail -3; then
   echo -e "${DIM}   ✓ dashboard-i18n.json generated${RST}"
 else
@@ -108,8 +153,8 @@ else
 fi
 echo ""
 
-# Step 3 — prebuild dashboard data (soft fail)
-echo -e "${GRN}[3/5]${RST} npm run prebuild..."
+# ────────────────── Step 7 — prebuild dashboard data ──────────────────
+echo -e "${GRN}[7/12]${RST} npm run prebuild..."
 if npm run prebuild > /tmp/prebuild.log 2>&1; then
   tail -6 /tmp/prebuild.log
   echo -e "${DIM}   ✓ dashboard JSON 已重生${RST}"
@@ -120,12 +165,9 @@ fi
 rm -f /tmp/prebuild.log
 echo ""
 
-# Step 3.5 — refresh public/llms.txt content stats (2026-05-04, DNA #43)
-# 為什麼: llms.txt 是 LLM training pipeline 的 robots.txt-equivalent，
-# 內含文章數 / 語言覆蓋 / contributors 等 stat，必須跟 dashboard-vitals 同步。
-# 之前手動維護導致 4/14 snapshot 過時 ~3 週才被外部 reviewer (Grok) 抓到。
-# 純機械 regex replace，<100ms，無 LLM call。
-echo -e "${GRN}[3.5/5]${RST} refresh public/llms.txt content stats..."
+# ────────────────── Step 8 — refresh public/llms.txt content stats ──────────────────
+# 為什麼: llms.txt 是 LLM training pipeline 的 robots.txt-equivalent，必須跟 dashboard-vitals 同步
+echo -e "${GRN}[8/12]${RST} refresh public/llms.txt content stats..."
 if python3 scripts/tools/refresh-llms-txt.py 2>&1 | tail -3; then
   echo -e "${DIM}   ✓ llms.txt 已同步 dashboard-vitals${RST}"
 else
@@ -133,8 +175,8 @@ else
 fi
 echo ""
 
-# Step 4 — GitHub stats (soft fail)
-echo -e "${GRN}[4/5]${RST} GitHub stats..."
+# ────────────────── Step 9 — GitHub stats ──────────────────
+echo -e "${GRN}[9/12]${RST} GitHub stats..."
 if bash scripts/tools/update-stats.sh > /tmp/stats.log 2>&1; then
   tail -5 /tmp/stats.log
   echo -e "${DIM}   ✓ README/stats 已刷新${RST}"
@@ -145,12 +187,9 @@ fi
 rm -f /tmp/stats.log
 echo ""
 
-# Step 4.5 — extract build perf trend (2026-05-03 sleepy-colden, DNA #15 N+6)
-# 為什麼: 12 天內 per-page render time 漲 70%（98ms → 167ms）沒人發現，因為
-# build 效能不在 dashboard freshness check 範圍。本 step 把 GitHub Actions
-# build duration 抓出來、aggregate、寫進 dashboard-build-perf.json，未來
-# regression 在第 3 天而非第 12 天 flag。
-echo -e "${GRN}[4.5/5]${RST} extract build perf trend..."
+# ────────────────── Step 10 — extract build perf trend ──────────────────
+# 為什麼: 12 天內 per-page render time 漲 70%（98ms → 167ms）沒人發現，因為 build 效能不在 dashboard freshness check 範圍
+echo -e "${GRN}[10/12]${RST} extract build perf trend..."
 if node scripts/core/extract-build-perf.mjs --runs 30 2>&1 | tail -5; then
   echo -e "${DIM}   ✓ dashboard-build-perf.json updated${RST}"
 else
@@ -158,11 +197,9 @@ else
 fi
 echo ""
 
-# Step 5 — verify dashboard freshness (2026-05-02 γ-late, DNA #43)
-# 為什麼: refresh-data.sh 只有 invoke generators，沒驗證每個 dashboard JSON 都有今天的 mtime。
-# 結果: 如果某個 generator silent skip / fail / 不在 pipeline 裡，user 看到 12h ago timestamp 才發現。
-# 這條 verify 把每個 public/api/dashboard-*.json 的 mtime 跟今天比，列出 stale 的。
-echo -e "${GRN}[5/5]${RST} verify dashboard freshness..."
+# ────────────────── Step 11 — verify dashboard freshness ──────────────────
+# DNA #43: 每個 public/api/dashboard-*.json 都必須有今天的 mtime，否則 generator 漏跑了
+echo -e "${GRN}[11/12]${RST} verify dashboard freshness..."
 TODAY=$(date +%Y-%m-%d)
 STALE_COUNT=0
 STALE_LIST=""
@@ -183,11 +220,10 @@ else
 fi
 echo ""
 
-# Step 5.5 — spore data SSOT validation (2026-05-03 objective-khorana day 2)
-# 為什麼: dashboard freshness check 只看 mtime，不檢查 spore 解析正確性。
-# 過去發現 generator parser bug (K suffix) silent fail → views_latest=null but mtime fresh.
-# 這條跑 validate-spore-data.py 主動檢查 SPORE-LOG / dashboard JSON 內容一致性。
-echo -e "${GRN}[5.5/6]${RST} spore data SSOT validation..."
+# ────────────────── Step 12 — spore data SSOT validation ──────────────────
+# 為什麼: dashboard freshness 只看 mtime，不檢查 spore 解析正確性
+# 過去 generator parser bug (K suffix) silent fail → views_latest=null but mtime fresh
+echo -e "${GRN}[12/12]${RST} spore data SSOT validation..."
 if python3 scripts/tools/validate-spore-data.py 2>&1 | tail -4 | head -3; then
   echo -e "${DIM}   ✓ spore data validation passed${RST}"
 else


### PR DESCRIPTION
## Summary

Phase 0 of the spore SSOT cleanup ([proposal #903](https://github.com/frank890417/taiwan-md/pull/903)).

修 `refresh-data.sh` 兩個 silent stale 製造機:

### 1. cwd assertion（防 worktree vs main repo 混淆）
過去從 main repo 路徑跑 worktree pipeline 會寫 stale dashboard JSON。現在強制 `cd` 到 `git rev-parse --show-toplevel` + 顯示當前 branch + HEAD short SHA。

### 2. git-dirty false positive 修復（auto-stash 取代 silent skip）
過去 `git diff-index --quiet HEAD --` 在 clean worktree 仍會回非零（filemode bits / submodule / index lock metadata）→ silent skip pull → stale base diagnosis。

新邏輯:
- **dirty** → stash with timestamped label → pull → pop → hard abort if pull fails
- **clean** → just pull
- **stash pop conflict** → warn but continue，local changes 留 `git stash list` 等手動處理

### 3. 步驟編號 1-12 整數化
- 舊: `1, 2, 2.5, 2.7, 2.8, 2.9, 3, 3.5, 4, 4.5, 5, 5.5`（decimal accretion，每次新 step 不敢動既有編號）
- 新: `1-12` decimal-free，未來新 step 直接 renumber

## Test plan

- [x] `bash -n scripts/tools/refresh-data.sh` syntax OK
- [x] Step 1 兩種 scenario (clean / dirty) 各跑一次，stash + pull + pop chain 正確
- [x] 完整 12-step pipeline 端對端跑通，Step 12 spore SSOT validation 0 errors / 0 warnings
- [ ] @frank890417 review

## 範圍

- `scripts/tools/refresh-data.sh` — 重寫 Step 1 + cwd assertion + 整數編號
- `docs/pipelines/DATA-REFRESH-PIPELINE.md` — table + Step 1 prose + changelog v1.2

## 不涉及

- 任何資料層 schema 改動（Phase 1+ 才動）
- generator 行為（Phase 2 才動）
- sporeLinks frontmatter（Phase 3 才動）

## Next phases

依 [proposal #903](https://github.com/frank890417/taiwan-md/pull/903) 5-phase plan:
- Phase 1 — Spore validation 強化 audit
- Phase 2 — Generator 改吃 SPORE-HARVESTS body table
- Phase 3 — sporeLinks 變 derived
- Phase 4 — Demolish deprecated layers (砍 SPORE-LOG 成效追蹤 + extract-spore-metrics.py)
- Phase 5 — 23 個 pipeline doc dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)