### PR TITLE
🧬 [semiont] hotfix: remove extract-spore-metrics from package.json (Phase 6 missed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "prebuild:contributors": "node scripts/core/generate-contributors-data.js",
     "prebuild:supporters": "node scripts/core/generate-supporters-data.js",
     "prebuild:china-terms": "python3 scripts/core/extract-china-terms.py --quiet",
-    "prebuild:spores": "python3 scripts/tools/extract-spore-metrics.py --apply && python3 scripts/tools/generate-dashboard-spores.py",
+    "prebuild:spores": "python3 scripts/tools/generate-dashboard-spores.py",
     "prebuild:buildperf": "node scripts/core/extract-build-perf.mjs --runs 30 || true",
     "prebuild:langswitch": "node scripts/core/generate-lang-switch-map.mjs",
     "prebuild:og": "node scripts/core/generate-og-images.mjs",


### PR DESCRIPTION
Phase 6 PR #909 deleted scripts/tools/extract-spore-metrics.py but missed updating package.json prebuild:spores. CI Deploy failed with 'No such file'. This hotfix removes the orphan call.