### PR TITLE
🧬 [semiont] fix: prepare-batch reuse existing slug for ANY status (slug regression)

### DIFF
--- a/scripts/tools/lang-sync/prepare-batch.py
+++ b/scripts/tools/lang-sync/prepare-batch.py
@@ -184,7 +184,14 @@ def main():
         status = entry["status"]
         category = zh_path.split("/")[0]
 
-        if status == "stale" and entry["en_path_existing"]:
+        # Reuse existing slug for ANY translation that already exists.
+        # Bug fix (2026-05-09 babel-batch2): previously only `stale` status reused existing slug;
+        # `metadata-stale` / other statuses fell through to slug_map / fallback, creating
+        # duplicate-slug files (e.g. 斗笠 → bamboo-hat.md created alongside existing
+        # bamboo-hat-craft.md). The status doesn't matter — if a translation file exists for
+        # this (lang, zh_path) pair, that file's slug is canonical. See PR #921 + reports/
+        # session-id-naming-2026-05-04.md context.
+        if entry["en_path_existing"]:
             en_path = "knowledge/" + entry["en_path_existing"]
             slug = Path(en_path).stem
         else:


### PR DESCRIPTION
## Summary

Fixes slug regression in `prepare-batch.py` that created duplicate-slug translation files for non-\`stale\` statuses.

## Root cause

Line 187 (before fix):
\`\`\`python
if status == "stale" and entry["en_path_existing"]:
    en_path = "knowledge/" + entry["en_path_existing"]
    slug = Path(en_path).stem
else:
    slug = slug_map.get(zh_path)  # falls through for metadata-stale, fresh, etc.
\`\`\`

The reuse path was gated on \`status == "stale"\`. Articles with \`metadata-stale\` status (or any other status with an existing translation file) fell through to slug_map / fallback — creating brand-new slugs alongside the existing canonical translation.

## Failures observed (in-flight 2026-05-09 babel-batch, killed)

| zh_path | status | Existing translation | New slug created (BUG) |
|---------|--------|----------------------|-------------------------|
| Culture/斗笠.md | metadata-stale | bamboo-hat-craft.md | bamboo-hat.md ❌ |
| People/鄭麗文.md | metadata-stale | cheng-li-wun.md | cheng-li-wen.md ❌ |
| History/退出聯合國.md (en) | metadata-stale | withdrawal-from-united-nations.md | un-withdrawal.md ❌ |

## Fix

\`\`\`python
if entry["en_path_existing"]:  # status doesn't matter — file existence does
    en_path = "knowledge/" + entry["en_path_existing"]
    slug = Path(en_path).stem
else:
    ...  # slug_map / fallback only for truly missing translations
\`\`\`

## Validation

\`/tmp/slug-test.txt\` with 3 problem articles → post-fix all map to existing canonical paths:

- 斗笠 → bamboo-hat-craft.md ✅
- 鄭麗文 → cheng-li-wun.md ✅
- 退出聯合國 → withdrawal-from-united-nations.md ✅

## Why this matters

Tier 1 cascade (owl-alpha full re-translate) is invoked for stale + missing + metadata-stale articles. Without this fix, any metadata-stale article entering Tier 1 would create a duplicate file. P2.5 → Tier 0b (PR #921) handles 95%+ of metadata-stale, but the remaining edge cases (langs with missing instead of metadata-stale for the same article) would still hit Tier 1 with the bug.

This unblocks the next P1 Tier 1 batch (running in flight as PR forthcoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)