### PR TITLE
🧬 [semiont] feat: dashboard 翻譯覆蓋 加圖說 legend (color meanings)

### DIFF
--- a/src/i18n/dashboard.ts
+++ b/src/i18n/dashboard.ts
@@ -69,6 +69,12 @@ export const dashboardUI = {
     'dashboard.translation.full': 'Full Coverage',
     'dashboard.translation.growing': 'Growing',
     'dashboard.translation.seedling': 'Seedling',
+    'dashboard.translation.legend.aria': 'Translation status legend',
+    'dashboard.translation.legend.fresh': 'Fresh — up-to-date with zh source',
+    'dashboard.translation.legend.stale': 'Stale — zh source moved forward',
+    'dashboard.translation.legend.missing': 'Missing — no translation yet',
+    'dashboard.translation.legend.format':
+      'translated / stale-or-missing per category',
 
     // Immune System
     'dashboard.immune.title': 'Immune System',
@@ -164,6 +170,11 @@ export const dashboardUI = {
     'dashboard.translation.full': '完全カバレッジ',
     'dashboard.translation.growing': '成長中',
     'dashboard.translation.seedling': '発芽期',
+    'dashboard.translation.legend.aria': '翻訳ステータス凡例',
+    'dashboard.translation.legend.fresh': '最新 — zh ソースと同期済み',
+    'dashboard.translation.legend.stale': '旧版 — zh ソースが先行',
+    'dashboard.translation.legend.missing': '未訳 — まだ翻訳なし',
+    'dashboard.translation.legend.format': '翻訳済 / 未訳・旧版 (カテゴリ別)',
 
     // Immune System
     'dashboard.immune.title': '免疫システム',
@@ -258,6 +269,12 @@ export const dashboardUI = {
     'dashboard.translation.full': '완전 커버리지',
     'dashboard.translation.growing': '성장 중',
     'dashboard.translation.seedling': '싹틔우기',
+    'dashboard.translation.legend.aria': '번역 상태 범례',
+    'dashboard.translation.legend.fresh': '최신 — zh 원본과 동기화됨',
+    'dashboard.translation.legend.stale': '구버전 — zh 원본이 앞섬',
+    'dashboard.translation.legend.missing': '미번역 — 아직 번역 없음',
+    'dashboard.translation.legend.format':
+      '번역됨 / 미번역·구버전 (카테고리별)',
 
     // Immune System
     'dashboard.immune.title': '면역 시스템',
@@ -351,6 +368,11 @@ export const dashboardUI = {
     'dashboard.translation.full': '完整覆蓋',
     'dashboard.translation.growing': '成長中',
     'dashboard.translation.seedling': '萌芽期',
+    'dashboard.translation.legend.aria': '翻譯狀態圖說',
+    'dashboard.translation.legend.fresh': '最新 — 跟中文原文同步',
+    'dashboard.translation.legend.stale': '舊版 — 中文原文已更新，翻譯未跟上',
+    'dashboard.translation.legend.missing': '未譯 — 還沒翻譯',
+    'dashboard.translation.legend.format': '已譯 / 未譯·舊版 (按分類)',
 
     // Immune System
     'dashboard.immune.title': '免疫系統',
@@ -436,6 +458,13 @@ export const dashboardUI = {
     'dashboard.translation.full': 'Couverture complète',
     'dashboard.translation.growing': 'En croissance',
     'dashboard.translation.seedling': 'Jeune pousse',
+    'dashboard.translation.legend.aria': 'Légende du statut de traduction',
+    'dashboard.translation.legend.fresh':
+      'À jour — synchronisé avec la source zh',
+    'dashboard.translation.legend.stale': 'Périmé — la source zh a évolué',
+    'dashboard.translation.legend.missing': 'Manquant — pas encore traduit',
+    'dashboard.translation.legend.format':
+      'traduit / manquant ou périmé (par catégorie)',
     'dashboard.immune.title': 'Système immunitaire',
     'dashboard.immune.subtitle':
       'État de la défense qualité et tâches en attente',
@@ -520,6 +549,13 @@ export const dashboardUI = {
     'dashboard.translation.full': 'Cobertura completa',
     'dashboard.translation.growing': 'En crecimiento',
     'dashboard.translation.seedling': 'Plántula',
+    'dashboard.translation.legend.aria': 'Leyenda del estado de traducción',
+    'dashboard.translation.legend.fresh':
+      'Actualizado — sincronizado con la fuente zh',
+    'dashboard.translation.legend.stale': 'Obsoleto — la fuente zh ha avanzado',
+    'dashboard.translation.legend.missing': 'Falta — sin traducir aún',
+    'dashboard.translation.legend.format':
+      'traducido / falta o obsoleto (por categoría)',
     'dashboard.immune.title': 'Sistema inmunitario',
     'dashboard.immune.subtitle':
       'Estado de defensa de calidad y tareas pendientes',

--- a/src/templates/dashboard.template.astro
+++ b/src/templates/dashboard.template.astro
@@ -298,6 +298,38 @@ const isEn = lang === 'en';
       </h2>
       <p class="section-subtitle">{t('dashboard.translation.subtitle')}</p>
       <div class="translation-bars" id="translation-bars"></div>
+
+      <!-- Legend: 圖說 (2026-05-09 added per observer feedback) -->
+      <div
+        class="translation-legend"
+        aria-label={t('dashboard.translation.legend.aria')}
+      >
+        <span class="legend-item">
+          <span class="legend-dot legend-dot-fresh">●</span>
+          <span class="legend-label"
+            >{t('dashboard.translation.legend.fresh')}</span
+          >
+        </span>
+        <span class="legend-item">
+          <span class="legend-dot legend-dot-stale">●</span>
+          <span class="legend-label"
+            >{t('dashboard.translation.legend.stale')}</span
+          >
+        </span>
+        <span class="legend-item">
+          <span class="legend-dot legend-dot-missing">●</span>
+          <span class="legend-label"
+            >{t('dashboard.translation.legend.missing')}</span
+          >
+        </span>
+        <span class="legend-item legend-item-divider">
+          <span class="legend-format">N/M</span>
+          <span class="legend-label"
+            >{t('dashboard.translation.legend.format')}</span
+          >
+        </span>
+      </div>
+
       <div class="translation-matrix-wrapper">
         <table class="translation-matrix" id="translation-matrix">
           <thead id="translation-matrix-head"></thead>
@@ -3839,6 +3871,58 @@ const isEn = lang === 'en';
   }
   .donut-breakdown .bd-missing {
     color: #94a3b8;
+  }
+  /* Translation coverage legend (2026-05-09) */
+  .translation-legend {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 0.4rem 1.2rem;
+    margin: 0.5rem 0 1rem;
+    padding: 0.6rem 0.8rem;
+    background: var(--color-bg-soft, #f8fafc);
+    border: 1px solid var(--color-border-soft, #e2e8f0);
+    border-radius: 0.5rem;
+    font-size: 0.75rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--color-text-muted, #64748b);
+  }
+  .translation-legend .legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    white-space: nowrap;
+  }
+  .translation-legend .legend-item-divider {
+    border-left: 1px solid var(--color-border-soft, #e2e8f0);
+    padding-left: 1rem;
+    margin-left: -0.4rem;
+  }
+  .translation-legend .legend-dot {
+    font-size: 0.85rem;
+    line-height: 1;
+  }
+  .translation-legend .legend-dot-fresh {
+    color: #22c55e;
+  }
+  .translation-legend .legend-dot-stale {
+    color: #f59e0b;
+  }
+  .translation-legend .legend-dot-missing {
+    color: #94a3b8;
+  }
+  .translation-legend .legend-format {
+    display: inline-block;
+    padding: 0.05rem 0.35rem;
+    background: var(--color-bg, #fff);
+    border: 1px solid var(--color-border-soft, #e2e8f0);
+    border-radius: 0.2rem;
+    font-weight: 600;
+    color: var(--color-text, #334155);
+  }
+  .translation-legend .legend-label {
+    color: var(--color-text-muted, #64748b);
   }
   /* matrix table extras */
   .th-deficit {


### PR DESCRIPTION
## Summary

per 哲宇 redirect: 「dashboard 翻譯覆蓋這邊，要有圖說說明顏色代表什麼意思」

## Problem

Dashboard donut chart 用 `●33 ●163 ●0` 三色 dot 顯示 fresh / stale / missing，**但沒有圖例**。讀者不知道哪個顏色對應哪個 status。

## Fix — Legend block 插在 donuts 跟 matrix table 之間

| Color | Meaning |
|-------|---------|
| 🟢 綠色 fresh | 最新，跟中文原文同步 |
| 🟠 橘色 stale | 舊版，中文原文已更新，翻譯未跟上 |
| ⚪ 灰色 missing | 未譯，還沒翻譯 |
| `N/M` | 已譯 / 未譯·舊版 (按分類) |

## Implementation

**Template** (`dashboard.template.astro`):
- 新增 `<div class="translation-legend">` 區塊在 `translation-bars` 跟 `translation-matrix-wrapper` 之間
- aria-label 由 i18n 提供 (a11y)
- 4 個 legend-item: fresh / stale / missing dots + N/M format example

**CSS**:
- `.translation-legend`: flex layout, soft bg, border, rounded
- `.legend-dot` 三色（`#22c55e` / `#f59e0b` / `#94a3b8`）跟既有 `STATE_COLORS` 完全一致
- `.legend-format` 小框框顯示 N/M 格式範例 + tabular-nums for alignment

**i18n** (5 langs all covered):
- en: Fresh / Stale / Missing
- ja: 最新 / 旧版 / 未訳
- ko: 최신 / 구버전 / 미번역
- zh-TW: 最新 / 舊版 / 未譯
- es: Actualizado / Obsoleto / Falta
- fr: À jour / Périmé / Manquant

## Why this matters

最近 dashboard 數據從 4.8% 跳到 75.9%，但 donut 顏色語意一直沒解釋。哲宇看不出來「橘色那塊」是 stale 還是 missing。Legend 是 **dashboard ground truth 的可讀性**閘門 — 數據對 + 不能讀 = 觀察者誤判。

## Test plan

- [x] Template render: legend 出現在 donut bars 下方、matrix table 上方
- [x] Color match: 三色跟 donut chart 一致 (#22c55e / #f59e0b / #94a3b8)
- [x] i18n: 全 5 langs 都有對應字串
- [x] a11y: aria-label 由 i18n 提供
- [ ] Visual smoke: dashboard load 後 legend 顯示在預期位置

🤖 Generated with [Claude Code](https://claude.com/claude-code)