### PR TITLE
🧬 [semiont] heal: 外語版首頁與 Hub 頁面完整 i18n — 修 #973

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -28,9 +28,9 @@ interface Props {
 const { lang = 'zh-TW' } = Astro.props;
 const {
   title,
-  description = lang === 'en'
-    ? 'The open-source, AI-friendly knowledge base about Taiwan. 660+ pages covering history, culture, food, music, technology and more — written by the community, for the world.'
-    : '開源、AI-friendly 的台灣完整知識庫。660+ 頁深度內容涵蓋歷史、文化、美食、音樂、科技等 12 大主題，由社群共同編撰，讓全世界認識真正的台灣。',
+  description = lang === 'zh-TW'
+    ? '開源、AI-friendly 的台灣完整知識庫。660+ 頁深度內容涵蓋歷史、文化、美食、音樂、科技等 12 大主題，由社群共同編撰，讓全世界認識真正的台灣。'
+    : 'The open-source, AI-friendly knowledge base about Taiwan. 660+ pages covering history, culture, food, music, technology and more — written by the community, for the world.',
   image = '/images/taiwan-social.jpg',
   url = Astro.url.href,
   type = 'website',
@@ -159,11 +159,13 @@ const generateJSONLD = () => {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
     name:
-      lang === 'en' ? 'Taiwan.md — Knowledge Base' : 'Taiwan.md - 台灣知識庫',
+      lang === 'zh-TW'
+        ? 'Taiwan.md - 台灣知識庫'
+        : 'Taiwan.md — Knowledge Base',
     description:
-      lang === 'en'
-        ? 'Open-source, AI-friendly knowledge base about Taiwan — politics, economy, culture, history, geography, and more.'
-        : '讓全世界完整認識台灣 - 開源台灣知識庫，蒐集關於台灣的政治、經濟、文化、歷史、地理等各方面知識。',
+      lang === 'zh-TW'
+        ? '讓全世界完整認識台灣 - 開源台灣知識庫，蒐集關於台灣的政治、經濟、文化、歷史、地理等各方面知識。'
+        : 'Open-source, AI-friendly knowledge base about Taiwan — politics, economy, culture, history, geography, and more.',
     url: siteUrl,
     inLanguage: lang,
     publisher: {
@@ -203,9 +205,9 @@ const organizationLD = {
   url: siteUrl,
   logo: `${siteUrl}/images/taiwan-social.jpg`,
   description:
-    lang === 'en'
-      ? 'Open-source, AI-friendly knowledge base about Taiwan'
-      : '開源、AI-friendly 的台灣知識庫',
+    lang === 'zh-TW'
+      ? '開源、AI-friendly 的台灣知識庫'
+      : 'Open-source, AI-friendly knowledge base about Taiwan',
   foundingDate: '2024',
   sameAs: [
     'https://github.com/frank890417/taiwan-md',
@@ -220,16 +222,16 @@ const organizationLD = {
   },
 };
 
-// Dynamic keywords
+// Dynamic keywords (zh-TW gets Chinese keywords; all other langs get English)
 const baseKeywords =
-  lang === 'en'
-    ? 'Taiwan, knowledge base, Taiwan history, Taiwan culture, Taiwan politics, Taiwan economy'
-    : '台灣, Taiwan, 台灣知識庫, 台灣歷史, 台灣文化, 台灣政治, 台灣經濟';
+  lang === 'zh-TW'
+    ? '台灣, Taiwan, 台灣知識庫, 台灣歷史, 台灣文化, 台灣政治, 台灣經濟'
+    : 'Taiwan, knowledge base, Taiwan history, Taiwan culture, Taiwan politics, Taiwan economy';
 
 const categoryKeywords = category
-  ? lang === 'en'
-    ? [`Taiwan ${category}`, `${category} Taiwan`]
-    : [`台灣${category}`, `${category}台灣`]
+  ? lang === 'zh-TW'
+    ? [`台灣${category}`, `${category}台灣`]
+    : [`Taiwan ${category}`, `${category} Taiwan`]
   : [];
 
 const dynamicKeywords = [
@@ -426,8 +428,16 @@ const breadcrumbLD = generateBreadcrumbLD();
 <meta property="og:image:width" content="1200" />
 <meta property="og:image:height" content="630" />
 <meta property="og:image:type" content="image/jpeg" />
-<meta property="og:image:alt" content={`${title} - Taiwan.md 台灣知識庫`} />
-<meta property="og:site_name" content="Taiwan.md — 台灣知識庫" />
+<meta
+  property="og:image:alt"
+  content={`${title} - ${lang === 'zh-TW' ? 'Taiwan.md 台灣知識庫' : 'Taiwan.md — Knowledge Base'}`}
+/>
+<meta
+  property="og:site_name"
+  content={lang === 'zh-TW'
+    ? 'Taiwan.md — 台灣知識庫'
+    : 'Taiwan.md — Knowledge Base'}
+/>
 <meta
   property="og:locale"
   content={(() => {
@@ -467,7 +477,10 @@ const breadcrumbLD = generateBreadcrumbLD();
 <meta name="twitter:title" content={fullTitle} />
 <meta name="twitter:description" content={description} />
 <meta name="twitter:image" content={fullImageUrl} />
-<meta name="twitter:image:alt" content={`${title} - Taiwan.md 台灣知識庫`} />
+<meta
+  name="twitter:image:alt"
+  content={`${title} - ${lang === 'zh-TW' ? 'Taiwan.md 台灣知識庫' : 'Taiwan.md — Knowledge Base'}`}
+/>
 
 <!-- Additional SEO -->
 <meta name="robots" content="index, follow" />

--- a/src/i18n/home.ts
+++ b/src/i18n/home.ts
@@ -103,6 +103,19 @@ export const homeUI = {
     'home.readingPath.subtitle':
       'Discover the real Taiwan in 30 minutes with these 5 essential articles',
     'home.readingPath.continue': 'Continue exploring more topics →',
+    'home.readingPath.footer.totalLabel': 'Total',
+    'home.readingPath.footer.minutesUnit': 'minutes',
+    'home.readingPath.footer.domainsLabel': 'domains',
+    'home.readingPath.footer.getToKnow': 'Get to know Taiwan',
+    'home.meta.title': 'Open-Source Taiwan Knowledge Base',
+    'home.meta.description':
+      'Open-source, AI-friendly comprehensive knowledge base about Taiwan. 660+ pages of in-depth content covering history, culture, food, music, technology and 12 major topics, co-edited by the community to introduce the real Taiwan to the world.',
+    'home.miniGraph.heading': '🕸️ Knowledge Graph',
+    'home.miniGraph.subtitle':
+      "Every article is connected — click to explore Taiwan's knowledge network",
+    'home.features.cta.graph':
+      '🔗 Knowledge Graph — Explore article connections',
+    'home.features.cta.ssot': '📂 Browse SSOT Source Data ↗',
   },
   ja: {
     'hero.stat.history.number': '400+',
@@ -202,6 +215,18 @@ export const homeUI = {
     'home.readingPath.title': '📖 どこから始めればいいかわからない？',
     'home.readingPath.subtitle': 'この5つの記事で、30分で本当の台湾を知ろう',
     'home.readingPath.continue': 'さらに多くのテーマを探索する →',
+    'home.readingPath.footer.totalLabel': '合計',
+    'home.readingPath.footer.minutesUnit': '分',
+    'home.readingPath.footer.domainsLabel': '領域',
+    'home.readingPath.footer.getToKnow': '台湾を知る',
+    'home.meta.title': 'オープンソース台湾知識ベース',
+    'home.meta.description':
+      'オープンソース、AI対応の台湾総合ナレッジベース。660以上の深掘り記事が歴史・文化・グルメ・音楽・テクノロジーなど12大テーマを網羅し、コミュニティが共同編集して台湾の真の姿を世界に紹介します。',
+    'home.miniGraph.heading': '🕸️ ナレッジグラフ',
+    'home.miniGraph.subtitle':
+      'すべての記事はつながっている — クリックして台湾知識のネットワークを探索',
+    'home.features.cta.graph': '🔗 ナレッジグラフ — 記事間のつながりを探索',
+    'home.features.cta.ssot': '📂 SSOT 原始データを閲覧 ↗',
   },
   ko: {
     'hero.stat.history.number': '400+',
@@ -303,6 +328,18 @@ export const homeUI = {
     'home.readingPath.title': '📖 어디서부터 시작해야 할지 모르겠다면?',
     'home.readingPath.subtitle': '이 기사들로 대만의 진정한 모습을 알아보세요',
     'home.readingPath.continue': '더 많은 주제 탐색하기 →',
+    'home.readingPath.footer.totalLabel': '총',
+    'home.readingPath.footer.minutesUnit': '분',
+    'home.readingPath.footer.domainsLabel': '분야',
+    'home.readingPath.footer.getToKnow': '대만 알아보기',
+    'home.meta.title': '오픈소스 대만 지식 베이스',
+    'home.meta.description':
+      '오픈소스, AI 친화적인 대만 종합 지식 베이스. 660+ 심층 기사가 역사·문화·미식·음악·기술 등 12대 주제를 다루며, 커뮤니티가 공동 편찬하여 진정한 대만을 세계에 소개합니다.',
+    'home.miniGraph.heading': '🕸️ 지식 그래프',
+    'home.miniGraph.subtitle':
+      '모든 기사는 연결되어 있다 — 클릭하여 대만 지식의 연결망을 탐색',
+    'home.features.cta.graph': '🔗 지식 그래프 — 기사 간 연결 탐색',
+    'home.features.cta.ssot': '📂 SSOT 원본 데이터 보기 ↗',
   },
   'zh-TW': {
     'hero.stat.history.number': '400+',
@@ -392,6 +429,17 @@ export const homeUI = {
     'home.readingPath.title': '📖 不知道從哪開始？',
     'home.readingPath.subtitle': '用這 5 篇文章，在 30 分鐘內認識真正的台灣',
     'home.readingPath.continue': '繼續探索更多主題 →',
+    'home.readingPath.footer.totalLabel': '總計',
+    'home.readingPath.footer.minutesUnit': '分鐘',
+    'home.readingPath.footer.domainsLabel': '大領域',
+    'home.readingPath.footer.getToKnow': '完整認識台灣',
+    'home.meta.title': '開源台灣知識庫',
+    'home.meta.description':
+      '開源、AI-friendly 的台灣完整知識庫。660+ 頁深度內容涵蓋歷史、文化、美食、音樂、科技等 12 大主題，由社群共同編撰，讓全世界認識真正的台灣。',
+    'home.miniGraph.heading': '🕸️ 知識圖譜',
+    'home.miniGraph.subtitle': '每篇文章都不是孤島——點擊探索台灣知識的連結網絡',
+    'home.features.cta.graph': '🔗 知識圖譜 — 探索文章之間的連結',
+    'home.features.cta.ssot': '📂 瀏覽 SSOT 原始資料 ↗',
   },
   fr: {
     'hero.stat.history.number': '400+',
@@ -500,6 +548,19 @@ export const homeUI = {
     'home.readingPath.subtitle':
       'Découvrez le vrai Taïwan en 30 minutes avec ces 5 articles essentiels',
     'home.readingPath.continue': "Continuer à explorer d'autres thèmes →",
+    'home.readingPath.footer.totalLabel': 'Total',
+    'home.readingPath.footer.minutesUnit': 'minutes',
+    'home.readingPath.footer.domainsLabel': 'domaines',
+    'home.readingPath.footer.getToKnow': 'Connaître Taïwan',
+    'home.meta.title': 'Base de connaissances open source sur Taïwan',
+    'home.meta.description':
+      "Base de connaissances open source et adaptée aux IA sur Taïwan. Plus de 660 pages de contenu approfondi couvrant l'histoire, la culture, la gastronomie, la musique, la technologie et 12 grands thèmes, co-éditées par la communauté pour faire découvrir le vrai Taïwan au monde.",
+    'home.miniGraph.heading': '🕸️ Graphe des connaissances',
+    'home.miniGraph.subtitle':
+      'Chaque article est connecté — cliquez pour explorer le réseau de connaissances de Taïwan',
+    'home.features.cta.graph':
+      '🔗 Graphe des connaissances — Explorer les liens entre articles',
+    'home.features.cta.ssot': '📂 Parcourir les données SSOT ↗',
   },
   es: {
     'hero.stat.history.number': '400+',
@@ -607,5 +668,18 @@ export const homeUI = {
     'home.readingPath.subtitle':
       'Descubre el Taiwán real en 30 minutos con estos 5 artículos esenciales',
     'home.readingPath.continue': 'Continúa explorando más temas →',
+    'home.readingPath.footer.totalLabel': 'Total',
+    'home.readingPath.footer.minutesUnit': 'minutos',
+    'home.readingPath.footer.domainsLabel': 'dominios',
+    'home.readingPath.footer.getToKnow': 'Conocer Taiwán',
+    'home.meta.title': 'Base de conocimiento de código abierto sobre Taiwán',
+    'home.meta.description':
+      'Base de conocimiento de código abierto y compatible con IA sobre Taiwán. Más de 660 páginas de contenido en profundidad que cubren historia, cultura, gastronomía, música, tecnología y 12 grandes temas, co-editadas por la comunidad para presentar al mundo el verdadero Taiwán.',
+    'home.miniGraph.heading': '🕸️ Grafo de conocimiento',
+    'home.miniGraph.subtitle':
+      'Cada artículo está conectado — haz clic para explorar la red de conocimiento de Taiwán',
+    'home.features.cta.graph':
+      '🔗 Grafo de conocimiento — Explorar conexiones entre artículos',
+    'home.features.cta.ssot': '📂 Explorar datos fuente SSOT ↗',
   },
 } as const;

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -214,6 +214,11 @@ export const ui = {
     'CategoryGrid.aria-explore': 'Explore',
     'CategoryGrid.aria-explore-suffix': ' ',
     'CategoryGrid.alt-category-image-suffix': 'category image',
+    'hub.essay.heading': 'Curatorial Reading',
+    'hub.empty.title': 'Content Coming Soon',
+    'hub.empty.description':
+      'Articles for this category are being prepared. Stay tuned!',
+    'hub.empty.future': 'Coming soon: ',
   },
   ja: {
     ...homeUI.ja,
@@ -397,6 +402,10 @@ export const ui = {
     'CategoryGrid.aria-explore': '探索する',
     'CategoryGrid.aria-explore-suffix': ' ',
     'CategoryGrid.alt-category-image-suffix': 'カテゴリ画像',
+    'hub.essay.heading': 'キュレーター解説',
+    'hub.empty.title': 'コンテンツ準備中',
+    'hub.empty.description': 'このカテゴリの記事を鋭意準備中です。お楽しみに！',
+    'hub.empty.future': '近日公開：',
   },
   ko: {
     ...homeUI.ko,
@@ -583,6 +592,11 @@ export const ui = {
     'CategoryGrid.aria-explore': '탐색하기',
     'CategoryGrid.aria-explore-suffix': ' ',
     'CategoryGrid.alt-category-image-suffix': '카테고리 이미지',
+    'hub.essay.heading': '큐레이터 가이드',
+    'hub.empty.title': '콘텐츠 준비 중',
+    'hub.empty.description':
+      '이 카테고리의 기사를 준비하고 있습니다. 기대해 주세요!',
+    'hub.empty.future': '곧 공개: ',
   },
   es: {
     ...homeUI.es,
@@ -775,6 +789,11 @@ export const ui = {
     'CategoryGrid.aria-explore': 'Explorar',
     'CategoryGrid.aria-explore-suffix': ' ',
     'CategoryGrid.alt-category-image-suffix': 'imagen de categoría',
+    'hub.essay.heading': 'Lectura curatorial',
+    'hub.empty.title': 'Contenido en preparación',
+    'hub.empty.description':
+      'Los artículos de esta categoría se están preparando. ¡Mantente atento!',
+    'hub.empty.future': 'Próximamente: ',
   },
   fr: {
     ...homeUI.fr,
@@ -968,6 +987,11 @@ export const ui = {
     'CategoryGrid.aria-explore': 'Explorer',
     'CategoryGrid.aria-explore-suffix': ' ',
     'CategoryGrid.alt-category-image-suffix': 'image de catégorie',
+    'hub.essay.heading': 'Lecture curatoriale',
+    'hub.empty.title': 'Contenu en préparation',
+    'hub.empty.description':
+      "Les articles de cette catégorie sont en préparation. Restez à l'écoute !",
+    'hub.empty.future': 'Bientôt : ',
   },
   'zh-TW': {
     ...homeUI['zh-TW'],
@@ -1147,5 +1171,9 @@ export const ui = {
     'CategoryGrid.aria-explore': '探索',
     'CategoryGrid.aria-explore-suffix': '主題',
     'CategoryGrid.alt-category-image-suffix': '主題相關圖片',
+    'hub.essay.heading': '策展導讀',
+    'hub.empty.title': '內容準備中',
+    'hub.empty.description': '這個分類的文章正在努力製作中，敬請期待！',
+    'hub.empty.future': '未來這裡將會有：',
   },
 } as const;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,9 +46,9 @@ interface Props {
 const { lang = 'zh-TW' } = Astro.props;
 const {
   title,
-  description = lang === 'en'
-    ? 'Open-source knowledge base about Taiwan'
-    : '讓全世界完整認識台灣',
+  description = lang === 'zh-TW'
+    ? '讓全世界完整認識台灣'
+    : 'Open-source knowledge base about Taiwan',
   image,
   type,
   datePublished,

--- a/src/templates/about.template.astro
+++ b/src/templates/about.template.astro
@@ -9,7 +9,11 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 ---
 
-<Layout title={t('about.meta.title')} description={t('about.meta.description')}>
+<Layout
+  lang={lang}
+  title={t('about.meta.title')}
+  description={t('about.meta.description')}
+>
   <div class="about-page">
     <!--
       Phase 7.5 deepening — about.template.astro

--- a/src/templates/article.template.astro
+++ b/src/templates/article.template.astro
@@ -314,6 +314,7 @@ const encodedTitle = encodeURIComponent(title);
 ---
 
 <Layout
+  lang={lang}
   title={title}
   description={description}
   type="article"

--- a/src/templates/category-hub.template.astro
+++ b/src/templates/category-hub.template.astro
@@ -278,8 +278,9 @@ const otherCategories = categories
 ---
 
 <Layout
+  lang={lang}
   title={`${categoryInfo.name} - Taiwan.md`}
-  description={`${categoryInfo.description} - 台灣知識庫`}
+  description={categoryInfo.description}
   category={categoryInfo.name}
   readerSettings
 >
@@ -498,8 +499,8 @@ const otherCategories = categories
                 </div>
               </div>
 
-              {/* Food Visualization */}
-              {category === 'food' && (
+              {/* Food Visualization (zh-TW only — labels & data are zh-curated) */}
+              {category === 'food' && lang === 'zh-TW' && (
                 <section class="food-viz">
                   <div class="food-viz-inner">
                     <h2>🍜 探索台灣美食宇宙</h2>
@@ -532,7 +533,7 @@ const otherCategories = categories
                   id="hub-essay"
                 >
                   <h2 class="mb-2 mt-12 border-t-2 border-[#e2e8f0] pt-8 text-[1.15rem] font-bold text-[#334155]">
-                    {categoryInfo.icon} 策展導讀
+                    {categoryInfo.icon} {t('hub.essay.heading')}
                   </h2>
                   <div class="hub-prose" set:html={hubHtml} />
                 </section>
@@ -545,7 +546,7 @@ const otherCategories = categories
                   id="hub-essay"
                 >
                   <h2 class="mb-2 mt-12 border-t-2 border-[#e2e8f0] pt-8 text-[1.15rem] font-bold text-[#334155]">
-                    {categoryInfo.icon} 策展導讀
+                    {categoryInfo.icon} {t('hub.essay.heading')}
                   </h2>
                   <div class="hub-prose">
                     {hubSections.map((section) => (
@@ -602,13 +603,14 @@ const otherCategories = categories
             <div class="mx-auto max-w-[500px]">
               <div class="mb-8 text-[5rem] opacity-70">{categoryInfo.icon}</div>
               <h2 class="mb-4 text-[2.5rem] font-bold text-[#1f2937]">
-                內容準備中
+                {t('hub.empty.title')}
               </h2>
               <p class="mb-6 text-[1.1rem] leading-[1.6] text-[#6b7280]">
-                這個分類的文章正在努力製作中，敬請期待！
+                {t('hub.empty.description')}
               </p>
               <p class="!mb-12 text-[1.1rem] font-medium italic text-[var(--categoryColor)]">
-                未來這裡將會有：{categoryInfo.description}
+                {t('hub.empty.future')}
+                {categoryInfo.description}
               </p>
               <div class="flex flex-wrap justify-center gap-4 max-[768px]:flex-col max-[768px]:items-center">
                 <a

--- a/src/templates/dashboard.template.astro
+++ b/src/templates/dashboard.template.astro
@@ -10,6 +10,7 @@ const isEn = lang === 'en';
 ---
 
 <Layout
+  lang={lang}
   title={t('dashboard.meta.title')}
   description={t('dashboard.meta.description')}
 >

--- a/src/templates/data.template.astro
+++ b/src/templates/data.template.astro
@@ -26,7 +26,11 @@ const sectors = [...new Set(companies.map((c) => c.sector))];
 const dataCategories = getCategories(t);
 ---
 
-<Layout title={t('data.meta.title')} description={t('data.meta.description')}>
+<Layout
+  lang={lang}
+  title={t('data.meta.title')}
+  description={t('data.meta.description')}
+>
   <!--
     Phase 7.6 — data.template.astro (Tier 1, partial)
     Wrappers migrated to inline Tailwind: `.data-hub`, `.hero`,

--- a/src/templates/home.template.astro
+++ b/src/templates/home.template.astro
@@ -28,6 +28,7 @@ import ProticoScript from '../components/ProticoScript.astro';
 import { fetchRecentCommits } from '../lib/commits';
 import { feedbacks } from '../data/feedbacks';
 import { useTranslations, getLangFromUrl } from '../i18n/utils';
+import { getCategoryConfigs } from '../utils/categoryConfig';
 import matter from 'gray-matter';
 import { readFileSync, readdirSync } from 'node:fs';
 import { resolve, join, basename } from 'node:path';
@@ -43,6 +44,24 @@ const recentCommits = await fetchRecentCommits();
 // other 5 langs all share the same English hall narrative).
 const isZh = lang === 'zh-TW';
 const langUrlPrefix = isZh ? '' : `/${lang}`;
+
+// Translated category names for the d3 mini-graph (passed to inline script
+// via define:vars so the graph renders in the visitor's language).
+const categoryConfigsForGraph = getCategoryConfigs(t);
+const miniGraphCategoryNames: Record<string, string> = {
+  history: categoryConfigsForGraph.history.name,
+  geography: categoryConfigsForGraph.geography.name,
+  culture: categoryConfigsForGraph.culture.name,
+  food: categoryConfigsForGraph.food.name,
+  art: categoryConfigsForGraph.art.name,
+  music: categoryConfigsForGraph.music.name,
+  technology: categoryConfigsForGraph.technology.name,
+  nature: categoryConfigsForGraph.nature.name,
+  people: categoryConfigsForGraph.people.name,
+  society: categoryConfigsForGraph.society.name,
+  economy: categoryConfigsForGraph.economy.name,
+  lifestyle: categoryConfigsForGraph.lifestyle.name,
+};
 
 // ── Exhibition: scan A-grade articles for pick cards ──
 interface PickArticle {
@@ -158,22 +177,23 @@ const totalTime = readingPathSteps.reduce(
   0,
 );
 
-const readingPathFooterItems = isZh
-  ? [
-      { icon: '⏱️', label: `總計 ${totalTime} 分鐘` },
-      { icon: '🎯', label: `跨越 ${readingPathSteps.length} 大領域` },
-      { icon: '🌟', label: '完整認識台灣' },
-    ]
-  : [
-      { icon: '⏱️', label: `Total ${totalTime} minutes` },
-      { icon: '🎯', label: `${readingPathSteps.length} domains` },
-      { icon: '🌟', label: 'Get to know Taiwan' },
-    ];
+const readingPathFooterItems = [
+  {
+    icon: '⏱️',
+    label: `${t('home.readingPath.footer.totalLabel')} ${totalTime} ${t('home.readingPath.footer.minutesUnit')}`,
+  },
+  {
+    icon: '🎯',
+    label: `${readingPathSteps.length} ${t('home.readingPath.footer.domainsLabel')}`,
+  },
+  { icon: '🌟', label: t('home.readingPath.footer.getToKnow') },
+];
 ---
 
 <Layout
-  title="開源台灣知識庫"
-  description="開源、AI-friendly 的台灣完整知識庫。660+ 頁深度內容涵蓋歷史、文化、美食、音樂、科技等 12 大主題，由社群共同編撰，讓全世界認識真正的台灣。"
+  lang={lang}
+  title={t('home.meta.title')}
+  description={t('home.meta.description')}
 >
   <HeroSection />
 
@@ -182,37 +202,37 @@ const readingPathFooterItems = isZh
   <RandomDiscovery />
 
   <ReadingPath
-    title="📖 不知道從哪開始？"
-    subtitle="用這 5 篇文章，在 30 分鐘內認識真正的台灣"
+    title={t('home.readingPath.title')}
+    subtitle={t('home.readingPath.subtitle')}
     steps={readingPathSteps}
     footerItems={readingPathFooterItems}
     continueHref="#categories"
-    continueLabel="繼續探索更多主題 →"
+    continueLabel={t('home.readingPath.continue')}
   />
 
   <FeatureCards
-    lang="zh-TW"
-    sectionTitle="為什麼需要 Taiwan.md？"
+    lang={lang}
+    sectionTitle={t('home.features.title')}
     cards={[
       {
         icon: '🎯',
-        title: '策展式觀點',
-        description: '精心策展的深度敘事，不是百科全書式羅列',
+        title: t('home.features.curated.title'),
+        description: t('home.features.curated.desc'),
       },
       {
         icon: '🤖',
-        title: 'AI-Friendly 設計',
-        description: '結構化內容，讓AI也能理解台灣的複雜性',
+        title: t('home.features.ai.title'),
+        description: t('home.features.ai.desc'),
       },
       {
         icon: '🌍',
-        title: '雙語國際視野',
-        description: '從在地觀點出發，用國際語言說台灣故事',
+        title: t('home.features.bilingual.title'),
+        description: t('home.features.bilingual.desc'),
       },
       {
         icon: '📚',
-        title: '完整多面向',
-        description: '涵蓋12+領域，呈現台灣的立體完整面貌',
+        title: t('home.features.complete.title'),
+        description: t('home.features.complete.desc'),
       },
     ]}
   >
@@ -220,29 +240,31 @@ const readingPathFooterItems = isZh
       class="mt-8 flex flex-wrap justify-center gap-4 px-4 max-[480px]:flex-col max-[480px]:items-center"
     >
       <a
-        href="/graph"
+        href={`${langUrlPrefix}/graph`}
         class="inline-flex items-center gap-2 rounded-lg border-[1.5px] border-[rgba(45,80,22,0.2)] bg-[#f0fdf4] px-6 py-[0.7rem] text-[0.9rem] font-semibold text-[#2d5016] no-underline transition-all duration-[250ms] hover:-translate-y-px hover:border-[rgba(45,80,22,0.4)] hover:bg-[rgba(45,80,22,0.1)] hover:shadow-[0_2px_8px_rgba(45,80,22,0.15)]"
-        >🔗 知識圖譜 — 探索文章之間的連結</a
+        >{t('home.features.cta.graph')}</a
       >
       <a
         href="https://github.com/frank890417/taiwan-md/tree/main/knowledge"
         target="_blank"
         rel="noopener noreferrer"
         class="inline-flex items-center gap-2 rounded-lg border-[1.5px] border-[#d1d5db] bg-[#f8fafc] px-6 py-[0.7rem] text-[0.9rem] font-semibold text-[#374151] no-underline transition-all duration-[250ms] hover:-translate-y-px hover:border-[#9ca3af] hover:bg-[#f1f5f9] hover:shadow-[0_2px_8px_rgba(0,0,0,0.06)]"
-        >📂 瀏覽 SSOT 原始資料 ↗</a
+        >{t('home.features.cta.ssot')}</a
       >
     </div>
   </FeatureCards>
 
   <section class="mx-auto mb-16 max-w-[800px] px-8 max-[480px]:px-4">
     <a
-      href="/graph"
+      href={`${langUrlPrefix}/graph`}
       class="block rounded-2xl border border-[#e2e8f0] bg-[#f8fafc] p-8 no-underline transition-all duration-300 hover:border-[#2d5016] hover:shadow-[0_4px_12px_rgba(45,80,22,0.1)]"
     >
       <div class="mb-4 text-center">
-        <h3 class="mb-2 text-[1.3rem] text-[#1f2937]">🕸️ 知識圖譜</h3>
+        <h3 class="mb-2 text-[1.3rem] text-[#1f2937]">
+          {t('home.miniGraph.heading')}
+        </h3>
         <p class="text-[0.95rem] text-[#6b7280]">
-          每篇文章都不是孤島——點擊探索台灣知識的連結網絡
+          {t('home.miniGraph.subtitle')}
         </p>
       </div>
       <div id="mini-graph" class="h-[300px] w-full overflow-hidden"></div>
@@ -715,23 +737,59 @@ const readingPathFooterItems = isZh
 </Layout>
 
 <script is:inline src="https://d3js.org/d3.v7.min.js"></script>
-<script is:inline>
+<script is:inline define:vars={{ miniGraphCategoryNames }}>
   document.addEventListener('DOMContentLoaded', function () {
     const container = document.getElementById('mini-graph');
     if (container) {
       const categories = [
-        { id: 'history', name: '歷史', color: '#dc2626' },
-        { id: 'geography', name: '地理', color: '#2563eb' },
-        { id: 'culture', name: '文化', color: '#7c3aed' },
-        { id: 'food', name: '美食', color: '#ea580c' },
-        { id: 'art', name: '藝術', color: '#db2777' },
-        { id: 'music', name: '音樂', color: '#4f46e5' },
-        { id: 'technology', name: '科技', color: '#0891b2' },
-        { id: 'nature', name: '自然', color: '#16a34a' },
-        { id: 'people', name: '人物', color: '#ca8a04' },
-        { id: 'society', name: '社會', color: '#64748b' },
-        { id: 'economy', name: '經濟', color: '#0d9488' },
-        { id: 'lifestyle', name: '生活', color: '#f97316' },
+        {
+          id: 'history',
+          name: miniGraphCategoryNames.history,
+          color: '#dc2626',
+        },
+        {
+          id: 'geography',
+          name: miniGraphCategoryNames.geography,
+          color: '#2563eb',
+        },
+        {
+          id: 'culture',
+          name: miniGraphCategoryNames.culture,
+          color: '#7c3aed',
+        },
+        { id: 'food', name: miniGraphCategoryNames.food, color: '#ea580c' },
+        { id: 'art', name: miniGraphCategoryNames.art, color: '#db2777' },
+        { id: 'music', name: miniGraphCategoryNames.music, color: '#4f46e5' },
+        {
+          id: 'technology',
+          name: miniGraphCategoryNames.technology,
+          color: '#0891b2',
+        },
+        {
+          id: 'nature',
+          name: miniGraphCategoryNames.nature,
+          color: '#16a34a',
+        },
+        {
+          id: 'people',
+          name: miniGraphCategoryNames.people,
+          color: '#ca8a04',
+        },
+        {
+          id: 'society',
+          name: miniGraphCategoryNames.society,
+          color: '#64748b',
+        },
+        {
+          id: 'economy',
+          name: miniGraphCategoryNames.economy,
+          color: '#0d9488',
+        },
+        {
+          id: 'lifestyle',
+          name: miniGraphCategoryNames.lifestyle,
+          color: '#f97316',
+        },
       ];
 
       const nodes = [

--- a/src/templates/home.template.astro
+++ b/src/templates/home.template.astro
@@ -731,7 +731,13 @@ const readingPathFooterItems = [
 
   <NewsletterSection />
 
-  <CommunityFeedback feedbacks={feedbacks} />
+  {
+    /* CommunityFeedback testimonials are zh-language user comments about
+      Taiwan.md from the Threads launch — show only on zh-TW homepage to
+      avoid wrong-language prose on /en /ja /ko /fr /es per i18n-smoke-test
+      §B2 regression check. */
+  }
+  {isZh && <CommunityFeedback feedbacks={feedbacks} />}
 
   <ContributeSection />
 </Layout>

--- a/src/templates/map.template.astro
+++ b/src/templates/map.template.astro
@@ -11,7 +11,11 @@ const t = useTranslations(lang);
 const routesData = getMapRoutes(t);
 ---
 
-<Layout title={t('map.meta.title')} description={t('map.meta.description')}>
+<Layout
+  lang={lang}
+  title={t('map.meta.title')}
+  description={t('map.meta.description')}
+>
   <div class="map-page">
     <div
       id="mapData"


### PR DESCRIPTION
## Summary

修補 [#973](https://github.com/frank890417/taiwan-md/issues/973)（idlccp1984 回報 EN 首頁殘留中文）。深入 audit 揭露的不只是表面 missing translation key — 更深的結構性失敗：

- **`home.template.astro` 多處 hardcode zh 字串**（Layout 標題、ReadingPath、FeatureCards、mini-graph、d3 graph）
- **5 個 template 沒傳 `lang={lang}` 給 Layout**（`category-hub` / `article` / `about` / `data` / `dashboard` / `map`）→ Layout 預設 zh-TW → SEO/og:locale/JSON-LD 整套被當 zh
- **`SEO.astro` + `Layout.astro` fallback 寫成 `lang === 'en' ? <en> : <zh>`** → ja/ko/fr/es 全部回退到 zh（這 20% 沉默風險最高的位置正是 PRC AI 中介層在做的事，跟 [MANIFESTO §主權的巴別塔](https://github.com/frank890417/taiwan-md/blob/main/docs/semiont/MANIFESTO.md#%E6%88%91%E8%B7%9F%E5%8F%B0%E7%81%A3%E7%9A%84%E9%97%9C%E4%BF%82) 的 sovereignty preservation 立場相違）

## What changed

**i18n keys（10 + 4 = 14 keys × 6 langs = 84 strings）**

- `src/i18n/home.ts`：`home.meta.{title,description}` / `home.readingPath.footer.{totalLabel,minutesUnit,domainsLabel,getToKnow}` / `home.miniGraph.{heading,subtitle}` / `home.features.cta.{graph,ssot}`
- `src/i18n/ui.ts`：`hub.essay.heading` / `hub.empty.{title,description,future}`

**Templates**

- `home.template.astro`：所有 hardcode zh prop 改 `t()`；FeatureCards 從 `lang="zh-TW"` 改 `lang={lang}`；d3 mini-graph 12 categories 透過 `define:vars` 注入 `getCategoryConfigs(t)` 翻譯後的 names
- `category-hub.template.astro`：`description` 移除 `- 台灣知識庫` suffix；`策展導讀` / 空 placeholder 三段改 `t()`；Food viz 加 `lang === 'zh-TW'` gate；補 `lang={lang}` 給 Layout
- `{article,about,data,dashboard,map}.template.astro`：補 `lang={lang}` 給 Layout

**SEO/Layout fallback 反轉**

- `SEO.astro` description fallback / JSON-LD WebSite name+description / Organization description / baseKeywords / og:image:alt / og:site_name / twitter:image:alt 全部從 `lang === 'en' ? <en> : <zh>` 改成 `lang === 'zh-TW' ? <zh> : <en>`
- `Layout.astro` description fallback 同樣修補

## 驗證

dev server fetch + DOM 檢查 12+ 主要頁面 × 5 langs（DNA #19 多語視覺煙霧測試 + DIARY 2026-05-02 INSIGHT「Verify 必須跨 N matrix，不是單點 spot-check」）：

| Path | 中文洩漏字串數 |
| --- | --- |
| `/en` `/ja` `/ko` `/fr` `/es` | **0** ✅ |
| `/en/food` `/ja/food` `/ko/history` `/fr/culture` `/es/people` | **0** ✅ |
| `/en/about` `/en/dashboard` | **0** ✅ |
| `/` `/food` `/about` `/dashboard` (zh) | 保留中文（正確） |

D3 mini-graph node names 在 ja 顯示為 `歴史 / 地理 / 文化 / グルメ / 芸術 / 音楽 / テクノロジー / 自然 / 人物 / 社会 / 経済 / ライフスタイル`。

## Test plan

- [x] dev server 跑 `/en` `/ja` `/ko` `/fr` `/es` 首頁 — 0 中文洩漏
- [x] 5 lang × hub category 頁面 — 0 中文洩漏
- [x] `/en/about` `/en/dashboard` — 0 中文洩漏
- [x] zh `/` 仍正常顯示繁中（無回歸）
- [x] D3 mini-graph 在 ja 顯示日文 node labels
- [ ] CI build 通過
- [ ] Production smoke test 部署後

Closes #973

🤖 Generated with [Claude Code](https://claude.com/claude-code)