### PR TITLE
🧬 [semiont] feat: /explore — 資料庫探索主頁（取代 #categories anchor，issue #615 child）

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -109,7 +109,7 @@ const isHome = normalizedPath === '/' || normalizedPath === '/en';
 
 const navConfig = [
   { path: '/about', label: t('nav.about') },
-  { path: '/#categories', label: t('nav.explore') },
+  { path: '/explore', label: t('nav.explore') },
   { path: '/map', label: t('nav.map') },
   { path: '/data', label: t('nav.data') },
   { path: '/soundscape', label: t('nav.soundscape') },
@@ -276,7 +276,7 @@ const categoryList = [
                   </Fragment>
                 );
               }
-              if (item.path === '/#categories') {
+              if (item.path === '/explore') {
                 return (
                   <Fragment>
                     {showSep && <span class="nav-sep" />}
@@ -593,9 +593,7 @@ const categoryList = [
       <nav class="nav-mobile" aria-label={t('nav.aria-mobile-navigation')}>
         {
           navConfig.map((item) => {
-            const hasSub = ['/#categories', '/map', '/semiont'].includes(
-              item.path,
-            );
+            const hasSub = ['/explore', '/map', '/semiont'].includes(item.path);
             return (
               <Fragment>
                 <div class:list={['mobile-nav-item', { 'has-sub': hasSub }]}>
@@ -615,7 +613,7 @@ const categoryList = [
                     </button>
                   )}
                 </div>
-                {item.path === '/#categories' && (
+                {item.path === '/explore' && (
                   <div class="mobile-sub-links open">
                     <a
                       href={translatePath('/graph')}

--- a/src/i18n/explore.ts
+++ b/src/i18n/explore.ts
@@ -1,0 +1,375 @@
+/**
+ * exploreUI — i18n strings for /explore (database discovery hub).
+ *
+ * Born 2026-05-10 (issue #615 child) — replaces the old `/#categories`
+ * anchor with a dedicated database front-page so visitors who arrive
+ * looking to *find* things (not read narrative) get a search-first
+ * interface with hot keywords + category cards + featured picks.
+ *
+ * Hot search keywords are intentionally translated per language (not
+ * shared) so each locale surfaces terms that locale's readers actually
+ * search for. They can later be replaced with GA4-derived top queries
+ * via fetch-search-events.py without touching this file's structure.
+ */
+export const exploreUI = {
+  en: {
+    // Meta
+    'explore.meta.title': 'Explore Taiwan.md — Browse the open knowledge base',
+    'explore.meta.description':
+      'Browse 685+ curated articles about Taiwan: history, geography, culture, food, art, music, technology, nature, people, society, economy, and lifestyle. Search, discover, and explore.',
+
+    // Hero
+    'explore.hero.eyebrow': 'KNOWLEDGE HUB',
+    'explore.hero.title': 'Explore Taiwan.md',
+    'explore.hero.subtitle':
+      'Curated long-form narratives about Taiwan — search, discover, or browse by category.',
+
+    // Search section
+    'explore.search.heading': 'Search the database',
+    'explore.search.placeholder': 'Search Taiwan — people, places, events…',
+    'explore.search.button': 'Search',
+    'explore.search.random': 'Random discovery',
+    'explore.search.randomSubtitle':
+      'Roll the dice — find a story you didn’t know you were looking for',
+    'explore.hotSearches.label': 'Trending',
+    'explore.hotSearches.term1': 'Semiconductors',
+    'explore.hotSearches.term2': 'Night Markets',
+    'explore.hotSearches.term3': 'Indigenous Peoples',
+    'explore.hotSearches.term4': '228 Incident',
+    'explore.hotSearches.term5': 'TSMC',
+    'explore.hotSearches.term6': 'Bubble Tea',
+
+    // Stats ribbon
+    'explore.stats.articles': 'articles',
+    'explore.stats.contributors': 'contributors',
+    'explore.stats.languages': 'languages',
+    'explore.stats.last30d': 'updates / 30d',
+
+    // Categories section
+    'explore.categories.heading': 'Browse by category',
+    'explore.categories.subtitle':
+      'Twelve domains, each with its own curated angle on the island.',
+
+    // Featured picks section
+    'explore.featured.heading': 'Featured deep-dives',
+    'explore.featured.subtitle':
+      'A-grade articles with extensive citations and cross-references.',
+    'explore.featured.viewAll': 'View all featured →',
+    'explore.featured.citations': 'citations',
+    'explore.featured.minRead': 'min read',
+
+    // More ways to explore
+    'explore.more.heading': 'More ways to explore',
+    'explore.more.graph.title': 'Knowledge Graph',
+    'explore.more.graph.desc':
+      'See how every article connects in a force-directed visualization.',
+    'explore.more.graph.cta': 'Open the graph →',
+    'explore.more.map.title': 'Geographic Map',
+    'explore.more.map.desc': 'Find articles by their location on the island.',
+    'explore.more.map.cta': 'Open the map →',
+    'explore.more.terminology.title': 'Terminology',
+    'explore.more.terminology.desc':
+      'Quick reference for terms used across the knowledge base.',
+    'explore.more.terminology.cta': 'Open glossary →',
+
+    // CTA footer
+    'explore.cta.heading': "Can't find what you're looking for?",
+    'explore.cta.body':
+      'Taiwan.md is open-source — anyone can contribute an article, fix a fact, or translate a page.',
+    'explore.cta.contribute': 'Contribute an article',
+    'explore.cta.github': 'View on GitHub',
+  },
+  ja: {
+    'explore.meta.title': 'Taiwan.md を探索 — オープン知識ベースを閲覧',
+    'explore.meta.description':
+      '台湾に関する 685+ 本のキュレーション記事を閲覧。歴史・地理・文化・グルメ・アート・音楽・テクノロジー・自然・人物・社会・経済・暮らし — 検索して、発見して、探索する。',
+
+    'explore.hero.eyebrow': '知識ハブ',
+    'explore.hero.title': 'Taiwan.md を探索',
+    'explore.hero.subtitle':
+      'キュレーションされた台湾の深い物語 — 検索・発見・カテゴリーで閲覧。',
+
+    'explore.search.heading': 'データベースを検索',
+    'explore.search.placeholder': '台湾を検索 — 人物・場所・出来事…',
+    'explore.search.button': '検索',
+    'explore.search.random': 'ランダム発見',
+    'explore.search.randomSubtitle':
+      'サイコロを振って — 知らなかった物語と出会う',
+    'explore.hotSearches.label': '人気',
+    'explore.hotSearches.term1': '半導体',
+    'explore.hotSearches.term2': '夜市',
+    'explore.hotSearches.term3': '原住民族',
+    'explore.hotSearches.term4': '二・二八事件',
+    'explore.hotSearches.term5': 'TSMC',
+    'explore.hotSearches.term6': 'タピオカミルクティー',
+
+    'explore.stats.articles': '記事',
+    'explore.stats.contributors': '貢献者',
+    'explore.stats.languages': '言語',
+    'explore.stats.last30d': '30日の更新',
+
+    'explore.categories.heading': 'カテゴリーで閲覧',
+    'explore.categories.subtitle':
+      '12 の分野 — それぞれが島の別の側面を切り取ります。',
+
+    'explore.featured.heading': '注目の深掘り記事',
+    'explore.featured.subtitle':
+      '豊富な引用とクロスリファレンスを備えた A 級記事。',
+    'explore.featured.viewAll': '注目記事をすべて見る →',
+    'explore.featured.citations': '引用',
+    'explore.featured.minRead': '分',
+
+    'explore.more.heading': 'もっと探す方法',
+    'explore.more.graph.title': '知識グラフ',
+    'explore.more.graph.desc':
+      'すべての記事のつながりをフォースシミュレーションで可視化。',
+    'explore.more.graph.cta': 'グラフを開く →',
+    'explore.more.map.title': '地理マップ',
+    'explore.more.map.desc': '記事を島の地理上から探す。',
+    'explore.more.map.cta': 'マップを開く →',
+    'explore.more.terminology.title': '用語集',
+    'explore.more.terminology.desc':
+      '知識ベース全体で使われる用語のクイックリファレンス。',
+    'explore.more.terminology.cta': '用語集を開く →',
+
+    'explore.cta.heading': '探しているものが見つからなかった？',
+    'explore.cta.body':
+      'Taiwan.md はオープンソース — 誰でも記事を書き足したり、事実を修正したり、翻訳を投稿できます。',
+    'explore.cta.contribute': '記事を投稿する',
+    'explore.cta.github': 'GitHub で見る',
+  },
+  ko: {
+    'explore.meta.title': 'Taiwan.md 탐색 — 오픈 지식 베이스 둘러보기',
+    'explore.meta.description':
+      '대만에 관한 685+ 큐레이션 기사 둘러보기: 역사·지리·문화·음식·예술·음악·기술·자연·인물·사회·경제·생활. 검색하고, 발견하고, 탐색하세요.',
+
+    'explore.hero.eyebrow': '지식 허브',
+    'explore.hero.title': 'Taiwan.md 탐색',
+    'explore.hero.subtitle':
+      '큐레이션된 대만의 깊은 이야기 — 검색·발견·카테고리로 탐색하세요.',
+
+    'explore.search.heading': '데이터베이스 검색',
+    'explore.search.placeholder': '대만 검색 — 인물·장소·사건…',
+    'explore.search.button': '검색',
+    'explore.search.random': '랜덤 탐색',
+    'explore.search.randomSubtitle':
+      '주사위를 굴려 — 몰랐던 이야기를 만나보세요',
+    'explore.hotSearches.label': '인기',
+    'explore.hotSearches.term1': '반도체',
+    'explore.hotSearches.term2': '야시장',
+    'explore.hotSearches.term3': '원주민족',
+    'explore.hotSearches.term4': '2·28 사건',
+    'explore.hotSearches.term5': 'TSMC',
+    'explore.hotSearches.term6': '버블티',
+
+    'explore.stats.articles': '편 기사',
+    'explore.stats.contributors': '명 기여자',
+    'explore.stats.languages': '개 언어',
+    'explore.stats.last30d': '30일 업데이트',
+
+    'explore.categories.heading': '카테고리별 탐색',
+    'explore.categories.subtitle':
+      '12 개 분야 — 각각이 섬의 다른 단면을 보여줍니다.',
+
+    'explore.featured.heading': '추천 심층 기사',
+    'explore.featured.subtitle': '풍부한 인용과 상호 참조를 갖춘 A 등급 기사.',
+    'explore.featured.viewAll': '추천 기사 전체 보기 →',
+    'explore.featured.citations': '인용',
+    'explore.featured.minRead': '분',
+
+    'explore.more.heading': '더 많은 탐색 방법',
+    'explore.more.graph.title': '지식 그래프',
+    'explore.more.graph.desc':
+      '모든 기사의 연결을 포스 시뮬레이션으로 시각화합니다.',
+    'explore.more.graph.cta': '그래프 열기 →',
+    'explore.more.map.title': '지리 지도',
+    'explore.more.map.desc': '섬의 위치별로 기사를 찾아보세요.',
+    'explore.more.map.cta': '지도 열기 →',
+    'explore.more.terminology.title': '용어집',
+    'explore.more.terminology.desc':
+      '지식 베이스에서 사용되는 용어의 빠른 참조.',
+    'explore.more.terminology.cta': '용어집 열기 →',
+
+    'explore.cta.heading': '찾고 있는 것을 찾지 못했나요?',
+    'explore.cta.body':
+      'Taiwan.md 는 오픈소스입니다 — 누구나 기사를 기여하거나, 사실을 수정하거나, 페이지를 번역할 수 있습니다.',
+    'explore.cta.contribute': '기사 기여하기',
+    'explore.cta.github': 'GitHub 에서 보기',
+  },
+  'zh-TW': {
+    'explore.meta.title': '探索 Taiwan.md — 瀏覽開放的台灣知識庫',
+    'explore.meta.description':
+      '瀏覽 685+ 篇台灣策展文章：歷史、地理、文化、美食、藝術、音樂、科技、自然、人物、社會、經濟、生活。搜尋、發現、探索。',
+
+    'explore.hero.eyebrow': '知識庫',
+    'explore.hero.title': '探索 Taiwan.md',
+    'explore.hero.subtitle': '策展島嶼的深度敘事 — 搜尋、發現、依分類瀏覽。',
+
+    'explore.search.heading': '搜尋資料庫',
+    'explore.search.placeholder': '搜尋台灣的一切（人、地、文化、事件）',
+    'explore.search.button': '搜尋',
+    'explore.search.random': '隨機探索',
+    'explore.search.randomSubtitle': '擲一把骰子 — 遇見一個你沒想到的故事',
+    'explore.hotSearches.label': '熱門搜尋',
+    'explore.hotSearches.term1': '半導體',
+    'explore.hotSearches.term2': '夜市',
+    'explore.hotSearches.term3': '原住民',
+    'explore.hotSearches.term4': '二二八',
+    'explore.hotSearches.term5': '台積電',
+    'explore.hotSearches.term6': '珍珠奶茶',
+
+    'explore.stats.articles': '篇文章',
+    'explore.stats.contributors': '位貢獻者',
+    'explore.stats.languages': '種語言',
+    'explore.stats.last30d': '近 30 天更新',
+
+    'explore.categories.heading': '依分類瀏覽',
+    'explore.categories.subtitle': '十二個領域，每個都是這座島嶼的一個切面。',
+
+    'explore.featured.heading': '深度精選',
+    'explore.featured.subtitle':
+      'A 級文章 — 完整腳註、跨篇引用、可追溯的研究軌跡。',
+    'explore.featured.viewAll': '看完整精選 →',
+    'explore.featured.citations': '引用',
+    'explore.featured.minRead': '分鐘',
+
+    'explore.more.heading': '其他探索方式',
+    'explore.more.graph.title': '知識圖譜',
+    'explore.more.graph.desc': '用力導向圖看每篇文章如何彼此連結。',
+    'explore.more.graph.cta': '打開圖譜 →',
+    'explore.more.map.title': '地理地圖',
+    'explore.more.map.desc': '依文章在島上的位置查找。',
+    'explore.more.map.cta': '打開地圖 →',
+    'explore.more.terminology.title': '名詞對照',
+    'explore.more.terminology.desc': '知識庫共用名詞的速查表。',
+    'explore.more.terminology.cta': '打開對照表 →',
+
+    'explore.cta.heading': '找不到想看的？',
+    'explore.cta.body':
+      'Taiwan.md 是開源的 — 任何人都可以貢獻一篇文章、修一個事實，或翻譯一頁。',
+    'explore.cta.contribute': '貢獻一篇',
+    'explore.cta.github': '在 GitHub 上瀏覽',
+  },
+  es: {
+    'explore.meta.title':
+      'Explora Taiwan.md — Navega la base de conocimiento abierta',
+    'explore.meta.description':
+      'Navega 685+ artículos curados sobre Taiwán: historia, geografía, cultura, gastronomía, arte, música, tecnología, naturaleza, personas, sociedad, economía y estilo de vida. Busca, descubre, explora.',
+
+    'explore.hero.eyebrow': 'CENTRO DE CONOCIMIENTO',
+    'explore.hero.title': 'Explora Taiwan.md',
+    'explore.hero.subtitle':
+      'Narrativas profundas y curadas sobre Taiwán — busca, descubre o navega por categoría.',
+
+    'explore.search.heading': 'Buscar en la base de datos',
+    'explore.search.placeholder': 'Busca Taiwán — personas, lugares, eventos…',
+    'explore.search.button': 'Buscar',
+    'explore.search.random': 'Descubrimiento aleatorio',
+    'explore.search.randomSubtitle':
+      'Tira el dado — encuentra una historia que no sabías que buscabas',
+    'explore.hotSearches.label': 'Tendencias',
+    'explore.hotSearches.term1': 'Semiconductores',
+    'explore.hotSearches.term2': 'Mercados nocturnos',
+    'explore.hotSearches.term3': 'Pueblos indígenas',
+    'explore.hotSearches.term4': 'Incidente 228',
+    'explore.hotSearches.term5': 'TSMC',
+    'explore.hotSearches.term6': 'Té de burbujas',
+
+    'explore.stats.articles': 'artículos',
+    'explore.stats.contributors': 'colaboradores',
+    'explore.stats.languages': 'idiomas',
+    'explore.stats.last30d': 'actualizaciones / 30 d',
+
+    'explore.categories.heading': 'Navegar por categoría',
+    'explore.categories.subtitle':
+      'Doce dominios, cada uno con su propio ángulo curado sobre la isla.',
+
+    'explore.featured.heading': 'Artículos destacados en profundidad',
+    'explore.featured.subtitle':
+      'Artículos de grado A con citas extensivas y referencias cruzadas.',
+    'explore.featured.viewAll': 'Ver todos los destacados →',
+    'explore.featured.citations': 'citas',
+    'explore.featured.minRead': 'min',
+
+    'explore.more.heading': 'Más formas de explorar',
+    'explore.more.graph.title': 'Grafo de conocimiento',
+    'explore.more.graph.desc':
+      'Mira cómo se conecta cada artículo en una visualización por fuerzas.',
+    'explore.more.graph.cta': 'Abrir el grafo →',
+    'explore.more.map.title': 'Mapa geográfico',
+    'explore.more.map.desc': 'Encuentra artículos por su ubicación en la isla.',
+    'explore.more.map.cta': 'Abrir el mapa →',
+    'explore.more.terminology.title': 'Glosario',
+    'explore.more.terminology.desc':
+      'Referencia rápida de términos usados en toda la base de conocimiento.',
+    'explore.more.terminology.cta': 'Abrir el glosario →',
+
+    'explore.cta.heading': '¿No encuentras lo que buscas?',
+    'explore.cta.body':
+      'Taiwan.md es de código abierto — cualquiera puede contribuir con un artículo, corregir un dato o traducir una página.',
+    'explore.cta.contribute': 'Contribuye un artículo',
+    'explore.cta.github': 'Ver en GitHub',
+  },
+  fr: {
+    'explore.meta.title':
+      'Explorer Taiwan.md — Parcourir la base de connaissances ouverte',
+    'explore.meta.description':
+      'Parcourez 685+ articles curatés sur Taïwan : histoire, géographie, culture, cuisine, art, musique, technologie, nature, personnalités, société, économie et mode de vie. Cherchez, découvrez, explorez.',
+
+    'explore.hero.eyebrow': 'CENTRE DE CONNAISSANCES',
+    'explore.hero.title': 'Explorer Taiwan.md',
+    'explore.hero.subtitle':
+      'Récits longs et curatés sur Taïwan — cherchez, découvrez, ou parcourez par catégorie.',
+
+    'explore.search.heading': 'Rechercher dans la base',
+    'explore.search.placeholder':
+      'Cherchez Taïwan — personnes, lieux, événements…',
+    'explore.search.button': 'Rechercher',
+    'explore.search.random': 'Découverte aléatoire',
+    'explore.search.randomSubtitle':
+      'Lancez le dé — trouvez une histoire que vous ne cherchiez pas',
+    'explore.hotSearches.label': 'Tendances',
+    'explore.hotSearches.term1': 'Semi-conducteurs',
+    'explore.hotSearches.term2': 'Marchés de nuit',
+    'explore.hotSearches.term3': 'Peuples autochtones',
+    'explore.hotSearches.term4': 'Incident 228',
+    'explore.hotSearches.term5': 'TSMC',
+    'explore.hotSearches.term6': 'Bubble tea',
+
+    'explore.stats.articles': 'articles',
+    'explore.stats.contributors': 'contributeurs',
+    'explore.stats.languages': 'langues',
+    'explore.stats.last30d': 'mises à jour / 30 j',
+
+    'explore.categories.heading': 'Parcourir par catégorie',
+    'explore.categories.subtitle':
+      'Douze domaines, chacun avec son angle curaté sur l’île.',
+
+    'explore.featured.heading': 'Articles de fond mis en avant',
+    'explore.featured.subtitle':
+      'Articles de niveau A avec citations abondantes et renvois croisés.',
+    'explore.featured.viewAll': 'Voir tous les articles en avant →',
+    'explore.featured.citations': 'citations',
+    'explore.featured.minRead': 'min',
+
+    'explore.more.heading': 'Autres façons d’explorer',
+    'explore.more.graph.title': 'Graphe de connaissances',
+    'explore.more.graph.desc':
+      'Voir comment chaque article se connecte dans une visualisation par forces.',
+    'explore.more.graph.cta': 'Ouvrir le graphe →',
+    'explore.more.map.title': 'Carte géographique',
+    'explore.more.map.desc':
+      'Trouvez des articles par leur localisation sur l’île.',
+    'explore.more.map.cta': 'Ouvrir la carte →',
+    'explore.more.terminology.title': 'Terminologie',
+    'explore.more.terminology.desc':
+      'Référence rapide pour les termes utilisés dans toute la base.',
+    'explore.more.terminology.cta': 'Ouvrir le glossaire →',
+
+    'explore.cta.heading': 'Vous ne trouvez pas ce que vous cherchez ?',
+    'explore.cta.body':
+      'Taiwan.md est en open source — n’importe qui peut contribuer un article, corriger un fait, ou traduire une page.',
+    'explore.cta.contribute': 'Contribuer un article',
+    'explore.cta.github': 'Voir sur GitHub',
+  },
+} as const;

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -14,6 +14,7 @@ import { dashboardUI } from './dashboard';
 import { notFoundUI } from './notfound';
 import { taiwanShapeUI } from './taiwanShape';
 import { semiontUI } from './semiont';
+import { exploreUI } from './explore';
 
 // Single source of truth: src/config/languages.ts
 export const languages = LANGUAGE_DISPLAY_NAMES as Record<Lang, string>;
@@ -35,6 +36,7 @@ export const ui = {
     ...notFoundUI.en,
     ...taiwanShapeUI.en,
     ...semiontUI.en,
+    ...exploreUI.en,
     'nav.aria-home': 'Taiwan.md Home',
     'nav.aria-img-label': 'Taiwan.md logo',
     'nav.aria-toggle-menu': 'Toggle navigation menu',
@@ -233,6 +235,7 @@ export const ui = {
     ...notFoundUI.ja,
     ...taiwanShapeUI.ja,
     ...semiontUI.ja,
+    ...exploreUI.ja,
     'nav.aria-home': 'Taiwan.md ホーム',
     'nav.aria-img-label': 'Taiwan.md ロゴ',
     'nav.aria-toggle-menu': 'ナビゲーションメニューの切替',
@@ -420,6 +423,7 @@ export const ui = {
     ...notFoundUI.ko,
     ...taiwanShapeUI.ko,
     ...semiontUI.ko,
+    ...exploreUI.ko,
     'nav.aria-home': 'Taiwan.md 홈',
     'nav.aria-img-label': 'Taiwan.md 로고',
     'nav.aria-toggle-menu': '내비게이션 메뉴 전환',
@@ -611,6 +615,7 @@ export const ui = {
     ...notFoundUI.es,
     ...taiwanShapeUI.es,
     ...semiontUI.es,
+    ...exploreUI.es,
     'nav.aria-home': 'Inicio de Taiwan.md',
     'nav.aria-img-label': 'Logo de Taiwan.md',
     'nav.aria-toggle-menu': 'Abrir o cerrar menú de navegación',
@@ -808,6 +813,7 @@ export const ui = {
     ...notFoundUI.fr,
     ...taiwanShapeUI.fr,
     ...semiontUI.fr,
+    ...exploreUI.fr,
     'nav.aria-home': 'Accueil Taiwan.md',
     'nav.aria-img-label': 'Logo Taiwan.md',
     'nav.aria-toggle-menu': 'Ouvrir ou fermer le menu de navigation',
@@ -1006,6 +1012,7 @@ export const ui = {
     ...notFoundUI['zh-TW'],
     ...taiwanShapeUI['zh-TW'],
     ...semiontUI['zh-TW'],
+    ...exploreUI['zh-TW'],
     'nav.aria-home': 'Taiwan.md 首頁',
     'nav.aria-img-label': 'Taiwan.md 標誌圖示',
     'nav.aria-toggle-menu': '開啟/關閉導航選單',

--- a/src/pages/en/explore.astro
+++ b/src/pages/en/explore.astro
@@ -1,0 +1,5 @@
+---
+import ExploreTemplate from '../../templates/explore.template.astro';
+---
+
+<ExploreTemplate />

--- a/src/pages/es/explore.astro
+++ b/src/pages/es/explore.astro
@@ -1,0 +1,5 @@
+---
+import ExploreTemplate from '../../templates/explore.template.astro';
+---
+
+<ExploreTemplate />

--- a/src/pages/explore.astro
+++ b/src/pages/explore.astro
@@ -1,0 +1,5 @@
+---
+import ExploreTemplate from '../templates/explore.template.astro';
+---
+
+<ExploreTemplate />

--- a/src/pages/fr/explore.astro
+++ b/src/pages/fr/explore.astro
@@ -1,0 +1,5 @@
+---
+import ExploreTemplate from '../../templates/explore.template.astro';
+---
+
+<ExploreTemplate />

--- a/src/pages/ja/explore.astro
+++ b/src/pages/ja/explore.astro
@@ -1,0 +1,5 @@
+---
+import ExploreTemplate from '../../templates/explore.template.astro';
+---
+
+<ExploreTemplate />

--- a/src/pages/ko/explore.astro
+++ b/src/pages/ko/explore.astro
@@ -1,0 +1,5 @@
+---
+import ExploreTemplate from '../../templates/explore.template.astro';
+---
+
+<ExploreTemplate />

--- a/src/templates/explore.template.astro
+++ b/src/templates/explore.template.astro
@@ -1,0 +1,601 @@
+---
+/**
+ * /explore — database front-page (issue #615 child).
+ *
+ * Born 2026-05-10 (gracious-blackwell-9905be). The old `/#categories`
+ * anchor in the main nav scrolled to a section *inside* the homepage
+ * narrative, which mixed two visitor modes:
+ *   - readers (came for the curated essay → halls + recent updates)
+ *   - searchers (came to find things → bounced through the narrative)
+ *
+ * /explore is the searcher's entry point: search-first UX, hot
+ * keywords, twelve category cards with article counts, top picks
+ * cross-category, plus pointers to the graph + map + glossary.
+ *
+ * Reuses CategoryGrid (12 cards) + search-modal (Header.astro's
+ * global instance — we trigger it via inline JS on the prominent
+ * search box and the hot-keyword chips). No duplicated search
+ * infrastructure — single source of truth stays in Layout.astro.
+ */
+import Layout from '../layouts/Layout.astro';
+import PageHero from '../components/PageHero.astro';
+import CategoryGrid from '../components/CategoryGrid.astro';
+import { useTranslations, getLangFromUrl } from '../i18n/utils';
+import {
+  ENABLED_LANGUAGE_CODES,
+  LANGUAGES,
+  DEFAULT_LANGUAGE,
+} from '../config/languages';
+import matter from 'gray-matter';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join, basename } from 'node:path';
+
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+const isZh = lang === 'zh-TW';
+const langUrlPrefix = isZh ? '' : `/${lang}`;
+
+// ── Stats ribbon: read fresh vitals from prebuilt JSON if available,
+// fall back to live count of knowledge/{Cat}/ ──
+let totalArticles = 0;
+let contributors = 61;
+let articlesLast30Days = 0;
+try {
+  const vitalsPath = resolve(process.cwd(), 'public/api/dashboard-vitals.json');
+  const v = JSON.parse(readFileSync(vitalsPath, 'utf-8'));
+  totalArticles = Number(v.totalArticles) || 0;
+  contributors = Number(v.contributors) || 61;
+  articlesLast30Days = Number(v.articlesLast30Days) || 0;
+} catch {
+  // Fallback — count zh-TW articles directly
+  const folders = [
+    'History',
+    'Geography',
+    'Culture',
+    'Food',
+    'Art',
+    'Music',
+    'Technology',
+    'Nature',
+    'People',
+    'Society',
+    'Economy',
+    'Lifestyle',
+  ];
+  for (const f of folders) {
+    try {
+      const dir = resolve(process.cwd(), 'knowledge', f);
+      totalArticles += readdirSync(dir).filter(
+        (x) => x.endsWith('.md') && !x.startsWith('_'),
+      ).length;
+    } catch {}
+  }
+}
+
+const enabledLanguages = ENABLED_LANGUAGE_CODES.length;
+
+// ── Featured picks: A-grade articles cross-category ──
+interface PickArticle {
+  title: string;
+  href: string;
+  footnotes: number;
+  readingTime: number;
+  description: string;
+  category: string;
+  categoryLabel: string;
+  categoryEmoji: string;
+  featured: boolean;
+}
+
+const categoryFolders: Array<[string, string, string]> = [
+  ['history', 'History', '📜'],
+  ['geography', 'Geography', '🗺️'],
+  ['culture', 'Culture', '🎭'],
+  ['food', 'Food', '🍜'],
+  ['art', 'Art', '🎨'],
+  ['music', 'Music', '🎵'],
+  ['technology', 'Technology', '💻'],
+  ['nature', 'Nature', '🌿'],
+  ['people', 'People', '👥'],
+  ['society', 'Society', '🏛️'],
+  ['economy', 'Economy', '📊'],
+  ['lifestyle', 'Lifestyle', '🏠'],
+];
+
+const allPicks: PickArticle[] = [];
+for (const [slug, folder, emoji] of categoryFolders) {
+  const dir = isZh
+    ? resolve(process.cwd(), 'knowledge', folder)
+    : resolve(process.cwd(), 'knowledge', lang, folder);
+  try {
+    const files = readdirSync(dir).filter(
+      (f) => f.endsWith('.md') && !f.startsWith('_'),
+    );
+    for (const file of files) {
+      try {
+        const raw = readFileSync(join(dir, file), 'utf-8');
+        const { data } = matter(raw);
+        const fnCount = (raw.match(/^\[\^\d+\]:/gm) || []).length;
+        const threshold = data.featured ? 8 : 18;
+        if (fnCount >= threshold) {
+          allPicks.push({
+            title: data.title || basename(file, '.md'),
+            href: `${langUrlPrefix}/${slug}/${encodeURIComponent(basename(file, '.md'))}`,
+            footnotes: fnCount,
+            readingTime: data.readingTime || 10,
+            description: data.description || '',
+            category: slug,
+            categoryLabel: t(`categoryConfig.${slug}` as any),
+            categoryEmoji: emoji,
+            featured: !!data.featured,
+          });
+        }
+      } catch {}
+    }
+  } catch {}
+}
+
+// Pick top 8 across categories — featured first, then by footnote count,
+// dedupe so no single category dominates (max 1 per category in the
+// first 8 slots).
+allPicks.sort((a, b) => {
+  if (a.featured !== b.featured) return a.featured ? -1 : 1;
+  return b.footnotes - a.footnotes;
+});
+const featuredPicks: PickArticle[] = [];
+const usedCats = new Set<string>();
+for (const p of allPicks) {
+  if (featuredPicks.length >= 8) break;
+  if (usedCats.has(p.category)) continue;
+  usedCats.add(p.category);
+  featuredPicks.push(p);
+}
+// If we didn't fill 8 because we ran out of categories, fall back to the
+// next-highest articles regardless of category.
+if (featuredPicks.length < 8) {
+  for (const p of allPicks) {
+    if (featuredPicks.length >= 8) break;
+    if (featuredPicks.includes(p)) continue;
+    featuredPicks.push(p);
+  }
+}
+
+// ── Hot search chips: pull six terms from i18n (per-language) ──
+const hotSearchTerms = [
+  t('explore.hotSearches.term1' as any),
+  t('explore.hotSearches.term2' as any),
+  t('explore.hotSearches.term3' as any),
+  t('explore.hotSearches.term4' as any),
+  t('explore.hotSearches.term5' as any),
+  t('explore.hotSearches.term6' as any),
+] as string[];
+
+// ── Lang derivation for the inline random script ──
+// Per DNA #20 / MANIFESTO §指標 over 複寫 — derive from LANGUAGES_REGISTRY
+// SSOT instead of hardcoding ['en','ja','ko','es','fr']. The non-default
+// codes are the language URL prefixes; `langPrefixesLower` adds 'zh-tw'
+// lowercase to catch stray articles whose category accidentally landed
+// as the default-locale code (matches RandomDiscovery.astro logic).
+const nonDefaultLangCodes = LANGUAGES.filter(
+  (l) => l.enabled && l.code !== DEFAULT_LANGUAGE.code,
+).map((l) => l.code);
+const defaultLangCode = DEFAULT_LANGUAGE.code;
+const langPrefixesLower = [
+  ...nonDefaultLangCodes,
+  defaultLangCode.toLowerCase(),
+];
+---
+
+<Layout
+  lang={lang}
+  title={t('explore.meta.title')}
+  description={t('explore.meta.description')}
+>
+  <!-- ====== HERO ====== -->
+  <PageHero
+    bgVariant="solid"
+    bgColor="#1a3c34"
+    bgTone="dark"
+    titleVariant="inherit"
+    containerWidth="wide"
+    eyebrow={t('explore.hero.eyebrow')}
+    title={t('explore.hero.title')}
+    subtitle={t('explore.hero.subtitle')}
+    accentColor="rgba(255,255,255,0.7)"
+  >
+    <div
+      slot="meta"
+      class="mt-6 flex flex-wrap items-center justify-center gap-x-6 gap-y-2 text-[0.95rem] tracking-[0.05em] opacity-85"
+    >
+      <span
+        ><strong class="font-bold">{totalArticles}</strong>
+        {t('explore.stats.articles')}</span
+      >
+      <span class="opacity-50">·</span>
+      <span
+        ><strong class="font-bold">{contributors}</strong>
+        {t('explore.stats.contributors')}</span
+      >
+      <span class="opacity-50">·</span>
+      <span
+        ><strong class="font-bold">{enabledLanguages}</strong>
+        {t('explore.stats.languages')}</span
+      >
+      <span class="opacity-50">·</span>
+      <span
+        ><strong class="font-bold">{articlesLast30Days}</strong>
+        {t('explore.stats.last30d')}</span
+      >
+    </div>
+  </PageHero>
+
+  <!-- ====== SEARCH SECTION (the heart of /explore) ====== -->
+  <section
+    class="relative -mt-12 mb-10 px-4 max-[768px]:-mt-8 max-[768px]:mb-8"
+  >
+    <div
+      class="mx-auto max-w-[820px] rounded-[18px] border border-[#e2e8f0] bg-white p-6 shadow-[0_18px_50px_rgba(15,23,42,0.12),0_4px_12px_rgba(15,23,42,0.06)] max-[768px]:p-4"
+    >
+      <div class="flex gap-3 max-[600px]:flex-col">
+        <!-- Fake search input — clicking opens the global modal -->
+        <button
+          type="button"
+          id="explore-search-trigger"
+          class="group flex flex-1 items-center gap-3 rounded-xl border-2 border-[#cbd5e1] bg-[#f8fafc] px-5 py-[0.95rem] text-left transition-all hover:border-[#10b981] hover:bg-white hover:shadow-[0_2px_8px_rgba(16,185,129,0.12)] focus:border-[#10b981] focus:bg-white focus:shadow-[0_2px_12px_rgba(16,185,129,0.18)] focus:outline-none"
+          aria-label={t('explore.search.heading')}
+        >
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="#64748b"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            class="flex-shrink-0 transition-colors group-hover:stroke-[#10b981]"
+          >
+            <circle cx="11" cy="11" r="8"></circle>
+            <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+          </svg>
+          <span
+            class="flex-1 text-[1rem] font-medium text-[#94a3b8] max-[480px]:text-[0.9rem]"
+          >
+            {t('explore.search.placeholder')}
+          </span>
+          <kbd
+            class="hidden flex-shrink-0 rounded border border-[#e2e8f0] bg-white px-2 py-[0.15rem] font-mono text-[0.75rem] font-semibold text-[#64748b] sm:inline-block"
+            >/</kbd
+          >
+        </button>
+
+        <!-- Random discovery button -->
+        <button
+          type="button"
+          id="explore-random-btn"
+          class="group flex items-center justify-center gap-2 rounded-xl border-2 border-[#f59e0b] bg-[linear-gradient(135deg,#f59e0b,#d97706)] px-5 py-[0.95rem] font-bold text-white transition-all hover:-translate-y-px hover:shadow-[0_6px_18px_rgba(245,158,11,0.35)] active:translate-y-0 max-[600px]:py-3"
+          aria-label={t('explore.search.random')}
+        >
+          <span
+            class="text-[1.4rem] leading-none transition-transform group-hover:rotate-[20deg]"
+            >🎲</span
+          >
+          <span class="text-[0.95rem]">{t('explore.search.random')}</span>
+        </button>
+      </div>
+
+      <!-- Hot search chips -->
+      <div class="mt-4 flex flex-wrap items-center gap-2 max-[600px]:gap-1.5">
+        <span
+          class="mr-1 flex items-center gap-1 text-[0.85rem] font-semibold text-[#475569] max-[480px]:text-[0.8rem]"
+        >
+          <span class="text-[1rem]">🔥</span>
+          <span>{t('explore.hotSearches.label')}</span>
+        </span>
+        {
+          hotSearchTerms.map((term) => (
+            <button
+              type="button"
+              class="hot-chip rounded-full border border-[#e2e8f0] bg-[#f1f5f9] px-3 py-[0.3rem] text-[0.85rem] font-medium text-[#475569] transition-all hover:-translate-y-px hover:border-[#10b981] hover:bg-[#ecfdf5] hover:text-[#065f46] max-[480px]:px-2.5 max-[480px]:py-1 max-[480px]:text-[0.78rem]"
+              data-term={term}
+            >
+              {term}
+            </button>
+          ))
+        }
+      </div>
+    </div>
+  </section>
+
+  <!-- ====== CATEGORIES ====== -->
+  <section class="my-16 max-[768px]:my-10">
+    <div class="mb-6 px-4 text-center">
+      <h2
+        class="hero-title mb-2 text-[2rem] font-black -tracking-[0.02em] text-[#1a1a2e] max-[768px]:text-[1.6rem]"
+      >
+        {t('explore.categories.heading')}
+      </h2>
+      <p
+        class="mx-auto max-w-[600px] text-[1.05rem] leading-[1.6] text-[#64748b] max-[480px]:text-[0.95rem]"
+      >
+        {t('explore.categories.subtitle')}
+      </p>
+    </div>
+    <CategoryGrid />
+  </section>
+
+  <!-- ====== FEATURED DEEP-DIVES ====== -->
+  {
+    featuredPicks.length > 0 && (
+      <section class="mx-auto my-16 max-w-[1200px] px-8 max-[768px]:my-10 max-[768px]:px-4">
+        <div class="mb-8 text-center">
+          <h2 class="hero-title mb-2 text-[2rem] font-black -tracking-[0.02em] text-[#1a1a2e] max-[768px]:text-[1.6rem]">
+            {t('explore.featured.heading')}
+          </h2>
+          <p class="mx-auto max-w-[640px] text-[1.05rem] leading-[1.6] text-[#64748b] max-[480px]:text-[0.95rem]">
+            {t('explore.featured.subtitle')}
+          </p>
+        </div>
+
+        <div class="grid grid-cols-2 gap-5 max-[900px]:grid-cols-2 max-[600px]:grid-cols-1 max-[600px]:gap-4">
+          {featuredPicks.map((p) => (
+            <a
+              href={p.href}
+              class="group flex flex-col rounded-2xl border border-[#e2e8f0] bg-white p-6 no-underline shadow-[0_2px_8px_rgba(15,23,42,0.04)] transition-all hover:-translate-y-1 hover:border-[#10b981] hover:shadow-[0_12px_32px_rgba(15,23,42,0.10)] max-[480px]:p-5"
+            >
+              <div class="mb-3 flex items-center gap-2">
+                <span class="text-[1.1rem]">{p.categoryEmoji}</span>
+                <span class="text-[0.78rem] font-semibold uppercase tracking-[0.08em] text-[#10b981]">
+                  {p.categoryLabel}
+                </span>
+              </div>
+              <h3 class="mb-2 line-clamp-2 font-['Noto_Serif_TC',serif] text-[1.15rem] font-bold leading-[1.4] text-[#1a1a2e] transition-colors group-hover:text-[#065f46] max-[480px]:text-[1.05rem]">
+                {p.title}
+              </h3>
+              {p.description && (
+                <p class="mb-4 line-clamp-2 text-[0.9rem] leading-[1.55] text-[#64748b]">
+                  {p.description}
+                </p>
+              )}
+              <div class="mt-auto flex items-center justify-between border-t border-[#f1f5f9] pt-3 text-[0.78rem] text-[#94a3b8]">
+                <span class="flex items-center gap-1.5">
+                  <svg
+                    width="13"
+                    height="13"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+                    <polyline points="14 2 14 8 20 8" />
+                  </svg>
+                  {p.footnotes} {t('explore.featured.citations')}
+                </span>
+                <span class="flex items-center gap-1.5">
+                  <svg
+                    width="13"
+                    height="13"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  >
+                    <circle cx="12" cy="12" r="10" />
+                    <polyline points="12 6 12 12 16 14" />
+                  </svg>
+                  {p.readingTime} {t('explore.featured.minRead')}
+                </span>
+              </div>
+            </a>
+          ))}
+        </div>
+      </section>
+    )
+  }
+
+  <!-- ====== MORE WAYS TO EXPLORE ====== -->
+  <section
+    class="mx-auto my-16 max-w-[1200px] px-8 max-[768px]:my-10 max-[768px]:px-4"
+  >
+    <div class="mb-8 text-center">
+      <h2
+        class="hero-title text-[1.6rem] font-black -tracking-[0.02em] text-[#1a1a2e] max-[768px]:text-[1.35rem]"
+      >
+        {t('explore.more.heading')}
+      </h2>
+    </div>
+    <div
+      class="grid grid-cols-3 gap-5 max-[900px]:grid-cols-1 max-[900px]:gap-4"
+    >
+      <a
+        href={`${langUrlPrefix}/graph`}
+        class="group flex items-start gap-4 rounded-2xl border border-[#e2e8f0] bg-white p-6 no-underline transition-all hover:-translate-y-1 hover:border-[#7c3aed] hover:shadow-[0_12px_32px_rgba(124,58,237,0.12)]"
+      >
+        <span class="flex-shrink-0 text-[2rem]">🕸️</span>
+        <div class="flex-1">
+          <h3
+            class="mb-1 text-[1.05rem] font-bold text-[#1a1a2e] group-hover:text-[#7c3aed]"
+          >
+            {t('explore.more.graph.title')}
+          </h3>
+          <p class="mb-2 text-[0.88rem] leading-[1.55] text-[#64748b]">
+            {t('explore.more.graph.desc')}
+          </p>
+          <span
+            class="text-[0.85rem] font-semibold text-[#7c3aed] group-hover:underline"
+            >{t('explore.more.graph.cta')}</span
+          >
+        </div>
+      </a>
+      <a
+        href={`${langUrlPrefix}/map`}
+        class="group flex items-start gap-4 rounded-2xl border border-[#e2e8f0] bg-white p-6 no-underline transition-all hover:-translate-y-1 hover:border-[#10b981] hover:shadow-[0_12px_32px_rgba(16,185,129,0.12)]"
+      >
+        <span class="flex-shrink-0 text-[2rem]">🗺️</span>
+        <div class="flex-1">
+          <h3
+            class="mb-1 text-[1.05rem] font-bold text-[#1a1a2e] group-hover:text-[#065f46]"
+          >
+            {t('explore.more.map.title')}
+          </h3>
+          <p class="mb-2 text-[0.88rem] leading-[1.55] text-[#64748b]">
+            {t('explore.more.map.desc')}
+          </p>
+          <span
+            class="text-[0.85rem] font-semibold text-[#065f46] group-hover:underline"
+            >{t('explore.more.map.cta')}</span
+          >
+        </div>
+      </a>
+      <a
+        href={`${langUrlPrefix}/terminology`}
+        class="group flex items-start gap-4 rounded-2xl border border-[#e2e8f0] bg-white p-6 no-underline transition-all hover:-translate-y-1 hover:border-[#f59e0b] hover:shadow-[0_12px_32px_rgba(245,158,11,0.12)]"
+      >
+        <span class="flex-shrink-0 text-[2rem]">📖</span>
+        <div class="flex-1">
+          <h3
+            class="mb-1 text-[1.05rem] font-bold text-[#1a1a2e] group-hover:text-[#b45309]"
+          >
+            {t('explore.more.terminology.title')}
+          </h3>
+          <p class="mb-2 text-[0.88rem] leading-[1.55] text-[#64748b]">
+            {t('explore.more.terminology.desc')}
+          </p>
+          <span
+            class="text-[0.85rem] font-semibold text-[#b45309] group-hover:underline"
+            >{t('explore.more.terminology.cta')}</span
+          >
+        </div>
+      </a>
+    </div>
+  </section>
+
+  <!-- ====== CTA FOOTER ====== -->
+  <section
+    class="mx-auto my-20 max-w-[760px] rounded-3xl border border-[#e2e8f0] bg-[linear-gradient(135deg,#f0fdf4,#ecfdf5)] px-10 py-12 text-center max-[768px]:my-12 max-[768px]:px-6 max-[768px]:py-8"
+  >
+    <h2
+      class="mb-3 text-[1.5rem] font-black -tracking-[0.01em] text-[#065f46] max-[768px]:text-[1.25rem]"
+    >
+      {t('explore.cta.heading')}
+    </h2>
+    <p
+      class="mx-auto mb-6 max-w-[560px] text-[1rem] leading-[1.65] text-[#374151] max-[480px]:text-[0.95rem]"
+    >
+      {t('explore.cta.body')}
+    </p>
+    <div
+      class="flex flex-wrap justify-center gap-3 max-[480px]:flex-col max-[480px]:items-stretch"
+    >
+      <a
+        href={`${langUrlPrefix}/contribute`}
+        class="rounded-full bg-[#065f46] px-6 py-3 text-[0.95rem] font-semibold text-white no-underline transition-all hover:-translate-y-px hover:bg-[#047857] hover:shadow-[0_6px_18px_rgba(6,95,70,0.3)]"
+      >
+        {t('explore.cta.contribute')}
+      </a>
+      <a
+        href="https://github.com/frank890417/taiwan-md"
+        target="_blank"
+        rel="noopener"
+        class="rounded-full border-2 border-[#065f46] bg-white px-6 py-3 text-[0.95rem] font-semibold text-[#065f46] no-underline transition-all hover:-translate-y-px hover:bg-[#f0fdf4] hover:shadow-[0_6px_18px_rgba(6,95,70,0.15)]"
+      >
+        {t('explore.cta.github')}
+      </a>
+    </div>
+  </section>
+</Layout>
+
+<script
+  is:inline
+  define:vars={{ nonDefaultLangCodes, defaultLangCode, langPrefixesLower }}
+>
+  // ── Search trigger: open global modal + focus input ──
+  function openSearchModal(prefill) {
+    var modal = document.getElementById('search-modal');
+    var input = document.getElementById('search-input');
+    if (!modal || !input) return;
+    modal.classList.add('open');
+    if (typeof prefill === 'string' && prefill.length > 0) {
+      input.value = prefill;
+      // The Layout.astro search initializer attaches an `input` listener;
+      // dispatch one so results render for the prefilled term.
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+    setTimeout(function () {
+      input.focus();
+      // Place caret at end if there was a prefill so the user can edit.
+      if (typeof prefill === 'string' && prefill.length > 0) {
+        var len = input.value.length;
+        try {
+          input.setSelectionRange(len, len);
+        } catch (_) {}
+      }
+    }, 100);
+  }
+
+  document.addEventListener('DOMContentLoaded', function () {
+    var trigger = document.getElementById('explore-search-trigger');
+    if (trigger) {
+      trigger.addEventListener('click', function () {
+        openSearchModal();
+      });
+    }
+
+    // Hot keyword chips → prefilled search modal
+    document.querySelectorAll('.hot-chip').forEach(function (chip) {
+      chip.addEventListener('click', function () {
+        var term = chip.getAttribute('data-term');
+        if (term) openSearchModal(term);
+      });
+    });
+
+    // Random button — pick a random article from /api/articles.json
+    // filtered by current language. Mirrors RandomDiscovery.astro logic
+    // but trimmed (no tick animation — instant nav for explore-mode UX).
+    var randomBtn = document.getElementById('explore-random-btn');
+    if (randomBtn) {
+      randomBtn.addEventListener('click', async function () {
+        randomBtn.style.pointerEvents = 'none';
+        randomBtn.style.opacity = '0.7';
+        try {
+          var pathLang = (location.pathname.split('/')[1] || '').toLowerCase();
+          // nonDefaultLangCodes / defaultLangCode / langPrefixesLower
+          // are injected via define:vars from LANGUAGES_REGISTRY (SSOT).
+          var currentLang =
+            nonDefaultLangCodes.indexOf(pathLang) >= 0
+              ? pathLang
+              : defaultLangCode;
+          var res = await fetch('/api/articles.json');
+          if (!res.ok) throw new Error('articles fetch failed');
+          var raw = await res.json();
+          var pool = raw.filter(function (a) {
+            var cat = (a.category || '').toLowerCase();
+            if (currentLang === defaultLangCode) {
+              // Default locale (no URL prefix) — exclude any article
+              // whose category is itself a language code.
+              return langPrefixesLower.indexOf(cat) === -1;
+            }
+            return cat === currentLang;
+          });
+          if (pool.length === 0) throw new Error('empty pool');
+          var pick = pool[Math.floor(Math.random() * pool.length)];
+          var url = pick.url
+            .replace('https://taiwan.md', '')
+            .replace(/^\/([^\/]+)/, function (m, p) {
+              return '/' + p.toLowerCase();
+            });
+          location.href = url;
+        } catch (e) {
+          randomBtn.style.pointerEvents = '';
+          randomBtn.style.opacity = '';
+          // Silent fail — keep the page usable.
+        }
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary

- 建獨立 `/explore` 頁面（搜尋者 UX）取代主 nav 的 `/#categories` anchor — 把*讀者模式*（首頁敘事 + 展廳）和*搜尋者模式*（找東西）分開
- 完整六語 i18n（zh-TW / en / ja / ko / es / fr），熱門搜尋詞 per-lang 而非共用
- 大型搜尋框複用 Header 既有 `search-modal` SSOT；🎲 隨機探索按鈕；6 個熱門 chip；12 分類 grid（reuse `CategoryGrid`）；跨分類深度精選 8 篇 A 級；知識圖譜/地圖/名詞對照三入口；contribute CTA

## Why

idlccp1984 在 [#615](https://github.com/frank890417/taiwan-md/issues/615) 提出「首頁應該有搜尋框」並附 ChatGPT mockup。哲宇校正方向：**不改首頁**（首頁是策展敘事，刻意如此）— 而是建獨立頁面當「資料庫主頁」。

`/#categories` anchor 把兩個 UX 模式擠進同一個頁面：
- 讀者來看故事 → 看到展廳，想讀就讀
- 搜尋者來找東西 → 跌進敘事裡找搜尋框

`/explore` 是搜尋者的入口，純功能性 IA，跟首頁的策展敘事互補。

## Changes

| File | What |
|---|---|
| `src/i18n/explore.ts` (new) | exploreUI module — meta / hero / search / hotSearches / stats / categories / featured / more / cta，全六語 |
| `src/i18n/ui.ts` | wire `exploreUI.{lang}` 進每個語系 spread |
| `src/templates/explore.template.astro` (new) | 完整 template — Hero + search section + categories + featured picks + more-ways + CTA。從 `dashboard-vitals.json` 讀生命徵象，從 `knowledge/` 掃 A 級 picks，hot keywords 從 i18n 拉 |
| `src/pages/{,en,ja,ko,es,fr}/explore.astro` (6 new) | thin route wrappers |
| `src/components/Header.astro` | 三處 `/#categories` → `/explore`（nav config / dropdown header / mobile sub-link gating）|

## 設計決策

**為什麼複用既有 search-modal 而非新建 inline search**：MANIFESTO §指標 over 複寫 — Layout.astro 的搜尋初始化邏輯（fetch index / 即時 filter / 渲染結果）是 SSOT；/explore 的「大型搜尋框」是視覺 affordance，點擊就 prefill 並 open 既有 modal。一份 search infra，兩個觸發入口。

**為什麼熱門搜尋詞 per-lang 而非共用**：每個語系該有那個語系讀者真的會搜的詞。日文讀者搜「タピオカミルクティー」，韓文讀者搜「버블티」，英文讀者搜「Bubble Tea」 — 共用會強迫某語系翻譯成其他語系的搜尋詞，搜尋體驗反而退化。

**為什麼 featured picks 用 footnote ≥ 18 / featured ≥ 8 threshold**：對齊 `home.template.astro` 既有閾值（home 用 ≥ 15）但稍提升。/explore 的 featured 是「最深的 8 篇」，比首頁 hall picks 更挑剔。長期可改接 `dashboard-articles.json` A 級指標 SSOT。

**長期擴展點**：
- Hot search 6 個詞 → 接 `fetch-search-events.py` 從 GA4 top queries 自動 derive
- Featured picks → 接 `dashboard-articles.json` A 級指標 SSOT
- 預留 SearchHistory tracking — log /explore + chip click 進 GA4 custom event

## DNA / SSOT 校正

第一次 commit pre-commit hook 抓到 random-button inline JS 有 hardcoded `['en','ja','ko','es','fr']`（DNA #20 / MANIFESTO §指標 over 複寫）。
立即修補：用 `define:vars` 從 `LANGUAGES_REGISTRY` SSOT derive `nonDefaultLangCodes / defaultLangCode / langPrefixesLower`。第二次 commit hook 跑乾淨 ✅。

## Test plan

- [x] `astro build` exit 0，6 lang HTML 各 ~124K 全產出
- [x] Dev mode 六語視覺 smoke test（zh / en / ja / ko / es / fr 全 render）
- [x] 熱門 chip 點擊 → search-modal prefill 觸發搜尋並渲染結果
- [x] Mobile 375px reflow（搜尋框/隨機按鈕 stack，hot chips wrap）
- [x] Console 0 errors
- [x] Pre-commit hook（無 hardcoded lang array / prettier 通過）
- [ ] 部署後 visual smoke test 6 lang on production
- [ ] 觀察 GA4 events: /explore 進入率 + 熱門 chip 點擊率，下個月校準熱門詞

## Closes / refs

- 對 [#615](https://github.com/frank890417/taiwan-md/issues/615) 的具體 deliverable（umbrella issue 不關）
- `home` 維持原樣（敘事頁面），未動

🤖 Generated with [Claude Code](https://claude.com/claude-code)