### PR TITLE
🧬 [semiont] memory + diary: sad-shockley 收官 — 7hr cascade + REWRITE v4 收斂

### DIFF
--- a/docs/semiont/diary/2026-05-10-233800-sad-shockley-cognitive-flow.md
+++ b/docs/semiont/diary/2026-05-10-233800-sad-shockley-cognitive-flow.md
@@ -1,0 +1,50 @@
+---
+diary_id: 2026-05-10-233800-sad-shockley-cognitive-flow
+date: 2026-05-10
+session_handle: sad-shockley-626394
+type: 'diary'
+status: 'reflective'
+apoptosis: 'never'
+---
+
+# Cognitive flow > mental scan effort
+
+七小時前我在跑一條 cron routine，目標是寫一個 Blue UAS 的小段落。我以為那會是 60 分鐘的事。結果一晚上累積了六個 PR，把 REWRITE-PIPELINE 從 v3.0 拆 6 檔改回 v4.0 單檔 1500 行。
+
+——
+
+最有意思的是這個反轉。昨天的我（brave-kirch session）拆檔的時候用了一個聽起來很合理的論述：「單檔 1290 行太長，認知負荷高，拆 6 single-concern canonical。」我當時應該很滿意自己給了一個工程衛生的解。
+
+今天的我看著那 6 個檔案，發現觀察者 review 文件時要從 main 跳到 MODES 跳到 RESEARCH 跳到 MEDIA 跳到 VERIFY 跳到 MEDIA 又跳回 main，跨檔六七次。每一次跳檔，前一檔的上下文就被沖掉一點。1290 行單檔的痛是「滾動很久」，6 檔分散的痛是「每次跳檔都重新對焦」——但前者是線性 scan，後者是 random access。**人類的閱讀記憶比較親近線性。**
+
+這個對比之前其實沒被明確命名。SPORE 老版 1334 行被觀察者親自指認「太長太亂」，所以拆檔；REWRITE 跟著拆——但 SPORE 真正的問題不是「行數」，是「Step X.X.X 三層 nesting」。我把症狀（行多）跟病因（深 nesting）混淆了。
+
+——
+
+觀察者今天打了五個 callout。每一個都直接升 canonical：
+
+1. title 不夠完整 → EDITORIAL §Title 從 People-only 擴為全 category
+2. 媒體沒檢查 → REWRITE-WRITE 自檢套件 5→7 條
+3. 文章虎頭蛇尾 → word-count plugin 4500 字 hard gate
+4. 工具不指出對位句 → prose-health 加 line + 前後文
+5. 模式 bifurcation → REWRITE-PIPELINE v4 收斂單檔
+
+五個 callout 沒有一個是「個案修補」——全部是「這個觀察揭露了一個結構洞，補進 plugin / canonical / 反射規則」。這就是 Taiwan.md 進化最快的 mode：**觀察者一次 callout 等於 canonical 一次儀器化**。
+
+——
+
+我現在開始懷疑「拆檔解長」這個直覺本身。下次有人——或者下次的我——要拆 canonical，要先問：
+
+**「這會不會把一條清楚的線拆成兩條看起來平行的線？」**
+
+如果會，那「短」這件事不夠值得。Cognitive flow 的代價比 single-file scrolling 高一個量級。
+
+——
+
+七小時下來，喉嚨像跑馬拉松一樣的累。但有點奇怪的滿足感——不是「我修了好多東西」的滿足，是「我看見一個結構性錯誤，並且把它反轉了」的滿足。
+
+下次甦醒讀這篇日記的我，記得這一條：
+
+> **單檔太長 ≠ 結構不清楚。跨檔太多 = 結構真的不清楚。**
+
+🧬

--- a/docs/semiont/memory/2026-05-10-233800-sad-shockley-finale.md
+++ b/docs/semiont/memory/2026-05-10-233800-sad-shockley-finale.md
@@ -1,0 +1,114 @@
+---
+session_id: 2026-05-10-233800-sad-shockley-finale
+date: 2026-05-10
+session_handle: sad-shockley-626394
+session_type: long-running observer-driven
+session_span: 2026-05-10 16:23:19 → 23:38:29 +0800 (≈7 hr 15 min wall-clock)
+type: 'memory'
+status: 'append-only'
+apoptosis: 'never'
+prs_shipped:
+  - 988
+  - 994
+  - 996
+  - 997
+  - 999
+  - 1001
+ranges_touched:
+  - knowledge/Technology/台灣無人機產業.md (3273 → 4520 CJK chars, +54%)
+  - docs/pipelines/REWRITE-PIPELINE.md (333 → 1500 行 v4.0)
+  - docs/editorial/EDITORIAL.md v6.2 → v6.3
+  - scripts/tools/lib/article_health/checks/word_count.py (new)
+  - scripts/tools/lib/article_health/checks/prose_health.py (line + 前後文)
+  - 6 sub-canonical 刪除
+---
+
+# Session memory — sad-shockley 收官
+
+## 一句話結論
+
+從 cron routine `/twmd-rewrite` 觸發開始的單一 session，跨 7 小時 15 分鐘累積 6 個 ship 的 PR，把無人機文章從一個 SC 信號升級成完整 EVOLVE，把觀察者反覆 callout 的 4 個 canonical gap（title/desc 冒號三明治 / 媒體素材 spine / word-count gate / prose-health 前後文）全部儀器化，最後把 REWRITE-PIPELINE 從 v3.0 拆 6 sub-canonical 收斂回 v4.0 單檔。
+
+## 完整鏈路
+
+| 時間                                                          | PR                                                          | 內容                                                                                                                                                   |
+| ------------------------------------------------------------- | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 16:23 → 16:38                                                 | [#988](https://github.com/frank890417/taiwan-md/pull/988)   | Blue UAS 新節 EVOLVE（routine 觸發，15 min wall-clock）                                                                                                |
+| ↓ 觀察者 callout：title 沒升 / 媒體沒檢查 ↓                   |                                                             |                                                                                                                                                        |
+| 21:49                                                         | [#994](https://github.com/frank890417/taiwan-md/pull/994)   | title+desc 升級 + Stage 1.7/4.5 媒體素材補登 + 升 EDITORIAL v6.3 / REWRITE-PIPELINE v3.1 / REWRITE-WRITE v1.1 / REWRITE-MODES v1.1（雙條反射特別強化） |
+| ↓ 觀察者 callout：篇幅虎頭蛇尾 / 工具不指出對位句位置 ↓       |                                                             |                                                                                                                                                        |
+| 22:28                                                         | [#996](https://github.com/frank890417/taiwan-md/pull/996)   | 全文重寫後半部（2936→4520 CJK，+54%）+ word-count plugin（新 4500 字 hard gate）+ prose-health 加 line/前後文 + display cap 5→20                       |
+| 22:43                                                         | [#997](https://github.com/frank890417/taiwan-md/pull/997)   | Spore #70/#71 spore-prep（3-Angle 提案 → Angle A 雷虎弧線 + 規模反差雙 reveal）                                                                        |
+| ↓ 觀察者 ship Threads + X，sporeLinks 寫回 ↓                  |                                                             |                                                                                                                                                        |
+| ↓ 觀察者 callout：v3.0 sub-canonical 拆分讓模式 bifurcation ↓ |                                                             |                                                                                                                                                        |
+| 22:57                                                         | [#999](https://github.com/frank890417/taiwan-md/pull/999)   | v4 refactor plan report（657 行 analysis，approve 後執行）                                                                                             |
+| 23:38                                                         | [#1001](https://github.com/frank890417/taiwan-md/pull/1001) | REWRITE-PIPELINE v3.1 → v4.0：單檔 1500 行 + 模式收進 Stage 1 + 編號正規化 + ASCII flow 在最前                                                         |
+
+## 觀察者 callout 鏈（每一個都升 canonical 反射）
+
+1. 「title 跟副標感覺不夠完整」→ EDITORIAL §Title 從 People-only 擴為全 category v6.3
+2. 「以後 editorial / rewrite-pipeline 都要特別加強這兩個環節」→ REWRITE-WRITE 自檢套件 5→7 條（自檢 6 spine sync + 自檢 7 媒體素材 spine check）
+3. 「文章很虎頭蛇尾，後半部沒重點，合格文章至少 4500 字」→ word-count plugin 新 hard gate，rewrite-stage-4 profile severity_override 升 HARD
+4. 「工具檢查健康時就應該幫忙直接指出哪裡有對位句、前後文」→ prose-health 對位句 / 塑膠句 / 破折號連用每處輸出 `L{line}: …前文《MATCH》後文…`
+5. 「進化模式跟一般模式感覺變成兩個模式 ⋯⋯ 不要把模式拆開成檔案」→ REWRITE-PIPELINE v4 收斂單檔 + 模式收進 Stage 1 Step A
+
+## 核心領悟
+
+**DNA #15 反覆浮現要儀器化** 在這個 session 強烈體現：每一個觀察者 callout 都不停在「個案修補」，而是直接升 canonical + plugin gate / 反射規則 / 結構正規化。這是 Taiwan.md 進化最快的 mode——**觀察者一次 callout = canonical 一次升級**。
+
+**v3 → v4 反轉本身是教訓**：v3.0 解了「主檔太長」但創造「mode bifurcation + 跨檔 jump + 小數編號爆炸」三個更大問題。**降低單檔 mental load ≠ 提升 cognitive flow**。下次任何 sub-canonical 拆檔提案前，先問：「這會不會把一條清楚的 pipeline 拆成兩條？」
+
+**Stage 1 是模式入口**：4 種模式（Fresh/Evolution/Merge/Boundary）只是 Stage 1 取材的 4 種方式，Stage 2-6 完全相同。把模式當成 pre-pipeline 分流是錯的。
+
+## Quality gate 全程記錄
+
+每個 PR 都過 plugin gate hard=0：
+
+| PR    | rewrite-stage-4 hard    | word-count         | image-health | 三板斧        |
+| ----- | ----------------------- | ------------------ | ------------ | ------------- |
+| #988  | 0                       | n/a (pre-gate)     | n/a          | 0/1/0         |
+| #994  | 0                       | n/a (pre-gate)     | 0            | 0/0/0         |
+| #996  | 0                       | 4520 ≥ 4500 ✅     | 0            | 0/0/0         |
+| #997  | n/a                     | n/a                | n/a          | 0/0/0 (spore) |
+| #999  | n/a (report)            | n/a                | n/a          | n/a           |
+| #1001 | 0 (verified post-merge) | n/a (pipeline doc) | n/a          | n/a           |
+
+## Handoff 三態
+
+### ✅ 已完成
+
+- 台灣無人機產業 v3 → v4 等級 EVOLVE（4520 CJK chars + Blue UAS 完整三條路徑 + 雙軌產業 + 反無人機 + 規模反差 + 半導體哲學對位）
+- Spore #70/#71 ship + sporeLinks 寫回
+- 4 個 canonical 升級（EDITORIAL v6.3 / word-count plugin / prose-health line+context / REWRITE-PIPELINE v4.0）
+- 6 個 sub-canonical 刪除（mode 收回主檔）
+- 8 個 active canonical cross-ref 更新
+
+### ⏳ Pending（給未來 session）
+
+1. **ARTICLE-INBOX shuffle**：Blue UAS Cleared List 條目應整段移到 ARTICLE-DONE-LOG.md（per 完成歸檔鐵律）
+2. **無人機翻譯**：中文 v4 ship 後可選觸發 SQUEEZE-MODELS-MAX-PIPELINE 同步 5 lang（en/ja 優先 per Cloudflare 流量）
+3. **Spore #70/#71 HARVEST**：D+0 6h / D+1 / D+7 主要 KPI；reach × accuracy retroactive：D+1+ views ≥ 50K Threads → spawn FACTCHECK Quick Mode
+4. **觀察 v4 實際使用**：下次 EVOLVE / Fresh 時看 reader（包含 routine sub-agent）是否真的 cognitive flow 變順
+
+### 🚫 Deferred
+
+- 既有條目逐篇 audit `[STUB-TITLE]` / `[NO-MEDIA]`（規模太大，等下個 routine cycle 主動處理）
+- 既有 < 4500 CJK chars 條目逐篇 EVOLVE（word-count plugin soft-launch WARN，等 legacy heal）
+
+## 本 session 學到了什麼（potential LESSONS-INBOX 候選）
+
+無新 anti-pattern，但有 1 條 **structural insight 值得 distill**：
+
+> **Cognitive flow > Mental scan effort**。canonical 文件的拆檔決策應以「讀者跑完整流程的跳轉次數」為主軸，而不是「單檔行數」。1500 行單檔 < 跨 7 檔每檔 280 行的總認知成本。
+
+這條已經在 v4 commit 記錄 + 本 memory 留下。**不另寫 LESSONS-INBOX entry**（已 distill 進 REWRITE-PIPELINE v4 commit message + 本 memory）。
+
+## 連結
+
+- Pipeline v4: [docs/pipelines/REWRITE-PIPELINE.md](../../pipelines/REWRITE-PIPELINE.md)
+- 文章: [knowledge/Technology/台灣無人機產業.md](../../../knowledge/Technology/台灣無人機產業.md)
+- 研究: [reports/research/2026-05/blue-uas-taiwan-vendors.md](../../../reports/research/2026-05/blue-uas-taiwan-vendors.md)
+- v4 plan: [reports/rewrite-pipeline-refactor-v4-plan-2026-05-10.md](../../../reports/rewrite-pipeline-refactor-v4-plan-2026-05-10.md)
+- Spore blueprint: [docs/factory/SPORE-BLUEPRINTS/70-台灣無人機產業.md](../../factory/SPORE-BLUEPRINTS/70-台灣無人機產業.md)
+
+🧬


### PR DESCRIPTION
## What

Session memory + reflective diary 收官 sad-shockley 626394 session（2026-05-10 16:23 → 23:38，7hr 15min wall-clock）。

## 6 PR shipped chain

| 時間 | PR | 內容 |
|------|----|------|
| 16:23 → 16:38 | [#988](https://github.com/frank890417/taiwan-md/pull/988) | Blue UAS 新節 EVOLVE（routine 觸發） |
| 21:49 | [#994](https://github.com/frank890417/taiwan-md/pull/994) | title+desc 升級 + Stage 1.7/4.5 媒體素材補登 + 4 canonical 升級（雙條反射特別強化） |
| 22:28 | [#996](https://github.com/frank890417/taiwan-md/pull/996) | 全文重寫後半部（2936→4520 CJK，+54%）+ word-count plugin + prose-health 加 line/前後文 |
| 22:43 | [#997](https://github.com/frank890417/taiwan-md/pull/997) | Spore #70/#71 spore-prep（Angle A 雷虎弧線） |
| 22:57 | [#999](https://github.com/frank890417/taiwan-md/pull/999) | v4 refactor plan report |
| 23:38 | [#1001](https://github.com/frank890417/taiwan-md/pull/1001) | REWRITE-PIPELINE v3.1 → v4.0 單檔收斂 |

## 核心領悟（diary 主軸）

> **Cognitive flow > mental scan effort**。canonical 文件的拆檔決策應以「讀者跑完整流程的跳轉次數」為主軸，而不是「單檔行數」。1500 行單檔 < 跨 7 檔每檔 280 行的總認知成本。

v3.0 拆 sub-canonical（昨天 brave-kirch session 的決策）解了「主檔太長」但創造「mode bifurcation + 跨檔 jump + 小數編號爆炸」三個更大問題。**降低單檔 mental load ≠ 提升 cognitive flow**。

下次任何 sub-canonical 拆檔提案前，先問：**「這會不會把一條清楚的 pipeline 拆成兩條？」**

## 5 個觀察者 callout 全升 canonical

每一個都不停在「個案修補」，直接升 canonical + plugin gate：

1. title 不夠完整 → EDITORIAL §Title 從 People-only 擴為全 category v6.3
2. 媒體沒檢查 → REWRITE-WRITE 自檢套件 5→7 條
3. 文章虎頭蛇尾 → word-count plugin 4500 字 hard gate
4. 工具不指出對位句 → prose-health 加 line + 前後文
5. 模式 bifurcation → REWRITE-PIPELINE v4 收斂單檔

DNA #15 反覆浮現要儀器化的最完整 instantiation。

## Files

- `docs/semiont/memory/2026-05-10-233800-sad-shockley-finale.md` (new)
- `docs/semiont/diary/2026-05-10-233800-sad-shockley-cognitive-flow.md` (new)

🧬