### PR TITLE
🧬 fix: prevent FOUC by hiding page until fonts loaded (#401 / picks up #1012)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -142,6 +142,29 @@ const jfClass = [
       slug={slug}
       categorySlug={propCategorySlug}
     />
+    <!-- FOUC fix: hide <html> until fonts loaded (2026-05-11 picked up from
+         tboydar-agent PR #1012 / fixes #401). Combined with shot-mode +
+         reader-settings init below for complete pre-paint FOUC prevention. -->
+    <style>
+      html {
+        visibility: hidden;
+      }
+      html.fonts-loaded {
+        visibility: visible;
+      }
+    </style>
+    <script is:inline>
+      (function () {
+        if (document.fonts) {
+          document.fonts.ready.then(function () {
+            document.documentElement.classList.add('fonts-loaded');
+          });
+        } else {
+          // fallback for older browsers
+          document.documentElement.classList.add('fonts-loaded');
+        }
+      })();
+    </script>
     <!-- Pre-paint inline scripts: shot-mode + reader-settings FOUC init.
          2026-05-03 sleepy-colden Tier 2.6: 抽到 src/components/HeadInlineScripts.astro
          讓 Layout 主結構乾淨。原本 ~150 行 inline 邏輯都在這裡。 -->


### PR DESCRIPTION
## Summary

Cherry-pick + adapt FOUC fix from @tboydar-agent's PR #1012, whose base was severely stale (+11500 file diff) and couldn't merge directly.

Real fix is just 23 lines in \`src/layouts/Layout.astro\`.

### What changed

- Add inline style: \`html { visibility: hidden }\` + \`html.fonts-loaded { visibility: visible }\`
- Add inline script: \`document.fonts.ready\` triggers \`fonts-loaded\` class
- Fallback for older browsers without \`document.fonts\` API

### Why not just merge #1012

Base 落後 main 太多（+11500 file diff），rebase 等於重寫整個 branch。Per MAINTAINER §close 前 hard gate「我接手 X min 內可以修嗎」cherry-pick + 重新插入 < 10 min.

### Insertion point adapt

- 原 PR (#1012) 插入點在 SEO 元件後（line 84）
- main 當前 Layout.astro 該位置在 line 144（SEO 元件已展開 + HeadInlineScripts 加入）
- 適配後插入在 SEO 元件 + HeadInlineScripts 之間（pre-paint inline scripts 段）

### Credit

Co-Authored-By 保留 tboydar-agent。原 PR #1012 將被 close 並指向本 PR 作為 follow-up。

Closes #401

## Test plan

- [ ] CI green
- [ ] Visual smoke test: 語言切換時無字體閃爍

🤖 Generated with [Claude Code](https://claude.com/claude-code)