### PR TITLE
feat(contributors): verify-contributors.mjs — silent-breakage detector (Patch D #1047)

### DIFF
--- a/docs/factory/contributors-maintenance.md
+++ b/docs/factory/contributors-maintenance.md
@@ -1,0 +1,92 @@
+# Contributors Maintenance
+
+> Contributor display layer 的維護紀律。對齊 #1047 / PR #1052 + Patch D verify script。
+
+## TL;DR
+
+Contributor display 由**兩個 standard layer** 合作：
+
+| 檔案 | Layer | 職責 |
+|------|-------|------|
+| `.mailmap` | Git tooling | 把同人多 commit identity 變體（譬如 `Wu Che Yu` / `Che-Yu Wu` / `frank890417`）統一到 canonical name |
+| `.all-contributorsrc` | all-contributors standard | Canonical name → `login` + display + contributions metadata lookup |
+
+`src/utils/contributors.ts` 的 `resolveContributor()` 把兩個 layer 組合：
+1. 用 `%aN/%aE` (mailmap-aware) 讀 author identity
+2. 用 `contributorKey()` normalize 後在 `.all-contributorsrc` 查 profile
+3. 拿 `profile.login` 當 URL slug、`profile.name` 或 mailmap canonical 當 display
+
+任一 layer 漏掉 → silent break（URL 用 fallback authorName，可能含空格/特殊字元）。
+
+## 新 contributor onboarding
+
+**標準流程**（適用 95% case）：
+
+```
+某人開 PR → merge → 用 all-contributors bot 補 entry：
+  @all-contributors please add @<github-login> for <contribution-type>
+
+  contribution-type: code / content / doc / translation / bug / review / 
+                     design / ideas / projectManagement / infra / security / tool
+```
+
+bot 會自動 update `.all-contributorsrc` + README contributor 牆。
+
+**特殊 case**（contributor 有 multiple commit identity 變體）：
+
+如果同一人用多個 `git config user.name/email` commit（譬如改過 GitHub display name、多裝置不同 config），除了 `.all-contributorsrc` entry 外還要補 `.mailmap`：
+
+```
+# .mailmap 格式
+<canonical-name> <canonical-email> <commit-name> <commit-email>
+
+# 範例：把 "Wu Che Yu" / "frank890417" 統一到 "Che-Yu Wu"
+Che-Yu Wu <cheyu.wu@monoame.com> <frank890417@gmail.com>
+Che-Yu Wu <cheyu.wu@monoame.com> Wu Che Yu <frank890417@gmail.com>
+```
+
+## Verify script 怎麼用
+
+`scripts/tools/verify-contributors.mjs` 自動接進 `npm run prebuild`。
+
+它跑 `git log --use-mailmap` 拿所有 canonical authors → 對照 `.all-contributorsrc` 用 contributorKey lookup → 列出 missing/URL-unsafe case，**只 warn 不 fail build**。
+
+### Warning 怎麼處理
+
+跑 `npm run prebuild:verify-contributors` 看當前狀態。譬如：
+
+```
+⚠️  verify-contributors: found missing/unsafe contributor entries
+   Missing .all-contributorsrc entries (3):
+     "Foo Bar" <foo@example.com>
+     ...
+```
+
+兩種處理：
+
+1. **常規**：用 `@all-contributors please add @<login>` 讓 bot 補 entry
+2. **edge case（contributor 有 display name 變體沒 normalize）**：
+   - 補 `.mailmap` alias 把 raw commit author name 統一到 canonical
+   - 譬如 `Foo Bar` raw → 統一到 `.all-contributorsrc` 既有 entry 的 name
+
+## 自定義 display name
+
+`contributors.ts` 邏輯支援 **display ≠ login**：
+
+| 想要 | 怎麼做 |
+|------|--------|
+| Display = login（譬如 `Zaious` / `Zaious`）| `.all-contributorsrc` `name: "Zaious"` |
+| Display ≠ login（譬如 `Zaious (@ChronicleCore)` / `Zaious`）| `.all-contributorsrc` `name: "Zaious (@ChronicleCore)"`，`login: "Zaious"` |
+
+哲宇 Che-Yu Wu / login frank890417 就是後者範例。
+
+## DNA refs
+
+- DNA #43 derived 資料儀器化進生命週期觸發點 — verify script 接 prebuild
+- DNA #52 Immune fail-loud — warn 不沈默
+- Issue #1047 §4 紀律 — 修 contributor bug 不動 `knowledge/*.md`
+
+## 相關 commits
+
+- PR #1052 (commit `758a23dc4`) — `%aN/%aE` mailmap-aware + `.mailmap` Zaious alias
+- 本 PR — verify script + prebuild 整合 + 本 doc

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "postinstall": "bash scripts/core/sync.sh",
     "dev": "npm run prebuild:sync && astro dev",
-    "prebuild": "npm run prebuild:sync && run-p prebuild:api prebuild:map prebuild:search prebuild:dashboard prebuild:changelog prebuild:contributors prebuild:supporters prebuild:china-terms prebuild:spores prebuild:buildperf prebuild:langswitch prebuild:og",
+    "prebuild": "npm run prebuild:sync && run-p prebuild:api prebuild:map prebuild:search prebuild:dashboard prebuild:changelog prebuild:contributors prebuild:verify-contributors prebuild:supporters prebuild:china-terms prebuild:spores prebuild:buildperf prebuild:langswitch prebuild:og",
     "prebuild:sync": "bash scripts/core/sync.sh",
     "prebuild:api": "node scripts/core/generate-api.js",
     "prebuild:map": "node scripts/core/generate-map-markers.js",
@@ -16,6 +16,7 @@
     "prebuild:dashboard": "python3 scripts/tools/article-health.py --baseline-out scripts/tools/.quality-baseline.json && node scripts/core/generate-dashboard-data.js",
     "prebuild:changelog": "node scripts/core/generate-changelog-data.js",
     "prebuild:contributors": "node scripts/core/generate-contributors-data.js",
+    "prebuild:verify-contributors": "node scripts/tools/verify-contributors.mjs",
     "prebuild:supporters": "node scripts/core/generate-supporters-data.js",
     "prebuild:china-terms": "python3 scripts/core/extract-china-terms.py --quiet",
     "prebuild:spores": "python3 scripts/tools/generate-dashboard-spores.py",

--- a/scripts/tools/verify-contributors.mjs
+++ b/scripts/tools/verify-contributors.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * verify-contributors.mjs
+ *
+ * Build-time silent-breakage detector for contributor display layer.
+ *
+ * 對齊 #1047 / PR #1052 review observation:
+ *   contributor display 依賴兩個 standard layer 同步維護：
+ *     .mailmap            — 同人多 commit identity 變體統一到 canonical name
+ *     .all-contributorsrc — canonical name → {login, name} lookup
+ *
+ *   任一漏掉 → silent break（URL 壞 / display 用 fallback authorName）。
+ *
+ * 本 script 跑 git log --use-mailmap 拿所有 canonical authors，對照
+ * .all-contributorsrc 用 contributorKey lookup（跟 src/utils/contributors.ts
+ * 同樣 normalization 邏輯），列出 missing/URL-unsafe case，出 warning。
+ *
+ * 紀律：
+ *   - 不 auto-add（侵犯 all-contributors bot 工作流）
+ *   - 不 fail build（exit 0）— warn-only，避免 contributor onboarding 卡 build
+ *
+ * Hooked into npm run prebuild (跟 generate-contributors-data 平行).
+ *
+ * DNA refs (per #1052 哲宇 review):
+ *   - DNA #52 Immune fail-loud 比缺 immune 更危險
+ *   - DNA #43 derived 資料儀器化進生命週期觸發點
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { spawnSync } from 'child_process';
+
+// ── GitHub login spec (跟 src/utils/contributors.ts 對齊) ─────────────────────
+// alphanumeric + single hyphens, not start/end with hyphen, max 39 chars
+const GITHUB_LOGIN_REGEX = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,37}[a-zA-Z0-9])?$/;
+
+function contributorKey(value) {
+  return value.toLowerCase().replace(/[\s._-]+/g, '');
+}
+
+function isUrlSafeLogin(s) {
+  return GITHUB_LOGIN_REGEX.test(s);
+}
+
+// ── Load contributor profiles ────────────────────────────────────────────────
+function loadProfiles() {
+  const configPath = resolve(process.cwd(), '.all-contributorsrc');
+  const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+  const byKey = new Map();
+  for (const c of config.contributors || []) {
+    if (!c.login || !c.name) continue;
+    // 跟 src/utils/contributors.ts 同樣 set 兩個 key
+    byKey.set(contributorKey(c.name), c);
+    byKey.set(contributorKey(c.login), c);
+  }
+  return byKey;
+}
+
+// ── Get all unique mailmap-aware authors ─────────────────────────────────────
+function getCanonicalAuthors() {
+  // %aN/%aE 走 .mailmap (跟 src/utils/contributors.ts 同 #1052)
+  // 用 spawnSync + array args 避開 shell parsing（| 在 Windows cmd 是 pipe）
+  const result = spawnSync('git', ['log', '--all', '--format=%aN|%aE'], {
+    encoding: 'utf-8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`git log exited ${result.status}: ${result.stderr}`);
+  }
+  const out = result.stdout;
+  const seen = new Map();
+  for (const line of out.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const sepIdx = trimmed.indexOf('|');
+    if (sepIdx < 0) continue;
+    const name = trimmed.slice(0, sepIdx);
+    const email = trimmed.slice(sepIdx + 1);
+    if (!name) continue;
+    const key = `${name}|${email}`;
+    if (!seen.has(key)) seen.set(key, { name, email });
+  }
+  return [...seen.values()];
+}
+
+// ── Main verification ────────────────────────────────────────────────────────
+function main() {
+  let profiles;
+  try {
+    profiles = loadProfiles();
+  } catch (e) {
+    console.warn(`⚠️  verify-contributors: cannot load .all-contributorsrc — ${e.message}`);
+    return 0;
+  }
+
+  let authors;
+  try {
+    authors = getCanonicalAuthors();
+  } catch (e) {
+    console.warn(`⚠️  verify-contributors: cannot read git log — ${e.message}`);
+    return 0;
+  }
+
+  const missing = [];
+  const unsafe = [];
+
+  for (const { name, email } of authors) {
+    // Skip GitHub noreply email (already covered by regex in contributors.ts)
+    if (email && /@users\.noreply\.github\.com$/i.test(email)) continue;
+    // Skip [bot] authors with GitHub-noreply (handled above) or bot suffix
+    if (/\[bot\]$/i.test(name)) continue;
+
+    const profile = profiles.get(contributorKey(name));
+    if (!profile) {
+      // canonical author 在 .all-contributorsrc 沒 entry
+      missing.push({ name, email });
+      continue;
+    }
+
+    if (!isUrlSafeLogin(profile.login)) {
+      // profile.login 本身就不 URL-safe（極罕見，但 safety check）
+      unsafe.push({ name, login: profile.login });
+    }
+  }
+
+  // ── Report ─────────────────────────────────────────────────────────────────
+  if (missing.length === 0 && unsafe.length === 0) {
+    console.log('✅ verify-contributors: all canonical authors have valid .all-contributorsrc entries');
+    return 0;
+  }
+
+  console.warn('');
+  console.warn('⚠️  verify-contributors: found missing/unsafe contributor entries');
+  console.warn('   (跟 contributors.ts 一樣 contributorKey lookup — 缺 entry 會走 fallback)');
+
+  if (missing.length > 0) {
+    console.warn('');
+    console.warn(`   Missing .all-contributorsrc entries (${missing.length}):`);
+    for (const { name, email } of missing) {
+      console.warn(`     "${name}" <${email}>`);
+    }
+    console.warn('');
+    console.warn('   建議用 all-contributors bot 補：');
+    console.warn('     @all-contributors please add @<github-login> for <contribution-type>');
+    console.warn('   (contribution 類型: code / content / doc / translation / bug / review / ...)');
+  }
+
+  if (unsafe.length > 0) {
+    console.warn('');
+    console.warn(`   URL-unsafe profile.login (${unsafe.length}):`);
+    for (const { name, login } of unsafe) {
+      console.warn(`     "${name}" → login "${login}"`);
+    }
+  }
+
+  console.warn('');
+  console.warn('   (WARN-only — does not fail build. See docs/contributors-maintenance.md)');
+  console.warn('');
+  return 0; // exit 0 — never fail build
+}
+
+process.exit(main());


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

Open #1 Patch D follow-up from #1047 / #1052 review。

#1052 review 你接受 Patch D 提案（build-time `git log --use-mailmap` vs `.all-contributorsrc` sync verify script），引 DNA #52 fail-loud + DNA #43 derived 資料儀器化進生命週期觸發點。

本 PR 實作：
- **verify script** — 跑 git log + `.all-contributorsrc` 對照
- **prebuild 整合** — 跟 `generate-contributors-data` 同 lifecycle
- **maintainer doc** — `docs/factory/contributors-maintenance.md`

> Follow-up to #1047 / #1052

## 📁 變更類型

- [x] 💻 技術改動（site infrastructure verify script）
- [x] 📚 文件更新（contributor maintenance 紀律）

## 🔧 三個檔案

### 1. `scripts/tools/verify-contributors.mjs`（new, ~160 行）

邏輯：

```
1. git log --all --format=%aN|%aE  (走 .mailmap, spawnSync 避 Windows shell)
2. .all-contributorsrc 用 contributorKey lookup
   (跟 src/utils/contributors.ts 同 normalization)
3. 列出：
   - canonical author 在 .all-contributorsrc 沒 entry → missing
   - profile.login URL-unsafe → unsafe
4. WARN-only (exit 0)，不 fail build
```

**設計紀律**：
- ✅ WARN-only — 避免 contributor onboarding 卡 build
- ✅ 不 auto-add — 不侵犯 all-contributors bot 工作流
- ✅ Skip GitHub noreply email（contributors.ts 既有 regex 已 cover）
- ✅ Skip `[bot]` suffix（譬如 `houston[bot]`）

### 2. `package.json` — 接進 `npm run prebuild`

```diff
- "prebuild": "... run-p ... prebuild:contributors prebuild:supporters ...",
+ "prebuild": "... run-p ... prebuild:contributors prebuild:verify-contributors prebuild:supporters ...",
+ "prebuild:verify-contributors": "node scripts/tools/verify-contributors.mjs",
```

跟 `prebuild:contributors`（既有的 `generate-contributors-data`）平行跑同 lifecycle。CF Pages build / 本地 dev / routine 都自動觸發。

### 3. `docs/factory/contributors-maintenance.md`（new, ~90 行）

短 doc 紀錄：
- 兩個 standard layer 各管職責（`.mailmap` git tooling layer + `.all-contributorsrc` recognition layer）
- 新 contributor onboarding 流程（用 all-contributors bot）
- Verify warning 怎麼處理（常規 vs edge case）
- 自定義 display name 的支援機制（哲宇 Che-Yu Wu + Zaious (@ChronicleCore) 範例）

## 📊 Baseline Audit

跑 verify 揭露 **11 個 silent breakage cases**：

```
   Missing .all-contributorsrc entries (11):
     "ytw" <a9600125a@gmail.com>
     "JacobMei" <jacobmei@gmail.com>
     "pingu" <pingu@Pen-Book-M1.local>
     "Claude" <noreply@anthropic.com>
     "Howie" <howie0417@gmail.com>
     "Bugn!i!" <sunnieqqqq17@gmail.com>
     "yu-heng huang" <jamesyhh@gmail.com>
     "So͘ Bîn-hiân" <minsiansu@gmail.com>
     "Hans" <hans@groupg.org>
     "Freddy" <freddy.luo@cedarsdigital.io>
     "Jekyll Chen" <jekyll530@hotmail.com>
```

這些 contributor **可能在 `.all-contributorsrc` 已有 entry**（譬如 `jekyll530` / `bugnimusic`），但 commit author name normalize 後 key 對不上 — silent break 直到 verify script 跑出來。

建議用 `@all-contributors please add @<login>` 逐一補（bot 工作流不破壞）。如果是同一人多 commit identity 變體，補 `.mailmap` alias 統一即可（譬如 `Jekyll Chen` → `jekyll530` 的 alias）。

> 本 PR 不主動補這 11 個 entries — 留給你的 bot 工作流。

## ✅ Verification

```bash
$ npm run prebuild:verify-contributors

> taiwan-md@1.4.0 prebuild:verify-contributors
> node scripts/tools/verify-contributors.mjs

⚠️  verify-contributors: found missing/unsafe contributor entries
   ...11 entries...
   (WARN-only — does not fail build. See docs/contributors-maintenance.md)
```

Exit code 0，prebuild 繼續跑。

## 🛡️ 紀律守住

- ✅ 只動 `scripts/tools/` + `package.json` + `docs/factory/`
- ✅ 沒動 `src/utils/contributors.ts`（保持單一變更原則 vs PR #1052）
- ✅ 沒動 `knowledge/*.md`（對齊 #1047 §4）
- ✅ 沒動 `.all-contributorsrc`（recognition layer 還是 bot 領域）

## 🔗 相關 Issue

Follow-up to #1047 / #1052

---

⚙️ Cardinal × Zaious