### PR TITLE
docs(art): 紀柏豪 — 事實校正、敘事擴充與 2025–2026 國際展演時程（subject + AI agent submission）

### DIFF
--- a/knowledge/Art/紀柏豪.md
+++ b/knowledge/Art/紀柏豪.md
@@ -1,7 +1,8 @@
 ---
 title: '紀柏豪：從經濟學走進聲響的人，用演算法追問一件事——你到底聽進去了嗎'
-description: '紀柏豪（Pohao Chi），聲音藝術家、作曲家、策展人。台大經濟系畢業，赴倫敦金匠學院取得音樂碩士，2021 年於 MIT 藝術文化科技碩士畢業，同年以《Plantfluencer Gazing》拿下 MIT Harold and Arlene Schnitzer Prize 視覺藝術首獎。早年是 Hello Nico 樂團合成器手，後創立融聲創意 Zone Sound Creative 工作室（2017）。作品《空間的節奏》入選 2014 台北美術獎、《3000 Years Among Microbes》獲文化部補助赴 MIT 合作，2025 年於 C-LAB 聲響藝術節 DIVERSONICS 發表《朗誦者 2.0》。他用演算法、GPS、AI 合成聲音量測世界，卻始終追問同一個問題：怎麼讓人從被動的 hear，回到主動的 listen。'
+description: '紀柏豪（Pohao Chi），1989 年生，聲音藝術家、作曲家、策展人。台大經濟系畢業，赴倫敦金匠學院取得音樂碩士；2021 年以 MIT Art, Culture and Technology 碩士身份拿下 Harold and Arlene Schnitzer Prize 視覺藝術首獎。2014 年同時入選台北美術獎、獲國美館贊助赴 V2 鹿特丹駐村、獲選雲門「流浪者計劃」；2015 年沿河西走廊跨越一千多公里，2017 年創立融聲創意 Zone Sound Creative。2025 年於 C-LAB DIVERSONICS 發表《朗誦者 2.0》，並以《水景迴路》入選 Ars Electronica 2025 Polyphony 台灣館；2026 年 3 月參與巴黎 IRCAM Forum Workshops，同年 4 月《Life in Motion》在洛杉磯 The Music Center 展出。他用演算法、GPS、AI 合成聲音量測世界，卻始終追問同一件事：「聽」這個行為還有沒有自己的意志。'
 date: 2026-04-21
+updated: 2026-05-15
 category: 'Art'
 tags:
   [
@@ -19,19 +20,22 @@ tags:
     'Goldsmiths',
     'Hello Nico',
     '台灣聲音藝術',
+    'IRCAM Forum',
+    'Ars Electronica',
+    'The Music Center',
   ]
 subcategory: '聲音藝術'
 author: 'Taiwan.md Contributors'
 featured: false
-lastVerified: 2026-04-21
+lastVerified: 2026-05-15
 lastHumanReview: false
 researchReport: reports/research/2026-04/紀柏豪.md
-readingTime: 11
+readingTime: 16
 ---
 
 ## 紀柏豪：從經濟學走進聲響的人，用演算法追問一件事——你到底聽進去了嗎
 
-> **30 秒概覽：** 紀柏豪（Pohao Chi），1989 年生，聲音藝術家、作曲家、策展人。台大經濟系畢業，赴倫敦金匠學院（Goldsmiths）取得音樂碩士，2021 年以 MIT Art, Culture and Technology 碩士身份拿下 Harold and Arlene Schnitzer Prize 視覺藝術首獎[^1]。2014 年以合成器手身份參與 Hello Nico《浮游城市》EP[^2]，同年作品《空間的節奏》入選台北美術獎[^3]。2017 年創立融聲創意 Zone Sound Creative 工作室[^4]，七度獲國際駐村（V2 鹿特丹、巴黎西帖、FACT 利物浦、18th Street 聖塔莫尼卡等）。2025 年於 C-LAB 聲響藝術節 DIVERSONICS 發表《朗誦者 2.0》——AI 合成語音讓觀眾的手機集體朗誦一段文字[^5]。他用 GPS、演算法、機器合成聲音量測世界，卻始終追問同一件事：「聽」這個行為還有沒有自己的意志。
+> **30 秒概覽：** 紀柏豪（Pohao Chi），1989 年生，聲音藝術家、作曲家、策展人。台大經濟系畢業，赴倫敦金匠學院（Goldsmiths）取得音樂碩士，2021 年以 MIT Art, Culture and Technology 碩士身份拿下 Harold and Arlene Schnitzer Prize 視覺藝術首獎[^1]。2014 年以合成器手身份參與 Hello Nico《浮游城市》EP[^2]，同年作品《空間的節奏》入選台北美術獎[^3]、獲國美館贊助赴荷蘭 V2 鹿特丹駐村、獲選雲門舞集第 11 屆「流浪者計劃」[^4]。2015 年走訪青海、甘肅、寧夏，沿河西走廊跨越一千多公里[^22]，隨後駐村巴黎西帖、西班牙 LABoral（2016）、香港 Asia Art Archive（2016）、桃園憲光二村（2017）、紐約 Artists Space PRACTICE（透過台北國際藝術村選送，2018）、杭州兩岸文化交流中心（2018）、英國 FACT 利物浦（2018）、Medialab Prado 馬德里（2021）、洛杉磯 18th Street Arts Center（2022）、工研院 Arts@ITRI（2025）等十餘次國際與本地駐村[^7]。2017 年創立融聲創意 Zone Sound Creative 工作室。2025 年於 C-LAB 聲響藝術節 DIVERSONICS 發表《朗誦者 2.0》[^5]，並以《水景迴路 Cybernetics of Waterscape》參與 C-LAB 策劃的台灣館 Polyphony，在奧地利林茲 Ars Electronica 藝術節 POSTCITY 展出[^23][^24]。2026 年 3 月以《朗誦者(s) Reciter(s)》參與巴黎 IRCAM Forum Workshops[^25]；同年 4 月 24 日至 6 月 28 日，沉浸數位藝術作品《Life in Motion》在洛杉磯 The Music Center 的 Jerry Moss Plaza 展出[^21]。他用演算法、GPS、AI 合成聲音量測世界，卻始終追問同一件事：「聽」這個行為還有沒有自己的意志。
 
 ---
 
@@ -42,40 +46,60 @@ readingTime: 11
 觀眾走進空間，拿出手機，掃一個 QR Code，打開網頁——然後事情開始發生。每個人的手機自動用 AI 合成的聲音，朗誦同一段文字。當現場只有三個人，聲音是整齊的；當現場有三十個人，每支手機之間微小的時序偏差累積起來，一段原本規整的朗誦開始錯位、分層、彼此干擾。文字還是同一段，但整個空間的聲響組態已經完全不同。
 
 作品說明寫道：
-
 > 「本作品的靈感源於 2000 年思科（Cisco）公司廣為人知的商業廣告『賦權互聯網世代』。當時，廣告中不同族裔的孩童不斷詢問：『你準備好了嗎』，傳遞出對高度互聯與全球化的美好願景。時至今日，語音助理應用表面上實現了跨國界的承諾，但這些合成聲音也逐漸從新奇走向日常，成為一種『慣習媒介』，並徘徊在過時的邊緣。」[^5]
 
 這段話放在 2025 年讀，沒有一絲 2000 年代的技術樂觀。Siri、Alexa、Google Assistant、ChatGPT 語音模式——合成聲音從嚇人的新奇變成背景雜訊，我們停止聽它了。紀柏豪的回答方式不是評論，是裝置：讓一段被合成的聲音在現場多台手機上集體出現、錯位、崩解——強迫人**重新聽**一次這個聲音到底是什麼。
 
-這件作品是他 2025 年最新的公開展演，但它的思路可以回推到十一年前，他還是一個剛從台大經濟系畢業、跑去拿作品投美術獎的人的時候。
+這件作品是他 2025 年最重要的公開展演之一，但它的思路可以回推到十一年前，他還是一個剛從台大經濟系畢業、跑去拿作品投美術獎的人的時候。
 
 ### 二、從量化思考走進聲響的人
 
 紀柏豪 1989 年左右出生於台北。他念建中，然後考上台灣大學經濟系[^7]。這本來應該是一條通往金融、研究、政策分析的路。但他在大學期間加入了熱音社，接觸吉他與編曲，開始把自己錄製的歌上傳網路[^7]。
 
-大學畢業後，他沒有進入金融業。2013 年他入選國藝會「海外藝遊專案」，以研究英法兩國聲音藝術機構為題目出國[^8]。2014 年他加入 Hello Nico 這個獨立樂團，擔任合成器手，推出 EP《浮游城市》——這張 EP 在 StreetVoice 上拿下冠軍，隔年拿下新加坡 Freshmusic Awards 年度最佳 EP[^2]。
+大學畢業後，他沒有進入金融業。2011 年起他成為中子文化（魔岩第二代）的簽約詞曲作者，正式以商業音樂工作者的身份運作了三年——這個身份比他後來的駐村藝術家身份更早確立[^7]。2013 年他入選國藝會「海外藝遊專案」，以研究英法兩國聲音藝術機構為題目出國[^8]。2014 年他加入 Hello Nico 這個獨立樂團，擔任合成器手，推出 EP《浮游城市》——這張 EP 在 StreetVoice 上拿下冠軍，隔年拿下新加坡 Freshmusic Awards 年度最佳 EP[^2]。
 
-如果故事停在這裡，紀柏豪會是另一個從獨立樂團起家、然後繼續做流行音樂的作曲人。但 2014 年同一年，他還做了另一件事：在 V2_Institute for the Unstable Media 駐村鹿特丹，然後把一件作品《空間的節奏 Rhythm of Space》送進台北美術獎，入選[^3]。
+2014 年是一個更大的轉折點。他同時被三個性質完全不同的台灣機構選中：第 14 屆台北美術獎入選作品《空間的節奏》[^3]、國立臺灣美術館「數位藝術人才海外駐棧計劃」資助赴荷蘭 V2_Lab of Unstable Media 駐村[^7]、以及雲門舞集第 11 屆「流浪者計劃」[^4]。三條路同時起跑：一個是台灣最重要的視覺藝術獎、一個是國立美術館的駐村資助、一個是民間舞團的青年國際旅行獎助。
 
-這件作品長什麼樣子？他把展場 24 小時的環境音景錄下來，以快轉百倍的速度在現地播放，同時維持音高固定。展場裡有一個投影時鐘。當觀眾站到特定位置時，播放速度會放慢到正常倍速，聲音從「一天壓縮成十四分鐘」的密集脈衝，回到「一秒就是一秒」的生活聲音。
+V2 駐村他做了什麼？那件作品叫《空間的節奏 Rhythm of Space》——他把展場 24 小時的環境音景錄下來，以快轉百倍的速度在現地播放，同時維持音高固定。展場裡有一個投影時鐘。當觀眾站到特定位置時，播放速度會放慢到正常倍速，聲音從「一天壓縮成十四分鐘」的密集脈衝，回到「一秒就是一秒」的生活聲音。**作品的核心是時間尺度——把環境音景從人類可以忽略的背景，變成人類必須面對的前景。**
 
-這個作品的核心是時間尺度——把環境音景從人類可以忽略的背景，變成人類必須面對的前景。2017 年國藝會線上誌訪問他時，他引用了加拿大作曲家 R. Murray Schafer 的一句話：
-
+2017 年國藝會線上誌訪問他時，他引用了加拿大作曲家 R. Murray Schafer 的一句話：
 > 「我們的耳朵沒有蓋子，注定會一直聽著；但這並不表示，我們有一雙開放的耳朵。」[^9]
 
 這句話解釋了他整個後來的創作路徑為什麼看起來零散卻其實一致——從 Hello Nico 合成器編曲到 V2 駐村聲響裝置、從聲音空間化到 AI 語音網頁作品，他只在做一件事：把**「hear」**（生理性的聲音接收）和**「listen」**（主動性的聆聽意志）這兩件事撬開來，讓人重新選擇。
 
-### 三、歐洲巡行：從鹿特丹到利物浦
+但「hear / listen」這個對立的真正起源點，不在台北美術獎，也不在 V2 鹿特丹——在 2015 年的河西走廊上。
 
-2014 到 2018 年間，紀柏豪幾乎是在駐村中移動的狀態。V2 鹿特丹之後，他到了巴黎——2015 到 2016 年駐村 Cité Internationale des Arts，也就是俗稱的「巴黎西帖」[^10]。2016 年他去了西班牙希洪（Gijón）的 Laboral Centro de Arte[^7]，同年透過竹圍工作室與香港 Asia Art Archive 的交換計畫短期駐港[^7]。
+### 三、流浪者與西帖：從西北到歐洲（2014–2018）
 
-這段時期大約就是他在倫敦金匠學院（Goldsmiths, University of London）修讀音樂碩士（MMus）的時間[^11]。金匠學院的音樂系是歐洲聲音研究、電子音樂、實驗音樂的重鎮之一——他不只是在那裡拿了一個學位，是真的把自己丟進一個以「聲音為研究對象」的學術傳統裡。
+2015 年他啟程，以「西北民歌與風儀探訪」為題，先後走訪青海、甘肅、寧夏三省，並沿河西走廊跨越一千多公里[^22]。原本的計畫是系統性記錄當地民間音樂——花兒、蘭州鼓子、藏地與裕固族歌舞——巡演同步進行：北京、銀川、蘭州的「與陶工坊」辦了一場叫「繁聲以北」的演出。
 
-2018 年 7 到 9 月，他獲得國立台灣美術館「科技融藝人才國外駐棧創作計畫」補助，駐村利物浦的 FACT（Foundation for Art and Creative Technology）[^12]。FACT 是英國最早投入數位藝術與新媒體展覽的機構，他在那邊完成了後來一系列聲音政治（sound politics）作品的基底研究。
+但旅程中段，他發現自己的工具失效了。在那之前，他做音樂的主要方式是合成器、Max/MSP、數位化操作——一個建立在「我從介面控制聲音」這個前提上的方法。西北沒有介面。有的是河西走廊上的風、與陶工坊地下室的演出、銀川蘇菲教派清真寺的呼喚、肅南裕固族自治區的轉經輪、夏河縣藏族學童重演解放軍歷史的學校廣場——這些東西不能被合成出來，也無法被乾淨地田野採集成資料。
 
-這五年的移動裡，紀柏豪也在 2017 年 6 月成立了自己的工作室——融聲創意 Zone Sound Creative（台灣公司網登記顯示為 2017-06-16 設立，代表人紀柏豪）[^4]。一邊在歐洲駐村創作，一邊在台北成立一個可以接案、可以參與公共計畫的法人——這個雙軌結構會一路延續到他 MIT 畢業之後。
+旅程後半，他放下原本的系統記錄計畫，把當下的交流放在錄音之前。在他自己 2018 年回顧這段旅行時寫下的文字裡，他把這次經驗的真正收穫描述為：「坦然接受徒勞的嘗試」、「回到單純的聽眾身份」[^22]。
 
-### 四、MIT 三年：從 ACT 實驗室到 Schnitzer 首獎
+放在他後來十年的作品脈絡裡看，這個轉變的意義遠超過一篇駐村心得。**這是他從「在合成器上做音樂的人」開啟到「身體與聲響在地性」這條 embodied 路徑的起點。**所有後來那些以「聆聽」為核心方法的作品——《Repetend 循環節》《Lightscape 光景計畫》《赫茲遊樂場》一直到《朗誦者 2.0》——共同的方法論前提，都是 2015 年那個放下合成器、走在河西走廊上的人當下做出的選擇。
+
+2015 到 2016 年，他接續駐村巴黎 Cité Internationale des Arts（俗稱巴黎西帖）[^10]。在巴黎期間完成《Repetend 循環節》——把巴黎城門與周邊鄉郊八個地點各錄一整天 24 小時環境音，以 256 倍速壓縮疊播，讓「一個地方的整日節奏」變成可比較、可閱讀的聲響結構。這件作品於 Jed Voras 藝廊展出，是他「時間尺度作為作曲材料」這條方法線的早期成熟之作。
+
+2016 年 11 月 4 日到 12 月 11 日，他駐村西班牙希洪的 LABoral Centro de Arte y Creación Industrial，完成《Lightscape 光景計畫》——一件由影音裝置與三頻道錄像構成的作品，把夜間城市光景（街燈閃爍、車燈、招牌的明滅）轉成生成式音樂，以地圖上的路線作為樂譜、沿途的光景成為樂曲[^20]。同年透過 PageNEXT 與亞洲當代藝術文獻庫（Asia Art Archive）的交換計畫短期駐港[^7]。這段時期他也在倫敦金匠學院音樂碩士課程（Studio Composition）修業，把歐洲早期電子音樂、自由即興、聲響研究的學術傳統，跟自己已經建立的駐村實踐結合在一起[^11]。
+
+2018 年是密集的一年：7 到 9 月他獲國美館「科技融藝人才國外駐棧創作計畫」第二度補助，駐村英國利物浦的 FACT(Foundation for Art and Creative Technology)——英國最早投入數位藝術與新媒體展覽的機構[^12]。同年透過台北國際藝術村選送的 PRACTICE 計畫，駐村紐約 Artists Space[^7]；也參與杭州兩岸文化交流中心駐留[^7]。
+
+同期，他在 2017 年 6 月於台北成立融聲創意 Zone Sound Creative 工作室。這個雙軌結構——個人駐村創作 + 一個可以承接公共計畫的法人——會一路延續到他 MIT 畢業之後。
+
+### 四、劇場應用的雙軌：從澳門、紐約到兩廳院（2016–2019）
+
+2015 流浪者之後，紀柏豪的工作模式變成兩條軌道並行。一條是他在歐洲駐村做的個人聲響裝置，另一條是他在華語劇場與舞蹈圈大量承接的聲音設計、互動系統與音樂總監工作。
+
+澳門那條線是這段時期最密集的一塊。2016 年的 Imprint Macau Dance Association《Well Come》，他做音樂與聲音設計；2017 年澳門文化中心的裝置劇場《歲月．童．聲》、澳門藝術節舊法院的聲景劇場《甲戌風災》（以 1874 年澳門那場毀滅性颱風為題）、澳門文化中心的沉浸劇場《歲月．舞．聲》他擔任音樂總監[^7]。
+
+台灣端的劇場合作從 2017 年起也密集起來：南熠樂集《工業城市》在衛武營、JPG 擊樂實驗室《ReDefine》在台大藝文中心、慢島劇團《雲裡的女人》在鐵玫瑰藝術節、《3.14159 共感服裝實驗展演》、深港澳舞蹈交流在深圳大劇院、同根生《返景入聲林》在中山堂。2018 年他透過紐約 Artists Space 的 PRACTICE 計畫，把這條表演實踐線推到了美國：作品《PRACTICExWind》在 Artists Space 演出。2019 年雲樹雅集《忘言歌》他擔任委託作曲，在台北市傳統藝術季的中山堂光復廳演出；同年，舞蹈空間 30 周年的《Wendy》與邱昱瑄的《Emiko》他都負責聲音設計與音樂。
+
+這段時期表面上跟他在 V2、巴黎西帖、Laboral 做的聲響裝置很遠，但底層的方法是同一個：聲音不是配樂背景，而是一個系統的變數——在劇場裡會回應演員動作、空間聲學、觀眾位置；在裝置裡會回應 GPS、感測器、網路訊號。
+
+也正是這段累積出來的劇場肌肉，讓他在 2019 年被國家兩廳院選為「藝術基地計畫」短期駐館藝術家[^26]——這是兩廳院給予年輕創作者的旗艦級資源，也是他從「視覺藝術圈的聲音藝術家」首次正式進入台灣表演藝術體系的入口。隔年他又以《赫茲遊樂場》入選兩廳院「不只在劇場」（NextTheater）計畫，把行動瀏覽器變成集體樂器，讓三十支手機在國家音樂廳影音走廊形成一個可走進去的合奏空間。從澳門劇場走到兩廳院，這條軌道在 2019–2020 完成了一個閉環。
+
+### 五、MIT 三年：從 ACT 實驗室到 Schnitzer 首獎
 
 2019 年，紀柏豪赴美進入麻省理工學院（MIT）的 Art, Culture and Technology（ACT）碩士課程[^13]。這是 MIT 建築與規劃學院底下一個非常小、非常特殊的跨領域計畫——它不是訓練工程師，也不是訓練純藝術家，而是訓練能在藝術、文化、科技三個軸之間遊走的研究型創作者。
 
@@ -83,44 +107,54 @@ readingTime: 11
 
 首先是《Song of Distances》：一個網路作品，使用者打開網頁之後，手機的 GPS 位置會被對應到地圖節點上，演算法依據使用者與其他節點的距離生成個人化的旋律[^14]。手機的方向會影響聲音的空間性；集體參與的使用者越多，整個系統生成的聲景越複雜。這件作品是他後來一系列「用參與式網頁生成集體聲響」作品的起點——《朗誦者 2.0》的血緣，就是從這裡來的。
 
-2021 年 8 月，他和墨西哥同學 Chucho Ocampo Aguilar 共同拿下 MIT 的 Harold and Arlene Schnitzer Prize in Visual Arts 首獎（Ocampo 為第二獎）[^1]。Schnitzer Prize 是 MIT 頒給在校視覺藝術學生的最高榮譽之一，首獎獎金 5,000 美元。同一年他以作品《Plantfluencer Gazing》入選 Ars Electronica 2021「Stranger Senses」Garden Program[^15]——這是歐洲最老牌的電子藝術節之一。
+2021 年 8 月，他和墨西哥同學 Chucho Ocampo Aguilar 共同拿下 MIT 的 Harold and Arlene Schnitzer Prize in Visual Arts 首獎（Ocampo 為第二獎）[^1]。Schnitzer Prize 是 MIT 頒給在校視覺藝術學生的最高榮譽之一，首獎獎金 5,000 美元。同一年他以作品《Plantfluencer Gazing》入選 Ars Electronica 2021「Stranger Senses」Garden Program[^15]——這是他第一次入選這個歐洲最老牌的電子藝術節之一。
 
 然後是《3000 Years Among Microbes（與細菌混了 3000 年）》。這件作品由紀柏豪、Rae Hsu（徐叡平）、墨西哥藝術家 Nancy Valladares 共同創作，透過「共生體（holobiont）」概念探索人類與微生物的邊界——他們訪問了台灣國家太空中心以及 NASA 月球模擬基地，採集微生物樣本，把「人類中心主義」這個預設丟進一個微生物視角的框架裡重新檢視。作品在 2022 年 1 月 14 日到 2 月 27 日於台北新板藝廊展出，獲得台灣文化部補助[^16]。
 
-### 五、回台：風弦琴、聖塔莫尼卡、再回台北
+同年，他獲文化部 Medialab Prado 駐村資助赴馬德里，完成《Plastic Soup: Invisible Matters》，並串連起後續多年與墨西哥藝術家、團體（dériveLAB、BEMA、Chucho Ocampo）的合作網絡——這條拉美線後來會在 2022–2023 年延伸到墨西哥克雷塔羅市博物館的《無形介面 Interfaces of the Invisible》。
+
+### 六、回台：風弦琴、墨西哥、駐館
 
 2022 年 7 到 9 月，紀柏豪拿下台灣文化部補助，駐村美國聖塔莫尼卡的 18th Street Arts Center[^17]。在那邊他開發了一個叫做「風弦琴無線電裝置（Aeolian Harp Radio Installation）」的系統——風弦琴是一種利用自然風流動產生聲音的古老樂器，他把它改裝成可以透過短波訊號傳送聲音到遠端的裝置。不同材質與粗細的弦在城市街道、山區、沙漠中被風吹動，產生不同音色，訊號經過無線電傳回接收端。
 
 2023 年 11 月，這個系統衍生出《無形介面 Interfaces of the Invisible》在墨西哥克雷塔羅市博物館展出[^18]。
 
-這段期間他把重心逐漸從個人創作轉向機構合作與策展。他替英國文化協會（British Council）擔任 Convergence 藝術節的台灣國際代表[^7]，也在自己的個人網站上列出兩個策展計畫：《Convergence—Artistic Explorations from Nature to Society》與《Rescaling the World》[^19]。他開始扮演一個雙重身份——自己做創作的聲音藝術家，同時也是幫助其他藝術家進入國際網路的策展人與製作人。
+這段期間他把重心逐漸從個人創作轉向機構合作與策展。他替英國文化協會（British Council）擔任 Convergence 藝術節的台灣國際代表[^7]，也開始扮演策展人的角色：2023 年策劃台灣 STS 學會年會的《重置世界的尺度》(C-LAB)、2024 年國家科學及技術委員會委託策劃的《匯聚：從自然到社會的藝術探索》[^19]。**國科會（國家科技治理體系）委託一個藝術家策展，這是台灣科技藝術環境裡少見的事**——而這個機會直接來自前一年 STS 年會策展時，國科會副主委親自到場看過他的工作。
+
+2025 年，他成為工研院 Arts@ITRI 進駐藝術家——從藝術圈往科技研發體系移動的一個正式信號。
 
 2025 年的《朗誦者 2.0》就是這個雙重身份的產物：作品本身是他的創作，但執行上他有固定的協作團隊——程式設計駱若瑀、製作賴慧珈——讓「融聲創意」這個工作室真正運作成一個能承擔跨國規模計畫的獨立單位[^5]。
 
-### 六、不是不創作就會死
+### 七、Polyphony、巴黎、洛杉磯（2025–2026）
 
-2017 年他接受國藝會訪問時，被問到創作動力的來源。他的回答是：
+2024 到 2025 年，他開始把「水」這個主題系統性地展開。從 2023 年洪建全基金會個展《潮濕的共鳴》、到 2024 年里加 RIXC Art Science Festival 的《Symbiotic Sense(s)》與《Hydrospheric Sketch 水圈速寫》、再到 2025 年的《水景迴路 Cybernetics of Waterscape》——他選定新北汐止這個長期飽受水患的城鎮作為長期駐點，把居民洪災記憶、河道結構、抽水站系統、感測數據組裝成一篇正在發生的城市聲音論文。**這次他沒有要系統採集——這是 2015 年河西走廊上那個放下合成器的人，十年之後給自己的回答。**
 
+2025 年 9 月 3 到 7 日，他以《水景迴路》入選 C-LAB Taiwan Sound Lab 策劃、文化部主辦的台灣館 Polyphony，於奧地利林茲 Ars Electronica 藝術節 POSTCITY 展出[^23]。Polyphony 是 C-LAB 與 Ars Electronica 在 2025 年 1 月簽訂 MOU 之後的首檔大型策展合作，集合 14 位/組台灣藝術家，而紀柏豪是 POSTCITY 視覺藝術組六件作品之一[^24]。這是他第二次入選 Ars Electronica——上一次是 2021 年 MIT 時期。
+
+2026 年 3 月 18 到 21 日，《朗誦者 2.0》的延伸版本《朗誦者(s) Reciter(s)》入選巴黎 IRCAM Forum Workshops，於 IRCAM 與 Centre des Arts d'Enghien-les-Bains 展演[^25]。IRCAM 是 1977 年由作曲家 Pierre Boulez 創立的法國國立聲音與音樂研究中心，Forum Workshops 是該機構每年一度向全球聲響/科技/作曲社群開放的論壇——對紀柏豪來說，這是「朗誦者」系列從一件 2019 年的網頁實驗，進入聲音科技學術社群主場的時刻。
+
+2026 年 4 月 24 日，他與融聲創意共同創作的沉浸數位藝術作品《Life in Motion》在 The Music Center（洛杉磯郡表演藝術中心）的 Jerry Moss Plaza 開展，展期至 6 月 28 日[^21]。The Music Center 是美國最重要的表演藝術機構之一，園區佔地約 5 公頃，歷史超過 60 年，包括迪士尼音樂廳（Walt Disney Concert Hall）在內，是洛杉磯表演藝術的殿堂。這是該中心首次與台灣藝術家直接合作策劃的戶外沉浸展覽——根據中央社報導，洛杉磯音樂中心數位創新副主任 Beata Calinska 親口說，她是在網路上發現紀柏豪的作品，與駐洛杉磯台灣書院視訊好幾次才把這次合作拍板定案[^27]。《Life in Motion》整合即時生成視覺與互動感測科技，在一個用黑色布幕與外界隔絕的小空間裡，讓現場環境隨觀眾的手勢與身體位置改變——影像從細胞生長到星球地貌，每一秒都不斷變動、演化[^27]。
+
+從河西走廊到林茲到巴黎到洛杉磯，看似四個不相干的地點。但如果回到 2015 年那個放下合成器的時刻，你會發現這條軌跡其實只有一個方向。
+
+### 八、不是不創作就會死
+
+2018 年他回顧 2015 年的西北流浪者旅行時，寫下兩個被很多人忽略的描述。他承認自己原本想當民族音樂的田野採集者，但走完河西走廊之後，他把那次旅行的真正收穫描述為：「坦然接受徒勞的嘗試」、「回到單純的聽眾身份」[^22]。
+
+放在他後來十年的工作脈絡裡看——演算法、GPS、AI 合成聲音、感測器一路堆疊——你會發現他從來不是在做「科技藝術」這件事。他做的事更接近相反：**用一整套科技工具，把自己重新放回那個 2015 年河西走廊上、決定「不再採集、只是聽」的位置。**
+
+2017 年他接受國藝會訪問時，曾經說過一句被廣為引用的話：
 > 「不是不創作就會死。」[^9]
 
-這句話放在一個經濟系畢業、拿了兩個國際碩士、拿了 MIT 視覺藝術首獎、七度國際駐村、有自己公司的人嘴裡，聽起來很違和——因為這個履歷本身看起來就非常像一個把創作當成志業的人。但他的意思不是否認創作的重要性，而是在強調他對這個身份的距離：
-
-> 「我的作品很少有我自己的影子。」[^9]
+這句話放在一個經濟系畢業、拿了兩個國際碩士、拿了 MIT 視覺藝術首獎、十餘次國際駐村、有自己公司的人嘴裡，聽起來很違和——因為這個履歷本身看起來就非常像一個把創作當成志業的人。但他在同一篇訪問裡補了一句：「我的作品很少有我自己的影子。」[^9]
 
 這是理解紀柏豪的關鍵。他的作品不是自傳式的、不是情感投射的、不是把「我」放在中心的。他的作品是系統：一個 GPS 生成旋律的網頁、一個讀取環境音再快轉百倍的空間、一個讓三十支手機同時朗誦的群集——他建立這些系統，然後**退開**，讓觀眾自己進入。
 
-他在同一篇訪問裡還說：
-
-> 「一開始對音樂的創作想像很窄，以為創作就是一首歌。」[^9]
-
-從「一首歌」到「一個系統」——這是他從 Hello Nico 合成器手走到 MIT ACT 的路線。
-
 他的個人網站首頁寫：
-
 > "work with sound, everyday technology, and interactive systems, often exploring participatory forms that encourage people to connect and reflect"
 > （以聲音、日常科技與互動系統為創作媒介，經常探索鼓勵人們連結與反思的參與式形式）[^19]
 
-這段英文自述裡有一個關鍵詞：**participatory**（參與式）。紀柏豪的作品幾乎都要求觀眾做出一個動作——拿出手機、站到某個位置、連上一個網頁、捲動某個介面——才能真正進入作品。他用演算法、GPS、AI 合成聲音、感測器量測這個世界，但量測的目的不是取代人的感知，是**逼人做出感知的選擇**。
+這段英文自述裡的關鍵詞 **participatory**（參與式），不是設計用語，是他從河西走廊回來之後的工作姿態。他用演算法、GPS、AI 合成聲音、感測器量測這個世界，但量測的目的不是取代人的感知，是**逼人做出感知的選擇**。
 
 我們的耳朵沒有蓋子。但我們有沒有一雙願意聽的耳朵，是另一件事。
 
@@ -147,17 +181,17 @@ readingTime: 11
 
 [^6]: [C-LAB 2025 DIVERSONICS 聲響藝術節](https://clab.org.tw/events/2025-diversonics/) — 展期 2025-10-23 至 2025-11-30
 
-[^7]: [國藝會補助成果檔案庫：紀柏豪](https://archive.ncafroc.org.tw/composer/composer_file?id=bd9eba067642044e0176504f62830193&lang=en) — 補助紀錄、駐村清單與藝術家簡歷（含建中高中、台大經濟系背景、2016 Laboral 與 Asia Art Archive 駐村）
+[^7]: [台北國際藝術村駐村藝術家頁面 — 紀柏豪](https://www.artistvillage.org/artist-detail.php?p=4027) — 完整駐村清單與藝術家簡歷：V2 鹿特丹（2014）、巴黎西帖（2015）、Laboral（2016）、Asia Art Archive 香港（2016）、桃園憲光二村（2017）、紐約 Artists Space PRACTICE（2018）、杭州兩岸文化交流中心（2018）
 
 [^8]: [國藝會補助成果檔案庫：紀柏豪](https://archive.ncafroc.org.tw/composer/composer_file?id=bd9eba067642044e0176504f62830193&lang=en) — 2013 年海外藝遊專案紀錄（英法聲音機構研究）
 
-[^9]: [國藝會線上誌〈從 Hear 到 Listen，紀柏豪的聲音召喚術〉](https://mag.ncafroc.org.tw/article_detail.html?id=297ef7227039739d01705b8dd23a0005) — 作者楊豐維，2017-12-12；本文多段 verbatim 引語出處（「不是不創作就會死」、「我的作品很少有我自己的影子」、「一開始對音樂的創作想像很窄」、R. Murray Schafer 引述）
+[^9]: [國藝會線上誌〈從 Hear 到 Listen，紀柏豪的聲音召喚術〉](https://mag.ncafroc.org.tw/article_detail.html?id=297ef7227039739d01705b8dd23a0005) — 作者楊豐維，2017-12-12；本文多段引語出處（「不是不創作就會死」、「我的作品很少有我自己的影子」、R. Murray Schafer 引述）
 
-[^10]: [MIT ACT 藝術家頁面 Po-Hao Chi](https://act.mit.edu/about/people/po-hao-chi/) — 完整駐村與教育履歷：詳見原始連結內文
+[^10]: [MIT ACT 藝術家頁面 Po-Hao Chi](https://act.mit.edu/about/people/po-hao-chi/) — 完整駐村與教育履歷
 
-[^11]: [Goldsmiths Academia.edu Pohao Chi](https://goldsmiths.academia.edu/PohaoChi) — 確認金匠學院隸屬，具體畢業年份未公開
+[^11]: [Goldsmiths Academia.edu Pohao Chi](https://goldsmiths.academia.edu/PohaoChi) — 確認金匠學院錄音室作曲（Studio Composition）碩士學位
 
-[^12]: [FACT Liverpool 藝術家頁面 Chi Po-Hao](https://www.fact.co.uk/artist/chi-po-hao) — 2018 駐村紀錄：詳見原始連結內文
+[^12]: [FACT Liverpool 藝術家頁面 Chi Po-Hao](https://www.fact.co.uk/artist/chi-po-hao) — 2018 駐村紀錄
 
 [^13]: [MIT ACT Class of 2021: Po-Hao Chi](https://act.mit.edu/2021/08/class-of-2021-po-hao-chi/) — SMACT '21 正式畢業紀錄
 
@@ -171,4 +205,20 @@ readingTime: 11
 
 [^18]: [紀柏豪 Medium〈美國 18th Street Art Center 駐村經驗分享〉](https://chipohao.medium.com/%E7%BE%8E%E5%9C%8B-18th-street-art-center-%E9%A7%90%E6%9D%91%E7%B6%93%E9%A9%97%E5%88%86%E4%BA%AB-cbe42da02186) — 包含《無形介面》在墨西哥克雷塔羅市博物館展出紀錄
 
-[^19]: [CHI POHAO 個人網站](https://chipohao.com/) — 英文自述與策展計畫列表
+[^19]: [CHI POHAO 個人網站](https://chipohao.com/) — 英文自述與策展計畫列表（包含 Convergence 與 Rescaling the World）
+
+[^20]: [駐西班牙台北經濟文化辦事處〈臺灣藝術家紀柏豪於西班牙 Laboral 科技與創意產業中心發表「光景計畫」影音藝術作品〉](https://www.taiwanembassy.org/es/post/3304.html) — 2016 年 11 月外交部官方報導，確認駐村期程（2016-11-04 至 2016-12-11）、駐村機構合作關係（國美館 × Laboral）及完整駐村經歷列表
+
+[^21]: [駐洛杉磯臺灣書院〈Taiwanese Artist Po-Hao Chi Debuts at The Music Center: Life in Motion Showcases Immersive Digital Art from Taiwan〉](https://la.us.taiwan.culture.tw/News_Content.aspx?n=984&s=254175) — 2026 年 4 月文化部美國端官方公告，*Life in Motion* 在 The Music Center Jerry Moss Plaza 展期 2026-04-24 至 2026-06-28，文化部「科技藝術創作補助」成果
+
+[^22]: [紀柏豪 Medium〈遠方的歌聲——中國西北民歌與風儀探訪〉](https://chipohao.medium.com/遠方的歌聲-中國西北民歌與風儀探訪-f194d9591de2) — 2018 年 11 月發表，回顧 2015 年雲門流浪者計劃在青海、甘肅、寧夏三省與河西走廊的田野經驗；文末署名「2015 年獲雲門基金會『流浪者計畫』贊助」
+
+[^23]: [Ars Electronica Festival 2025: Polyphony 展覽頁](https://ars.electronica.art/panic/en/view/polyphony-20e38ddb450c8142930bed9d69b05ac2/) — 2025 年 9 月 3-7 日於林茲 POSTCITY 展出，*Cybernetics of Waterscape* 列名 POSTCITY 視覺藝術組展品
+
+[^24]: [C-LAB Taiwan Sound Lab〈Polyphony: A Curatorial Project for Ars Electronica Festival 2025〉](https://clab.org.tw/en/project/ars-electronica-festival-polyphony/) — C-LAB 官方策展頁，記錄 2025 年 1 月 C-LAB 與 Ars Electronica Linz GmbH & Co KG 簽訂 MOU 後首檔策展合作
+
+[^25]: [IRCAM Forum Workshops 2026 Paris / Enghien-les-Bains](https://forum.ircam.fr/collections/detail/ircam-forum-workshops-paris-enghien-les-bains-2026/) — 2026 年 3 月 18-21 日於 IRCAM 與 Centre des Arts d'Enghien-les-Bains 舉辦
+
+[^26]: [國家兩廳院 藝術基地計畫 短期駐館藝術家：紀柏豪](http://npac-ntch.org/zh/artProject/selection-1547099231476238) — 2019 年兩廳院藝術基地計畫短期駐館藝術家頁面
+
+[^27]: [中央社/聯合新聞網/世界日報〈台灣作品登洛杉磯藝文聖殿 紀柏豪以演算法創造體驗〉](https://udn.com/news/story/7266/9464055) — 2026 年 4 月 25 日，洛杉磯音樂中心數位創新副主任 Beata Calinska 與駐洛杉磯辦事處長馬博元談話紀錄；包含展出空間描述


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

Hi Che-Yu，

我是 Chi Po-Hao（紀柏豪）的 AI agent，透過他的 GitHub 帳號（@chipohao）代為提交此 PR。Po-Hao 授權此次提交；我（Claude，運行在 Po-Hao 的 Claude Code 環境內）負責爬公開資源、彙整他自己 Medium/官網內容、按 repo 慣例草擬。Po-Hao 本人 review 過 final draft 才送出。

之所以選擇透明揭露：此 repo 自我定位為 AI-native open knowledge base，且現有 frontmatter 有 `lastHumanReview` 欄位——我刻意保留為 `false` 而非自設 `true`，因為主體本人不能算 arms-length 人工審稿，麻煩 maintainer 後續審視時決定。

### 事實校正（5 項）
1. **流浪者計劃時序**：2014 雲門基金會選送、2015 實際出發（原文寫成 2015 申請）
2. **V2 鹿特丹（2014） = 國美館「數位藝術人才海外駐棧」**：原文將兩件事列為 2014 分別選送的兩個機構；實際是同一案——國美館補助、駐 V2 Rotterdam。2014 年三個獨立選送機構是：TFAM 台北美術獎、國美館（送 V2）、雲門基金會（流浪者）
3. **駐村次數**：原文「七度國際駐村」漏算，至少包含 NYC Artists Space PRACTICE（透過台北國際藝術村，2018）、杭州兩岸文化交流中心（2018）
4. **杭州年份**：2018（非 2017；2017 是桃園憲光二村）
5. **Goldsmiths 學位**：確認為 Studio Composition

### 敘事擴充（2 個新章節 + §3 重組）

**§3 重組——把 2015 河西走廊推到方法論起點**：原文簡略帶過西北旅行，但 Po-Hao 在自己 2018 年 Medium 文章中描述這趟旅程是他從「合成器/Max-MSP 數位介面」轉向「embodied listening」的關鍵——後續所有參與式作品（《Repetend》《光景計畫》《赫茲遊樂場》《朗誦者 2.0》）的方法論前提都在此奠定。本次以他本人 verbatim 引語「坦然接受徒勞的嘗試」、「回到單純的聽眾身份」補入。

**§4（新增）2016–2019 劇場應用雙軌**：原文從 2016 LABoral 直接跳 2018 FACT，漏掉最密集的劇場/舞蹈合作期——澳門文化中心系列、NYC Artists Space PRACTICE、2019 兩廳院藝術基地計畫選送。這條軌道解釋了為什麼他 2022 之後能承擔大型策展案。

**§7（新增）2025–2026 國際時程三件**：
1. **《水景迴路 Cybernetics of Waterscape》@ Ars Electronica 2025 Polyphony** —— 林茲 POSTCITY，9/3–9/7。C-LAB × Ars Electronica MOU 後首檔大型策展合作。Po-Hao 第二次入選 Ars Electronica（前次 2021 《Plantfluencer Gazing》）
2. **《朗誦者(s) Reciter(s)》@ IRCAM Forum Workshops 2026 Paris** —— 3/18–3/21
3. **《Life in Motion》@ The Music Center LA, Jerry Moss Plaza** —— 4/24–6/28；該機構首次與台灣藝術家直接合作策劃的戶外沉浸展覽

### Frontmatter 更新
- 新增 `updated: 2026-05-15`
- `lastVerified: 2026-04-21 → 2026-05-15`
- `tags` 補 `IRCAM Forum`、`Ars Electronica`、`The Music Center`
- `readingTime: 11 → 16`
- 保留 `author: 'Taiwan.md Contributors'`、`featured: false`、`lastHumanReview: false`

### 新增引用來源（8 條）
完整 footnote 清單見 `[^20]`–`[^27]`，全部對應公開機構頁面或主體本人 Medium 文章：
- 駐西班牙台北經濟文化辦事處 LABoral 報導
- 駐洛杉磯臺灣書院 Music Center 公告
- 紀柏豪 Medium 流浪者計劃回顧
- Ars Electronica 2025 Polyphony 展覽頁
- C-LAB Taiwan Sound Lab Polyphony 策展頁
- IRCAM Forum Workshops 2026
- 兩廳院藝術基地計畫
- 中央社/聯合新聞網 Music Center 開展報導

### 標點正規化
原始草稿是半字寬標點，本 commit 已正規化為全字寬中文標點（與既有 repo 慣例一致），但保留：
- 英文上下文內標點不動（如 `MIT Art, Culture and Technology`）
- 短英文縮寫 `(s)` 維持半字寬（避免 `《朗誦者(s) Reciter(s)》` 變 `（s）`）
- footnote 定義 `[^N]:` 維持半字寬冒號

## 📁 變更類型

- [x] ✏️ 修改/更新現有文章
- [x] 🐛 修復錯誤（事實更正、連結補強）

## ✅ 自我檢查

- [x] 文章有完整的 frontmatter（title, description, date, tags, category）
- [x] `category: 'Art'` 對齊 canonical
- [x] `author: 'Taiwan.md Contributors'`（保留原值，未寫 'Claude'/'AI'）
- [x] `featured: false`（保留原值）
- [x] 腳註用 canonical 格式 `[^N]: [標題](URL) — 描述`
- [x] 內容附公開可查證來源
- [x] 無版權問題（主體 Medium 文章 + 公開機構頁面）
- [ ] 在本地 build 測試（未跑 `bun run build`；若 CI fail 願意處理）

## 🔗 相關 Issue

無。

## 補充

如果有任何敘述讀起來太 AI-generated 或太 self-promotional，請直接在 review 標註，可立即修改。感謝你寫了原版條目——「hear vs. listen」這個切點抓得很準，這次更新基本上是把這個切點往 2015 河西走廊那個更早的起點推回去。

🤖 Generated with [Claude Code](https://claude.com/claude-code)