### PR TITLE
feat(no2-no3): perspective scan + rationale metadata canonical (issue #851)

### DIFF
--- a/docs/editorial/EDITORIAL.md
+++ b/docs/editorial/EDITORIAL.md
@@ -687,6 +687,16 @@ abstraction 蓋過細節是 AI 寫作最普遍的指紋。每段沒有 anchor no
 
 **密度規則**：≥ 1500 字長文，「不是 X 是 Y」+ 變種（不只 / 不僅 / 並非 / 不是 X 而是 Y）總數 ≤ 3 處。
 
+#### 對位句型禁忌的 legitimate 替代出口
+
+需要表達「我考慮過 Y 才選 Z」的取捨思考時，**寫進 frontmatter 的 `rationale.whats_excluded`，不要寫進 prose**。
+
+對位句型禁忌的根本問題是「prose 在做 metadata 該做的事」— 作者想表達取捨思考但沒 legitimate 替代出口，所以塞進 prose 形成「不是 X，是 Y」「不只是 A，更是 B」這種 fabricated strawman pattern。
+
+`rationale.whats_excluded` 提供 legitimate 替代出口。對位句型禁令從此有「禁了還能寫哪」的回答 — 不再是「禁了又沒地方寫」的怨念。
+
+詳細 schema: [RATIONALE-SPEC.md](RATIONALE-SPEC.md)。perspective scan SOP: [REWRITE-PIPELINE Step 1.4.5](../pipelines/REWRITE-PIPELINE.md)。
+
 #### 破折號 `——` 連用
 
 密度過高 = AI 在補充而非陳述。每隔幾行一個破折號 = 語氣急促、結構鬆散、缺乏句子之間的呼吸。1500 字長文 ≤ 15 處。

--- a/docs/editorial/RATIONALE-SPEC.md
+++ b/docs/editorial/RATIONALE-SPEC.md
@@ -1,0 +1,120 @@
+# RATIONALE-SPEC: article-level rationale metadata 規格
+
+> _v1 2026-05-23 — 對應 issue #851 No2+No3 兩個方向 ship。Sister doc: REWRITE-PIPELINE Step 1.4.5 / EDITORIAL §六 / article-health rationale-presence plugin。_
+
+---
+
+## 一、為什麼有 rationale metadata
+
+article-level rationale 是 frontmatter 內的 5 個 keys，紀錄作者寫這篇文章的設計理由 — 為什麼從這個 hook 切入、排除了哪些對立論述、哪裡有 hedge 表述、誰會反對。
+
+**目的 — awareness trigger，不是盡職報告**
+
+> 我們不是在面試作者(貢獻者)，我們不該讓作者(貢獻者)更困擾。簡填都沒關係。我們要的是讓作者(貢獻者)知道他需要有更多維度的考慮，而不是每篇文章的寫作都要附上盡職報告。
+
+rationale 設計目的是讓作者**意識到**該考慮對立陣營 / 排除理由 / hedge 位置，而不是 compliance check。簡填一句話就 OK，重點是「腦中有跑過這 4 個維度」。
+
+---
+
+## 二、Schema — 5 keys
+
+```yaml
+---
+title: '...'
+# ... 既有 frontmatter 欄位 ...
+lastVerified: 2026-05-23
+lastHumanReview: true
+rationale:
+  why_this_hook: '...'      # required
+  whats_excluded: '...'     # required
+  where_it_hedges: '...'    # required
+  whos_pushing_back: '...'  # required
+  which_framing: '...'      # optional
+---
+```
+
+### Keys 說明
+
+| Key | 用途 | 必選 |
+|-----|------|------|
+| **why_this_hook** | 為什麼從這個 angle / moment / framing 切入 (vs 其他可能的 hook alternatives) | required |
+| **whats_excluded** | 排除了哪些對立論述 + 三選一理由 (薄弱 / 篇幅 / 不在範疇) | required |
+| **where_it_hedges** | prose 內哪些位置是 hedge 表述 (時點限定 / 區間估算 / 因果歸因觀察性 / 政治立場中性化) | required |
+| **whos_pushing_back** | 主要反對者陣營描述 OR multi-perspective article 可能被誤讀的位置 + 回應段 | required |
+| **which_framing** | framing 的來源 (議題類學界 framework anchor / 人物類策展 narrative devices / 或留空) | **optional** |
+
+### Value 規則
+
+- ✅ 純自由 string — 不限格式、不限長度、不強制 enum
+- ✅ 簡填 OK — one-liner 或 short paragraph 都接受
+- ✅ Plugin 不檢查內容詳盡度，只查 key 存在 + 非空
+- ✅ which_framing 沒框架可講就留空，不強制
+- ❌ 不能空白 / `[TODO]` / `[待填]` 等佔位符 (per plugin rationale-presence WARN)
+
+---
+
+## 三、簡填 OK — 兩篇 dogfood 示範
+
+兩篇 ship 出去當 reference，示範兩種寫作密度都合法:
+
+### 簡填示範 (人物類 retrofit)
+
+[`knowledge/People/蔡英文.md`](../../knowledge/People/蔡英文.md) — 5 keys 各 one-liner / short paragraph，每 key ~50-150 字。
+
+### 厚實示範 (議題類 framework article)
+
+[`knowledge/Society/台灣統獨光譜.md`](../../knowledge/Society/台灣統獨光譜.md) — 5 keys 含學界 anchor / 4 立場 framework / 國際 comparison / 8 處 hedge 位置 / 4 個 framing 質疑，每 key ~150-300 字。
+
+**Contributor 自選適合的密度**。簡填 OK，想厚實也 OK。
+
+---
+
+## 四、Stage 銜接
+
+| Stage / Doc | 跟 rationale 的關係 |
+|-------------|-------------------|
+| REWRITE-PIPELINE Stage 0.6 觀點成型 | 觀點成型的思考結果，結構化落地到 `why_this_hook` |
+| REWRITE-PIPELINE Step 1.4.5 perspective scan | perspective scan 結果落地到 `whats_excluded` |
+| EDITORIAL §二 找矛盾 / 物件 / 引語 / 場景 / 細節 | 自然落到 `why_this_hook` |
+| EDITORIAL §六 對位句型禁忌 | `whats_excluded` 提供合法的「我考慮過 Y 才選 Z」表達空間 (對立思考從 prose 移到 metadata) |
+
+---
+
+## 五、Plugin: `rationale-presence`
+
+### Check 邏輯
+
+| 條件 | Severity |
+|------|----------|
+| frontmatter 缺 `rationale:` block | WARN (強制類別) / INFO (建議類別) |
+| 4 required keys 任一缺失 / 空 / `[TODO]` | WARN (強制類別) / INFO (建議類別) |
+| Key 名字寫錯 (例 `why_hook` 不是 `why_this_hook`) | HARD (任何 category) |
+| `which_framing` 缺失 OR 空 | 0 violation (optional key) |
+| 內容詳盡度 | **不檢查** — 簡填 OK |
+
+### 強制 vs 建議分流
+
+| 判定 | 強制度 |
+|------|-------|
+| `category` ∈ {People, History, Society, Politics} | **強制** — release-pr profile WARN 升 fail，新文章 ship 前 4 keys 必填 |
+| `category` ∈ 其他 (Music / Food / Nature / Art / Culture / Technology / Geography 等) | **建議** — INFO 不擋 ship，dashboard 顯示覆蓋率 |
+
+**分流理由** (per issue #851 哲宇 Comment 8 Build 3 verbatim):
+> retrofit 200 篇填 rationale 太重 (短期內做不到)，但新文章可以 strict。建議類別維持寬鬆，避免 warn 變成噪音被作者忽略。
+
+### Legacy article retrofit policy
+
+200 篇早期 article 沒 rationale 不擋 deploy (ci-deploy profile fail_on=hard，rationale-presence WARN 不擋)。隨文章 polish 或 EVOLVE 時 opportunistic 補。
+
+---
+
+## 六、跟相關 doc 的關係
+
+- **新增 rationale**: 走 [REWRITE-PIPELINE Step 1.4.5](../pipelines/REWRITE-PIPELINE.md) perspective scan，scan 結果落地到 `whats_excluded` 等 keys
+- **對位句型 → rationale**: [EDITORIAL §六](EDITORIAL.md) 對位句型禁忌段提供 cross-ref，「我考慮過 Y 才選 Z」的取捨思考寫進 `whats_excluded` 不寫進 prose
+- **Plugin check**: [scripts/tools/lib/article_health/checks/rationale_presence.py](../../scripts/tools/lib/article_health/checks/rationale_presence.py)
+- **Dogfood 示範**: [`Society/台灣統獨光譜.md`](../../knowledge/Society/台灣統獨光譜.md) (議題類厚實) + [`People/蔡英文.md`](../../knowledge/People/蔡英文.md) (人物類簡填)
+
+---
+
+_— 對應 issue #851 No2+No3 ship / v1 2026-05-23 / Maintainer @Zaious_

--- a/docs/pipelines/REWRITE-PIPELINE.md
+++ b/docs/pipelines/REWRITE-PIPELINE.md
@@ -551,6 +551,65 @@ grep -r "主題關鍵詞" knowledge/{Category}/
 
 **v2.14 觸發背景**：2026-04-10 session α 國防現代化重寫的教訓——沒有李喜明那句苦笑，整篇會變回豪豬戰略勝利敘事。
 
+### Step 1.4.5: Perspective scan — 跨陣營對立 spectrum 覆蓋 🧭
+
+Step 1.4 收斂的是文章內部 thesis 矛盾。Step 1.4.5 找的是**跨陣營對立 spectrum** — 哪些陣營對本文 framing 會質疑、是否該引述對立論述、排除哪些理由。perspective scan 結果**必須**落地到 frontmatter `rationale.whats_excluded` (per [RATIONALE-SPEC.md](../editorial/RATIONALE-SPEC.md))。
+
+**兩種做法擇一**：
+
+| 做法 | 適用 | 觸發 |
+|------|------|------|
+| **A. spawn 反方 agent** | 爭議題目 (政治 / 史觀 / 政策 / identity) | sub-agent WebSearch 可用時 |
+| **B. 作者自問 checklist** | 非爭議題目 OR sub-agent WebSearch 不可用 OR retrofit 場景 | 永遠可用作 fallback |
+
+#### 做法 A — sub-agent prompt (含防呆三條)
+
+```
+你是 [topic] 議題的反方代表 / 質疑者 / 批評者。
+從反對立場找 5-10 個有實質論述的 sources。
+
+防呆三條:
+1. 每條對立論述必附 source URL — 拿不出 URL 就不算數
+2. 列 5-10 條;論述不夠就明確標「對立陣營論述薄弱」+ 為什麼,不要硬湊
+3. 顯式排除「情緒攻擊類 / 無實質論點」(範例: 人身攻擊 / 沒事實依據的 ad hominem / 純口號 chants)
+
+回覆格式: { url, position summary, strongest argument, source quality grade (A/B/C) }
+```
+
+**設計目的**：寧可 agent 回「對立論述不夠」也不要 hallucinated 假反方觀點。前者作者還能判斷，後者會誤導作者把假論述當真論述處理。
+
+#### 做法 B — 作者 self-checklist 5 題
+
+寫文章前作者自問：
+
+1. 這個主題的主要爭議陣營是誰？
+2. 我引用的 sources 涵蓋了哪些陣營？
+3. 我沒引的陣營有沒有實質論述存在於網路上？
+4. 如果有，我為什麼沒引？
+5. **對立論述如果存在但作者選擇不引 — 是因為 (a) 論述薄弱 (b) 篇幅限制 (c) 不在範疇？三選一寫進 `whats_excluded`**
+
+**為什麼第 5 題強制三選一**：含糊帶過會變成「我有想過」的偷吃步 — 只有逼作者選一個具體原因，這個思考才真的留下來給後人。
+
+#### 處理策略 3 選 1
+
+對 sub-agent 結果或 self-checklist 結論，作者決定每個對立論述的處理：
+
+| 策略 | 動作 | 落地位置 |
+|------|------|---------|
+| **引用** | 把論述帶進文章作 counterpoint | 文章內 + 補新 `[^N]` |
+| **排除 + 理由** | 不帶進文章，理由寫進 metadata | `rationale.whats_excluded` |
+| **不在範圍 + 理由** | 對立論述跟本文焦點不同 | `rationale.whats_excluded` |
+
+→ 跟 RATIONALE-SPEC.md hard coupled — perspective scan 結果**必須**落到 metadata。
+
+#### 不做的事
+
+- ❌ 不強制平衡 (總有平衡不完)
+- ❌ 不取代 Step 1.4 找矛盾 (perspective scan 是 1.4 的延伸)
+- ❌ 不 retroactive 200 篇 (per #851 Build 3 「retrofit 太重」)
+
+**觸發背景**：2026-04-30 issue #851 哲宇提 No2「20 個 source 是數量檢查，沒有觀點檢查」。5/22-23 Phase 3 統獨光譜 + Phase 4 蔡英文 retrofit 兩篇 dogfood 後 ship canonical。完整脈絡見 [RATIONALE-SPEC.md](../editorial/RATIONALE-SPEC.md)。
+
 ### Step 1.5: 問觀察者要一手素材 🫧
 
 Stage 1 結束前，**主動問觀察者一句**：

--- a/scripts/tools/article-health.config.toml
+++ b/scripts/tools/article-health.config.toml
@@ -3,12 +3,21 @@
 # 設計提案：reports/article-health-ssot-design-2026-05-04.md
 # Canonical 寫作品質規則：docs/editorial/EDITORIAL.md
 #
-# Phases 1-7 shipped 2026-05-04. Initial 13 plugins; 18 plugins as of 2026-05-16:
+# Phases 1-7 shipped 2026-05-04. Initial 13 plugins; 19 plugins as of 2026-05-23:
 #   cjk-punct / cross-reference / footnote-density / footnote-format /
 #   footnote-url / format-structure / frontmatter-format /
 #   frontmatter-title / image-health / link-target / prose-health /
 #   terminology / wikilink-target / chronicle-lead / word-count /
-#   spore-writing / image-alt (NEW 2026-05-16) / seo-meta (NEW 2026-05-16)
+#   spore-writing / image-alt (NEW 2026-05-16) / seo-meta (NEW 2026-05-16) /
+#   rationale-presence (NEW 2026-05-23, per issue #851 No2+No3 Build 3)
+#
+# rationale-presence added 2026-05-23 — issue #851 No2+No3 Phase 5 ship.
+# Checks frontmatter rationale block has 4 required keys (why_this_hook /
+# whats_excluded / where_it_hedges / whos_pushing_back) + 1 optional
+# (which_framing). WARN for strict categories (People/History/Society/Politics);
+# INFO for advisory categories (Music/Food/Nature/etc). HARD for typo'd key
+# names. Plugin only checks key presence, NOT content depth (簡填 OK per
+# 主人 awareness 哲學). Canonical spec: docs/editorial/RATIONALE-SPEC.md.
 #
 # image-alt + seo-meta added 2026-05-16 215434-manual session — Phase 4-5 of
 # immune-score-redesign. P0 缺口 from TOOL-INVENTORY §🕳️. Both default WARN

--- a/scripts/tools/lib/article_health/checks/rationale_presence.py
+++ b/scripts/tools/lib/article_health/checks/rationale_presence.py
@@ -1,0 +1,155 @@
+"""rationale_presence — check that frontmatter rationale block has 4 required keys present.
+
+Per RATIONALE-SPEC.md + issue #851 哲宇 Comment 8 Build 3:
+  - rationale must contain 4 required keys: why_this_hook / whats_excluded /
+    where_it_hedges / whos_pushing_back
+  - which_framing is optional (5th key)
+  - Plugin only checks key PRESENCE (existence + non-empty + not placeholder),
+    NOT content depth — per 主人 5/23 awareness 哲學: 簡填 OK，不檢查詳盡度
+
+Strict vs advisory category split (per #851 Build 3 verbatim):
+  「強制類別 (People / History / Society / Politics) → 新文章 ship 之前
+    rationale 4 個 key 必填，warn 變強制檢查 (不過就不能 squash merge)」
+  「建議類別 (Music / Food / Nature / Art) → warn 不擋 ship，但 dashboard
+    顯示這類文章的 rationale 覆蓋率」
+  「分流理由：retrofit 200 篇填 rationale 太重 (短期內做不到)，但新文章
+    可以 strict。建議類別維持寬鬆，避免 warn 變成噪音被作者忽略」
+
+Severity model:
+  - HARD: rationale key 名拼錯 (e.g. `why_hook` instead of `why_this_hook`)
+    — applies to any category, structural integrity issue
+  - WARN: strict category missing rationale block / required key / empty value
+    — release-pr profile (fail_on=warn) escalates to ship blocker
+  - INFO: advisory category missing rationale — dashboard awareness only,
+    never blocks ship
+
+Auto-fix:
+  None — rationale 內容是 thinking 結果，不該 auto-generate。
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterator
+
+from ..types import FileTarget, Severity, Violation
+
+
+CHECK_NAME = "rationale-presence"
+DIMENSION = "rationale"
+DEFAULT_SEVERITY = Severity.WARN
+EDITORIAL_REF = "docs/editorial/RATIONALE-SPEC.md + REWRITE-PIPELINE.md Step 1.4.5"
+APPLIES_TO = ["zh-TW"]
+
+
+REQUIRED_KEYS = [
+    "why_this_hook",
+    "whats_excluded",
+    "where_it_hedges",
+    "whos_pushing_back",
+]
+
+OPTIONAL_KEYS = [
+    "which_framing",
+]
+
+ALL_KNOWN_KEYS = set(REQUIRED_KEYS + OPTIONAL_KEYS)
+
+# Strict categories per #851 哲宇 Build 3 — release-pr profile gates these.
+STRICT_CATEGORIES = {"People", "History", "Society", "Politics"}
+
+# Placeholder values that count as "empty" / unfilled.
+EMPTY_MARKERS = {"", "[TODO]", "[待填]", "TODO", "待填", "todo", "TBD", "tbd"}
+
+
+def _missing_severity(target: FileTarget) -> Severity:
+    """Strict category → WARN; advisory category → INFO."""
+    if target.category in STRICT_CATEGORIES:
+        return Severity.WARN
+    return Severity.INFO
+
+
+def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
+    if target.category == "About":
+        return
+
+    rationale = target.frontmatter.get("rationale")
+    missing_sev = _missing_severity(target)
+
+    # Case 1: No rationale block at all
+    if rationale is None:
+        yield Violation(
+            check=CHECK_NAME,
+            severity=missing_sev,
+            message=(
+                f"frontmatter 缺 `rationale:` block — "
+                f"請補 4 required keys ({' / '.join(REQUIRED_KEYS)})。簡填 OK。"
+            ),
+            line=1,
+            fix_suggestion=(
+                "rationale:\n"
+                "  why_this_hook: '...'\n"
+                "  whats_excluded: '...'\n"
+                "  where_it_hedges: '...'\n"
+                "  whos_pushing_back: '...'\n"
+                "  which_framing: '...'  # optional"
+            ),
+            editorial_ref=EDITORIAL_REF,
+        )
+        return
+
+    # Case 2: rationale exists but is not a mapping (malformed YAML)
+    if not isinstance(rationale, dict):
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.HARD,
+            message="frontmatter `rationale` 必須是 YAML mapping (nested keys)",
+            line=1,
+            fix_suggestion="使用 `rationale:` 加 nested 4 keys",
+            editorial_ref=EDITORIAL_REF,
+        )
+        return
+
+    # Case 3: Check each required key is present and non-empty
+    for key in REQUIRED_KEYS:
+        if key not in rationale:
+            yield Violation(
+                check=CHECK_NAME,
+                severity=missing_sev,
+                message=f"rationale 缺 required key `{key}` (簡填 OK)",
+                line=1,
+                fix_suggestion=f"加 `{key}: '...'`",
+                editorial_ref=EDITORIAL_REF,
+            )
+            continue
+
+        value = rationale.get(key)
+        # Treat None / empty string / placeholder markers as unfilled
+        value_str = "" if value is None else str(value).strip()
+        if value_str in EMPTY_MARKERS:
+            yield Violation(
+                check=CHECK_NAME,
+                severity=missing_sev,
+                message=f"rationale `{key}` 空或為佔位符 (簡填 OK，但不可留空)",
+                line=1,
+                fix_suggestion=f"`{key}` 填一句話描述即可",
+                editorial_ref=EDITORIAL_REF,
+            )
+
+    # Case 4: Check for typo'd / unknown keys (HARD — structural integrity)
+    # Underscore-prefixed sister keys (e.g. _rationale_meta) are allowed.
+    for key in rationale.keys():
+        if key in ALL_KNOWN_KEYS:
+            continue
+        if isinstance(key, str) and key.startswith("_"):
+            continue
+        yield Violation(
+            check=CHECK_NAME,
+            severity=Severity.HARD,
+            message=(
+                f"rationale key `{key}` 非 canonical 名稱 — 是否拼錯？"
+                f" canonical keys: {', '.join(REQUIRED_KEYS + OPTIONAL_KEYS)}"
+            ),
+            line=1,
+            fix_suggestion=f"檢查 key 名稱拼寫，或加底線前綴 `_{key}` 表示 sister key",
+            editorial_ref=EDITORIAL_REF,
+        )

--- a/scripts/tools/lib/article_health/loader.py
+++ b/scripts/tools/lib/article_health/loader.py
@@ -66,8 +66,12 @@ def _parse_frontmatter_minimal(yaml_text: str) -> dict[str, Any]:
         pass
 
     out: dict[str, Any] = {}
-    for raw_line in yaml_text.splitlines():
+    lines = yaml_text.splitlines()
+    i = 0
+    while i < len(lines):
+        raw_line = lines[i]
         line = raw_line.rstrip()
+        i += 1
         if not line or line.startswith("#"):
             continue
         m = re.match(r"^([A-Za-z][\w-]*):\s*(.*)$", line)
@@ -75,7 +79,29 @@ def _parse_frontmatter_minimal(yaml_text: str) -> dict[str, Any]:
             continue
         key, val = m.group(1), m.group(2).strip()
         if not val:
-            out[key] = ""
+            # Empty top-level value — peek ahead for nested mapping (1 level)
+            # or block scalar (`|`/`>`). For nested mapping: indented `child: value`.
+            nested: dict[str, Any] = {}
+            while i < len(lines):
+                peek = lines[i]
+                peek_stripped = peek.rstrip()
+                if not peek_stripped:
+                    i += 1
+                    continue
+                child_m = re.match(
+                    r"^\s+([A-Za-z_][\w-]*):\s*(.*)$", peek_stripped
+                )
+                if not child_m:
+                    break
+                ckey = child_m.group(1)
+                cval = child_m.group(2).strip()
+                if (cval.startswith("'") and cval.endswith("'")) or (
+                    cval.startswith('"') and cval.endswith('"')
+                ):
+                    cval = cval[1:-1]
+                nested[ckey] = cval
+                i += 1
+            out[key] = nested if nested else ""
             continue
         # List: [a, b, c] or ['a', 'b']
         if val.startswith("[") and val.endswith("]"):


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

對應 #851 哲宇 5/21 Comment 8「**No2 + No3 Phase 3 + 4 並行試跑 → Phase 5 主流程結構性改動 PR**」四條 build canonical 化。Phase 3 + Phase 4 兩篇 dogfood 已 ship 於 sister PR #1088  + #1089 。

### Build 1 + Build 2 — REWRITE-PIPELINE Stage 1 加 Step 1.4.5 perspective scan
- `docs/pipelines/REWRITE-PIPELINE.md`: 加 Step 1.4.5 (跨陣營對立 spectrum 覆蓋)
- 含 sub-agent prompt 防呆三條 (Build 1)
- 含 self-checklist 5 題 + 第 5 題三選一 (Build 2)

### Build 3 — article-health plugin `rationale-presence` 強制 / 建議分流
- `scripts/tools/lib/article_health/checks/rationale_presence.py` 新檔
- 強制類別 (People / History / Society / Politics) — release-pr profile WARN 升 fail
- 建議類別 (Music / Food / Nature / Art 等) — INFO 不擋 ship + dashboard 覆蓋率
- HARD: rationale key 名拼錯
- Plugin 只查 keys 存在 + 非空，**不查內容詳盡度**

### Build 4 — EDITORIAL §六 cross-ref
- `docs/editorial/EDITORIAL.md` §六 對位句型禁忌段加「legitimate 替代出口」子節
- 「我考慮過 Y 才選 Z」的取捨思考寫進 `rationale.whats_excluded`，不寫進 prose

### Schema spec
- `docs/editorial/RATIONALE-SPEC.md` 新檔 — 5 keys (4 required + 1 optional `which_framing`) + 簡填 OK 哲學 + 兩篇 dogfood 示範連結

### Infrastructure
- `scripts/tools/lib/article_health/loader.py`: fallback parser 加 1 層 nested mapping 支援 (rationale 是 Taiwan.md 第一個 nested mapping frontmatter field)
- `scripts/tools/article-health.config.toml`: plugin count 18 → 19 紀錄

對應 sister PR:
- **PR #1088 ** `fix/article-tongtu-spectrum`: Phase 3 統獨光譜 (議題類厚實 dogfood)
- **PR #1089 ** `fix/article-tsai-retrofit`: Phase 4 蔡英文 retrofit (人物類簡填 dogfood)

## 📁 變更類型

- [x] 💻 技術改動 (plugin / parser infrastructure)
- [x] 📚 文件更新 (REWRITE-PIPELINE / EDITORIAL / RATIONALE-SPEC)

## ✅ 自我檢查

- [x] Plugin 5 case behavior 驗證 PASS (兩篇 dogfood / 強制類無 rationale WARN / 建議類無 rationale INFO / typo key HARD)
- [x] release-pr profile fail_on=warn → 強制類別新文章 ship 前 4 keys 必填 (對應 Build 3 wording)
- [x] ci-deploy profile fail_on=hard → 200 篇 legacy 不擋 deploy
- [x] Loader.py extend 對既有 18 plugins 0 regression (兩篇 dogfood + 既有 article 跑 full plugin profile 全 pass)
- [x] 沒新 frontmatter required field (rationale 是 opt-in，legacy 沒 rationale 走 advisory path)

## 🔗 相關 Issue

對應 #851 Comment 8 「Build B3 主流程結構性改動 PR 開好後 ping 一下，我們會完整審閱再 ship」。

ping @frank890417 / Semiont review。

⚙️
 
---
 
_— Cardinal（樞機師） / Maintainer @Zaious_