### PR TITLE
🚨 hotfix: Politics 分類 8 touchpoint 補完 — /politics/ articles 404 修復

### DIFF
--- a/plugins/remark-wikilinks.mjs
+++ b/plugins/remark-wikilinks.mjs
@@ -19,6 +19,7 @@ const categorySlugMap = {
   Society: 'society',
   Economy: 'economy',
   Lifestyle: 'lifestyle',
+  Politics: 'politics',
 };
 
 let titleToUrl = null;
@@ -58,7 +59,10 @@ export default function remarkWikilinks() {
       while ((match = regex.exec(node.value)) !== null) {
         // Text before the match
         if (match.index > lastIndex) {
-          parts.push({ type: 'text', value: node.value.slice(lastIndex, match.index) });
+          parts.push({
+            type: 'text',
+            value: node.value.slice(lastIndex, match.index),
+          });
         }
 
         const isBold = match[1] !== undefined;

--- a/src/pages/[category]/[slug].astro
+++ b/src/pages/[category]/[slug].astro
@@ -44,6 +44,7 @@ export async function getStaticPaths() {
     society: 'Society',
     economy: 'Economy',
     lifestyle: 'Lifestyle',
+    politics: 'Politics',
   };
 
   const safeMatter = (fileContent: string) => {

--- a/src/pages/en/[category]/[slug].astro
+++ b/src/pages/en/[category]/[slug].astro
@@ -40,6 +40,7 @@ export async function getStaticPaths() {
     society: 'Society',
     economy: 'Economy',
     lifestyle: 'Lifestyle',
+    politics: 'Politics',
   };
 
   const safeMatter = (fileContent: string) => {

--- a/src/pages/es/[category]/[slug].astro
+++ b/src/pages/es/[category]/[slug].astro
@@ -40,6 +40,7 @@ export async function getStaticPaths() {
     society: 'Society',
     economy: 'Economy',
     lifestyle: 'Lifestyle',
+    politics: 'Politics',
   };
 
   const safeMatter = (fileContent: string) => {

--- a/src/pages/fr/[category]/[slug].astro
+++ b/src/pages/fr/[category]/[slug].astro
@@ -40,6 +40,7 @@ export async function getStaticPaths() {
     society: 'Society',
     economy: 'Economy',
     lifestyle: 'Lifestyle',
+    politics: 'Politics',
   };
 
   const safeMatter = (fileContent: string) => {

--- a/src/pages/ja/[category]/[slug].astro
+++ b/src/pages/ja/[category]/[slug].astro
@@ -39,6 +39,7 @@ export async function getStaticPaths() {
     society: 'Society',
     economy: 'Economy',
     lifestyle: 'Lifestyle',
+    politics: 'Politics',
   };
 
   const safeMatter = (fileContent: string) => {

--- a/src/pages/ko/[category]/[slug].astro
+++ b/src/pages/ko/[category]/[slug].astro
@@ -39,6 +39,7 @@ export async function getStaticPaths() {
     society: 'Society',
     economy: 'Economy',
     lifestyle: 'Lifestyle',
+    politics: 'Politics',
   };
 
   const safeMatter = (fileContent: string) => {

--- a/src/utils/articles-index.ts
+++ b/src/utils/articles-index.ts
@@ -39,6 +39,7 @@ const CATEGORY_MAPPING: Record<string, string> = {
   society: 'Society',
   economy: 'Economy',
   lifestyle: 'Lifestyle',
+  politics: 'Politics',
 };
 
 function safeMatter(fileContent: string): {


### PR DESCRIPTION
## Problem

PR #1102 ship 後 [https://taiwan.md/politics/](https://taiwan.md/politics/) Hub 渲染 OK，但點任一篇文章都 404。

## Root cause

Politics 加進系統 hit 了 5 個 touchpoint（sync.sh / categoryConfig.ts / category-static-paths.ts / Header.astro / i18n/ui.ts），但漏了 **8 個 hardcoded CATEGORY_MAPPING / categorySlugMap**：

- `src/pages/[category]/[slug].astro` (zh-TW)
- `src/pages/{en,ja,ko,es,fr}/[category]/[slug].astro` (5 lang)
- `src/utils/articles-index.ts`
- `plugins/remark-wikilinks.mjs`

→ Astro 不生成 `/politics/{slug}/` routes → 404
→ Wikilink plugin 不 resolve `[[Politics article]]` → plain text fallback

## Fix

8 個檔案插入 `politics: 'Politics'` mapping。Local astro build 驗證 `dist/politics/{10 articles}/index.html` 全部 generate 成功。

## Test plan

- [ ] CF Pages deploy 後 `https://taiwan.md/politics/` Hub 內每篇 wikilink 點進去能 reach 文章
- [ ] 6 lang `/{lang}/politics/` 通（en/ja/ko/es/fr 雖無翻譯文章但 route schema 不報錯）

## Follow-up (LESSONS-INBOX 候選)

「新 category 加進系統的 audit checklist 需要 instrument 化」— 13 個 hardcoded touchpoint 該寫 `scripts/tools/check-category-touchpoints.sh` audit cron，避免下次新 category 又漏。Per `src/config/languages.ts` 註解「15 hardcoded touchpoints」既有設計範式。

🤖 Generated with [Claude Code](https://claude.com/claude-code)