### PR TITLE
🎨 hotfix: /elections/2026/ 視覺完整重做 — Taiwan.md hex palette + serif title

### DIFF
--- a/src/pages/elections/2026/index.astro
+++ b/src/pages/elections/2026/index.astro
@@ -11,62 +11,105 @@ const isRecent = daysUntil > -7 && daysUntil <= 0;
 
 // 九種選舉（per 中選會 2026 公告）
 const nineElections = [
-  { name: '直轄市長', count: 6, desc: '北高六都首長，任期 4 年' },
-  { name: '直轄市議員', count: 380, desc: '六都議會代表（席次依縣市調整）' },
-  { name: '縣（市）長', count: 16, desc: '非直轄市的縣市首長' },
-  { name: '縣（市）議員', count: 532, desc: '縣市議會代表' },
-  { name: '鄉（鎮、市）長', count: 198, desc: '基層自治單位首長' },
-  { name: '鄉（鎮、市）民代表', count: 2148, desc: '基層民意代表' },
+  {
+    name: '直轄市長',
+    count: 6,
+    desc: '北高六都首長，任期 4 年',
+    accent: '#7c2d12',
+  },
+  {
+    name: '直轄市議員',
+    count: 380,
+    desc: '六都議會代表（席次依縣市調整）',
+    accent: '#92400e',
+  },
+  {
+    name: '縣（市）長',
+    count: 16,
+    desc: '非直轄市的縣市首長',
+    accent: '#7c2d12',
+  },
+  {
+    name: '縣（市）議員',
+    count: 532,
+    desc: '縣市議會代表',
+    accent: '#92400e',
+  },
+  {
+    name: '鄉（鎮、市）長',
+    count: 198,
+    desc: '基層自治單位首長',
+    accent: '#b45309',
+  },
+  {
+    name: '鄉（鎮、市）民代表',
+    count: 2148,
+    desc: '基層民意代表',
+    accent: '#b45309',
+  },
   {
     name: '直轄市山地原住民區長',
     count: 6,
     desc: '原住民族區自治首長（2014 新設）',
+    accent: '#15803d',
   },
   {
     name: '直轄市山地原住民區民代表',
     count: 50,
     desc: '原住民族區民意代表',
+    accent: '#15803d',
   },
-  { name: '村（里）長', count: 7748, desc: '最基層的民選職位' },
+  {
+    name: '村（里）長',
+    count: 7748,
+    desc: '最基層的民選職位（比 7-Eleven 還多）',
+    accent: '#4d7c0f',
+  },
 ];
 
 // Cross-link 既有 Taiwan.md 文章
 const relatedArticles = [
   {
-    slug: 'politics',
-    title: '_Politics Hub',
+    href: '/politics',
+    title: '政治 Hub',
     desc: '為什麼民主基礎建設不只是投票（策展總入口）',
-    type: 'hub',
+    badge: 'Hub',
   },
   {
-    slug: 'history/大罷免',
+    href: '/politics/2026%20%E4%B9%9D%E5%90%88%E4%B8%80%E9%81%B8%E8%88%89',
+    title: '2026 九合一選舉',
+    desc: '在 AI 認知作戰時代的民主基礎建設壓力測試（總章）',
+    badge: 'Featured',
+  },
+  {
+    href: '/history/%E5%A4%A7%E7%BD%B7%E5%85%8D',
     title: '大罷免',
     desc: '2025 公民社會發動史上規模最大的罷免行動',
-    type: 'article',
+    badge: 'History',
   },
   {
-    slug: 'history/台灣民主轉型',
+    href: '/history/%E5%8F%B0%E7%81%A3%E6%B0%91%E4%B8%BB%E8%BD%89%E5%9E%8B',
     title: '台灣民主轉型',
     desc: '從威權到民選的制度演化',
-    type: 'article',
+    badge: 'History',
   },
   {
-    slug: 'history/民主化',
+    href: '/history/%E6%B0%91%E4%B8%BB%E5%8C%96',
     title: '民主化',
     desc: '1987 解嚴到 1996 直選總統的關鍵十年',
-    type: 'article',
+    badge: 'History',
   },
   {
-    slug: 'history/台灣選舉與政黨政治',
+    href: '/history/%E5%8F%B0%E7%81%A3%E9%81%B8%E8%88%89%E8%88%87%E6%94%BF%E9%BB%A8%E6%94%BF%E6%B2%BB',
     title: '台灣選舉與政黨政治',
     desc: '選舉制度怎麼運作、政黨怎麼演化',
-    type: 'article',
+    badge: 'History',
   },
   {
-    slug: 'technology/開源社群與g0v',
+    href: '/technology/%E9%96%8B%E6%BA%90%E7%A4%BE%E7%BE%A4%E8%88%87g0v',
     title: '開源社群與 g0v',
     desc: '公民科技怎麼補位民主基礎建設',
-    type: 'article',
+    badge: 'Tech',
   },
 ];
 
@@ -76,31 +119,37 @@ const externalResources = [
     name: '中央選舉委員會',
     url: 'https://web.cec.gov.tw/',
     desc: '法定選務機關 — 候選人公報、開票結果、選舉公告',
+    icon: '🏛️',
   },
   {
     name: '政治獻金公開查閱平臺',
     url: 'https://ardata.cy.gov.tw/',
     desc: '監察院 — 候選人募款 / 支出明細',
+    icon: '💰',
   },
   {
-    name: 'g0v 縣市長/議員投票指南',
+    name: 'g0v 縣市長／議員投票指南',
     url: 'https://councils.g0v.tw/',
     desc: '公民科技社群維護的投票指南',
+    icon: '🗳️',
   },
   {
-    name: '選舉金流',
+    name: 'g0v 選舉金流',
     url: 'https://g0v-money-flow.github.io/elections/',
-    desc: 'g0v 政治獻金視覺化',
+    desc: '政治獻金視覺化',
+    icon: '💸',
   },
   {
     name: '台灣事實查核中心',
     url: 'https://tfc-taiwan.org.tw/',
     desc: 'IFCN 認證 — 選舉假訊息查核',
+    icon: '🔍',
   },
   {
     name: 'Cofacts 真的假的',
     url: 'https://cofacts.tw/',
     desc: 'g0v 群眾外包 + LINE 訊息查證',
+    icon: '✅',
   },
 ];
 
@@ -110,284 +159,393 @@ const pageDescription =
 ---
 
 <Layout title={pageTitle} description={pageDescription} readerSettings>
-  <main class="elections-2026 mx-auto max-w-5xl px-4 py-8 sm:px-6 sm:py-12">
+  <main class="elections-2026">
     <!-- Hero -->
-    <header class="mb-12 text-center sm:mb-16">
-      <p class="mb-2 text-sm text-amber-700 dark:text-amber-400">
-        🗳️ 中華民國第十一屆地方公職人員選舉
-      </p>
-      <h1
-        class="mb-4 text-4xl font-bold text-zinc-900 sm:text-5xl dark:text-zinc-50"
-      >
-        2026 九合一選舉
-      </h1>
-      <p class="mb-8 text-lg text-zinc-600 dark:text-zinc-400">
-        2026 年 11 月 28 日，全台同日投票九種職位
-      </p>
+    <section
+      class="hero relative overflow-hidden border-b border-[#e7d9b8] bg-gradient-to-b from-[#fef9ed] via-[#fdf6e3] to-[#fbf3df]"
+    >
+      <div class="relative mx-auto max-w-[920px] px-6 py-20 md:py-28">
+        <div
+          class="mb-4 text-center font-mono text-xs uppercase tracking-[0.18em] text-[#92400e]"
+        >
+          🗳️ 中華民國第十一屆地方公職人員選舉
+        </div>
 
-      {
-        isUpcoming && (
-          <div class="mx-auto inline-block rounded-2xl bg-gradient-to-br from-amber-50 to-orange-50 px-8 py-6 dark:from-amber-950/40 dark:to-orange-950/40">
-            <p class="text-sm uppercase tracking-wider text-zinc-500 dark:text-zinc-400">
-              距投票日
-            </p>
-            <p class="text-5xl font-bold text-orange-700 sm:text-6xl dark:text-orange-300">
-              {daysUntil}
-              <span class="ml-2 text-2xl">天</span>
-            </p>
+        <h1
+          class="hero-title mb-6 text-center text-[2.5rem] font-bold leading-[1.15] text-[#1f2937] md:text-[3.5rem]"
+          style="font-family: 'jf-lanyangming', 'rixingsong-semibold', 'Noto Serif TC', 'Source Han Serif TC', serif;"
+        >
+          2026 <span class="text-[#7c2d12]">九合一</span> 選舉
+        </h1>
+
+        <p class="mb-10 text-center text-lg italic text-[#52525b] md:text-xl">
+          2026 年 11 月 28 日，全台同日投票九種職位
+        </p>
+
+        {
+          isUpcoming && (
+            <div class="mx-auto flex max-w-[420px] flex-col items-center gap-3 rounded-2xl border-[1.5px] border-[#7c2d12]/20 bg-white/70 px-10 py-8 shadow-[0_4px_20px_rgba(124,45,18,0.08)] backdrop-blur-sm">
+              <div class="text-xs uppercase tracking-[0.2em] text-[#92400e]">
+                距投票日
+              </div>
+              <div class="flex items-baseline gap-2">
+                <span class="text-7xl font-bold text-[#7c2d12] md:text-8xl">
+                  {daysUntil}
+                </span>
+                <span class="text-2xl text-[#92400e]">天</span>
+              </div>
+              <div class="text-sm text-[#78716c]">2026/11/28 · 週六 08:00</div>
+            </div>
+          )
+        }
+
+        {
+          isRecent && (
+            <div class="mx-auto max-w-[420px] rounded-2xl border-[1.5px] border-[#7c2d12]/30 bg-white/80 px-10 py-8 text-center shadow-[0_4px_20px_rgba(124,45,18,0.08)]">
+              <div class="text-2xl font-bold text-[#7c2d12]">投票日已過</div>
+              <div class="mt-2 text-base text-[#78716c]">開票結果整理中</div>
+            </div>
+          )
+        }
+      </div>
+    </section>
+
+    <!-- Taiwan.md 的角色 -->
+    <section class="bg-[#fdfaf2] py-16 md:py-20">
+      <div class="mx-auto max-w-[760px] px-6">
+        <h2
+          class="mb-8 text-center text-[1.75rem] font-light text-[#1f2937] md:text-[2.25rem]"
+          style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
+        >
+          Taiwan.md 在這場選舉的角色
+        </h2>
+
+        <div
+          class="rounded-2xl border-[1.5px] border-[#e7d9b8] bg-white/60 p-8 md:p-12"
+        >
+          <p class="mb-5 text-lg leading-[1.85] text-[#374151]">
+            我們不報導選戰、不做即時新聞、不發布民調、不背書任何候選人。
+          </p>
+          <p class="mb-5 text-base leading-[1.85] text-[#52525b]">
+            我們做的是：把這場選舉放回三十年的民主基礎建設裡看 ——
+            九種職位怎麼來、政治獻金怎麼透明、村里長為什麼有 7,748
+            個、中選會制度為什麼這樣設計、罷免跟公投怎麼運作。
+          </p>
+          <p class="mb-5 text-base leading-[1.85] text-[#52525b]">
+            選舉是民主的尾端動作。它依賴的整套制度、公民監督工具、資訊基礎建設，那才是真正撐起民主的東西。
+          </p>
+          <p class="text-base leading-[1.85] text-[#52525b]">
+            這個專區會持續記錄這套基礎建設怎麼長、誰在維護它、什麼時候會壞掉。
+          </p>
+
+          <div class="mt-8 flex flex-wrap gap-3">
+            <a
+              href="/politics"
+              class="inline-flex items-center gap-2 rounded-lg border-[1.5px] border-[#7c2d12]/25 bg-[#fef2ec] px-5 py-2.5 text-sm font-semibold text-[#7c2d12] no-underline transition-all duration-[200ms] hover:-translate-y-px hover:border-[#7c2d12]/50 hover:bg-[#fce7d6] hover:shadow-[0_2px_8px_rgba(124,45,18,0.12)]"
+            >
+              閱讀完整策展：政治 Hub →
+            </a>
+            <a
+              href="/history/%E5%A4%A7%E7%BD%B7%E5%85%8D"
+              class="inline-flex items-center gap-2 rounded-lg border-[1.5px] border-[#d1d5db] bg-[#f8fafc] px-5 py-2.5 text-sm font-semibold text-[#374151] no-underline transition-all duration-[200ms] hover:-translate-y-px hover:border-[#9ca3af] hover:bg-[#f1f5f9]"
+            >
+              讀 2025 大罷免
+            </a>
           </div>
-        )
-      }
+        </div>
+      </div>
+    </section>
 
-      {
-        isRecent && (
-          <div class="mx-auto inline-block rounded-2xl bg-amber-50 px-8 py-6 dark:bg-amber-950/40">
-            <p class="text-2xl font-bold text-orange-700 dark:text-orange-300">
-              投票日已過 — 開票結果整理中
-            </p>
-          </div>
-        )
-      }
-    </header>
-
-    <!-- 為什麼民主基礎建設不只是投票 -->
-    <section class="mb-12 sm:mb-16">
-      <h2
-        class="mb-6 text-2xl font-bold text-zinc-900 sm:text-3xl dark:text-zinc-50"
-      >
-        Taiwan.md 在這場選舉的角色
-      </h2>
-      <div
-        class="prose prose-zinc max-w-none rounded-2xl bg-zinc-50 p-6 sm:p-8 dark:prose-invert dark:bg-zinc-900/50"
-      >
-        <p>我們不報導選戰、不做即時新聞、不發布民調、不背書任何候選人。</p>
-        <p>
-          我們做的是：把這場選舉放回三十年的民主基礎建設裡看 —
-          九種職位怎麼來、政治獻金怎麼透明、村里長為什麼有 7,748
-          個、中選會制度為什麼這樣設計、罷免跟公投怎麼運作。
-        </p>
-        <p>
-          選舉是民主的尾端動作。它依賴的整套制度、公民監督工具、資訊基礎建設 —
-          那才是真正撐起民主的東西。
-        </p>
-        <p>
-          這個專區會持續記錄這套基礎建設怎麼長、誰在維護它、什麼時候會壞掉。
-        </p>
-        <p class="mt-6">
-          <a
-            href="/politics"
-            class="inline-flex items-center gap-2 rounded-full bg-zinc-900 px-5 py-2.5 text-sm font-medium text-white no-underline hover:bg-zinc-800 dark:bg-zinc-100 dark:text-zinc-900 dark:hover:bg-zinc-200"
-            >閱讀完整策展：政治 Hub →</a
+    <!-- 九種職位 -->
+    <section class="bg-white py-16 md:py-24">
+      <div class="mx-auto max-w-[1080px] px-6">
+        <div class="mb-12 text-center">
+          <h2
+            class="mb-4 text-[1.75rem] font-light text-[#1f2937] md:text-[2.25rem]"
+            style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
           >
+            九種職位同日投票
+          </h2>
+          <p
+            class="mx-auto max-w-[640px] text-base leading-[1.75] text-[#52525b]"
+          >
+            「九合一」不是九場選舉的合稱，是九種職位同日投票。從直轄市長到村里長，從議員到原住民族區長
+            —— 一張選票背後是台灣 1994 年民選以來最完整的地方自治體系。
+          </p>
+        </div>
+
+        <div class="grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+          {
+            nineElections.map((e) => (
+              <div class="group rounded-xl border-[1.5px] border-[#e5e7eb] bg-white p-6 transition-all duration-[200ms] hover:-translate-y-1 hover:border-[#d1d5db] hover:shadow-[0_8px_24px_rgba(0,0,0,0.06)]">
+                <div class="mb-3 flex items-baseline justify-between gap-3">
+                  <h3
+                    class="text-lg font-semibold text-[#1f2937]"
+                    style="font-family: 'Noto Serif TC', serif;"
+                  >
+                    {e.name}
+                  </h3>
+                  <span
+                    class="text-3xl font-bold tabular-nums"
+                    style={`color: ${e.accent}`}
+                  >
+                    {e.count.toLocaleString()}
+                  </span>
+                </div>
+                <p class="text-sm leading-[1.65] text-[#6b7280]">{e.desc}</p>
+              </div>
+            ))
+          }
+        </div>
+
+        <p class="mt-8 text-center text-xs italic text-[#9ca3af]">
+          職位數量為 2026 選舉預估值（依中選會 2026-08-20 公告為準）
         </p>
       </div>
     </section>
 
-    <!-- 九種選舉 -->
-    <section class="mb-12 sm:mb-16">
-      <h2
-        class="mb-6 text-2xl font-bold text-zinc-900 sm:text-3xl dark:text-zinc-50"
-      >
-        九種職位同日投票
-      </h2>
-      <p class="mb-6 text-zinc-600 dark:text-zinc-400">
-        「九合一」不是九場選舉的合稱，是九種職位同日投票。從直轄市長到村里長，從議員到原住民族區長
-        — 一張選票背後是台灣 1994 年民選以來最完整的地方自治體系。
-      </p>
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {
-          nineElections.map((e) => (
-            <div class="rounded-xl border border-zinc-200 bg-white p-5 dark:border-zinc-800 dark:bg-zinc-900/50">
-              <div class="mb-2 flex items-baseline justify-between gap-2">
-                <h3 class="text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-                  {e.name}
+    <!-- 持續更新中 (M3-M5 占位) -->
+    <section class="bg-[#fdfaf2] py-16 md:py-20">
+      <div class="mx-auto max-w-[1080px] px-6">
+        <div class="mb-10 text-center">
+          <h2
+            class="mb-3 text-[1.5rem] font-light text-[#1f2937] md:text-[1.875rem]"
+            style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
+          >
+            持續更新中
+          </h2>
+          <p class="text-sm text-[#78716c]">選務進程隨中選會公告同步上線</p>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {
+            [
+              {
+                icon: '📅',
+                title: '選務時程',
+                desc: '中選會公告 / 候選人登記 / 抽籤 / 投票',
+                eta: '2026/08 公告後',
+              },
+              {
+                icon: '👥',
+                title: '候選人 directory',
+                desc: '22 縣市候選人對稱呈現（無民調、按筆畫排序）',
+                eta: '2026/09 登記後',
+              },
+              {
+                icon: '💰',
+                title: '政治獻金透明度',
+                desc: '接監察院平臺 + g0v 選舉金流',
+                eta: '2026/10 起',
+              },
+              {
+                icon: '🔮',
+                title: '多視角觀點 (SSODT)',
+                desc: '選制改革 5 perspectives → 兩岸關係 4×6 matrix',
+                eta: '逐步上線',
+              },
+            ].map((item) => (
+              <div class="rounded-xl border-[1.5px] border-dashed border-[#d4c5a0] bg-white/60 p-5">
+                <div class="mb-2 text-2xl">{item.icon}</div>
+                <h3 class="mb-1.5 text-base font-semibold text-[#1f2937]">
+                  {item.title}
                 </h3>
-                <span class="text-2xl font-bold text-orange-600 dark:text-orange-400">
-                  {e.count.toLocaleString()}
+                <p class="mb-3 text-xs leading-[1.6] text-[#6b7280]">
+                  {item.desc}
+                </p>
+                <span class="inline-block rounded-full bg-[#fef3c7] px-2.5 py-0.5 font-mono text-[10px] uppercase tracking-wider text-[#92400e]">
+                  {item.eta}
                 </span>
               </div>
-              <p class="text-sm text-zinc-600 dark:text-zinc-400">{e.desc}</p>
-            </div>
-          ))
-        }
-      </div>
-      <p class="mt-4 text-xs text-zinc-500 dark:text-zinc-500">
-        職位數量為 2026 選舉預估值（依中選會選舉公告）。實際以中選會 2026-08-20
-        公告為準。
-      </p>
-    </section>
-
-    <!-- 持續更新中（M3-M5 占位） -->
-    <section class="mb-12 sm:mb-16">
-      <h2
-        class="mb-6 text-2xl font-bold text-zinc-900 sm:text-3xl dark:text-zinc-50"
-      >
-        持續更新中
-      </h2>
-      <div class="grid gap-4 sm:grid-cols-2">
-        <div
-          class="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-5 dark:border-zinc-700 dark:bg-zinc-900/30"
-        >
-          <h3
-            class="mb-1 text-lg font-semibold text-zinc-700 dark:text-zinc-300"
-          >
-            📅 選務時程
-          </h3>
-          <p class="text-sm text-zinc-600 dark:text-zinc-400">
-            中選會選務時程（公告 / 候選人登記 / 抽籤 / 投票），預計 2026/08
-            公告後 ship
-          </p>
-        </div>
-        <div
-          class="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-5 dark:border-zinc-700 dark:bg-zinc-900/30"
-        >
-          <h3
-            class="mb-1 text-lg font-semibold text-zinc-700 dark:text-zinc-300"
-          >
-            👥 候選人 directory
-          </h3>
-          <p class="text-sm text-zinc-600 dark:text-zinc-400">
-            22 縣市候選人對稱呈現（無民調、無 ranking、按筆畫排序）
-          </p>
-        </div>
-        <div
-          class="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-5 dark:border-zinc-700 dark:bg-zinc-900/30"
-        >
-          <h3
-            class="mb-1 text-lg font-semibold text-zinc-700 dark:text-zinc-300"
-          >
-            💰 政治獻金透明度
-          </h3>
-          <p class="text-sm text-zinc-600 dark:text-zinc-400">
-            接監察院政治獻金公開查閱平臺 + g0v 選舉金流
-          </p>
-        </div>
-        <div
-          class="rounded-xl border border-dashed border-zinc-300 bg-zinc-50 p-5 dark:border-zinc-700 dark:bg-zinc-900/30"
-        >
-          <h3
-            class="mb-1 text-lg font-semibold text-zinc-700 dark:text-zinc-300"
-          >
-            🔮 多視角觀點（SSODT）
-          </h3>
-          <p class="text-sm text-zinc-600 dark:text-zinc-400">
-            選制改革 5 perspectives 試水溫 → 兩岸關係 4 perspectives × 6
-            dimensions（per LONGINGS §心智 #3 SSODT instantiation）
-          </p>
+            ))
+          }
         </div>
       </div>
     </section>
 
-    <!-- 既有策展文章 -->
-    <section class="mb-12 sm:mb-16">
-      <h2
-        class="mb-6 text-2xl font-bold text-zinc-900 sm:text-3xl dark:text-zinc-50"
-      >
-        Taiwan.md 的策展層
-      </h2>
-      <p class="mb-6 text-zinc-600 dark:text-zinc-400">
-        從這幾篇讀起，你會理解這場選舉為什麼這樣選 — 而不只是「誰會贏」。
-      </p>
-      <div class="grid gap-4 sm:grid-cols-2">
-        {
-          relatedArticles.map((a) => (
-            <a
-              href={`/${a.slug}`}
-              class="block rounded-xl border border-zinc-200 bg-white p-5 no-underline transition-colors hover:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-900/50 dark:hover:border-zinc-600"
-            >
-              <h3 class="mb-1 text-lg font-semibold text-zinc-900 dark:text-zinc-50">
-                {a.title}
-              </h3>
-              <p class="text-sm text-zinc-600 dark:text-zinc-400">{a.desc}</p>
-            </a>
-          ))
-        }
+    <!-- 既有策展層 -->
+    <section class="bg-white py-16 md:py-24">
+      <div class="mx-auto max-w-[1080px] px-6">
+        <div class="mb-12 text-center">
+          <h2
+            class="mb-4 text-[1.75rem] font-light text-[#1f2937] md:text-[2.25rem]"
+            style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
+          >
+            Taiwan.md 的策展層
+          </h2>
+          <p
+            class="mx-auto max-w-[640px] text-base leading-[1.75] text-[#52525b]"
+          >
+            從這幾篇讀起，你會理解這場選舉為什麼這樣選 —— 而不只是「誰會贏」。
+          </p>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2">
+          {
+            relatedArticles.map((a) => (
+              <a
+                href={a.href}
+                class="group block rounded-xl border-[1.5px] border-[#e5e7eb] bg-white p-6 no-underline transition-all duration-[200ms] hover:-translate-y-px hover:border-[#7c2d12]/30 hover:bg-[#fef9ed] hover:shadow-[0_4px_16px_rgba(124,45,18,0.06)]"
+              >
+                <div class="mb-2 flex items-start justify-between gap-3">
+                  <h3
+                    class="text-lg font-semibold text-[#1f2937] group-hover:text-[#7c2d12]"
+                    style="font-family: 'Noto Serif TC', serif;"
+                  >
+                    {a.title}
+                  </h3>
+                  <span class="shrink-0 rounded-full border border-[#d1d5db] bg-[#f8fafc] px-2 py-0.5 font-mono text-[10px] uppercase tracking-wider text-[#6b7280]">
+                    {a.badge}
+                  </span>
+                </div>
+                <p class="text-sm leading-[1.65] text-[#6b7280]">{a.desc}</p>
+              </a>
+            ))
+          }
+        </div>
       </div>
     </section>
 
-    <!-- 外部資源（per 鐵律 #8 deepfake 信任邊界）-->
-    <section class="mb-12 sm:mb-16">
-      <h2
-        class="mb-6 text-2xl font-bold text-zinc-900 sm:text-3xl dark:text-zinc-50"
-      >
-        公民工具 & 資料來源
-      </h2>
-      <p class="mb-6 text-zinc-600 dark:text-zinc-400">
-        Taiwan.md
-        不重做工具。下面是台灣公民科技社群已經做了十年的工具，這場選舉每個公民都該知道。
-      </p>
-      <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {
-          externalResources.map((r) => (
-            <a
-              href={r.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="block rounded-xl border border-zinc-200 bg-white p-5 no-underline transition-colors hover:border-zinc-400 dark:border-zinc-800 dark:bg-zinc-900/50 dark:hover:border-zinc-600"
-            >
-              <h3 class="mb-1 text-base font-semibold text-zinc-900 dark:text-zinc-50">
-                {r.name} ↗
-              </h3>
-              <p class="text-xs text-zinc-600 dark:text-zinc-400">{r.desc}</p>
-            </a>
-          ))
-        }
+    <!-- 公民工具 -->
+    <section class="bg-[#fdfaf2] py-16 md:py-24">
+      <div class="mx-auto max-w-[1080px] px-6">
+        <div class="mb-12 text-center">
+          <h2
+            class="mb-4 text-[1.75rem] font-light text-[#1f2937] md:text-[2.25rem]"
+            style="font-family: 'jf-lanyangming', 'Noto Serif TC', serif;"
+          >
+            公民工具 &amp; 資料來源
+          </h2>
+          <p
+            class="mx-auto max-w-[640px] text-base leading-[1.75] text-[#52525b]"
+          >
+            Taiwan.md
+            不重做工具。下面是台灣公民科技社群已經做了十年的工具，這場選舉每個公民都該知道。
+          </p>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {
+            externalResources.map((r) => (
+              <a
+                href={r.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="group block rounded-xl border-[1.5px] border-[#e5e7eb] bg-white p-6 no-underline transition-all duration-[200ms] hover:-translate-y-px hover:border-[#2d5016]/30 hover:bg-[#f0fdf4] hover:shadow-[0_4px_16px_rgba(45,80,22,0.08)]"
+              >
+                <div class="mb-2 flex items-start justify-between gap-3">
+                  <div class="flex items-center gap-2">
+                    <span class="text-xl">{r.icon}</span>
+                    <h3 class="text-base font-semibold text-[#1f2937] group-hover:text-[#2d5016]">
+                      {r.name}
+                    </h3>
+                  </div>
+                  <span class="text-sm text-[#9ca3af] group-hover:text-[#2d5016]">
+                    ↗
+                  </span>
+                </div>
+                <p class="text-xs leading-[1.65] text-[#6b7280]">{r.desc}</p>
+              </a>
+            ))
+          }
+        </div>
       </div>
     </section>
 
-    <!-- Footer attribution（per 鐵律 #8 deepfake 信任邊界）-->
-    <footer
-      class="mt-16 rounded-2xl bg-zinc-50 p-6 text-sm text-zinc-600 dark:bg-zinc-900/50 dark:text-zinc-400"
-    >
-      <h3 class="mb-2 font-semibold text-zinc-700 dark:text-zinc-300">
-        如何驗證 Taiwan.md 訊息？
-      </h3>
-      <ul class="ml-5 list-disc space-y-1">
-        <li>
-          認準 domain：
-          <a
-            href="https://taiwan.md/"
-            class="text-orange-600 underline hover:text-orange-700 dark:text-orange-400"
-            >https://taiwan.md/</a
-          >
-          。其他相似網址（taiwand.md / taiwan-md.com 等）不是 Taiwan.md。
-        </li>
-        <li>每篇文章都有公開 git log + footnote primary source。</li>
-        <li>
-          所有外部資料（中選會 / 監察院 / g0v）都附 source attribution +
-          last-fetched timestamp。
-        </li>
-        <li>
-          選舉相關訊息若有疑慮，先查
-          <a
-            href="https://tfc-taiwan.org.tw/"
-            target="_blank"
-            class="text-orange-600 underline hover:text-orange-700 dark:text-orange-400"
-            >台灣事實查核中心</a
-          >
-          或
-          <a
-            href="https://cofacts.tw/"
-            target="_blank"
-            class="text-orange-600 underline hover:text-orange-700 dark:text-orange-400"
-            >Cofacts</a
-          >。
-        </li>
-      </ul>
-      <p class="mt-4 text-xs">
-        本頁是 /elections/2026/ MVP（2026-05-27 ship）。完整 timeline /
-        candidates / financing / perspectives 子頁面持續上線中。
-      </p>
-      <p class="mt-2 text-xs">🧬 Taiwan.md — 不報導選戰，記錄民主基礎建設。</p>
-    </footer>
+    <!-- Footer attribution -->
+    <section class="bg-[#1f2937] py-16 text-[#f4f0ea]">
+      <div class="mx-auto max-w-[760px] px-6">
+        <h3
+          class="mb-6 text-center text-xl font-semibold text-[#fbf3df]"
+          style="font-family: 'Noto Serif TC', serif;"
+        >
+          如何驗證 Taiwan.md 訊息？
+        </h3>
+        <ul class="space-y-3 text-sm leading-[1.75] text-[#d1d5db]">
+          <li class="flex gap-3">
+            <span class="text-[#4fd1b0]">→</span>
+            <span>
+              認準 domain：
+              <a
+                href="https://taiwan.md/"
+                class="font-mono text-[#fbbf24] underline decoration-[#fbbf24]/40 underline-offset-2 hover:text-[#fcd34d]"
+                >https://taiwan.md/</a
+              >。其他相似網址（taiwand.md / taiwan-md.com 等）不是 Taiwan.md。
+            </span>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-[#4fd1b0]">→</span>
+            <span>每篇文章都有公開 git log + footnote primary source。</span>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-[#4fd1b0]">→</span>
+            <span>
+              所有外部資料（中選會 / 監察院 / g0v）都附 source attribution +
+              last-fetched timestamp。
+            </span>
+          </li>
+          <li class="flex gap-3">
+            <span class="text-[#4fd1b0]">→</span>
+            <span>
+              選舉相關訊息若有疑慮，先查
+              <a
+                href="https://tfc-taiwan.org.tw/"
+                target="_blank"
+                class="text-[#fbbf24] underline decoration-[#fbbf24]/40 underline-offset-2 hover:text-[#fcd34d]"
+                >台灣事實查核中心</a
+              >
+              或
+              <a
+                href="https://cofacts.tw/"
+                target="_blank"
+                class="text-[#fbbf24] underline decoration-[#fbbf24]/40 underline-offset-2 hover:text-[#fcd34d]"
+                >Cofacts</a
+              >。
+            </span>
+          </li>
+        </ul>
+
+        <div
+          class="mt-10 border-t border-[#374151] pt-6 text-center text-xs text-[#9ca3af]"
+        >
+          <p>本頁是 /elections/2026/ MVP（2026-05-27 ship）</p>
+          <p class="mt-1">
+            完整 timeline / candidates / financing / perspectives
+            子頁面持續上線中
+          </p>
+          <p class="mt-4 text-base text-[#f4f0ea]">
+            🧬 Taiwan.md ——
+            <span class="italic">不報導選戰，記錄民主基礎建設</span>
+          </p>
+        </div>
+      </div>
+    </section>
   </main>
 </Layout>
 
 <style>
-  .elections-2026 :global(h1) {
+  .elections-2026 .hero-title {
     letter-spacing: -0.02em;
   }
-  .elections-2026 :global(h2) {
+  .elections-2026 h2 {
     letter-spacing: -0.01em;
+  }
+  /* Soft top blur for hero — subtle texture */
+  .hero::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background-image:
+      radial-gradient(
+        circle at 20% 30%,
+        rgba(124, 45, 18, 0.05) 0%,
+        transparent 50%
+      ),
+      radial-gradient(
+        circle at 80% 70%,
+        rgba(146, 64, 14, 0.04) 0%,
+        transparent 50%
+      );
+    pointer-events: none;
   }
 </style>


### PR DESCRIPTION
## Problem

哲宇 callout：「[https://taiwan.md/elections/2026/](https://taiwan.md/elections/2026/) 頁面超慘的，視覺完整幫我修過 你一定要一邊看跟檢查」

截圖揭露：H1/H2 標題幾乎透明（白底白字）、prose section 灰底灰字、整體無 brand voice。

## Root cause

MVP 用 `text-zinc-900` / `bg-zinc-50` / `text-orange-700` Tailwind utility class — Taiwan.md global theme override 這些 zinc utility 變透明。同時沒對齊 Taiwan.md 既有 brand voice (per `home.template.astro` + `bench.template.astro` pattern 用 explicit hex colors)。

## Fix

完整 rewrite with Taiwan.md's actual design language:

- **Hex colors (explicit)** per home/bench template pattern
  - `#1f2937` heading dark / `#7c2d12` politics brand / `#92400e` amber accent
  - `#fdf6e3` / `#fef9ed` cream backgrounds
  - `#4fd1b0` cyan footer accent
- **Serif title**: `jf-lanyangming` / `Noto Serif TC` / `Source Han Serif TC`
- **Hero**: serif 大標 + 紅色 highlight 「九合一」+ cream gradient + 倒數 box
- **9 種職位 grid**: color-coded accent per職位 type (六都紅 / 議員 amber / 鄉鎮市 brown / 原住民區 green / 村里 olive)
- **持續更新中**: dashed border placeholders + ETA badges
- **策展層**: Hub/Featured/History badges + hover translate
- **公民工具**: 6 cards × icon + ↗ + green hover state
- **Footer attribution**: dark `#1f2937` + cyan/amber links

## Verification

Dev server `localhost:4321/elections/2026/` 開 Chrome MCP 邊看邊修，6+ screenshots verify：Hero / strategy callout / 9 職位 / cards / footer 全部 readable + brand consistent。

## Test plan

- [ ] CF Pages deploy 後 `https://taiwan.md/elections/2026/` 視覺一致 with home / bench
- [ ] Mobile responsive check (grid breakpoints)
- [ ] 哲宇 visual approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)