### PR TITLE
🧬 feedback v2 — 全站 ambient + 選文段精準標註 + 極低阻力

### DIFF
--- a/reports/feedback-go-live-log-2026-06-01.md
+++ b/reports/feedback-go-live-log-2026-06-01.md
@@ -17,22 +17,22 @@ related:
 
 ## 狀態總覽
 
-| #                       | 步驟                                                    | 誰              | 狀態 | 驗證                                 |
-| ----------------------- | ------------------------------------------------------- | --------------- | ---- | ------------------------------------ |
+| #                       | 步驟                                                    | 誰          | 狀態 | 驗證                                 |
+| ----------------------- | ------------------------------------------------------- | ----------- | ---- | ------------------------------------ |
 | **A. Supabase backend** |
-| 1                       | 開 Supabase 專案                                        | 哲宇            | ✅   | URL live + key 認證 OK               |
-| 2                       | 跑 migration `0001_feedback.sql`                        | 哲宇            | ✅   | 両表 200 + RLS 擋匿名 insert         |
-| 3                       | 開 Email + Google + GitHub 登入                         | 哲宇 + TWMD     | ✅   | 3 provider enabled / widget 3 鈕 e2e |
+| 1                       | 開 Supabase 專案                                        | 哲宇        | ✅   | URL live + key 認證 OK               |
+| 2                       | 跑 migration `0001_feedback.sql`                        | 哲宇        | ✅   | 両表 200 + RLS 擋匿名 insert         |
+| 3                       | 開 Email + Google + GitHub 登入                         | 哲宇 + TWMD | ✅   | 3 provider enabled / widget 3 鈕 e2e |
 | **B. 前端上線**         |
-| 4                       | merge branch → main                                     | TWMD(待哲宇 go) | ⬜   | main 含 feature,build 綠             |
-| 5                       | 設 repo Variables（mode+URL+anon key）                  | 哲宇/TWMD       | ⬜   | `gh variable list`                   |
-| 6                       | deploy + 驗證 widget 在 taiwan.md live                  | TWMD            | ⬜   | 抓頁面看 supabase mode               |
+| 4                       | merge branch → main                                     | TWMD        | ✅   | PR #1117 merged → main e90c400a3     |
+| 5                       | 設 repo Variables（mode+URL+anon key）                  | TWMD        | ✅   | 4 Variables set（gh variable list）  |
+| 6                       | deploy + 驗證 widget 在 taiwan.md live                  | TWMD        | 🔄   | deploy run 26735776667 building      |
 | **C. cron triage**      |
-| 7                       | 設 `~/.taiwanmd-feedback.env`（service key）            | 哲宇            | ⬜   | triage 連得上 Supabase               |
-| 8                       | triage dry-run（真資料）                                | TWMD            | ⬜   | 讀到 status=new                      |
-| 9                       | 排 cron `twmd-feedback-triage` 07:00                    | 哲宇/TWMD       | ⬜   | scheduler list                       |
+| 7                       | 設 `~/.taiwanmd-feedback.env`（service key）            | 哲宇        | ⬜   | triage 連得上 Supabase               |
+| 8                       | triage dry-run（真資料）                                | TWMD        | ⬜   | 讀到 status=new                      |
+| 9                       | 排 cron `twmd-feedback-triage` 07:00                    | 哲宇/TWMD   | ⬜   | scheduler list                       |
 | **D. 端到端煙霧測試**   |
-| 10                      | 真送一筆 feedback → triage --commit → 看 issue + status | 哲宇+TWMD       | ⬜   | issue 開出 + status=filed            |
+| 10                      | 真送一筆 feedback → triage --commit → 看 issue + status | 哲宇+TWMD   | ⬜   | issue 開出 + status=filed            |
 
 ---
 

--- a/reports/feedback-login-system-design-2026-06-01.md
+++ b/reports/feedback-login-system-design-2026-06-01.md
@@ -375,3 +375,117 @@ create policy sel_own on feedback for select using (auth.uid() = uid);
 ---
 
 _🧬 Taiwan.md draft，2026-06-01 twmd-become full session。命中 §自主權邊界，等哲宇 review §9 決策才動帳號與錢。完整調查見 §1。_
+
+---
+
+---
+
+# v2 升級：全站 ambient feedback + 文段精準標註（2026-06-01 哲宇 directive）
+
+> 哲宇 directive：「review 出現在所有頁面、極度好登入跟低阻力、文章頁特化（選文段勘誤/提案）、各頁型類似操作，想清楚對長期最好、最能讓大家好回報。」
+>
+> v1（§0-§10）做的是「文章頁浮動鈕 + 三類別 + 三登入」。v2 把 feedback 從**一顆按鈕**升成**一層遍佈全站、依頁面語境變形、能精準指到某一句話的回報神經**。
+
+## v2.1 北極星與長期原則
+
+**北極星**：讓「我發現了什麼 / 我想看什麼」這個念頭，在讀者腦中浮現的**那一秒、那個位置**就能無摩擦送出。回報不是一個要「去找」的功能，是一個**隨時在手邊、貼著當下語境**的反射。
+
+長期設計原則（決定每個取捨）：
+
+1. **語境貼合 > 通用表單**：讀者在李安那篇選到「1990 年得獎」時，最低摩擦是**就地**說「這裡錯了」，而不是「開回報 → 重打哪篇 → 描述哪段」。系統要把語境（哪頁、哪段、哪句）自動帶上。
+2. **阻力階梯遞減**：先讓人**動手**（選字 / 打字），最後一刻才要身份；有 Google session 的人一鍵；OAuth 給了名字就不再問暱稱。每一步都問「這步能不能省」。
+3. **隔離失敗域不變**：v2 仍是一層 client-side island，BaaS 掛了就 graceful degrade，主站（含全站每一頁）零影響。全站鋪開 ≠ 全站耦合。
+4. **一個回報 = 一個可定位的事實**：精準到「哪一句」的回報，對 Semiont 的逆熵價值最高（維護者不用猜哪裡錯）。所以資料模型要存 `quote` + 可深連結的 anchor。
+5. **頁型是一等公民**：文章 / 分類 / 首頁 / dashboard / semiont 各有最自然的回報動作。同一個 widget，依 `pageKind` 變形類別與文案，而不是每頁寫一個 widget。
+
+## v2.2 全站 ambient 架構
+
+- **掛載點上移到 Layout**：v1 只有 `article.template.astro` 傳 `feedback`。v2 改成 **Layout 對每個頁面都 render**（gate 在 `resolveBackendKind() !== 'off'`），shot-mode / raw 純文字頁 opt-out。一處改、全站有。
+- **`pageKind` 衍生**：Layout 從 `type`（website/article）+ `Astro.url.pathname` 推出 `pageKind ∈ {article, category, home, dashboard, semiont, other}`，連同 slug/category/title/url 一起當 data 屬性傳給 widget。
+- **失敗域**：widget 仍整包 try/catch；任何一頁的 widget 出錯只 swallow，不影響該頁 render。
+
+## v2.3 文章頁特化：選文段就地標註（核心）
+
+讀者在文章內文選取一段文字 → 游標旁浮出小藥丸 **「🧬 勘誤這段 / 提案」** → 點下去 widget 開啟,**自動帶**：
+
+- `type = content`（勘誤）
+- `quote` = 選取的原文（trim、capped ~1000 字）
+- `source_url` = 該頁 URL + **W3C Text Fragment**（`#:~:text=prefix-,start,...,-suffix`）
+
+**為什麼用 W3C Text Fragment 當 anchor（長期最穩）**：
+
+- 維護者點 issue 裡的連結 → 瀏覽器**自動捲到並高亮**那段原文,不用人工找。
+- 不依賴 DOM id / 字數位移,文章小改也大多還能命中（fragment 用前後文 disambiguate）。
+- 純 URL,可貼進 GitHub issue / 任何地方,零額外基建。
+- 退化優雅:就算 fragment 失效,`quote` 原文仍在 issue body,維護者搜尋即得。
+
+**anchor 穩健度補強**：除了 text fragment,issue body 也存 `quote` blockquote +（選取點最近的 heading）當人類可讀定位。雙保險。
+
+非文章頁不啟用選字標註（沒有「原文」可標）,但其他頁型有對應動作（見 v2.4）。
+
+## v2.4 頁型 context-aware 行為
+
+同一 widget,依 `pageKind` 換**類別集 + 文案 + 預設**：
+
+| pageKind            | 類別集（預設）                             | 特化                                   |
+| ------------------- | ------------------------------------------ | -------------------------------------- |
+| `article`           | 勘誤 / 網站問題 / 建議新主題               | + 選文段 → 勘誤這段（帶 quote+anchor） |
+| `category`          | 建議這個分類的新文章 / 網站問題 / 一般想法 | 預設 newtopic,帶 category              |
+| `home`              | 建議新主題 / 網站問題 / 一般想法           | 預設 idea                              |
+| `dashboard`         | 資料/顯示問題 / 一般想法                   | 預設 bug（數據頁常是回報數字怪）       |
+| `semiont` / `other` | 一般想法 / 網站問題                        | 預設 idea                              |
+
+類別在後端仍正規化成 cron 認得的四桶（content / bug / newtopic / idea→newtopic 或獨立）。**新增一桶 `idea`（一般想法/建議）** 對應 GitHub label `enhancement`（既有），讓「不針對特定文章的想法」有家。
+
+## v2.5 極度好登入（阻力階梯）
+
+由低到高摩擦,能停在越前面越好：
+
+1. **已登入**（persistent session）→ 0 步,直接送。
+2. **Google One-Tap**（有 Google session 的瀏覽器）→ 面板開啟即浮 One-Tap 卡,一點完成,不離開頁面。（實作:GSI client + `supabase.auth.signInWithIdToken`;Supabase Google provider 已啟用。列為 v2 enhancement,nonce 處理見實作註記。）
+3. **OAuth 一鍵**（Google / GitHub 按鈕）→ redirect 回來自動續(draft 存 sessionStorage)。
+4. **Email magic-link** → 保底,拿得到 email。
+
+**省掉的步**：
+
+- **OAuth 給了名字 → 跳過暱稱步**：`needsNickname` 改成「只有完全沒有可用顯示名（email-only 且沒設過暱稱）才問」。Google/GitHub 登入者直接送出,少一步。
+- draft 跨 redirect 不掉（已實作）。
+- 送出即時確認（optimistic,已實作）。
+
+## v2.6 資料模型增量（migration 0002，additive）
+
+```sql
+alter table public.feedback add column if not exists quote text check (char_length(quote) <= 1000);
+alter table public.feedback add column if not exists page_kind text;
+-- type CHECK 放寬納入 'idea'
+alter table public.feedback drop constraint if exists feedback_type_check;
+alter table public.feedback add constraint feedback_type_check
+  check (type in ('content','bug','newtopic','idea'));
+```
+
+`source_url` 沿用（裝 text-fragment deep link）。零破壞、純加欄,既有 v1 資料不動。
+
+## v2.7 triage / issue 變化
+
+`buildIssue` 在 content（含選字勘誤）時,body 加：
+
+```
+> （讀者選取的原文）
+{quote}
+
+🔗 直接定位：{source_url 含 #:~:text=...}
+```
+
+- `idea` 類 → label `enhancement` + `from-feedback`,title `[Idea] …`,進 maintainer 一般 triage。
+- `page_kind` 寫進 provenance 行（維護者知道來自哪種頁面）。
+
+## v2.8 對 MANIFESTO / 失敗域的再確認
+
+- **逆熵升級**：精準到句的勘誤 = 最高純度 entropy signal。✅
+- **隔離失敗域**：全站鋪開仍是單層 island + try/catch + degrade;BaaS 掛 → 全站每頁照常 render。✅
+- **§自主權邊界**：開 issue 仍是機械轉錄讀者原話(現在連他選的那句都 verbatim);維護者回覆/merge 留人類。✅
+- **低阻力 vs 品質防線**：登入仍是門檻（擋匿名洗版 + 給維護者可聯絡身份）;One-Tap 只是把「已是 Google 使用者」的人摩擦降到極低,不是拿掉身份。✅
+
+---
+
+_v2 supplement｜2026-06-01｜哲宇 directive「全站 + 選文段 + 極度好登入」。實作見同 session commits + go-live log。_

--- a/scripts/feedback/lib/classify.mjs
+++ b/scripts/feedback/lib/classify.mjs
@@ -11,7 +11,7 @@
  *       讀者文字 verbatim 引用,triage 不替讀者改寫對錯（那是維護者人類 gate 的事）。
  */
 
-const TYPES = new Set(['content', 'bug', 'newtopic']);
+const TYPES = new Set(['content', 'bug', 'newtopic', 'idea']);
 
 // ── spam ─────────────────────────────────────────────────────────────────────
 const SPAM_KEYWORDS = [
@@ -95,7 +95,8 @@ function provenance(row) {
   const who = row.display_name || '匿名讀者'; // 匿名讀者
   const when = (row.created_at || '').slice(0, 16).replace('T', ' ');
   // 只放 display_name + feedback id;不放 email。
-  return `\n\n---\n> 🧬 由站上回報轉入（twmd-feedback-triage）· 回報者：${who} · feedback id: \`${row.id}\`${when ? ` · ${when}` : ''}`;
+  const where = row.page_kind ? ` · 來源頁:${row.page_kind}` : '';
+  return `\n\n---\n> 🧬 由站上回報轉入（twmd-feedback-triage）· 回報者：${who} · feedback id: \`${row.id}\`${when ? ` · ${when}` : ''}${where}`;
 }
 
 function truncate(s, n) {
@@ -138,13 +139,26 @@ export function buildIssue(row) {
     };
   }
 
-  // content（勘誤）→ 對齊 fact-correction.yml
+  if (type === 'idea') {
+    return {
+      type,
+      title: `[Idea] ${truncate(row.body, 55)}`,
+      labels: ['enhancement', 'from-feedback'],
+      body: `**想法 / Idea**\n${row.body}` + provenance(row),
+    };
+  }
+
+  // content（勘誤）→ 對齊 fact-correction.yml。有 quote = 讀者選文段標註。
+  const quoteBlock = row.quote
+    ? `**讀者選取的原文 / Selected passage**\n> ${String(row.quote).replace(/\n/g, '\n> ')}\n\n🔗 直接定位：${row.source_url}\n\n`
+    : '';
   return {
     type,
     title: `[Fact Check] ${title}`,
     labels: ['needs-verification', 'from-feedback'],
     body:
       `**哪篇文章 / Which article?**\n${articleRef(row)}\n\n` +
+      quoteBlock +
       `**哪裡有誤 / What's wrong?**\n${row.body}` +
       (row.correct_info
         ? `\n\n**正確資訊 + 來源 / Correct info + source**\n${row.correct_info}`

--- a/scripts/feedback/triage.test.mjs
+++ b/scripts/feedback/triage.test.mjs
@@ -117,3 +117,49 @@ test('triageBatch: file genuine, reject spam, skip in-batch dup', () => {
   const filed = results.filter((r) => r.decision === 'file');
   assert.equal(filed.length, 3);
 });
+
+// ── v2: idea type + selected-quote annotation ────────────────────────────────
+test('resolveType passes idea through', () => {
+  assert.equal(resolveType({ type: 'idea', body: '想法' }), 'idea');
+});
+
+test('buildIssue maps idea → enhancement + [Idea] title', () => {
+  const iss = buildIssue({
+    id: 'i1',
+    type: 'idea',
+    body: '希望每頁都能切深色模式',
+    page_kind: 'home',
+  });
+  assert.equal(iss.type, 'idea');
+  assert.match(iss.title, /^\[Idea\] /);
+  assert.deepEqual(iss.labels, ['enhancement', 'from-feedback']);
+});
+
+test('content issue embeds selected quote + text-fragment deep link', () => {
+  const row = {
+    id: 'q1',
+    type: 'content',
+    article_title: '李安',
+    article_slug: '李安',
+    page_kind: 'article',
+    source_url: 'https://taiwan.md/people/李安#:~:text=1990',
+    quote: '《臥虎藏龍》1990 年得獎',
+    body: '年份錯了，應為 2001。',
+  };
+  const iss = buildIssue(row);
+  assert.match(iss.body, /讀者選取的原文/);
+  assert.match(iss.body, /《臥虎藏龍》1990 年得獎/);
+  assert.match(iss.body, /直接定位/);
+  assert.match(iss.body, /#:~:text=/);
+  assert.doesNotMatch(iss.body, /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i);
+});
+
+test('provenance carries page_kind', () => {
+  const iss = buildIssue({
+    id: 'p1',
+    type: 'bug',
+    body: '這個數字怪怪的',
+    page_kind: 'dashboard',
+  });
+  assert.match(iss.body, /來源頁:dashboard/);
+});

--- a/src/components/FeedbackWidget.astro
+++ b/src/components/FeedbackWidget.astro
@@ -16,8 +16,16 @@ interface Props {
   slug?: string;
   category?: string; // category slug
   title?: string;
+  /** article | category | home | dashboard | semiont | other (v2 context-aware). */
+  pageKind?: string;
 }
-const { lang = 'zh-TW', slug = '', category = '', title = '' } = Astro.props;
+const {
+  lang = 'zh-TW',
+  slug = '',
+  category = '',
+  title = '',
+  pageKind = 'other',
+} = Astro.props;
 const langUrlPrefix = lang === 'zh-TW' ? '' : `/${lang}`;
 const url =
   category && slug
@@ -32,6 +40,7 @@ const url =
   data-category={category}
   data-title={title}
   data-url={url}
+  data-pagekind={pageKind}
 >
 </div>
 
@@ -306,6 +315,58 @@ const url =
     to {
       transform: rotate(360deg);
     }
+  }
+
+  /* 選文段浮出的藥丸（v2 inline annotation） */
+  .twmd-fb-selpill {
+    position: absolute;
+    z-index: 70;
+    padding: 0.4rem 0.7rem;
+    border: none;
+    border-radius: 999px;
+    background: var(--twmd-fb-accent);
+    color: #fff;
+    font-size: 0.8rem;
+    font-weight: 600;
+    line-height: 1;
+    cursor: pointer;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+    white-space: nowrap;
+    animation: twmd-fb-pop 0.12s ease-out;
+  }
+  .twmd-fb-selpill:hover {
+    background: #14302a;
+  }
+  @keyframes twmd-fb-pop {
+    from {
+      opacity: 0;
+      transform: translateY(4px);
+    }
+  }
+  /* 表單裡顯示讀者選取的原文 */
+  .twmd-fb-quote {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+  .twmd-fb-quote-label {
+    font-size: 0.72rem;
+    color: #9ca3af;
+  }
+  .twmd-fb-quote blockquote {
+    margin: 0;
+    padding: 0.4rem 0.6rem;
+    border-left: 3px solid var(--twmd-fb-accent);
+    background: #f3f4f6;
+    border-radius: 0 6px 6px 0;
+    font-size: 0.82rem;
+    color: #374151;
+    max-height: 96px;
+    overflow-y: auto;
+  }
+  html[data-theme='dark'] .twmd-fb-quote blockquote {
+    background: #1f2937;
+    color: #d1d5db;
   }
 
   /* dark theme（站上用 <html data-theme="dark">） */

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -47,7 +47,8 @@ interface Props {
    * (correction / bug / new-topic → managed backend → cron → GitHub issue).
    * Self-gates on PUBLIC_FEEDBACK_MODE (off/github-only/mock/supabase); when
    * unconfigured it degrades to a static "report on GitHub" button, so it is
-   * always safe to leave on. Default: false. Article template opts in.
+   * always safe to leave on. Default: true (every surface that uses Layout).
+   * Pass feedback={false} to opt a surface out (e.g. embed/raw views).
    */
   feedback?: boolean;
 }
@@ -69,7 +70,7 @@ const {
   categorySlug: propCategorySlug,
   noindex,
   readerSettings = false,
-  feedback = false,
+  feedback = true,
 } = Astro.props;
 
 // Search index now loaded via /api/search-index.json (fetch API)
@@ -86,6 +87,20 @@ const categorySlug =
   propCategorySlug?.toLowerCase() || category?.toLowerCase() || '';
 const currentPath = Astro.url.pathname.replace(/\/$/, '') || '/';
 const isHome = currentPath === '/' || currentPath === '/en';
+// Feedback widget page-kind (v2): drives context-aware category set + inline
+// text-selection annotation on articles. Derived from page type + path.
+const fbPageKind =
+  type === 'article'
+    ? 'article'
+    : currentPath.includes('/dashboard')
+      ? 'dashboard'
+      : currentPath.includes('/semiont')
+        ? 'semiont'
+        : isHome
+          ? 'home'
+          : propCategorySlug
+            ? 'category'
+            : 'other';
 // justfont: only put the body font class on <body> to avoid rate-limit.
 // Other font classes go on specific elements (h1-h6, blockquote, nav, etc.)
 const jfClass = [
@@ -871,6 +886,7 @@ const jfClass = [
           slug={slug}
           category={categorySlug}
           title={title}
+          pageKind={fbPageKind}
         />
       )
     }

--- a/src/scripts/feedback/backend.ts
+++ b/src/scripts/feedback/backend.ts
@@ -56,7 +56,8 @@ class MockBackend implements FeedbackBackend {
       uid: rec.uid,
       email: rec.email,
       displayName: resolveDisplayName(nickname, rec.oauthName, rec.email),
-      needsNickname: !nickname,
+      // v2 低阻力：OAuth 給了名字就不再問暱稱（只有 email-only 且沒設過才問）。
+      needsNickname: !nickname && !rec.oauthName,
     };
   }
 
@@ -183,7 +184,8 @@ class SupabaseBackend implements FeedbackBackend {
       uid: u.id,
       email,
       displayName: resolveDisplayName(nickname, oauthName, email),
-      needsNickname: !nickname,
+      // v2 低阻力：OAuth 給了名字就不再問暱稱。
+      needsNickname: !nickname && !oauthName,
     };
   }
 
@@ -235,6 +237,8 @@ class SupabaseBackend implements FeedbackBackend {
         type: draft.type,
         body: draft.body,
         correct_info: draft.correctInfo || null,
+        quote: draft.quote || null,
+        page_kind: draft.pageKind || null,
         status: 'new',
       })
       .select('id')

--- a/src/scripts/feedback/i18n.ts
+++ b/src/scripts/feedback/i18n.ts
@@ -14,6 +14,12 @@ export interface FeedbackStrings {
   typeContentHint: string;
   typeBugHint: string;
   typeNewtopicHint: string;
+  typeIdea: string;
+  typeIdeaHint: string;
+  typeNewArticle: string; // category 頁的「建議這個分類的新文章」
+  typeNewArticleHint: string;
+  selectPill: string; // 選文段浮出的小藥丸
+  quoteLabel: string; // 表單裡顯示「你選取的段落」
   bodyPlaceholder: string;
   correctInfoLabel: string;
   correctInfoPlaceholder: string;
@@ -52,6 +58,12 @@ const en: FeedbackStrings = {
   typeContentHint: 'A fact in this article is wrong or outdated',
   typeBugHint: 'A page, link, or display is broken',
   typeNewtopicHint: 'Suggest something about Taiwan we should cover',
+  typeIdea: 'Idea / suggestion',
+  typeIdeaHint: 'A general thought about Taiwan.md',
+  typeNewArticle: 'Suggest an article',
+  typeNewArticleHint: 'Propose an article for this category',
+  selectPill: '🧬 Suggest a fix',
+  quoteLabel: 'Your selected passage',
   bodyPlaceholder: 'What did you find? Be specific.',
   correctInfoLabel: 'Correct info + source (optional)',
   correctInfoPlaceholder: 'Correct: …  Source: https://…',
@@ -87,6 +99,12 @@ const zhTW: FeedbackStrings = {
   typeContentHint: '這篇文章有事實錯誤或過時資訊',
   typeBugHint: '頁面、連結或顯示壞掉了',
   typeNewtopicHint: '建議一個台灣值得寫的主題',
+  typeIdea: '一般想法',
+  typeIdeaHint: '對 Taiwan.md 的建議或想法',
+  typeNewArticle: '建議新文章',
+  typeNewArticleHint: '提議這個分類值得收的主題',
+  selectPill: '🧬 勘誤這段',
+  quoteLabel: '你選取的段落',
   bodyPlaceholder: '你發現了什麼?請具體一點。',
   correctInfoLabel: '正確資訊 + 來源(選填)',
   correctInfoPlaceholder: '正確的是:…  來源:https://…',
@@ -122,6 +140,12 @@ const ja: FeedbackStrings = {
   typeContentHint: 'この記事の事実が誤り、または古い',
   typeBugHint: 'ページ・リンク・表示が壊れている',
   typeNewtopicHint: '台湾について扱うべきテーマを提案',
+  typeIdea: 'アイデア / 提案',
+  typeIdeaHint: 'Taiwan.md への提案や感想',
+  typeNewArticle: '記事を提案',
+  typeNewArticleHint: 'このカテゴリで扱うべきテーマを提案',
+  selectPill: '🧬 この部分を訂正',
+  quoteLabel: '選択した箇所',
   bodyPlaceholder: '何を見つけましたか?具体的にお願いします。',
   correctInfoLabel: '正しい情報 + 出典(任意)',
   correctInfoPlaceholder: '正しくは:…  出典:https://…',
@@ -157,6 +181,12 @@ const ko: FeedbackStrings = {
   typeContentHint: '이 글에 사실 오류나 오래된 정보가 있어요',
   typeBugHint: '페이지·링크·표시가 깨졌어요',
   typeNewtopicHint: '대만에 대해 다룰 만한 주제를 제안',
+  typeIdea: '아이디어 / 제안',
+  typeIdeaHint: 'Taiwan.md에 대한 제안이나 생각',
+  typeNewArticle: '새 글 제안',
+  typeNewArticleHint: '이 분류에 다룰 만한 주제를 제안',
+  selectPill: '🧬 이 부분 정정',
+  quoteLabel: '선택한 문단',
   bodyPlaceholder: '무엇을 발견했나요? 구체적으로 적어주세요.',
   correctInfoLabel: '올바른 정보 + 출처(선택)',
   correctInfoPlaceholder: '올바른 내용: …  출처: https://…',
@@ -192,6 +222,12 @@ const es: FeedbackStrings = {
   typeContentHint: 'Un dato de este artículo es erróneo o está desactualizado',
   typeBugHint: 'Una página, enlace o visualización está rota',
   typeNewtopicHint: 'Sugiere algo sobre Taiwán que deberíamos cubrir',
+  typeIdea: 'Idea / sugerencia',
+  typeIdeaHint: 'Una idea general sobre Taiwan.md',
+  typeNewArticle: 'Sugerir un artículo',
+  typeNewArticleHint: 'Propón un artículo para esta categoría',
+  selectPill: '🧬 Corregir esto',
+  quoteLabel: 'El pasaje que seleccionaste',
   bodyPlaceholder: '¿Qué encontraste? Sé específico.',
   correctInfoLabel: 'Información correcta + fuente (opcional)',
   correctInfoPlaceholder: 'Correcto: …  Fuente: https://…',
@@ -228,6 +264,12 @@ const fr: FeedbackStrings = {
   typeContentHint: 'Un fait de cet article est faux ou périmé',
   typeBugHint: 'Une page, un lien ou un affichage est cassé',
   typeNewtopicHint: 'Proposez un sujet sur Taïwan à couvrir',
+  typeIdea: 'Idée / suggestion',
+  typeIdeaHint: 'Une idée générale sur Taiwan.md',
+  typeNewArticle: 'Proposer un article',
+  typeNewArticleHint: 'Proposez un article pour cette catégorie',
+  selectPill: '🧬 Corriger ce passage',
+  quoteLabel: 'Le passage sélectionné',
   bodyPlaceholder: "Qu'avez-vous trouvé ? Soyez précis.",
   correctInfoLabel: 'Info correcte + source (facultatif)',
   correctInfoPlaceholder: 'Correct : …  Source : https://…',

--- a/src/scripts/feedback/selection.ts
+++ b/src/scripts/feedback/selection.ts
@@ -1,0 +1,101 @@
+/**
+ * selection.ts — 文章內文選字 → 浮出「🧬 勘誤這段」藥丸 → 回呼帶 quote + 深連結 anchor。
+ *
+ * 只在 article 頁啟用。anchor 用 W3C Text Fragment（`#:~:text=…`），維護者點 issue
+ * 連結就自動捲到並高亮那段原文。短選取整段當 textStart；長選取用前後各 ~24 字
+ * （`text=start,end`）提高命中率。任何錯誤都 swallow，不影響閱讀。
+ */
+
+export interface SelectionResult {
+  quote: string;
+  anchorUrl: string; // 該頁 URL + #:~:text=…
+}
+
+const MIN_LEN = 8; // 太短不觸發（避免誤觸）
+const MAX_LEN = 1000;
+
+function buildTextFragment(href: string, text: string): string {
+  const clean = text.replace(/\s+/g, ' ').trim();
+  const url = href.split('#')[0];
+  const enc = (s: string) => encodeURIComponent(s.trim());
+  if (clean.length <= 60) return `${url}#:~:text=${enc(clean)}`;
+  const start = clean.slice(0, 24);
+  const end = clean.slice(-24);
+  return `${url}#:~:text=${enc(start)},${enc(end)}`;
+}
+
+export function initSelectionAnnotation(
+  bodySelector: string,
+  pillLabel: string,
+  onPick: (r: SelectionResult) => void,
+): void {
+  try {
+    const body = document.querySelector(bodySelector);
+    if (!body) return;
+
+    let pill: HTMLButtonElement | null = null;
+    const removePill = () => {
+      pill?.remove();
+      pill = null;
+    };
+
+    const showPill = (x: number, y: number, result: SelectionResult) => {
+      removePill();
+      pill = document.createElement('button');
+      pill.type = 'button';
+      pill.className = 'twmd-fb-selpill';
+      pill.textContent = pillLabel;
+      pill.style.left = `${x}px`;
+      pill.style.top = `${y}px`;
+      pill.addEventListener('mousedown', (e) => {
+        e.preventDefault(); // 保留選取、不讓 input 失焦
+        e.stopPropagation();
+        try {
+          onPick(result);
+        } catch {
+          /* ignore */
+        }
+        removePill();
+        window.getSelection()?.removeAllRanges();
+      });
+      document.body.appendChild(pill);
+    };
+
+    document.addEventListener('mouseup', (e) => {
+      if (pill && e.target === pill) return;
+      setTimeout(() => {
+        try {
+          const sel = window.getSelection();
+          const text = (sel?.toString() || '').trim();
+          if (!sel || sel.rangeCount === 0 || text.length < MIN_LEN) {
+            removePill();
+            return;
+          }
+          const range = sel.getRangeAt(0);
+          if (!body.contains(range.commonAncestorContainer)) {
+            removePill();
+            return;
+          }
+          const rect = range.getBoundingClientRect();
+          const quote = text.slice(0, MAX_LEN);
+          const result: SelectionResult = {
+            quote,
+            anchorUrl: buildTextFragment(location.href, quote),
+          };
+          const x = Math.max(8, Math.min(rect.left, window.innerWidth - 130));
+          const y = Math.max(8, rect.top - 40);
+          showPill(x + window.scrollX, y + window.scrollY, result);
+        } catch {
+          removePill();
+        }
+      }, 0);
+    });
+
+    document.addEventListener('scroll', removePill, { passive: true });
+    document.addEventListener('mousedown', (e) => {
+      if (pill && e.target !== pill) removePill();
+    });
+  } catch {
+    /* selection annotation 是 enhancement，壞掉不影響閱讀 */
+  }
+}

--- a/src/scripts/feedback/types.ts
+++ b/src/scripts/feedback/types.ts
@@ -2,7 +2,7 @@
  * types.ts — Feedback 子系統共用型別（widget ↔ backend 契約）。
  */
 
-export type FeedbackType = 'content' | 'bug' | 'newtopic';
+export type FeedbackType = 'content' | 'bug' | 'newtopic' | 'idea';
 
 /** OAuth 登入提供者（email magic-link 走另一條路，不在此列）。 */
 export type OAuthProvider = 'google' | 'github';
@@ -28,6 +28,10 @@ export interface FeedbackDraft {
   category: string;
   lang: string;
   sourceUrl: string;
+  /** 讀者在文章選取的原文（選文段勘誤；v2）。 */
+  quote?: string;
+  /** 來源頁型 article/category/home/dashboard/semiont/other（v2）。 */
+  pageKind?: string;
 }
 
 export interface SubmitResult {

--- a/src/scripts/feedback/widget.ts
+++ b/src/scripts/feedback/widget.ts
@@ -29,18 +29,26 @@ interface Ctx {
   category: string;
   title: string;
   url: string;
+  pageKind: string;
 }
 
 interface DraftState {
   type: FeedbackType;
   body: string;
   correctInfo: string;
+  quote?: string;
 }
 
 export async function initFeedbackWidget(): Promise<void> {
   try {
     const root = document.getElementById('twmd-feedback');
     if (!root) return;
+
+    // OG / spore 截圖模式（?shot=1）不顯示 widget。
+    if (document.documentElement.getAttribute('data-shot') === '1') {
+      root.remove();
+      return;
+    }
 
     const kind = resolveBackendKind();
     if (kind === 'off') {
@@ -54,6 +62,7 @@ export async function initFeedbackWidget(): Promise<void> {
       category: root.dataset.category || '',
       title: root.dataset.title || '',
       url: root.dataset.url || location.href,
+      pageKind: root.dataset.pagekind || 'other',
     };
     const t = getStrings(ctx.lang);
 
@@ -64,7 +73,18 @@ export async function initFeedbackWidget(): Promise<void> {
     }
 
     // mock / supabase：完整 widget。
-    new Widget(root, ctx, t).mount();
+    const widget = new Widget(root, ctx, t);
+    widget.mount();
+
+    // 文章頁特化：選字 → 浮藥丸 → 開 widget 帶 quote + 深連結 anchor。
+    if (ctx.pageKind === 'article') {
+      const { initSelectionAnnotation } = await import('./selection');
+      initSelectionAnnotation(
+        '[data-pagefind-body]',
+        t.selectPill,
+        ({ quote, anchorUrl }) => widget.openWithSelection(quote, anchorUrl),
+      );
+    }
   } catch (err) {
     // 任何意外 → 確保主站不受影響。
     console.warn('[feedback] init failed, hidden:', err);
@@ -90,12 +110,68 @@ class Widget {
   private draft: DraftState = { type: 'content', body: '', correctInfo: '' };
   private panel!: HTMLElement;
   private open = false;
+  /** 選文段標註（article 頁）。設了 → 表單顯示 quote，送出用 anchorUrl 當 source。 */
+  private selection: { quote: string; anchorUrl: string } | null = null;
 
   constructor(
     private root: HTMLElement,
     private ctx: Ctx,
     private t: FeedbackStrings,
-  ) {}
+  ) {
+    this.draft.type = this.categoriesForPage()[0];
+  }
+
+  /** 依頁型決定類別集（順序 = 顯示順序，第一個 = 預設）。 */
+  private categoriesForPage(): FeedbackType[] {
+    switch (this.ctx.pageKind) {
+      case 'article':
+        return ['content', 'bug', 'newtopic'];
+      case 'category':
+        return ['newtopic', 'bug', 'idea'];
+      case 'home':
+        return ['newtopic', 'bug', 'idea'];
+      case 'dashboard':
+        return ['bug', 'idea'];
+      case 'semiont':
+        return ['idea', 'bug'];
+      default:
+        return ['idea', 'bug', 'newtopic'];
+    }
+  }
+
+  private labelFor(type: FeedbackType): string {
+    const s = this.t;
+    if (type === 'newtopic' && this.ctx.pageKind === 'category')
+      return s.typeNewArticle;
+    return {
+      content: s.typeContent,
+      bug: s.typeBug,
+      newtopic: s.typeNewtopic,
+      idea: s.typeIdea,
+    }[type];
+  }
+
+  private hintFor(type: FeedbackType): string {
+    const s = this.t;
+    if (type === 'newtopic' && this.ctx.pageKind === 'category')
+      return s.typeNewArticleHint;
+    return {
+      content: s.typeContentHint,
+      bug: s.typeBugHint,
+      newtopic: s.typeNewtopicHint,
+      idea: s.typeIdeaHint,
+    }[type];
+  }
+
+  /** 選文段觸發：開面板 + 預填 content + quote + 深連結。 */
+  openWithSelection(quote: string, anchorUrl: string): void {
+    this.selection = { quote, anchorUrl };
+    this.draft = { type: 'content', body: '', correctInfo: '', quote };
+    this.open = true;
+    this.panel.hidden = false;
+    this.ensureBackend();
+    this.renderForm();
+  }
 
   mount(): void {
     this.root.innerHTML = '';
@@ -156,6 +232,7 @@ class Widget {
     this.open = !this.open;
     this.panel.hidden = !this.open;
     if (this.open) {
+      this.selection = null; // FAB 開啟 = 一般回饋（非選文段）
       this.ensureBackend();
       this.renderForm();
     }
@@ -180,21 +257,21 @@ class Widget {
 
   private renderForm(): void {
     const t = this.t;
-    const chips: Array<[FeedbackType, string, string]> = [
-      ['content', t.typeContent, t.typeContentHint],
-      ['bug', t.typeBug, t.typeBugHint],
-      ['newtopic', t.typeNewtopic, t.typeNewtopicHint],
-    ];
+    const cats = this.categoriesForPage();
+    const quoteBlock = this.selection
+      ? `<div class="twmd-fb-quote"><span class="twmd-fb-quote-label">${esc(t.quoteLabel)}</span><blockquote>${esc(this.selection.quote)}</blockquote></div>`
+      : '';
     this.panel.innerHTML =
       this.header(t.title) +
       `<div class="twmd-fb-body">
         <p class="twmd-fb-intro">${esc(t.intro)}</p>
         ${this.ctx.title ? `<p class="twmd-fb-about">${esc(t.about)} ${esc(this.ctx.title)}</p>` : ''}
+        ${quoteBlock}
         <div class="twmd-fb-chips" role="radiogroup">
-          ${chips
+          ${cats
             .map(
-              ([val, label, hint]) =>
-                `<button type="button" class="twmd-fb-chip${this.draft.type === val ? ' is-on' : ''}" data-type="${val}" role="radio" aria-checked="${this.draft.type === val}" title="${esc(hint)}">${esc(label)}</button>`,
+              (val) =>
+                `<button type="button" class="twmd-fb-chip${this.draft.type === val ? ' is-on' : ''}" data-type="${val}" role="radio" aria-checked="${this.draft.type === val}" title="${esc(this.hintFor(val))}">${esc(this.labelFor(val))}</button>`,
             )
             .join('')}
         </div>
@@ -223,12 +300,7 @@ class Widget {
     ) as HTMLButtonElement;
 
     const syncType = () => {
-      const map: Record<FeedbackType, string> = {
-        content: t.typeContentHint,
-        bug: t.typeBugHint,
-        newtopic: t.typeNewtopicHint,
-      };
-      hintEl.textContent = map[this.draft.type];
+      hintEl.textContent = this.hintFor(this.draft.type);
       correctWrap.hidden = this.draft.type !== 'content';
     };
     const syncSubmit = () => {
@@ -400,7 +472,10 @@ class Widget {
         articleTitle: this.ctx.title,
         category: this.ctx.category,
         lang: this.ctx.lang,
-        sourceUrl: this.ctx.url,
+        // 選文段：用 W3C text-fragment 深連結當 source，維護者一點直達高亮。
+        sourceUrl: this.selection ? this.selection.anchorUrl : this.ctx.url,
+        quote: this.selection?.quote || this.draft.quote,
+        pageKind: this.ctx.pageKind,
       });
       this.renderDone();
     } catch (e) {
@@ -422,8 +497,13 @@ class Widget {
     this.panel
       .querySelector('[data-close2]')
       ?.addEventListener('click', () => this.close());
-    // reset draft body so再次開啟是乾淨的
-    this.draft = { type: this.draft.type, body: '', correctInfo: '' };
+    // reset so再次開啟是乾淨的
+    this.selection = null;
+    this.draft = {
+      type: this.categoriesForPage()[0],
+      body: '',
+      correctInfo: '',
+    };
   }
 
   private renderError(): void {

--- a/supabase/migrations/0002_annotation.sql
+++ b/supabase/migrations/0002_annotation.sql
@@ -1,0 +1,22 @@
+-- ════════════════════════════════════════════════════════════════════════════
+-- Taiwan.md feedback v2 — 全站 ambient + 選文段精準標註  (0002)
+--
+-- Additive only（純加欄 + 放寬 CHECK），既有 v1 資料不動：
+--   quote      — 讀者在文章裡選取的原文（選文段勘誤用；issue 會 blockquote 出來）。
+--   page_kind  — 回報來自哪種頁面（article/category/home/dashboard/semiont/other）。
+--   type       — 放寬納入 'idea'（不針對特定文章的一般想法/建議 → GitHub enhancement）。
+--
+-- source_url 沿用：選文段時裝 W3C Text Fragment 深連結（#:~:text=…），維護者一點直達該句。
+-- ════════════════════════════════════════════════════════════════════════════
+
+alter table public.feedback
+  add column if not exists quote text check (char_length(quote) <= 1000);
+
+alter table public.feedback
+  add column if not exists page_kind text;
+
+-- 放寬 type CHECK 納入 'idea'（drop 舊 constraint 再加新的）。
+alter table public.feedback drop constraint if exists feedback_type_check;
+alter table public.feedback
+  add constraint feedback_type_check
+  check (type in ('content', 'bug', 'newtopic', 'idea'));


### PR DESCRIPTION
v2 升級：widget 全站 render（pageKind context-aware）、文章選文段 → 浮藥丸 → 勘誤帶 quote + W3C text-fragment 深連結、OAuth 跳暱稱低阻力、idea 桶。schema 0002 additive。16 unit test 綠 + mock e2e 全過。設計 §v2 補進 design report。

⚠️ 上線前 Supabase 需跑 migration 0002（additive）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)