### PR TITLE
translate(en): Society/天下雜誌 → commonwealth-magazine

### DIFF
--- a/knowledge/en/Society/commonwealth-magazine.md
+++ b/knowledge/en/Society/commonwealth-magazine.md
@@ -1,0 +1,272 @@
+---
+title: 'CommonWealth Magazine: Four Decades of Defining Taiwan''s "Success," Standing Closest to Capital'
+description: 'In June 1981, a business magazine called CommonWealth launched on a martial-law island, selling out its first print run of 10,000 copies in two days. Founded by economist Kao Hsi-chun, its editorial soul was Diane Ying — a former UPI, New York Times, and Asian Wall Street Journal reporter. Forty years later it became one of Taiwan''s most trusted media outlets, and the maker of rankings — the Top 2000, Top 50, Happiest Cities — that quietly define what "success" means. Its credibility and its power to rank others draw from the same distance.'
+date: 2026-06-04
+category: 'Society'
+tags:
+  ['media', 'business media', 'CommonWealth Magazine', 'Diane Ying', 'press freedom', 'publishing', 'media and journalism']
+subcategory: 'Media and Journalism'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-06-04
+lastHumanReview: false
+image: '/article-images/society/diane-ying-magsaysay.png'
+imageCredit: 'Ramon Magsaysay Award Foundation'
+imageLicense: 'Fair use editorial commentary'
+imageSource: 'https://rmaward.asia/rmawardees/ying-diane-yun-peng/'
+translatedFrom: 'Society/天下雜誌.md'
+sourceCommitSha: ''
+sourceContentHash: ''
+translatedAt: ''
+---
+
+> **30-second overview:** On June 1, 1981, a business magazine called CommonWealth launched in Taiwan, still under martial law and recently expelled from the international stage. Its first edition of 10,000 copies sold out in two days[^1]. The driving force was economist Kao Hsi-chun, who gathered Wang Li-hsing, Chang Tso-chin, and Diane Ying under the banner of "scholars serving the nation"[^2]; Ying — a reporter who had worked at the Philadelphia Inquirer, UPI, the New York Times, and the Asian Wall Street Journal — became the magazine's editorial soul, and the person who held it together after the 1986 split[^3]. Over four decades, it grew from a magazine that "made economics readable" into Taiwan's foremost maker of business and governance rankings: the Top 2000, Top 50, Benchmark Enterprises, Happiest Cities — names that quietly define what "success" means for an entire society. It is one of Taiwan's most trusted media outlets per the Reuters Institute[^4], a recipient of the Ramon Magsaysay Award and the SOPA Lifetime Achievement Award. Yet the position that makes it most trusted is precisely where it stands closest to capital and power. Its credibility, and its power to rank others, come from the same distance.
+
+## "To ruin someone, make them start a magazine"
+
+Diane Ying once said, with a laugh tinged with bitterness: "To ruin someone, make them start a magazine."[^5]
+
+The person who said this had interviewed Eileen Chang in Cambridge in 1968. She was a struggling student then, borrowing jeans to sit in Chang's room for a three-hour conversation. "After me, no one ever interviewed Eileen Chang one-on-one again — but she agreed to meet me, and we talked for three hours. She must have found the interview acceptable, because we stayed in touch for over a decade, and when I later founded CommonWealth Magazine, she even sent a congratulatory card."[^6] Diane Ying had interviewed people across the world — from semiconductor pioneer Morris Chang to literary giant Eileen Chang — and ultimately found that the hardest subject to cover was the magazine she had taken on herself.
+
+The actual invitation to start the magazine came from Kao Hsi-chun.
+
+In 1981, Taiwan was an island that had just been pushed off the international stage. It had withdrawn from the United Nations in 1971, severed diplomatic relations with the United States at the start of 1979, and was watching its diplomatic allies disappear one by one, all while still under martial law. The range of permissible topics was tightly constrained — yet the economy was about to take off. It was in this moment that Kao Hsi-chun, a Michigan State University economics PhD teaching at the University of Wisconsin-River Falls, motivated by a sense of scholars' duty to the nation, invited then-editor Wang Li-hsing, United Daily News editor-in-chief Chang Tso-chin, and Diane Ying to co-found CommonWealth Magazine in 1981[^7].
+
+> **📝 Curator's note**
+> A magazine that "only covers economics, not politics" looks like the safest, most neutral choice on an island where even politics could not be discussed. But seen another way, it was one of the most political choices available. When Taiwan had lost its UN seat, lost American recognition, and was all but invisible in international diplomacy, a group of scholars decided to use the language of "economics" to write a new story of agency — one the island could actually control. The four decades of trust that followed flowed directly from that initial angle: far enough from power, close enough to Taiwan. That distance was its foundation.
+
+Diane Ying's own question was more direct. Her often-quoted line: "Why doesn't Taiwan have a business magazine that everyone can understand?"[^8] This came from her experience as an Asian Wall Street Journal reporter: she had seen how good financial journalism could "make dry economic news genuinely readable," accessible to general audiences. The magazine she wanted to make would have "the depth of The Economist, the prose of Time."
+
+Ying's journalistic credentials were formidable: the Philadelphia Inquirer, UPI, the New York Times, the Asian Wall Street Journal — a career built at international wire services and flagship papers[^3]. A Taiwanese woman who had written for the New York Times and contributed to the Asian Wall Street Journal, turning back to found Taiwan's own business magazine: that trajectory was rare on its own terms.
+
+On June 1, 1981, CommonWealth launched. Its first edition of 10,000 copies sold out in two days, reprinted three times within a month[^1]. The inaugural issue held a conversation between Wang Yung-ching of Formosa Plastics and economist Wang Tso-jung, debating whether Taiwan should pursue "growth" or "stability"[^9]. A magazine opened its mouth in the moment Taiwan had the fewest international voices — and the first question it asked was about which direction Taiwan itself should go.
+
+## "Serving the nation as scholars" — and a trap hiding in a name
+
+![CommonWealth Magazine's logo, white characters on black — the characters 天下 drawn from Sun Yat-sen's calligraphy](/article-images/society/commonwealth-logo.svg)
+_CommonWealth Magazine's logo. The characters 天下 (_tiānxià_) are drawn from Sun Yat-sen's calligraphy "天下為公" (_tiānxià wèi gōng_ — "All under heaven belongs to the public"). Logo: CommonWealth Magazine. [Public domain (PD-textlogo) via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:CommonWealth_Magazine_logo.svg)._
+
+The title _tiānxià_ (天下 — "all under heaven") is drawn from Sun Yat-sen's calligraphy "天下為公"; the English name "Common Wealth" carries a double meaning: it evokes both "commonwealth" (a union of states, shared governance) and "wealth that belongs to everyone"[^10]. A magazine primarily covering private capital and corporate wealth, carrying a name that speaks of the public good and the common horizon. That tension has always been there.
+
+But the name 天下 is also connected to one of the most persistently confused pairs of brands in Taiwan's media history.
+
+Many people assume CommonWealth Magazine and CommonWealth Culture (天下文化) are the same entity. They are not. CommonWealth Culture is a publishing house belonging to the Global Views-CommonWealth Culture Group — that's Kao Hsi-chun's. CommonWealth Magazine publishing belongs to the CommonWealth Magazine Group — that's Diane Ying's[^11]. Both carry "CommonWealth" in their name, but they are two distinct business entities. The reason there are two is a split.
+
+> **💡 Did you know**
+> Next time you see a book published by "CommonWealth Culture" in a bookstore — from _Good to Great_ to any number of business bestsellers — that's Kao Hsi-chun's Global Views Group, not the CommonWealth Magazine Group that publishes the magazine. Two "CommonWealths," two owners, two paths: this is the most persistently mistaken brand pair in Taiwan's publishing world.
+
+## Four people, five years, two roads
+
+![Kao Hsi-chun speaking at a podium, wearing a dark suit, at what appears to be a book launch event](/article-images/society/kao-hsi-chun-2023.jpg)
+_Kao Hsi-chun, chairman of the Global Views-CommonWealth Culture Group. Motivated by scholars' duty to the nation, he assembled the founding team of CommonWealth. After the 1986 split, he went on to found Global Views Magazine and CommonWealth Culture publishing. Photo: Office of the President, Republic of China, 2023. [CC BY 2.0 via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Charles_Kao_2023-02-09.jpg)._
+
+In 1986, five years after its founding, the CommonWealth team went separate ways.
+
+The reason was editorial direction. Diane Ying wanted to stay on the path of journalistic professionalism, keeping Taiwan at the center. Kao Hsi-chun wanted to focus more on business operations, and even expand into China[^12]. The same group of scholar-founders had arrived at two different visions of what the magazine ultimately was: a journalism institution, or a knowledge-and-publishing enterprise for the broader Chinese-speaking world.
+
+Kao and Wang Li-hsing departed with part of the team, founded Global Views Magazine in 1986, and — combined with the publishing arm established in 1982 — built what became the Global Views-CommonWealth Culture Group. Diane Ying stayed, and held onto CommonWealth Magazine.
+
+> **📝 Curator's note**
+> The default script for a founding split reads: "breakup = failure." CommonWealth's split was the opposite. The version of CommonWealth that the world later came to know — "Taiwan-first, journalistic professionalism, most trusted" — was defined by the split. Once the "business-operations-plus-China-expansion" path was handed off to Global Views, the path that remained was finally given shape, and then held. In other words, CommonWealth's reputation for clarity came in part from what left. What an institution is, often only becomes clear after one parting — and what's left is what can finally be named.
+
+As for how many founders there were, the two camps remember differently. CommonWealth Magazine's official account usually names three founders: Diane Ying, Kao Hsi-chun, and Wang Li-hsing. The Global Views official history and Kao Hsi-chun's own memoirs include Chang Tso-chin as well, listing four; Chang was then editor-in-chief of United Daily News and served as deputy editor-in-chief of CommonWealth — a core participant[^13]. The same origin story, remembered by two companies with two different numbers. That discrepancy is itself a footnote to the split.
+
+## Who belongs in the Top 2000: how a magazine defines "success"
+
+![CommonWealth Economic Forum at the Grand Hyatt Taipei, a speaker on stage, a full audience of business, government, and academic figures](/article-images/society/cwef-economic-forum-2023.jpg)
+_The CommonWealth Economic Forum (CWEF), winter 2023, at the Grand Hyatt Taipei. Every year, CommonWealth brings executives, officials, and academics into the same room. The magazine that covers them is also the one that convenes them — that convening power is the other face of "standing closest to power." Photo: Chien Chih-hung / Office of the President, Republic of China. [CC BY 2.0 via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:At_the_CommonWealth_Economic_Forum_at_Grand_Hyatt_Taipei_2023-01-09.jpg)._
+
+Up to this point, CommonWealth is still just a well-run business magazine. What turned it into something else was rankings.
+
+In 1986 — the year of the split — CommonWealth published Taiwan's first large-scale corporate ranking, the "Top 1,000," covering the manufacturing sector, modeled on the American Fortune 500[^14]. From that year on, Taiwan's business world had a report card that was seriously read every year. One detail worth pinning down: the "Top 2000" brand name that is now the most recognized didn't take its current form until 2013, when CommonWealth expanded the list to cover manufacturing, services, and finance — 2,000 companies across three sectors[^14]. From 1986 to 2012, it was always called "Top 1,000."
+
+Rankings multiplied. The Benchmark Enterprises Reputation Survey has run since 1994 — now over thirty years. The method: identify the top twelve companies in each industry that have posted no losses, have industry leaders and analysts fill out questionnaires rating ten criteria, with TSMC and 7-Eleven consistently near the top[^15]. The Top 50 Conglomerates survey has been conducted three times: 2000, 2020, and 2025. In 2025, Foxconn reclaimed the top spot with NT$7.39 trillion in revenue; TSMC's group leapt from NT$1.11 trillion to NT$2.97 trillion to claim second, and eight conglomerates that appeared in the previous survey fell off[^16]. Long Jung University president Ming-Je Tang, surveying the list, called it "a ranking of Nvidia Island" — meaning Taiwan's corporate rankings are increasingly pulled along by a single AI supply chain[^16].
+
+> **✦** From the "Top 1,000" to the "Top 2,000," from "Benchmark Enterprises" to the "Top 50 Conglomerates," what this magazine has spent forty years actually doing is defining, for an entire society, what counts as success.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/VEJ63JJRw0U" title="Top 50 Conglomerates 2025 Survey Results | CommonWealth Magazine" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_CommonWealth Magazine video channel: the 2025 Top 50 Conglomerates survey. TSMC surging to second, and Ming-Je Tang's reading of the "Nvidia Island" list — this is how ranking power operates, every year._
+
+The standard story says business media like CommonWealth is a neutral third-party referee, objectively scoring companies from the sidelines. That story works — but it leaves something out: the referee and the players are often in the same room. The entity that decides who ranks where, which indicators count, and what gets defined as "success" is this magazine. Yet the companies being ranked are also this magazine's most important advertising clients, forum partners, and event sponsors. CommonWealth is not a referee standing outside the game; it is the scorekeeper with the most influence in the room. A scorekeeper can be highly professional and deeply trustworthy — CommonWealth mostly is — but the act of keeping score is itself a form of power.
+
+That power faces its sharpest scrutiny not on the corporate rankings, but on the city ones.
+
+## A sow that can climb trees, and a poll that doesn't add up
+
+Starting in 2003, CommonWealth began producing a major annual "County and City Survey," adding a "Governance Satisfaction" component in 2004. This evolved into the well-known "Happiest Cities" and "Mayor Approval Rating" rankings, which blend public opinion surveys with expert assessments into a weighted composite score[^17]. Published every year, it has drawn celebration from some mayors and fury from others.
+
+In 2017, Matsu County magistrate Liu Tseng-ying topped CommonWealth's ranking. Commentator Lu Chih-chun responded with full force. He accused CommonWealth of layering the results of "four major civic organizations" on top of the opinion poll to dilute the numbers — "a fraudulent, ghostly scheme" — and delivered a memorable line: "Pigs can fly if you can believe CommonWealth Magazine's 'poll'."[^18] Harsh words, but they pointed at a real problem: when an "objective ranking" mixes in subjective assessments, how objective is it really?
+
+More systematic criticism came from academia. Liu Chia-wei, a professor at National Taipei University's Department of Public Administration and Policy, issued five methodological critiques of the county and city survey in 2024: some county samples were too small (Matsu County's margin of error reached ±7.49 percentage points); supporting data did not match the rankings; evaluation criteria lacked transparency; mixing subjective and objective indicators introduced bias; and overall scores double-counted some sub-scores[^19]. In 2019, when Han Kuo-yu ranked last in governance satisfaction and his supporters flooded CommonWealth with criticism, the magazine issued a statement explaining its methodology and survey timeline[^20].
+
+> **📝 Curator's note**
+> The paradox of rankings is this: CommonWealth can run these surveys, and people care about the results, precisely because it is trustworthy. A ranking that no one believes in doesn't get attacked. Credibility gives its rankings weight; that weight then puts its methodology under the harshest scrutiny. What Lu and Liu are criticizing is not an obscure, unread publication — they are criticizing it precisely because its rankings make the news, get used by county governments as performance credentials, and shape how voters see their officials. CommonWealth's credibility underwrites its rankings; its rankings then push that credibility to its most exposed position. The same distance: on one side, trust; on the other, power.
+
+Beyond rankings, CommonWealth has also done many things pointing in the opposite direction from "success." The 1996 education special _Boundless Sky_ tracked five fifteen-year-olds over ten and twenty years[^21]; in 2001, "319 Townships Moving Forward" distributed over a million township passports, encouraging Taiwanese to visit the places they knew least about[^22]; from 2005 to 2006, "Smiling Taiwan" turned the same spirit into a long-running brand. The CommonWealth Magazine Education Foundation's "Reading Hope" program delivers books to rural communities and trains teachers, funded by sponsors including TSMC and ASML[^23]. These initiatives are genuine, and they have left real impact. But when the funding for public good comes from the same companies that CommonWealth ranks, that "distance" closes by another degree. There is no scandal here — only the structural reality of how one of Taiwan's most trusted media outlets actually operates day to day.
+
+## The article that was taken down
+
+The sharpest test of CommonWealth's credibility surfaced in November 2015.
+
+That year, Ma Ying-jeou and Xi Jinping met in Singapore — the Ma-Xi Summit. Huang Cheng-yi, a research fellow at the Academia Sinica Institute of Law, submitted an article to CommonWealth's affiliated platform _The Independent Review @CommonWealth_ arguing that the Legislative Yuan should immediately impeach President Ma. The article was published — and then taken down[^24].
+
+What followed was larger than the removal itself. Huang went public with his objection; over a dozen columnists — including Rex How, Ho Ming-sho, Wu Chieh-min, and Chang Chuan-fen — withdrew from _The Independent Review_ in protest[^25]. CommonWealth's official explanation was that the removal reflected a commitment to "presenting diverse perspectives." Senior writer Ma Yueh-lin stepped forward to defend the decision — the substance of her position being that it was a stupid, bad, and wrong call, but that the outside world should not use this to claim CommonWealth was taking instructions from Beijing, or that Taipei had become Beijing. CommonWealth had acted with precisely that caution because it did not want Taipei to become Beijing[^26]. Sociologist Tseng Po-wen wrote a piece arguing, in essence, that _The Independent Review_'s credibility came from the word "independent," not from the CommonWealth brand — and that CommonWealth had applied the editorial logic of running a magazine to a space it was never designed to manage that way[^27].
+
+> **📝 Curator's note**
+> What makes this incident genuinely difficult is that the same act carries opposite meanings in two different worlds. In the world of traditional magazines, an editor-in-chief has authority to decide what runs and what doesn't — that's professional gatekeeping, and it is a virtue. But in the world of an online commentary platform, contributors assume "I can speak freely here" as a baseline condition; removing an article after the fact becomes a violation of that speech. CommonWealth applied its most trusted, most practiced editorial discipline — and applied it to a space where that same logic was exactly the wrong tool. Its greatest strength, deployed in the wrong arena, became its biggest controversy. The distance appears again: the closer you stand to editorial authority, the further you may push from a contributor's trust.
+
+> ⚠️ **Contested interpretation:** Whether the removal was driven by political pressure remains unresolved. CommonWealth consistently denied any influence from Beijing or any external party, framing it as an internal editorial judgment that went wrong. Critics argued that even without an explicit external order, the very caution applied to a cross-Strait topic was itself evidence of a self-censorship climate. This article draws no conclusion — but records the event because it placed the question "how does one of Taiwan's most trusted media outlets handle its most pointed political article" directly in front of everyone.
+
+A similar editorial failure followed years later. In 2023, an opinion column by entertainer Huang Tzu-chiao was altered without proper process; CommonWealth issued a public apology, acknowledging it had not followed internal standard procedures[^28]. Once the power of gatekeeping is in your hands, the possibility of misusing it comes with it.
+
+## The publisher who put her shares in trust
+
+If the story ended at the removed article, CommonWealth would be a case study in how credibility can be undermined by its own power. But it didn't end there — it turned in the opposite direction.
+
+In 2021, Diane Ying placed the majority of her shares into a trust, directing the magazine's profits to be reinvested in the magazine itself[^29]. This was a structural act of building a firewall for editorial independence — when the publisher voluntarily locks shares into a trust, the magazine's direction becomes much harder for any single shareholder or short-term commercial interest to pull. A media outlet criticized for "standing too close to capital" chose to use institutional design to build a thicker wall between capital and the newsroom.
+
+The same year was CommonWealth's fortieth anniversary. On August 11, Diane Ying — at eighty — announced her handover[^30]. She did not pass the magazine to her family. She passed it to six professional managers: Wu Ying-chun, Cheng Yi-yuan, Wu Wan-yu, Yeh Yun, Chen Yi-shan, and Ho Chi-yu — with Wu Wan-yu, who had served as editor-in-chief for over a decade, at the editorial core[^30]. Ying herself moved to chair the CommonWealth Magazine Education Foundation. Her handover statement quoted a line: "To everything there is a season, A time for all seasons. After forty years of effort alongside CommonWealth, I have decided to pass the baton, to let the next generation of professional managers lead the way forward and begin the next journey."[^31]
+
+The reporter who once asked "why doesn't Taiwan have a business magazine everyone can understand" passed the magazine to others — and returned to the other thing she had always cared about: reading and education.
+
+## The print lights go out, the magazine stays lit
+
+When Diane Ying handed over, print media was going dark around the world. CommonWealth used a series of moves that seemed unlike itself to keep one of Taiwan's most rooted magazines alive.
+
+On March 15, 2017, CommonWealth launched "All Access" — Taiwan's first metered paywall for news media, modeled on the New York Times[^32]. By the end of that year, paid subscribers had crossed 10,000 and the renewal rate was around ninety percent[^33]. It was an unprecedented gamble for Taiwan at the time: the entire industry still operated on the assumption that "web content should be free, revenue comes from traffic and advertising." CommonWealth bet the other way — that readers would pay for depth.
+
+CommonWealth's digital transition contains two milestones that are often conflated. In 2017, digital advertising revenue first surpassed print advertising — a shift in revenue type[^34]. It was only after the pandemic, roughly between 2020 and 2022, that digital overall revenue and subscriber numbers genuinely surpassed print; CommonWealth announced this formally in an early-2023 transition report. The advertising shift and the revenue shift were years apart.
+
+The group's publications multiplied, all belonging to Diane Ying's CommonWealth Magazine Group: CommonHealth (康健) in 1998, the first health management magazine in the Chinese-speaking world; Cheers (快樂工作人) in 2000; CommonWealth Parenting (親子天下) in 2008; The Independent Review @CommonWealth (獨立評論@天下) in 2013; Crossing (換日線), launched in 2015 by senior correspondent Chang Hsiang-yi, gathering writing from Taiwanese youth around the world; and Smiling Taiwan (微笑台灣), formalized as a quarterly in 2016[^35]. A business magazine had propagated an entire content ecosystem spanning health, careers, education, overseas youth, and local travel.
+
+Then came the lights-out. In December 2024, CommonWealth Parenting published its final print issue — issue 133 — and in 2025 transitioned to the fully digital "CommonWealth Parenting Premium"[^36]. Also in late 2024, CommonWealth released Taiwan's first ESG impact report from a news organization; the year before, it had become Taiwan's first news outlet to conduct a carbon audit[^37].
+
+> **💡 Did you know**
+> CommonWealth was Taiwan's first news media to launch a paywall, then became the first news organization to conduct a carbon audit, and the first to publish an ESG impact report. A magazine that launched on an isolated island over forty years ago, asking "where is Taiwan going?" — today it is still showing the entire media industry what the next step looks like.
+
+The magazine's reporting reach has not shrunk with the retreat of print. In 2023, when the whole world was asking where AI would take us, CommonWealth conducted an exclusive interview with OpenAI founder Sam Altman.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/rELm8mjzK3k" title="The AI Future We Can't Escape: CommonWealth Magazine's Exclusive Interview with OpenAI Founder Sam Altman" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_CommonWealth Magazine video channel: the 2023 exclusive interview with OpenAI founder Sam Altman. The print lights went out — but this magazine's reach still extends to the front edge of the global AI wave._
+
+Diane Ying received the Ramon Magsaysay Award in 1987 — the first Taiwanese person to receive the award in the Journalism, Literature and Creative Communication Arts category[^38]. Her acceptance speech is a footnote to four decades of CommonWealth: "Journalism, perhaps, is the best profession in the world, because a journalist is paid to learn, and life itself is a process of ceaseless learning."[^39] In 2021, the Society of Publishers in Asia (SOPA) gave her its Lifetime Achievement Award; the jury described CommonWealth as Taiwan's "well-respected and highly trusted media organization"[^40]. In the Reuters Institute's surveys, Taiwan's overall news trust has long hovered around two to three in ten, ranking near the bottom globally — yet in the 2022 report, CommonWealth scored 57% trust, tied with Business Weekly as the most trusted outlet in Taiwan[^4].
+
+## The same distance
+
+Back to that wry line: "To ruin someone, make them start a magazine."
+
+Forty-plus years later, the magazine "ruined" into existence has become one of Taiwan's most trusted media outlets. It ranks companies, scores cities, and quietly defines what "success" means for an entire society. Its trustworthiness gives those rankings weight; that weight then pushes it to stand closest to capital and power. Lu Chih-chun condemned it, Liu Chia-wei questioned it, the removed article drove over a dozen writers away — not because it had done poorly, but precisely because it had done well enough, had been trusted enough, that every judgment it made was taken seriously.
+
+For that contradiction, Diane Ying left her own answer: she put the shares in trust, directed profits back into the magazine, and built the wall between capital and the newsroom a little thicker, and then a little thicker still. She could not erase the distance — a magazine that covers Taiwan's business world is always going to stand close to business — but she could choose, on that distance, whether to build more walls.
+
+Next time you see "CommonWealth Top 2000" or "Happiest City Ranking" scrolling across a news ticker, you might pause and think one layer deeper: who made this ranking, with what method, and for whom. Then one layer more: how close a distance did a magazine have to stand at to earn that "most trusted" status — and how hard did it have to work to hold that distance, to avoid trading the trust away.
+
+Diane Ying once borrowed a pair of jeans to visit Eileen Chang in Cambridge, and they stayed in touch for over a decade; when CommonWealth launched, Chang sent a congratulatory card. That was a magazine at its beginning — a reporter, a person she cared about, and a simple, clean distance between them. Forty years on, this magazine has learned to measure, and to hold, the far more complicated distance between itself and Taiwan's capital. It is still walking that path.
+
+**Further Reading:**
+
+- [The Reporter](/en/society/the-reporter-investigative-journalism/) — Another Taiwan outlet committed to in-depth journalism, but taking the opposite route: non-profit, no advertising, funded by donations from strangers. The direct counterpoint to CommonWealth's paywall and corporate ecosystem.
+- [PanSci](/en/society/pansci/) — Another new Taiwanese media outlet that emerged in the 2010s, sustaining a public-knowledge space through science communication and knowledge services — a different commercial model.
+- [PTS — Public Television Service](/en/society/pts-public-television-service/) — Taiwan's other path for public media: using public funding rather than market mechanisms to answer the same question of "who should media be accountable to?"
+- [Taiwan Media and Press Freedom](/en/society/media-and-press-freedom-in-taiwan/) — The removed-article incident, the trust rankings, and the PRC information-warfare backdrop are all embedded in the broader context of Taiwan's press freedom.
+- [Taiwan's Top 50 Companies](/en/economy/top-50-companies-taiwan/) — The companies that CommonWealth's "Top 2000" and "Top 50 Conglomerates" rankings define and measure are the protagonists behind those lists.
+- [TSMC — Taiwan Semiconductor Manufacturing Company](/en/economy/tsmc-taiwan-semiconductor/) — The company that consistently tops CommonWealth's Benchmark Enterprises and Top 50 rankings — and one of the most important sponsors of its education foundation.
+
+## Image Credits
+
+This article uses 4 images + 2 official video embeds (CommonWealth Magazine video channel via YouTube iframe). All images are cached at `public/article-images/society/` to avoid hotlinking:
+
+- [Diane Ying portrait](https://rmaward.asia/rmawardees/ying-diane-yun-peng/) (hero) — Ramon Magsaysay Award Foundation. Fair use editorial commentary (public figure documentary; this article analyzes CommonWealth Magazine and its founder).
+- [CommonWealth Magazine logo](https://commons.wikimedia.org/wiki/File:CommonWealth_Magazine_logo.svg) — CommonWealth Magazine. Public domain (PD-textlogo; the characters 天下 are drawn from Sun Yat-sen's calligraphy, PD-China-expired) via Wikimedia Commons.
+- [Kao Hsi-chun speaking](https://commons.wikimedia.org/wiki/File:Charles_Kao_2023-02-09.jpg) — Photo: Office of the President, Republic of China, 2023-02-09. CC BY 2.0 via Wikimedia Commons.
+- [CommonWealth Economic Forum CWEF 2023](https://commons.wikimedia.org/wiki/File:At_the_CommonWealth_Economic_Forum_at_Grand_Hyatt_Taipei_2023-01-09.jpg) — Photo: Chien Chih-hung / Office of the President, Republic of China, 2023-01-09. CC BY 2.0 via Wikimedia Commons.
+
+Embedded videos (YouTube iframe, [CommonWealth Magazine video channel @cwvideo](https://www.youtube.com/@cwvideo)): 2025 Top 50 Conglomerates Survey (VEJ63JJRw0U); 2023 exclusive interview with OpenAI founder Sam Altman (rELm8mjzK3k).
+
+## References
+
+[^1]: [Diane Ying — Ramon Magsaysay Award](https://rmaward.asia/rmawardees/ying-diane-yun-peng/) — 1987 Magsaysay Award laureate page; primary English source recording CommonWealth's June 1981 launch, 10,000-copy first print run sold in two days, circulation reaching over 90,000.
+
+[^2]: [Global Views-CommonWealth Culture Group — Official History](https://www.cwgv.com.tw/zh/history.html) — Official history records verbatim that "motivated by a sense of scholars' duty to the nation, Professor Kao Hsi-chun invited Wang Li-hsing, Chang Tso-chin, and Diane Ying to co-found [the magazine] in 1981."
+
+[^3]: [Diane Ying (Wikipedia)](https://zh.wikipedia.org/wiki/%E6%AE%B7%E5%85%81%E8%8A%83) — Born 1941 in Xi'an; National Cheng Kung University (foreign literature), University of Iowa (journalism MA). Journalism career: Philadelphia Inquirer, UPI, New York Times, Asian Wall Street Journal — not AP.
+
+[^4]: [Reuters Institute Digital News Report — Taiwan 2022](https://reutersinstitute.politics.ox.ac.uk/digital-news-report/2022/taiwan) — CommonWealth trust rating 57%, rising to joint first with Business Weekly; Taiwan's overall news trust long at 27–33%.
+
+[^5]: [CommonWealth Magazine founder Diane Ying: "Journalism is valuable work" (Yahoo News / Tsai Wan-tsai Taiwan Contribution Award)](https://tw.news.yahoo.com/%E7%8D%B2%E8%94%A1%E8%90%AC%E6%89%8D%E5%8F%B0%E7%81%A3%E8%B2%A2%E7%8D%BB%E7%8D%8E%E8%82%AF%E5%AE%9A%EF%BC%8C%E5%A4%A9%E4%B8%8B%E9%9B%9C%E8%AA%8C%E5%89%B5%E8%BE%A6%E4%BA%BA%E6%AE%B7%E5%85%81%E8%8A%83%EF%BC%9A%E8%A8%98%E8%80%85%E6%98%AF%E5%BE%88%E6%9C%89%E5%83%B9%E5%80%BC%E7%9A%84%E5%B7%A5%E4%BD%9C-144101985.html) — Diane Ying, accepting the Tsai Wan-tsai Taiwan Contribution Award, quoted verbatim saying "To ruin someone, make them start a magazine" (said with a laugh).
+
+[^6]: [CommonWealth Magazine founder Diane Ying: "Journalism is valuable work" (Yahoo News / Tsai Wan-tsai Taiwan Contribution Award)](https://tw.news.yahoo.com/%E7%8D%B2%E8%94%A1%E8%90%AC%E6%89%8D%E5%8F%B0%E7%81%A3%E8%B2%A2%E7%8D%BB%E7%8D%8E%E8%82%AF%E5%AE%9A%EF%BC%8C%E5%A4%A9%E4%B8%8B%E9%9B%9C%E8%AA%8C%E5%89%B5%E8%BE%A6%E4%BA%BA%E6%AE%B7%E5%85%81%E8%8A%83%EF%BC%9A%E8%A8%98%E8%80%85%E6%98%AF%E5%BE%88%E6%9C%89%E5%83%B9%E5%80%BC%E7%9A%84%E5%B7%A5%E4%BD%9C-144101985.html) — Diane Ying recalls verbatim: "After me, no one ever interviewed Eileen Chang one-on-one again — but she agreed to meet me, and we talked for three hours... we stayed in touch for over a decade, and when I later founded CommonWealth Magazine, she even sent a congratulatory card."
+
+[^7]: [Kao Hsi-chun: A Model of His Generation — Chang Tso-chin (Global Views)](https://www.gvm.com.tw/article/68498) — Kao Hsi-chun describes inviting Chang Tso-chin, Wang Li-hsing, and Diane Ying to discuss the possibility of founding a magazine, motivated by scholars' duty to the nation.
+
+[^8]: [Diane Ying Honorary Doctorate Speech at NCCU (Excellence in Journalism Award Foundation)](https://feja.org.tw/39939/) — Speech cites founding motivation "why doesn't Taiwan have a business magazine that everyone can understand," and inspiration from the Asian Wall Street Journal's writing approach.
+
+[^9]: [CommonWealth Magazine 40th Anniversary — 1981](https://40.cw.com.tw/story/1981/) — Launch details and inaugural-issue Wang Yung-ching / Wang Tso-jung "Growth vs. Stability" dialogue (official page).
+
+[^10]: [CommonWealth Magazine (Wikipedia)](https://zh.wikipedia.org/zh-tw/%E5%A4%A9%E4%B8%8B%E9%9B%9C%E8%AA%8C) — Title 天下 drawn from Sun Yat-sen's calligraphy "天下為公"; English name Common Wealth carries double meaning of "commonwealth" (political union) and "wealth belonging to all."
+
+[^11]: [Telling CommonWealth and Global Views Apart (SETN)](https://www.setn.com/News.aspx?NewsID=182036) — Clarifies the naming trap: "CommonWealth Culture publishing" belongs to the Global Views Group; "CommonWealth Magazine publishing" belongs to the CommonWealth Magazine Group.
+
+[^12]: [Global Views-CommonWealth Culture Group — Official History](https://www.cwgv.com.tw/zh/history.html) — Records the 1986 split over editorial direction: Kao Hsi-chun and Wang Li-hsing departed to found Global Views Magazine and CommonWealth Culture; Diane Ying stayed with CommonWealth Magazine.
+
+[^13]: [Kao Hsi-chun: A Model of His Generation — Chang Tso-chin (Global Views)](https://www.gvm.com.tw/article/68498) — Founder count discrepancy: CommonWealth's official account usually names three (Diane Ying, Kao, Wang Li-hsing); Global Views official history and Kao's own account list four, including Chang Tso-chin as deputy editor-in-chief.
+
+[^14]: [CommonWealth Top 2000 Database](https://www.cw.com.tw/cw2000/database) — First "Top 1,000" manufacturing ranking launched in 1986 (modeled on Fortune 500); expanded in 2013 to manufacturing, services, and finance — 2,000 companies total — when the "Top 2000" brand name took its current form.
+
+[^15]: [Benchmark Enterprise Reputation Survey (Cnyes / CommonWealth)](https://news.cnyes.com/news/id/3589341) — Running since 1994; methodology: top-12 profitable companies per sector, scored on 10 criteria by industry leaders and analysts.
+
+[^16]: [Top 50 Conglomerates 2025 (CSR@CommonWealth)](https://csr.cw.com.tw/article/44164) — Third survey; Foxconn NT$7.39T at No. 1; TSMC Group surges to No. 2; 8 conglomerates dropped; Tang Ming-che describes it as "a ranking of Nvidia Island."
+
+[^17]: [County and City Governance Satisfaction Survey (Wikipedia)](https://zh.wikipedia.org/zh-tw/%E5%A4%A9%E4%B8%8B%E9%9B%9C%E8%AA%8C) — County/city survey from 2003; governance satisfaction from 2004; evolved into "Happiest Cities" ranking; uses weighted blend of public opinion and expert assessment.
+
+[^18]: [Lu Chih-chun criticizes Happiest City survey (Liberty Times)](https://news.ltn.com.tw/news/politics/breakingnews/2191788) — 2017: commentator Lu Chih-chun accuses CommonWealth of overlaying "four civic organization" scores onto the poll, calling it a "fraudulent, ghostly scheme" and saying "if you can believe CommonWealth's 'poll,' a sow can climb a tree."
+
+[^19]: [County-city survey methodology critique — Liu Chia-wei (Taiwan FactCheck Center)](https://tstm.tw/Article/Detail/5252) — Professor Liu Chia-wei of National Taipei University, 2024: five methodological critiques — insufficient sample sizes (Matsu ±7.49%), data inconsistencies, lack of transparency, subjective-objective mixing bias, double-counting.
+
+[^20]: [CommonWealth responds to Han Kuo-yu governance satisfaction controversy (Storm Media)](https://www.storm.mg/article/73083) — 2019: Han Kuo-yu ranked last; supporters criticized; CommonWealth issued statement explaining methodology and timeline.
+
+[^21]: [CommonWealth Magazine "Boundless Sky" Education Special 1996](https://40.cw.com.tw/story/1996/) — 1996 education special tracking 5 fifteen-year-olds over 10 and 20 years (official page).
+
+[^22]: [Smiling Taiwan — About](https://smiletaiwan.cw.com.tw/about) — "319 Townships Moving Forward" distributed over 1 million township passports in 2001; extended into "Smiling Taiwan" long-running brand from 2005–2006.
+
+[^23]: [CommonWealth Magazine Education Foundation — Reading Hope Program](https://www.cw.com.tw/) — Rural book delivery and teacher training, sponsored by TSMC, ASML, and others.
+
+[^24]: [Ma-Xi Summit article removed — Huang Cheng-yi (ETtoday)](https://www.ettoday.net/news/20151104/591227.htm) — November 2015: Huang Cheng-yi's article in _The Independent Review @CommonWealth_ arguing for Ma Ying-jeou's impeachment is published then taken down.
+
+[^25]: [Removal sparks protest — writers withdraw (Liberty Times)](https://news.ltn.com.tw/news/politics/breakingnews/1498872) — Rex How, Ho Ming-sho, Wu Chieh-min, Chang Chuan-fen, and over 10 other columnists withdraw from _The Independent Review_ in protest.
+
+[^26]: [Ma Yueh-lin defends removal (Liberty Times)](https://news.ltn.com.tw/news/life/breakingnews/1497850) — Senior writer Ma Yueh-lin argues the removal was a wrong decision, but that outside observers should not take it as evidence of Beijing's instructions or that "Taipei has become Beijing."
+
+[^27]: [Removal controversy widens (Storm Media)](https://www.storm.mg/article/73083) — Sociologist Tseng Po-wen argues _The Independent Review_'s success came from "independent," not "CommonWealth," and that CommonWealth applied magazine editorial logic to an online platform.
+
+[^28]: [CommonWealth apologizes to Huang Tzu-chiao (China Times)](https://www.chinatimes.com/realtimenews/20230503001919-260404) — 2023: Huang Tzu-chiao's column altered; CommonWealth issues public apology acknowledging failure to follow internal standard procedures.
+
+[^29]: [Reuters Institute Digital News Report — Taiwan 2022](https://reutersinstitute.politics.ox.ac.uk/digital-news-report/2022/taiwan) — Notes Diane Ying placing majority shares into trust in 2021, with profits reinvested in the magazine, as a structural act for editorial independence.
+
+[^30]: [Diane Ying hands over to 6 managers (CNA)](https://www.cna.com.tw/news/firstnews/202108110245.aspx) — August 11, 2021: handover to Wu Ying-chun, Cheng Yi-yuan, Wu Wan-yu, Yeh Yun, Chen Yi-shan, Ho Chi-yu — professional managers, not family.
+
+[^31]: [Diane Ying handover statement (Brain)](https://www.brain.com.tw/news/articlecontent?ID=50067) — "To everything there is a season, A time for all seasons. After forty years of effort alongside CommonWealth, I have decided to pass the baton, to let the next generation of professional managers lead the way forward and begin the next journey." (verbatim)
+
+[^32]: [CommonWealth All Access back-story (Medium, official)](https://medium.com/commonwealth-magazine/best-reader-revenue-initiative-commonwealth-all-access-back-story-1fda846c10c6) — "All Access" launched March 15, 2017; Taiwan's first metered paywall for news media, modeled on the New York Times.
+
+[^33]: [All Access paywall renewal rate (INSIDE)](https://www.inside.com.tw/article/10341-common-wealth-magazine) — By end of 2017: paid subscribers surpassed 10,000; renewal rate approximately 90% (reported interview, secondary source).
+
+[^34]: [CommonWealth Magazine digital transformation (INSIDE)](https://www.inside.com.tw/article/10341-common-wealth-magazine) — 2017: digital advertising revenue first surpassed print (advertising-type shift); only around 2020–2022 did digital overall revenue and subscribers surpass print; formally announced in early-2023 transition report — these are two distinct milestones.
+
+[^35]: [Crossing (Wikipedia)](https://zh.wikipedia.org/zh-tw/%E6%8F%9B%E6%97%A5%E7%B7%9A) — CommonWealth Magazine Group publication timeline: CommonHealth (1998), Cheers (2000), CommonWealth Parenting (2008), The Independent Review @CommonWealth (2013), Crossing (2015, founded by Chang Hsiang-yi), Smiling Taiwan (quarterly from 2016).
+
+[^36]: [CommonWealth Parenting ends print (UDN)](https://udn.com/news/story/7314/8453979) — December 2024: CommonWealth Parenting publishes final print issue (No. 133); 2025 transitions to "CommonWealth Parenting Premium," fully digital.
+
+[^37]: [CommonWealth releases Taiwan's first media ESG impact report (Telum Media)](https://www.telummedia.com/public/news/reshuffle-at-commonwealth-magazine-group/8j1x0no91k) — Late 2024: CommonWealth releases Taiwan's first ESG impact report from a news organization; in 2023 became Taiwan's first news outlet to conduct a carbon audit.
+
+[^38]: [Ramon Magsaysay Taiwan awardees (en-academic)](https://en-academic.com/dic.nsf/enwiki/1376228) — Diane Ying received the 1987 Ramon Magsaysay Award in Journalism, Literature and Creative Communication Arts — the first Taiwanese to receive the award in the journalism category (Chiang Mung-lin received the Government Service category in 1958).
+
+[^39]: [Diane Ying — Ramon Magsaysay Award](https://rmaward.asia/rmawardees/ying-diane-yun-peng/) — Diane Ying's 1987 Ramon Magsaysay Award acceptance speech, verbatim: "Journalism, perhaps, is the best profession in the world, because a journalist is paid to learn, and life itself is a process of ceaseless learning."
+
+[^40]: [SOPA Lifetime Achievement Award 2021](https://2024.sopawards.com/the-sopa-awards/sopa-lifetime-achievement-award-2021/) — Diane Ying received the 2021 SOPA Lifetime Achievement Award; jury described CommonWealth as Taiwan's "well respected and highly trusted media organization."


### PR DESCRIPTION
  ## 📝 這個 PR 做了什麼？
  
  新增 `Society/天下雜誌.md` 的英文翻譯。CommonWealth Magazine
  是台灣最具影響力的財經媒體之一，內容涵蓋創刊故事、企業排名權力、撤稿爭議與創辦人交棒。
  
  ## 📁 變更類型
  
  - [ ] 📄 新增文章
  - [ ] ✏️  修改/更新現有文章
  - [x] 🌐 翻譯（中→英 / 英→中）
  - [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
  - [ ] 💻 技術改動（程式碼、樣式、設定）
  - [ ] 📚 文件更新（README、CONTRIBUTING 等）
  
  ## ✅ 自我檢查
  
  - [x] 文章有完整的 frontmatter（title, description, date, tags, category）
  - [x] `category` 用英文 + 對齊路徑（Society）
  - [x] `author: 'Taiwan.md'`
  - [x] `featured: true`（mirror 原文）
  - [x] **腳註用 canonical 格式**：40 個腳註完整保留
  - [x] 內容有附上可查證的參考資料來源
  - [x] 沒有抄襲或版權問題
  - [ ] 在本地 build 測試通過（未跑）
  
  ## 🎨 如果動到樣式（非內容 PR 才需要）
  
  不適用。
  
  ## 🔗 相關 Issue
  
  Closes #
  
  ## 📸 截圖（如果是視覺改動）

  不適用。