### PR TITLE
🧬 CI: bump GitHub Actions off Node 20 → Node 24 (before 6/16 forced switch)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,7 @@ jobs:
       NODE_OPTIONS: --max-old-space-size=12288
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       # 把檔案 mtime 從 git log 還原（修「每次 CI 都全量重產 OG」bug）
@@ -58,7 +58,7 @@ jobs:
         # reports/build-pipeline-audit-2026-06-10.md 熱點 #1。
         run: python3 scripts/ci/restore-mtime.py --verify-min-ratio 0.9
       - name: Setup Node (with npm cache)
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: 'npm' # Tier 1-2: 快取 npm 下載（不是 node_modules 本體）
@@ -90,13 +90,13 @@ jobs:
       # Incremental cache key 改 track v4 visual canonical：generate-og-images.mjs
       # + favicon.png（content 變動由 mtime 增量檢查，restore-keys 撿最新快取）。
       # 2026-06-13 refactor-article session（audit §⑤ cache churn 項）：
-      # actions/cache@v4 的 key 含 run_id = 每 run 必存新 186MB cache，
+      # actions/cache@v5 的 key 含 run_id = 每 run 必存新 186MB cache，
       # ~15 run/天 ≈ 2.8GB/天 quota churn 會 LRU 擠掉 npm/playwright cache。
       # 拆成 restore（每 run 都要）+ save（只在 OG generation 真的跑過時）。
       # 功能等價：needed=false 時 cache 內容不變，存回去是純浪費；
       # og-rename-sync 的 mv 冪等，skip save 最壞情況 = 下一 run 重做 mv。
       - name: Restore OG image cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: public/og-images
           key: og-images-${{ hashFiles('scripts/core/generate-og-images.mjs', 'public/favicon.png') }}-${{ github.run_id }}
@@ -113,7 +113,7 @@ jobs:
       # 拆成 install-deps（系統套件、always run、短）+ install chromium
       # （binary、conditional），觀察 log 時能更精確定位問題。
       - name: Restore Playwright cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -175,7 +175,7 @@ jobs:
       # 只在 OG generation 真的跑過時才存 cache（對應上方 restore/save 拆分註解）
       - name: Save OG image cache
         if: steps.og-changes.outputs.needed == 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         with:
           path: public/og-images
           key: og-images-${{ hashFiles('scripts/core/generate-og-images.mjs', 'public/favicon.png') }}-${{ github.run_id }}
@@ -196,7 +196,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
 
@@ -209,4 +209,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/i18n-smoke-test.yml
+++ b/.github/workflows/i18n-smoke-test.yml
@@ -30,9 +30,9 @@ jobs:
   i18n-smoke-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
           cache: 'npm'
@@ -55,7 +55,7 @@ jobs:
       # 此 workflow 跑 ubuntu-latest (x86_64)。共用 ${runner.os}-only key 會
       # cross-arch contamination（ARM binary 在 x86 不能跑）→ silent missing chromium。
       - name: Restore Playwright cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright

--- a/.github/workflows/instrumentation-audit.yml
+++ b/.github/workflows/instrumentation-audit.yml
@@ -25,9 +25,9 @@ jobs:
   instrumentation-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/npm-publish-cli.yml
+++ b/.github/workflows/npm-publish-cli.yml
@@ -33,10 +33,10 @@ jobs:
       run:
         working-directory: cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -47,7 +47,7 @@ jobs:
           # workflow false-classified every fork PR as `pr_type=engineering`
           # then SKIPPED review entirely. Fall back to the merge ref's two
           # parents (HEAD^1 = base, HEAD^2 = fork's PR head) which
-          # actions/checkout@v4 fetched as part of the synthetic merge commit.
+          # actions/checkout@v5 fetched as part of the synthetic merge commit.
           FILES=$(git diff --name-only --diff-filter=ACMR \
             "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}" \
             2>/dev/null)
@@ -114,7 +114,7 @@ jobs:
       - name: Label PR type
         if: steps.files.outputs.pr_type == 'mixed'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.issues.addLabels({
@@ -162,7 +162,7 @@ jobs:
 
       - name: Comment review result
         if: steps.files.outputs.pr_type == 'content' || steps.files.outputs.pr_type == 'mixed'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const result = `${{ steps.review.outputs.result }}`;
@@ -202,7 +202,7 @@ jobs:
       - name: Label result
         if: steps.files.outputs.pr_type == 'content' || steps.files.outputs.pr_type == 'mixed'
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const status = '${{ steps.review.outputs.status }}';

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -18,13 +18,13 @@ jobs:
       pull-requests: write
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
       - name: Auto-label translation PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             try {


### PR DESCRIPTION
## Why

GitHub is **forcing all Actions to run on Node 24 starting 2026-06-16** (2 days out) and removing the Node 20 runtime on 2026-09-16. Every workflow run currently logs the deprecation warning, and our production **Pages deploy** (`deploy.yml`) runs entirely on Node-20-based actions — so the forced switch is a real deploy-breakage risk.

Ref: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

## What changed (22 bumps across 6 workflows)

| Action | Before | After | Runtime (verified) |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | node20 → node24 |
| `actions/setup-node` | v4 | **v5** | node20 → node24 |
| `actions/cache` (+ `/restore`, `/save`) | v4 | **v5** | node20 → node24 |
| `actions/deploy-pages` | v4 | **v5** | node20 → node24 |
| `actions/upload-pages-artifact` | v3 | **v5** | composite (internals → node24) |
| `actions/setup-python` | v5 | **v6** | node20 → node24 |
| `actions/github-script` | v7 | **v8** | node20 → node24 |

Pinned to the **earliest `node24` major** of each action (minimal collateral, most battle-tested) rather than blindly the absolute latest.

## Verification (no guessing)

Every version's runtime was confirmed against the action's actual `action.yml` `using:` field via `gh api` — current pins all read `node20`, all targets read `node24`. Zero node20-era pins remain (grep-verified). All 6 files parse as valid YAML.

## Breaking-change analysis

- **github-script → v8, not latest v9**: v9 is ESM-only and breaks `require('@actions/github')`. Our 4 github-script blocks use **zero** `require()` calls, so v9 would technically work — but v8 is already node24, so we take it for the safety margin.
- **upload-pages-artifact v4+ excludes dotfiles**: our `public/` has only `.DS_Store` as dotfiles (which shouldn't be in the artifact anyway). `CNAME` is **not** a dotfile → custom domain `taiwan.md` is unaffected.
- **`runs-on` unchanged** (`ubuntu-latest`): `deploy.yml` has a documented ARM-runner instability history, so the runner is deliberately left alone.

## Testing

- This PR's checks exercise **checkout@v5 / setup-node@v5 / cache@v5 / github-script@v8 / setup-python@v6** in real CI (pr-review / translation-check / i18n-smoke / instrumentation-audit triggers).
- `deploy-pages@v5` + `upload-pages-artifact@v5` only run in `deploy.yml` (push to `main`), so they are **not** exercised by this PR. Watch the **first post-merge deploy**. Pages retains the last successful deployment if a build fails, so this is rollback-safe.

🧬 Taiwan.md — keeping the deploy pipeline breathing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
