### PR TITLE
fix(i18n): restore language switching on 2026 elections page

### DIFF
--- a/src/utils/getLangSwitchPath.ts
+++ b/src/utils/getLangSwitchPath.ts
@@ -255,6 +255,7 @@ const NON_ARTICLE_PATHS = new Set([
   'taiwan-shape',
   'semiont',
   'bench',
+  'elections',
 ]);
 
 function isArticlePagePath(basePath: string): boolean {


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

2026 選舉專頁已提供繁中、英文、日文與韓文路由，但語言切換器將 `/elections/2026` 誤判為文章頁，因此要求 `_translations.json` 映射，選單最後只顯示目前語言。

本 PR 將 `elections` 納入靜態頁命名空間，讓切換器依 `src/pages` 的實際路由判斷可用語言。修正後會顯示中文、English、日本語、한국어，且不會顯示尚不存在的 Français 或 Español。

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [x] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [x] 繁中、英文、日文與韓文靜態路由均存在
- [x] 法文與西文路由維持不可用
- [x] `git diff --check` 通過
- [ ] `npm run build`（由 CI 驗證）

## 🔗 相關 Issue

無

## 📸 截圖（如果是視覺改動）

不適用；本次僅修正語言選單的路由可用性判定。
