### PR TITLE
fix: handle translated article paths in PR review

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -162,6 +162,7 @@ jobs:
 
       - name: Comment review result
         if: steps.files.outputs.pr_type == 'content' || steps.files.outputs.pr_type == 'mixed'
+        continue-on-error: true
         uses: actions/github-script@v8
         with:
           script: |
@@ -232,3 +233,9 @@ jobs:
               issue_number: context.issue.number,
               labels: [labels[status]],
             });
+
+      - name: Fail on review failure
+        if: (steps.files.outputs.pr_type == 'content' || steps.files.outputs.pr_type == 'mixed') && steps.review.outputs.status == 'fail'
+        run: |
+          echo "Content review failed. See the Run content review log for details."
+          exit 1

--- a/scripts/tools/review-pr.sh
+++ b/scripts/tools/review-pr.sh
@@ -9,11 +9,43 @@ RED='\033[0;31m'; YEL='\033[0;33m'; GRN='\033[0;32m'
 BLU='\033[0;34m'; DIM='\033[0;90m'; RST='\033[0m'
 
 VALID_CATS=("About" "History" "Geography" "Culture" "Food" "Art" "Music" "Technology" "Nature" "People" "Society" "Economy" "Lifestyle")
+LOCALES=("en" "es" "ja" "ko" "fr" "de" "vi" "pt" "th" "id" "ar")
 SIMP_PAT='关|为|国|会|发|时|过|来|说|经|间|现|业|务|样|门|问|产|从|进|设|张|总|给|应|数|开|场|变|团|员|电|话|传|统|级|项|节|历'
 
 TOTAL=0; L0=0; L1=0; L2=0; L3=0
 STATUS="PASS"
 REPORT=""
+
+is_locale() {
+  local part="$1"
+  for v in "${LOCALES[@]}"; do
+    [[ "$part" == "$v" ]] && return 0
+  done
+  return 1
+}
+
+is_translation_path() {
+  local f="$1"
+  [[ "$f" =~ ^(knowledge|src/content)/([^/]+)/ ]] || return 1
+  is_locale "${BASH_REMATCH[2]}"
+}
+
+category_from_path() {
+  local f="$1"
+  local first="" second=""
+
+  if [[ "$f" =~ ^knowledge/([^/]+)/([^/]+)/ ]]; then
+    first="${BASH_REMATCH[1]}"
+    second="${BASH_REMATCH[2]}"
+    if is_locale "$first"; then
+      echo "$second"
+    else
+      echo "$first"
+    fi
+  elif [[ "$f" =~ ^knowledge/([^/]+)/ ]]; then
+    echo "${BASH_REMATCH[1]}"
+  fi
+}
 
 # ════════════════════════════════════════
 # Layer 0 — 安全隔離
@@ -65,11 +97,11 @@ layer1() {
     echo "$fm" | grep -q '^date:' || err+=("缺 date")
     echo "$fm" | grep -q '^tags:' || err+=("缺 tags")
     # featured: true rule — only enforced on ZH SSOT; translations mirror source
-    if echo "$f" | grep -qvE '/(en|ja|ko|es|fr)/'; then
+    if ! is_translation_path "$f"; then
       echo "$fm" | grep -q '^featured: true' && err+=("featured 不可 true")
     fi
     # category from path
-    local cd; cd=$(echo "$f" | sed -n 's|^knowledge/\([^/]*\)/.*|\1|p')
+    local cd; cd=$(category_from_path "$f")
     if [[ -n "$cd" ]]; then
       local ok=false
       for v in "${VALID_CATS[@]}"; do [[ "$cd" == "$v" ]] && ok=true && break; done
@@ -125,7 +157,8 @@ layer2() {
   (( ds > 4 )) && ((hs++))
 
   # quality: 教科書開場
-  echo "$body" | head -1 | grep -qE '^(台灣的|作為台灣|在台灣的)' 2>/dev/null && ((hs++))
+  local first_line; first_line=$(head -n 1 <<< "$body")
+  [[ "$first_line" =~ ^(台灣的|作為台灣|在台灣的) ]] && ((hs++))
 
   # quality: 總之結尾
   echo "$body" | tail -5 | grep -qE '總之|展望未來|綜上所述' 2>/dev/null && ((hs++))
@@ -170,7 +203,8 @@ layer3() {
   local body; body=$(awk '/^---$/{n++; next} n>=2 && NF{print}' "$f" 2>/dev/null)
 
   # 教科書開場
-  echo "$body" | head -1 | grep -qE '^(台灣的|作為|在台灣)' 2>/dev/null && wrn+=("教科書開場")
+  local first_line; first_line=$(head -n 1 <<< "$body")
+  [[ "$first_line" =~ ^(台灣的|作為|在台灣) ]] && wrn+=("教科書開場")
 
   # 引語
   grep -q '「' "$f" 2>/dev/null || wrn+=("缺引語")


### PR DESCRIPTION
## What this PR fixes

This PR fixes a false failure in the `PR Content Review` workflow that showed up while checking #1217.

In #1217, the review bot reported:

```text
knowledge/en/Music/chthonic.md
  L1 格式：🔴 無效 category: en

knowledge/en/People/dwagie.md
  L1 格式：🔴 無效 category: en

knowledge/en/People/freddy-lim.md
  L1 格式：🔴 無效 category: en
```

However, those files do not actually have `category: en` in frontmatter. Their frontmatter is correct:

- `knowledge/en/Music/chthonic.md` has `category: 'Music'`
- `knowledge/en/People/dwagie.md` has `category: 'People'`
- `knowledge/en/People/freddy-lim.md` has `category: 'People'`

The problem was in `scripts/tools/review-pr.sh`: Layer 1 inferred category from the first path segment after `knowledge/`. That works for Chinese source articles such as `knowledge/Music/閃靈.md`, but it misreads translated article paths such as `knowledge/en/Music/chthonic.md` as category `en`.

## Additional context from follow-up checks

After opening this fix PR, we checked the surrounding PR history to make sure the diagnosis was not just a local assumption.

Two details are useful:

1. #1218 reproduced the same pattern independently.
   - The first run on #1218, before English translations were added, passed `PR Content Review`.
   - After the English files were added under `knowledge/en/Technology/...`, the same workflow failed with `無效 category: en`.
   - This strongly points to translated article path parsing, not article quality or frontmatter content.

2. Earlier merged content PRs such as #1209, #1210, and #1211 also contained English files, but they do not appear to have been accepted because this exact reviewer path successfully handled those files.
   - The visible PR discussion indicates maintainer review and manual merge.
   - We could not find corresponding successful `PR Content Review` runs proving that `review-pr.sh` had correctly processed their `knowledge/en/...` files.
   - In other words, those earlier PRs being green/merged does not prove the reviewer already supported translated article paths. The bug seems to have been exposed once later PRs actually ran through this content-review path with English mirror files included.

The PR template checkbox for `🌐 翻譯` does not appear to control this behavior. The workflow classifies PRs from changed file paths, not from the checked boxes in the PR body. The separate `Translation PR Check` passed; the failure came from `PR Content Review` calling `review-pr.sh`.

## Changes

- Add locale-aware path parsing in `scripts/tools/review-pr.sh`.
  - `knowledge/Music/閃靈.md` still resolves to `Music`.
  - `knowledge/en/Music/chthonic.md` now resolves to `Music`, not `en`.
- Reuse the same locale list shape used by the PR workflow (`en`, `es`, `ja`, `ko`, `fr`, `de`, `vi`, `pt`, `th`, `id`, `ar`).
- Make the `featured: true` guard use the same translation-path detection, so translated articles are treated consistently.
- Remove two `Broken pipe` noise sources from the reviewer output by avoiding `echo "$body" | head -1 | grep -q...` pipelines.
- Make the PR comment step `continue-on-error: true`.
  - This avoids fork PRs failing only because `GITHUB_TOKEN` cannot create/update issue comments.
- Add an explicit `Fail on review failure` step.
  - This keeps content review failures as real CI failures, but makes the failure depend on the review result instead of on comment-posting side effects.

## Why this matters

Without this fix, any content PR that also touches English mirror files can fail the review bot even when the translated article frontmatter is correct. The failure message points contributors toward changing article metadata, but the actual issue is the reviewer’s path parser.

The second issue is that fork PRs can fail with `Resource not accessible by integration` when the workflow attempts to post the review comment. That makes the job look like a GitHub permission problem even when the useful review result is already available in logs.

## Verification

Before this change, running the reviewer on English translated files reproduced the false hard failure:

```bash
bash scripts/tools/review-pr.sh \
  knowledge/en/Music/chthonic.md \
  knowledge/en/People/freddy-lim.md
```

It reported `無效 category: en`.

After this change:

```bash
bash -n scripts/tools/review-pr.sh

bash scripts/tools/review-pr.sh \
  knowledge/en/Music/chthonic.md \
  knowledge/en/People/dwagie.md \
  knowledge/en/People/freddy-lim.md
```

Result:

```text
knowledge/en/Music/chthonic.md
  L1 格式：✅ frontmatter 完整

knowledge/en/People/dwagie.md
  L1 格式：✅ frontmatter 完整

knowledge/en/People/freddy-lim.md
  L1 格式：✅ frontmatter 完整

🟡 WARNING（3/3 安全 | 3/3 格式 | 3/3 品質）
```

The remaining warnings are content/editorial warnings, not the false `category: en` hard failure.

Also ran:

```bash
git diff --check
```

No whitespace errors.
