### PR TITLE
fix: guard contributor profile links

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -153,6 +153,13 @@
       "contributions": ["code", "security"]
     },
     {
+      "login": "ellenlee",
+      "name": "Ellen Lee",
+      "avatar_url": "https://avatars.githubusercontent.com/ellenlee",
+      "profile": "https://github.com/ellenlee",
+      "contributions": ["content", "translation"]
+    },
+    {
       "login": "eryet",
       "name": "EryetChen",
       "avatar_url": "https://avatars.githubusercontent.com/u/48248414?v=4",
@@ -424,13 +431,6 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/271172009?v=4",
       "profile": "https://github.com/sageotomo",
       "contributions": ["code"]
-    },
-    {
-      "login": "ellenlee",
-      "name": "Ellen Lee",
-      "avatar_url": "https://avatars.githubusercontent.com/ellenlee",
-      "profile": "https://github.com/ellenlee",
-      "contributions": ["content", "translation"]
     }
   ],
   "totalContributors": 52

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -424,7 +424,14 @@
       "avatar_url": "https://avatars.githubusercontent.com/u/271172009?v=4",
       "profile": "https://github.com/sageotomo",
       "contributions": ["code"]
+    },
+    {
+      "login": "ellenlee",
+      "name": "Ellen Lee",
+      "avatar_url": "https://avatars.githubusercontent.com/ellenlee",
+      "profile": "https://github.com/ellenlee",
+      "contributions": ["content", "translation"]
     }
   ],
-  "totalContributors": 51
+  "totalContributors": 52
 }

--- a/scripts/core/build-git-info.mjs
+++ b/scripts/core/build-git-info.mjs
@@ -59,6 +59,10 @@ function contributorKey(value) {
   return value.toLowerCase().replace(/[\s._-]+/g, '');
 }
 
+function isGitHubLogin(value) {
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(value);
+}
+
 function getContributorProfiles() {
   if (contributorProfiles) return contributorProfiles;
   contributorProfiles = new Map();
@@ -86,14 +90,14 @@ function resolveContributor(authorName, authorEmail) {
   const profile =
     getContributorProfiles().get(contributorKey(githubLogin || '')) ||
     getContributorProfiles().get(contributorKey(authorName));
-  const login = githubLogin || profile?.login || authorName;
+  const login = githubLogin || profile?.login || '';
   const isAuthorNameLogin =
     profile && contributorKey(authorName) === contributorKey(profile.login);
   return {
     name: isAuthorNameLogin
       ? profile.name
       : authorName || profile?.name || login,
-    login,
+    login: isGitHubLogin(login) ? login : '',
   };
 }
 
@@ -204,7 +208,11 @@ function main() {
       entry.revisionCount += 1;
       if (
         currentContributor &&
-        !entry.contributors.some((c) => c.login === currentContributor.login)
+        !entry.contributors.some(
+          (c) =>
+            contributorKey(c.login || c.name) ===
+            contributorKey(currentContributor.login || currentContributor.name),
+        )
       ) {
         entry.contributors.push(currentContributor);
       }

--- a/src/components/ArticleSidebar.astro
+++ b/src/components/ArticleSidebar.astro
@@ -106,11 +106,22 @@ const shareLINELabel = t('article.sidebar.shareLine');
 
 const contentLanguageName = languages[lang] ?? String(lang);
 
-const normalizedContributors = contributors.map((contributor) =>
-  typeof contributor === 'string'
-    ? { name: contributor, login: contributor }
-    : contributor,
-);
+function isGitHubLogin(value: string): boolean {
+  return /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$/.test(value);
+}
+
+const normalizedContributors = contributors.map((contributor) => {
+  const normalized =
+    typeof contributor === 'string'
+      ? { name: contributor, login: contributor }
+      : contributor;
+  return {
+    ...normalized,
+    profileUrl: isGitHubLogin(normalized.login)
+      ? `https://github.com/${normalized.login}`
+      : '',
+  };
+});
 ---
 
 <!--
@@ -405,16 +416,22 @@ const normalizedContributors = contributors.map((contributor) =>
           {contributorsHeading}
         </p>
         <div class="flex flex-wrap gap-[0.4rem]">
-          {normalizedContributors.map((contributor) => (
-            <a
-              href={`https://github.com/${contributor.login}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="rounded-full border border-[rgba(0,109,119,0.15)] bg-[rgba(0,109,119,0.07)] px-[0.6rem] py-[0.22rem] font-['Inter',system-ui,sans-serif] text-[0.75rem] text-[#006d77] no-underline transition-colors duration-150 hover:bg-[rgba(0,109,119,0.14)]"
-            >
-              {contributor.name}
-            </a>
-          ))}
+          {normalizedContributors.map((contributor) =>
+            contributor.profileUrl ? (
+              <a
+                href={contributor.profileUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="rounded-full border border-[rgba(0,109,119,0.15)] bg-[rgba(0,109,119,0.07)] px-[0.6rem] py-[0.22rem] font-['Inter',system-ui,sans-serif] text-[0.75rem] text-[#006d77] no-underline transition-colors duration-150 hover:bg-[rgba(0,109,119,0.14)]"
+              >
+                {contributor.name}
+              </a>
+            ) : (
+              <span class="rounded-full border border-[rgba(0,109,119,0.15)] bg-[rgba(0,109,119,0.07)] px-[0.6rem] py-[0.22rem] font-['Inter',system-ui,sans-serif] text-[0.75rem] text-[#006d77]">
+                {contributor.name}
+              </span>
+            ),
+          )}
         </div>
       </div>
     )


### PR DESCRIPTION
## What changed

This PR fixes article-sidebar contributor profile links when git author names are not the same as GitHub usernames.

- Adds `Ellen Lee` / `ellenlee` to `.all-contributorsrc`, so per-article git provenance can resolve the contributor profile correctly.
- Updates `scripts/core/build-git-info.mjs` so unresolved author names are no longer treated as GitHub logins by default.
- Updates `ArticleSidebar.astro` to render a plain contributor chip instead of a broken GitHub link when the login is not URL-safe.

## Why

On published article pages, a contributor chip could link to `https://github.com/Ellen%20Lee` when the git author was `Ellen Lee <leechinghui.tw@gmail.com>`. The correct profile is `https://github.com/ellenlee`.

Root cause: the article sidebar uses prebuilt per-article git provenance from `build-git-info.mjs`. When `.all-contributorsrc` did not contain a mapping for the author name, the generator fell back to `login = authorName`, and the sidebar then assembled `https://github.com/${login}`.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('.all-contributorsrc','utf8')); console.log('all-contributors JSON ok')"`
- `node scripts/core/build-git-info.mjs`
- Verified generated git-info resolves:
  - `knowledge/People/大支.md` → `[{"name":"Ellen Lee","login":"ellenlee"}]`
  - `knowledge/en/People/dwagie.md` includes `{"name":"Ellen Lee","login":"ellenlee"}`
- `git diff --check`
- `node scripts/tools/verify-contributors.mjs` exits 0; it still reports existing warn-only missing contributor mappings unrelated to this PR.
- `npm run build` passes; broken-link audit remains below gate (`0.35% < 7.0%`).
