### PR TITLE
edit: refine AI hardware series SVG diagrams

### DIFF
--- a/knowledge/en/Technology/ai-hardware-supply-chain.md
+++ b/knowledge/en/Technology/ai-hardware-supply-chain.md
@@ -15,7 +15,7 @@ rationale:
   whats_excluded: 'Does not attempt a complete industry encyclopedia or list every Taiwanese semiconductor, server, and component company.'
   where_it_hedges: 'Places Taiwan’s supply-chain value alongside power, water, carbon, income distribution, overseas manufacturing, and geopolitical risk.'
   whos_pushing_back: 'Global customers and allies need Taiwan, but they also use overseas manufacturing to reduce single-point dependence around the Taiwan Strait.'
-image: '/article-images/technology/ai-hardware-supply-chain-flow.svg'
+image: '/article-images/technology/ai-hardware-supply-chain-flow-en.svg'
 imageCredit: 'Taiwan.md Contributors'
 imageLicense: 'CC BY-SA 4.0'
 translatedFrom: 'Technology/AI硬體供應鏈.md'
@@ -60,7 +60,7 @@ Taiwan’s place is at many of the important workstations in that kitchen.
 
 An AI hardware supply chain often begins with a very ordinary demand: a cloud company, model company, or large enterprise needs more compute. That sounds like buying a cloud service, but it quickly becomes a string of physical questions: what chip should be designed? Where can it be manufactured? How does memory get close enough to it? How is heat removed? How is power delivered? And who turns those expensive parts into a machine that can be shipped, maintained, and placed in a data center?
 
-![AI hardware supply-chain flowchart showing AI demand moving through chip design, advanced nodes, advanced packaging, HBM and substrates, cooling and power, motherboards, ODM / EMS, AI racks, and finally data centers; the chart highlights manufacturing, packaging, electrical and thermal, board, assembly, and rack-integration checkpoints highly concentrated in Taiwan](/article-images/technology/ai-hardware-supply-chain-flow.svg)
+![AI hardware supply-chain flowchart showing AI demand moving through chip design, advanced nodes, advanced packaging, HBM and substrates, cooling and power, motherboards, ODM / EMS, AI racks, and finally data centers; the chart highlights manufacturing, packaging, electrical and thermal, board, assembly, and rack-integration checkpoints highly concentrated in Taiwan](/article-images/technology/ai-hardware-supply-chain-flow-en.svg)
 
 _A Taiwan.md self-made diagram. This is not a market-share chart or a complete company map; it shows one core path: how AI demand becomes machines that can be powered, cooled, and shipped._
 
@@ -70,7 +70,7 @@ But making the chip does not mean AI can go online. AI chips need to sit close t
 
 Further downstream, the supply chain looks less and less like a straight line. HBM, or high-bandwidth memory, is mainly led by Korean companies. Equipment, materials, and design software involve suppliers from the United States, the Netherlands, Japan, and Europe. Cloud platforms and model services are mostly in the United States. Taiwan does not monopolize every segment, and it does not capture the largest profit in every segment. Its special feature is that wafer foundry, packaging, testing, substrates, power, cooling, motherboards, and system assembly are close to one another and have long been used to solving engineering problems together.
 
-![AI server stack diagram showing chips and accelerators, boards and motherboards, power and cooling, servers and racks, and data centers stacked in sequence, explaining how a GPU becomes deployable AI infrastructure](/article-images/technology/ai-server-rack-stack.svg)
+![AI server stack diagram showing chips and accelerators, boards and motherboards, power and cooling, servers and racks, and data centers stacked in sequence, explaining how a GPU becomes deployable AI infrastructure](/article-images/technology/ai-server-rack-stack-en.svg)
 
 _A Taiwan.md self-made diagram. The GPU is only one core of an AI server; it still has to connect to boards, power, cooling, systems, racks, and data centers._
 
@@ -178,8 +178,8 @@ That is one of Taiwan’s clearest positions right now, and one that needs to be
 
 ## Image Sources
 
-- **AI hardware supply-chain flowchart**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/ai-hardware-supply-chain-flow.svg`. The nodes are organized from this article and its references to explain how AI demand moves through chip design, advanced nodes, advanced packaging, HBM / substrates, cooling / power, motherboards, ODM / EMS, and AI racks before entering data centers. It is not a market-share chart and does not represent a complete company map.
-- **AI server stack diagram**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/ai-server-rack-stack.svg`. It explains the system layers from chip to data center, and does not represent a complete company map or market share.
+- **AI hardware supply-chain flowchart**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/ai-hardware-supply-chain-flow-en.svg`. The nodes are organized from this article and its references to explain how AI demand moves through chip design, advanced nodes, advanced packaging, HBM / substrates, cooling / power, motherboards, ODM / EMS, and AI racks before entering data centers. It is not a market-share chart and does not represent a complete company map.
+- **AI server stack diagram**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/ai-server-rack-stack-en.svg`. It explains the system layers from chip to data center, and does not represent a complete company map or market share.
 - **Jensen Huang showing an RTX Blackwell GPU**: [Jensen Huang holding RTX Blackwell at CES 2025](<https://commons.wikimedia.org/wiki/File:Jensen_Huang_-_RTX_Blackwell_-_Nvidia_Keynote_-_CES_2025_Las_Vegas_(3).jpg>) — Photo: Pronoia, Wikimedia Commons, CC0. This article uses the cached version at `public/article-images/technology/jensen-huang-ces-2025-blackwell.webp`.
 - **Computex Nangang exhibition floor**: [Computex Taipei at Taipei Nangang Exhibition Center](https://commons.wikimedia.org/wiki/File:Computex_Taipei_at_Taipei_Nangang_Exhibition_Center_20150602.jpg) — Photo: NVIDIA Taiwan, Wikimedia Commons, CC BY 2.0. This article uses the cached version at `public/article-images/technology/computex-nangang-floor-2015.webp`.
 

--- a/knowledge/en/Technology/ai-supply-chain-overseas-manufacturing.md
+++ b/knowledge/en/Technology/ai-supply-chain-overseas-manufacturing.md
@@ -74,7 +74,7 @@ _TSMC Fab 21 under construction in Phoenix, Arizona. Overseas manufacturing even
 
 OpenAI and Foxconn later announced a partnership to design and manufacture AI data-center racks in the United States, including cabling, networking, and power systems. AP reported that Foxconn would use US facilities in Wisconsin, Ohio, Texas, and elsewhere.[^2] This makes overseas manufacturing more than chip production; the entire AI data-center hardware system is being pulled into domestic manufacturing.
 
-![AI supply-chain overseas manufacturing roadmap: Taiwan’s domestic core capabilities extend toward the United States, Japan, Europe, Mexico, Southeast Asia, India, and data-center markets, showing four pulls from companies, governments, local societies, and customers](/article-images/technology/ai-supply-chain-overseas-footprint.svg)
+![AI supply-chain overseas manufacturing roadmap: Taiwan’s domestic core capabilities extend toward the United States, Japan, Europe, Mexico, Southeast Asia, India, and data-center markets, showing four pulls from companies, governments, local societies, and customers](/article-images/technology/ai-supply-chain-overseas-footprint-en.svg)
 
 _Taiwan’s AI supply chain does not move abroad along one route. Different segments are pulled by different markets: chips and packaging are pulled by national security and cloud customers; servers, racks, power, and cooling move with data centers, tariffs, and delivery needs. A Taiwan.md Contributors self-made diagram._
 
@@ -197,7 +197,7 @@ That is the most important question in AI supply-chain overseas manufacturing: a
 
 - **Aerial view of TSMC Arizona Fab 21 under construction (hero / inline)**: [231105-1 TSMC Fab 21 construction](https://commons.wikimedia.org/wiki/File:231105-1_TSMC_Fab_21_construction.jpg) — Photo: Hunter Trick, 2023-11-05, Wikimedia Commons, CC BY-SA 4.0. This article uses the cached version at `public/article-images/economy/tsmc-fab21-arizona-2023.webp`.
 - **TSMC fabs in Hsinchu Science Park**: [TSMC fabs in Hsinchu 01](https://commons.wikimedia.org/wiki/File:TSMC_fabs_in_Hsinchu_01.jpg) — Photo: Tseng Cheng-Hsun, 2020-01-02, Wikimedia Commons, CC BY 2.0. This article uses the cached version at `public/article-images/economy/tsmc-fabs-hsinchu-2020.webp`.
-- **AI supply-chain overseas manufacturing roadmap**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/ai-supply-chain-overseas-footprint.svg`. It explains the multiple routes and stakeholder pulls behind Taiwan’s AI hardware supply chain going abroad, and does not represent complete company distribution or capacity share.
+- **AI supply-chain overseas manufacturing roadmap**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/ai-supply-chain-overseas-footprint-en.svg`. It explains the multiple routes and stakeholder pulls behind Taiwan’s AI hardware supply chain going abroad, and does not represent complete company distribution or capacity share.
 
 ## References
 

--- a/knowledge/en/Technology/semiconductor-water-use-and-taiwan-water-resources.md
+++ b/knowledge/en/Technology/semiconductor-water-use-and-taiwan-water-resources.md
@@ -104,7 +104,7 @@ Third, reclaimed water forces data to become more transparent. To earn local tru
 
 Reclaimed water is therefore not a “patch” for semiconductor water shortage. It is more like an institutional test: can Taiwan combine municipal sewage, industrial demand, local trust, and climate risk into a water-resource system that can operate over the long term?
 
-![Diagram of reclaimed water and semiconductor manufacturing water loop: reservoirs and rivers, municipal sewage, reclaimed-water plants, fabs, and local governance form a water-resource loop](/article-images/technology/reclaimed-water-semiconductor-loop.svg)
+![Diagram of reclaimed water and semiconductor manufacturing water loop: reservoirs and rivers, municipal sewage, reclaimed-water plants, fabs, and local governance form a water-resource loop](/article-images/technology/reclaimed-water-semiconductor-loop-en.svg)
 
 _A Taiwan.md self-made diagram. Reclaimed water connects municipal sewage, industrial demand, local trust, and drought response into a system, turning semiconductor water use into a public-infrastructure question._
 
@@ -171,7 +171,7 @@ That is why semiconductor water use is worth understanding: it turns the most ab
 
 - **TSMC Fab 18 and fields at Southern Taiwan Science Park (hero / inline)**: [TSMC Fab 18 and fields May 2025](https://commons.wikimedia.org/wiki/File:TSMC_Fab_18_and_fields_May_2025.jpg) — Photo: 4300streetcar, Wikimedia Commons, CC BY 4.0. This article uses the cached version at `public/article-images/technology/tainan-science-park-tsmc-fab18-fields-2025.webp`.
 - **Flooding in Minxiong, Chiayi, after Typhoon Morakot**: [2009-08-09 at a village under the Typhoon Morakot, in Minxiong, Chiayi](https://commons.wikimedia.org/wiki/File:2009-08-09_at_a_village_under_the_Typhoon_Morakot,_in_Minxiong,_Chiayi.jpg) — Photo: zilupe, Wikimedia Commons, CC BY 2.0. This article uses the cached version at `public/article-images/nature/morakot-minxiong-flood-2009.webp`.
-- **Reclaimed water and semiconductor manufacturing water-loop diagram**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/reclaimed-water-semiconductor-loop.svg`. It explains the relationship among reservoirs, municipal sewage, reclaimed-water plants, fabs, and local governance, and is not an engineering drawing of a specific site.
+- **Reclaimed water and semiconductor manufacturing water-loop diagram**: A Taiwan.md Contributors self-made SVG diagram, CC BY-SA 4.0, stored at `public/article-images/technology/reclaimed-water-semiconductor-loop-en.svg`. It explains the relationship among reservoirs, municipal sewage, reclaimed-water plants, fabs, and local governance, and is not an engineering drawing of a specific site.
 
 ## References
 

--- a/public/article-images/technology/ai-hardware-supply-chain-flow-en.svg
+++ b/public/article-images/technology/ai-hardware-supply-chain-flow-en.svg
@@ -20,7 +20,7 @@
     <style>
       .bg { fill: url(#paper); }
       .frame { fill: rgba(255,255,255,0.72); stroke: #d5e4e8; stroke-width: 1.5; }
-      .title { font: 700 38px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #14313a; }
+      .title { font: 700 36px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #14313a; }
       .subtitle { font: 400 20px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #47646b; }
       .eyebrow { font: 700 14px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #5f7f87; letter-spacing: 1.5px; }
       .band-title { font: 700 20px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #1f4c57; }
@@ -105,7 +105,7 @@
       <rect class="node-tw" width="180" height="150" rx="22"/>
       <circle class="pill" cx="34" cy="34" r="15"/>
       <text class="node-num" x="34" y="39" text-anchor="middle">04</text>
-      <text class="node-title" x="30" y="70">Advanced Packaging</text>
+      <text class="node-title" x="30" y="70">Adv. Packaging</text>
       <text class="node-note" x="30" y="101">CoWoS, SoIC, InFO</text>
       <text class="node-note" x="30" y="124">Dies meet memory</text>
     </g>
@@ -168,8 +168,10 @@
   <g transform="translate(90 705)">
     <rect class="pill-soft" x="0" y="0" width="1220" height="86" rx="22"/>
     <text class="band-title" x="34" y="36">How to Read This Map</text>
-    <text class="band-note" x="34" y="62">Taiwan does not own every segment; its leverage comes from nearby manufacturing and integration nodes that turn chips, power, heat, boards, and racks into shippable systems.</text>
+    <text class="band-note" x="34" y="58">Taiwan does not own every segment; its leverage comes from nearby manufacturing and integration nodes</text>
+    <text class="band-note" x="34" y="78">that turn chips, power, heat, boards, and racks into shippable systems.</text>
   </g>
 
-  <text class="small" x="90" y="836">Taiwan.md self-made diagram, 2026. This explains process relationships, not a single company, market share, or full supplier list; see article sources for specific facts.</text>
+  <text class="small" x="90" y="836">Taiwan.md self-made diagram, 2026. This explains process relationships, not a single company, market share,</text>
+  <text class="small" x="90" y="856">or full supplier list; see article sources for specific facts.</text>
 </svg>

--- a/public/article-images/technology/ai-hardware-supply-chain-flow-en.svg
+++ b/public/article-images/technology/ai-hardware-supply-chain-flow-en.svg
@@ -1,0 +1,175 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" role="img" aria-labelledby="title desc">
+  <title id="title">AI Hardware Supply Chain: Turning Cloud Demand Into Machines</title>
+  <desc id="desc">A flowchart showing how AI demand moves from chip design through advanced nodes, advanced packaging, HBM and substrates, cooling and power, motherboards, ODM/EMS, AI racks, and finally data centers. The mist-blue band marks manufacturing, packaging, electrical and thermal, board, assembly, and rack-integration nodes concentrated in Taiwan.</desc>
+  <defs>
+    <linearGradient id="paper" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#f8fbfc"/>
+      <stop offset="58%" stop-color="#eef6f8"/>
+      <stop offset="100%" stop-color="#eaf2f4"/>
+    </linearGradient>
+    <linearGradient id="taiwanBand" x1="0" x2="1" y1="0" y2="0">
+      <stop offset="0%" stop-color="#e7f5f7"/>
+      <stop offset="100%" stop-color="#d9eef2"/>
+    </linearGradient>
+    <filter id="softShadow" x="-10%" y="-15%" width="120%" height="135%">
+      <feDropShadow dx="0" dy="14" stdDeviation="16" flood-color="#0f2f3a" flood-opacity="0.10"/>
+    </filter>
+    <marker id="arrow" markerWidth="13" markerHeight="13" refX="10" refY="6.5" orient="auto" markerUnits="strokeWidth">
+      <path d="M2,2.2 L10.5,6.5 L2,10.8 Z" fill="#51747d"/>
+    </marker>
+    <style>
+      .bg { fill: url(#paper); }
+      .frame { fill: rgba(255,255,255,0.72); stroke: #d5e4e8; stroke-width: 1.5; }
+      .title { font: 700 38px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #14313a; }
+      .subtitle { font: 400 20px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #47646b; }
+      .eyebrow { font: 700 14px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #5f7f87; letter-spacing: 1.5px; }
+      .band-title { font: 700 20px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #1f4c57; }
+      .band-note { font: 400 15px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #54727a; }
+      .node-title { font: 700 19px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #17343c; }
+      .node-note { font: 400 14.5px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #547078; }
+      .node-num { font: 700 12px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #ffffff; }
+      .section-label { font: 700 15px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #385b63; }
+      .small { font: 400 14px -apple-system, BlinkMacSystemFont, "Noto Sans TC", "PingFang TC", "Microsoft JhengHei", sans-serif; fill: #668087; }
+      .flow { fill: none; stroke: #6f8f96; stroke-width: 2.6; stroke-linecap: round; stroke-linejoin: round; marker-end: url(#arrow); }
+      .branch { fill: none; stroke: #9bb4ba; stroke-width: 1.7; stroke-linecap: round; stroke-dasharray: 5 8; }
+      .node { fill: #ffffff; stroke: #c7dbe0; stroke-width: 1.4; filter: url(#softShadow); }
+      .node-tw { fill: #f8fdfd; stroke: #79aeb8; stroke-width: 2; filter: url(#softShadow); }
+      .node-global { fill: #fbfdfd; stroke: #d4e1e4; stroke-width: 1.4; filter: url(#softShadow); }
+      .node-final { fill: #f7fbfc; stroke: #94b3ba; stroke-width: 1.8; filter: url(#softShadow); }
+      .pill { fill: #2d6f7d; }
+      .pill-soft { fill: #e1f1f4; stroke: #b8d4da; stroke-width: 1; }
+      .band { fill: url(#taiwanBand); stroke: #8dbcc5; stroke-width: 1.6; }
+      .divider { stroke: #d7e5e8; stroke-width: 1.4; }
+    </style>
+  </defs>
+
+  <rect class="bg" width="1400" height="900"/>
+  <rect class="frame" x="44" y="42" width="1312" height="812" rx="34"/>
+
+  <text class="eyebrow" x="86" y="94">TAIWAN.MD SUPPLY CHAIN MAP</text>
+  <text class="title" x="86" y="138">AI Hardware Supply Chain: From Compute Demand to Data Centers</text>
+  <text class="subtitle" x="86" y="174">An AI service has to pass through chips, packaging, memory, power, cooling, boards, systems, and racks.</text>
+
+  <g transform="translate(90 220)">
+    <rect class="band" x="360" y="0" width="660" height="426" rx="30"/>
+    <text class="band-title" x="690" y="42" text-anchor="middle">Engineering Checkpoints Concentrated in Taiwan</text>
+    <text class="band-note" x="690" y="68" text-anchor="middle">Nodes, packaging, power, cooling, boards, systems, and racks sit close enough to react fast.</text>
+
+    <text class="section-label" x="5" y="24">Demand and Design</text>
+    <line class="divider" x1="0" y1="46" x2="290" y2="46"/>
+    <text class="section-label" x="1130" y="24" text-anchor="end">Deployment</text>
+    <line class="divider" x1="1050" y1="46" x2="1220" y2="46"/>
+
+    <path class="flow" d="M190 170 H238"/>
+    <path class="flow" d="M440 170 H488"/>
+    <path class="flow" d="M690 170 H738"/>
+    <path class="flow" d="M940 170 H988"/>
+    <path class="flow" d="M1090 255 V283"/>
+    <path class="flow" d="M988 370 H942"/>
+    <path class="flow" d="M738 370 H692"/>
+    <path class="flow" d="M488 370 H442"/>
+    <path class="flow" d="M238 370 H192"/>
+
+    <path class="branch" d="M1110 172 C1160 172 1190 202 1190 254 C1190 306 1168 338 1138 364"/>
+    <path class="branch" d="M620 225 C615 264 635 296 675 316"/>
+    <path class="branch" d="M875 228 C915 256 934 286 922 320"/>
+
+    <g transform="translate(0 95)">
+      <rect class="node-global" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">01</text>
+      <text class="node-title" x="30" y="70">AI Demand</text>
+      <text class="node-note" x="30" y="101">Training and inference</text>
+      <text class="node-note" x="30" y="124">Cloud demand</text>
+    </g>
+
+    <g transform="translate(250 95)">
+      <rect class="node-global" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">02</text>
+      <text class="node-title" x="30" y="70">Chip Design</text>
+      <text class="node-note" x="30" y="101">GPU, ASIC, platform</text>
+      <text class="node-note" x="30" y="124">Mostly U.S.-led</text>
+    </g>
+
+    <g transform="translate(500 95)">
+      <rect class="node-tw" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">03</text>
+      <text class="node-title" x="30" y="70">Advanced Nodes</text>
+      <text class="node-note" x="30" y="101">Foundry and yield</text>
+      <text class="node-note" x="30" y="124">Designs become chips</text>
+    </g>
+
+    <g transform="translate(750 95)">
+      <rect class="node-tw" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">04</text>
+      <text class="node-title" x="30" y="70">Advanced Packaging</text>
+      <text class="node-note" x="30" y="101">CoWoS, SoIC, InFO</text>
+      <text class="node-note" x="30" y="124">Dies meet memory</text>
+    </g>
+
+    <g transform="translate(1000 95)">
+      <rect class="node" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">05</text>
+      <text class="node-title" x="30" y="70">HBM / Substrates</text>
+      <text class="node-note" x="30" y="101">Memory bandwidth</text>
+      <text class="node-note" x="30" y="124">ABF, PCB, signals</text>
+    </g>
+
+    <g transform="translate(1000 295)">
+      <rect class="node-tw" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">06</text>
+      <text class="node-title" x="30" y="70">Cooling / Power</text>
+      <text class="node-note" x="30" y="101">Liquid cooling, PSU</text>
+      <text class="node-note" x="30" y="124">Heat comes first</text>
+    </g>
+
+    <g transform="translate(750 295)">
+      <rect class="node-tw" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">07</text>
+      <text class="node-title" x="30" y="70">Motherboards</text>
+      <text class="node-note" x="30" y="101">High-speed signals</text>
+      <text class="node-note" x="30" y="124">Parts become systems</text>
+    </g>
+
+    <g transform="translate(500 295)">
+      <rect class="node-tw" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">08</text>
+      <text class="node-title" x="30" y="70">ODM / EMS</text>
+      <text class="node-note" x="30" y="101">Assembly and tests</text>
+      <text class="node-note" x="30" y="124">Scale, delivery, repair</text>
+    </g>
+
+    <g transform="translate(250 295)">
+      <rect class="node-tw" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">09</text>
+      <text class="node-title" x="30" y="70">AI Racks</text>
+      <text class="node-note" x="30" y="101">Server clusters</text>
+      <text class="node-note" x="30" y="124">Power, network, cooling</text>
+    </g>
+
+    <g transform="translate(0 295)">
+      <rect class="node-final" width="180" height="150" rx="22"/>
+      <circle class="pill" cx="34" cy="34" r="15"/>
+      <text class="node-num" x="34" y="39" text-anchor="middle">10</text>
+      <text class="node-title" x="30" y="70">Data Centers</text>
+      <text class="node-note" x="30" y="101">Cloud service online</text>
+      <text class="node-note" x="30" y="124">Users see answers</text>
+    </g>
+  </g>
+
+  <g transform="translate(90 705)">
+    <rect class="pill-soft" x="0" y="0" width="1220" height="86" rx="22"/>
+    <text class="band-title" x="34" y="36">How to Read This Map</text>
+    <text class="band-note" x="34" y="62">Taiwan does not own every segment; its leverage comes from nearby manufacturing and integration nodes that turn chips, power, heat, boards, and racks into shippable systems.</text>
+  </g>
+
+  <text class="small" x="90" y="836">Taiwan.md self-made diagram, 2026. This explains process relationships, not a single company, market share, or full supplier list; see article sources for specific facts.</text>
+</svg>

--- a/public/article-images/technology/ai-server-rack-stack-en.svg
+++ b/public/article-images/technology/ai-server-rack-stack-en.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="880" viewBox="0 0 1400 880" role="img" aria-labelledby="title desc">
+  <title id="title">AI server supply chain stack</title>
+  <desc id="desc">A layered diagram showing how GPU boards, power, cooling, networking, servers, racks and data centers stack into AI infrastructure.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f6f8fb"/>
+      <stop offset="1" stop-color="#e9f0f3"/>
+    </linearGradient>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="10" stdDeviation="12" flood-color="#1f2937" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <rect width="1400" height="880" fill="url(#bg)"/>
+  <text x="92" y="92" font-family="Noto Sans TC, Arial, sans-serif" font-size="42" font-weight="700" fill="#1f2937">AI Server Stack: From Chips to Racks</text>
+  <text x="94" y="138" font-family="Noto Sans TC, Arial, sans-serif" font-size="22" fill="#52616f">A GPU is only the starting point; Taiwan's supply chain turns it into deployable data-center hardware.</text>
+  <g filter="url(#shadow)">
+    <rect x="110" y="205" width="1180" height="560" rx="28" fill="#ffffff"/>
+  </g>
+  <g font-family="Noto Sans TC, Arial, sans-serif">
+    <g transform="translate(180 255)">
+      <rect width="1040" height="72" rx="16" fill="#dceef3"/>
+      <text x="32" y="45" font-size="26" font-weight="700" fill="#214756">Chips and Accelerators</text>
+      <text x="430" y="45" font-size="21" fill="#45616c">GPU / CPU / HBM / high-speed I/O form the compute core.</text>
+    </g>
+    <g transform="translate(180 348)">
+      <rect width="1040" height="72" rx="16" fill="#e5edf7"/>
+      <text x="32" y="45" font-size="26" font-weight="700" fill="#283f63">Boards and Motherboards</text>
+      <text x="430" y="45" font-size="21" fill="#4e6178">Connect chips, power, signals, and memory into a working system.</text>
+    </g>
+    <g transform="translate(180 441)">
+      <rect width="1040" height="72" rx="16" fill="#e9f2e6"/>
+      <text x="32" y="45" font-size="26" font-weight="700" fill="#31553a">Power and Cooling</text>
+      <text x="430" y="45" font-size="21" fill="#526a55">High-power machines need stable power, liquid cooling, fans, and heat control.</text>
+    </g>
+    <g transform="translate(180 534)">
+      <rect width="1040" height="72" rx="16" fill="#f4ead8"/>
+      <text x="32" y="45" font-size="26" font-weight="700" fill="#65491d">Servers and Racks</text>
+      <text x="430" y="45" font-size="21" fill="#715d3f">ODM / EMS teams integrate parts into deliverable, serviceable systems.</text>
+    </g>
+    <g transform="translate(180 627)">
+      <rect width="1040" height="72" rx="16" fill="#eee7f3"/>
+      <text x="32" y="45" font-size="26" font-weight="700" fill="#4f3f63">Data Centers</text>
+      <text x="430" y="45" font-size="21" fill="#695d75">Only inside the machine room do racks become the body behind cloud services.</text>
+    </g>
+  </g>
+  <g fill="none" stroke="#6b8791" stroke-width="4" stroke-linecap="round">
+    <path d="M700 330v14"/>
+    <path d="M700 423v14"/>
+    <path d="M700 516v14"/>
+    <path d="M700 609v14"/>
+  </g>
+  <g font-family="Noto Sans TC, Arial, sans-serif" font-size="18" fill="#6b7280">
+    <text x="176" y="804">Taiwan.md Contributors self-made diagram. This explains supply-chain layers, not a complete company map or market share.</text>
+  </g>
+</svg>

--- a/public/article-images/technology/ai-server-rack-stack-en.svg
+++ b/public/article-images/technology/ai-server-rack-stack-en.svg
@@ -12,44 +12,51 @@
   </defs>
   <rect width="1400" height="880" fill="url(#bg)"/>
   <text x="92" y="92" font-family="Noto Sans TC, Arial, sans-serif" font-size="42" font-weight="700" fill="#1f2937">AI Server Stack: From Chips to Racks</text>
-  <text x="94" y="138" font-family="Noto Sans TC, Arial, sans-serif" font-size="22" fill="#52616f">A GPU is only the starting point; Taiwan's supply chain turns it into deployable data-center hardware.</text>
+  <text x="94" y="138" font-family="Noto Sans TC, Arial, sans-serif" font-size="22" fill="#52616f">A GPU is only the starting point.</text>
+  <text x="94" y="170" font-family="Noto Sans TC, Arial, sans-serif" font-size="22" fill="#52616f">Taiwan's supply chain turns it into deployable data-center hardware.</text>
   <g filter="url(#shadow)">
     <rect x="110" y="205" width="1180" height="560" rx="28" fill="#ffffff"/>
   </g>
   <g font-family="Noto Sans TC, Arial, sans-serif">
-    <g transform="translate(180 255)">
-      <rect width="1040" height="72" rx="16" fill="#dceef3"/>
-      <text x="32" y="45" font-size="26" font-weight="700" fill="#214756">Chips and Accelerators</text>
-      <text x="430" y="45" font-size="21" fill="#45616c">GPU / CPU / HBM / high-speed I/O form the compute core.</text>
+    <g transform="translate(180 245)">
+      <rect width="1040" height="86" rx="16" fill="#dceef3"/>
+      <text x="32" y="52" font-size="24" font-weight="700" fill="#214756">Chips and Accelerators</text>
+      <text x="455" y="37" font-size="18" fill="#45616c">GPU / CPU / HBM / high-speed I/O</text>
+      <text x="455" y="62" font-size="18" fill="#45616c">form the compute core.</text>
     </g>
     <g transform="translate(180 348)">
-      <rect width="1040" height="72" rx="16" fill="#e5edf7"/>
-      <text x="32" y="45" font-size="26" font-weight="700" fill="#283f63">Boards and Motherboards</text>
-      <text x="430" y="45" font-size="21" fill="#4e6178">Connect chips, power, signals, and memory into a working system.</text>
+      <rect width="1040" height="86" rx="16" fill="#e5edf7"/>
+      <text x="32" y="52" font-size="24" font-weight="700" fill="#283f63">Boards and Motherboards</text>
+      <text x="455" y="37" font-size="18" fill="#4e6178">Connect chips, power, signals, and memory</text>
+      <text x="455" y="62" font-size="18" fill="#4e6178">into a working system.</text>
     </g>
-    <g transform="translate(180 441)">
-      <rect width="1040" height="72" rx="16" fill="#e9f2e6"/>
-      <text x="32" y="45" font-size="26" font-weight="700" fill="#31553a">Power and Cooling</text>
-      <text x="430" y="45" font-size="21" fill="#526a55">High-power machines need stable power, liquid cooling, fans, and heat control.</text>
+    <g transform="translate(180 451)">
+      <rect width="1040" height="86" rx="16" fill="#e9f2e6"/>
+      <text x="32" y="52" font-size="24" font-weight="700" fill="#31553a">Power and Cooling</text>
+      <text x="455" y="37" font-size="18" fill="#526a55">High-power machines need stable power,</text>
+      <text x="455" y="62" font-size="18" fill="#526a55">liquid cooling, fans, and heat control.</text>
     </g>
-    <g transform="translate(180 534)">
-      <rect width="1040" height="72" rx="16" fill="#f4ead8"/>
-      <text x="32" y="45" font-size="26" font-weight="700" fill="#65491d">Servers and Racks</text>
-      <text x="430" y="45" font-size="21" fill="#715d3f">ODM / EMS teams integrate parts into deliverable, serviceable systems.</text>
+    <g transform="translate(180 554)">
+      <rect width="1040" height="86" rx="16" fill="#f4ead8"/>
+      <text x="32" y="52" font-size="24" font-weight="700" fill="#65491d">Servers and Racks</text>
+      <text x="455" y="37" font-size="18" fill="#715d3f">ODM / EMS teams integrate parts into</text>
+      <text x="455" y="62" font-size="18" fill="#715d3f">deliverable, serviceable systems.</text>
     </g>
-    <g transform="translate(180 627)">
-      <rect width="1040" height="72" rx="16" fill="#eee7f3"/>
-      <text x="32" y="45" font-size="26" font-weight="700" fill="#4f3f63">Data Centers</text>
-      <text x="430" y="45" font-size="21" fill="#695d75">Only inside the machine room do racks become the body behind cloud services.</text>
+    <g transform="translate(180 657)">
+      <rect width="1040" height="86" rx="16" fill="#eee7f3"/>
+      <text x="32" y="52" font-size="24" font-weight="700" fill="#4f3f63">Data Centers</text>
+      <text x="455" y="37" font-size="18" fill="#695d75">Only inside the machine room do racks become</text>
+      <text x="455" y="62" font-size="18" fill="#695d75">the body behind cloud services.</text>
     </g>
   </g>
   <g fill="none" stroke="#6b8791" stroke-width="4" stroke-linecap="round">
-    <path d="M700 330v14"/>
-    <path d="M700 423v14"/>
-    <path d="M700 516v14"/>
-    <path d="M700 609v14"/>
+    <path d="M700 334v10"/>
+    <path d="M700 437v10"/>
+    <path d="M700 540v10"/>
+    <path d="M700 643v10"/>
   </g>
   <g font-family="Noto Sans TC, Arial, sans-serif" font-size="18" fill="#6b7280">
-    <text x="176" y="804">Taiwan.md Contributors self-made diagram. This explains supply-chain layers, not a complete company map or market share.</text>
+    <text x="176" y="804">Taiwan.md Contributors self-made diagram. This explains supply-chain layers,</text>
+    <text x="176" y="828">not a complete company map or market share.</text>
   </g>
 </svg>

--- a/public/article-images/technology/ai-supply-chain-overseas-footprint-en.svg
+++ b/public/article-images/technology/ai-supply-chain-overseas-footprint-en.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="720" viewBox="0 0 1200 720" role="img" aria-labelledby="title desc">
+  <title id="title">AI Supply Chain Overseas Manufacturing Roadmap</title>
+  <desc id="desc">A diagram showing how Taiwan's AI hardware supply chain extends from domestic core capabilities toward the United States, Japan, Europe, Mexico, Southeast Asia, India, and data-center markets.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#f7fbfc"/>
+      <stop offset="1" stop-color="#edf3f4"/>
+    </linearGradient>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2 2 L10 6 L2 10 Z" fill="#527174"/>
+    </marker>
+    <style>
+      .title { font: 700 34px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
+      .subtitle { font: 400 17px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
+      .label { font: 700 21px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
+      .small { font: 400 15px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #4d6366; }
+      .tiny { font: 400 13px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
+      .node { fill: #ffffff; stroke: #c7d9dc; stroke-width: 2; rx: 20; }
+      .core { fill: #123f46; stroke: #123f46; }
+      .coreText { fill: #ffffff; }
+      .chip { fill: #d7ebe9; stroke: #84adae; stroke-width: 1.5; rx: 10; }
+      .line { fill: none; stroke: #527174; stroke-width: 3; marker-end: url(#arrow); }
+      .softLine { fill: none; stroke: #9eb9bb; stroke-width: 2; stroke-dasharray: 8 8; marker-end: url(#arrow); }
+      .band { fill: #e4eff0; stroke: #c4d8da; stroke-width: 1.5; rx: 16; }
+    </style>
+  </defs>
+
+  <rect width="1200" height="720" fill="url(#bg)"/>
+  <text class="title" x="72" y="68">Taiwan's AI Supply Chain Goes Abroad by Many Routes</text>
+  <text class="subtitle" x="72" y="101">Fabs, packaging, servers, power, cooling, and facilities know-how are pulled to different places by customers and governments.</text>
+
+  <rect class="node core" x="450" y="256" width="300" height="194" rx="24"/>
+  <text class="label coreText" x="600" y="304" text-anchor="middle">Taiwan Core</text>
+  <text class="small coreText" x="600" y="338" text-anchor="middle">Process yield / packaging know-how</text>
+  <text class="small coreText" x="600" y="366" text-anchor="middle">Supplier density / engineering teamwork</text>
+  <text class="small coreText" x="600" y="394" text-anchor="middle">Fast problem-solving / customer trust</text>
+
+  <rect class="node" x="66" y="168" width="270" height="146" rx="20"/>
+  <text class="label" x="201" y="211" text-anchor="middle">United States</text>
+  <text class="small" x="201" y="244" text-anchor="middle">AI chips, servers, racks</text>
+  <text class="small" x="201" y="271" text-anchor="middle">Near cloud and security markets</text>
+
+  <rect class="node" x="64" y="420" width="274" height="146" rx="20"/>
+  <text class="label" x="201" y="463" text-anchor="middle">Mexico / SE Asia / India</text>
+  <text class="small" x="201" y="496" text-anchor="middle">Assembly, parts, backup capacity</text>
+  <text class="small" x="201" y="523" text-anchor="middle">Tariff and single-point risk hedging</text>
+
+  <rect class="node" x="864" y="168" width="270" height="146" rx="20"/>
+  <text class="label" x="999" y="211" text-anchor="middle">Japan / Europe</text>
+  <text class="small" x="999" y="244" text-anchor="middle">Auto, industrial, materials, tools</text>
+  <text class="small" x="999" y="271" text-anchor="middle">Reconnect supply to allied markets</text>
+
+  <rect class="node" x="862" y="420" width="274" height="146" rx="20"/>
+  <text class="label" x="999" y="463" text-anchor="middle">Data-Center Markets</text>
+  <text class="small" x="999" y="496" text-anchor="middle">Power, cooling, networking, ops</text>
+  <text class="small" x="999" y="523" text-anchor="middle">Hardware finally enters the cloud</text>
+
+  <path class="line" d="M450 318 C380 285 360 244 336 232"/>
+  <path class="line" d="M450 401 C374 435 364 489 338 493"/>
+  <path class="line" d="M750 318 C821 282 835 244 864 232"/>
+  <path class="line" d="M750 401 C824 433 836 489 862 493"/>
+
+  <rect class="band" x="402" y="528" width="396" height="98" rx="16"/>
+  <text class="label" x="600" y="565" text-anchor="middle">One Question, Four Pulls</text>
+  <text class="tiny" x="600" y="594" text-anchor="middle">Firms want orders, governments want security, local communities want jobs, and customers want controllable backups.</text>
+
+  <path class="softLine" d="M600 450 L600 528"/>
+
+  <rect class="chip" x="472" y="168" width="118" height="44" rx="10"/>
+  <text class="tiny" x="531" y="196" text-anchor="middle">Advanced nodes</text>
+  <rect class="chip" x="610" y="168" width="118" height="44" rx="10"/>
+  <text class="tiny" x="669" y="196" text-anchor="middle">Adv. packaging</text>
+  <rect class="chip" x="472" y="478" width="118" height="44" rx="10"/>
+  <text class="tiny" x="531" y="506" text-anchor="middle">AI servers</text>
+  <rect class="chip" x="610" y="478" width="118" height="44" rx="10"/>
+  <text class="tiny" x="669" y="506" text-anchor="middle">Power / cooling</text>
+
+  <text class="tiny" x="72" y="670">Taiwan.md Contributors self-made diagram. Arrows show capability and manufacturing-pressure directions, not complete company distribution or capacity share.</text>
+</svg>

--- a/public/article-images/technology/ai-supply-chain-overseas-footprint-en.svg
+++ b/public/article-images/technology/ai-supply-chain-overseas-footprint-en.svg
@@ -15,6 +15,7 @@
       .label { font: 700 21px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
       .small { font: 400 15px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #4d6366; }
       .tiny { font: 400 13px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
+      .caption { font: 400 12px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
       .node { fill: #ffffff; stroke: #c7d9dc; stroke-width: 2; rx: 20; }
       .core { fill: #123f46; stroke: #123f46; }
       .coreText { fill: #ffffff; }
@@ -26,8 +27,9 @@
   </defs>
 
   <rect width="1200" height="720" fill="url(#bg)"/>
-  <text class="title" x="72" y="68">Taiwan's AI Supply Chain Goes Abroad by Many Routes</text>
-  <text class="subtitle" x="72" y="101">Fabs, packaging, servers, power, cooling, and facilities know-how are pulled to different places by customers and governments.</text>
+  <text class="title" x="72" y="68">Taiwan's AI Supply Chain Abroad</text>
+  <text class="subtitle" x="72" y="101">Fabs, packaging, servers, power, cooling, and facilities know-how</text>
+  <text class="subtitle" x="72" y="126">are pulled to different places by customers and governments.</text>
 
   <rect class="node core" x="450" y="256" width="300" height="194" rx="24"/>
   <text class="label coreText" x="600" y="304" text-anchor="middle">Taiwan Core</text>
@@ -60,9 +62,10 @@
   <path class="line" d="M750 318 C821 282 835 244 864 232"/>
   <path class="line" d="M750 401 C824 433 836 489 862 493"/>
 
-  <rect class="band" x="402" y="528" width="396" height="98" rx="16"/>
-  <text class="label" x="600" y="565" text-anchor="middle">One Question, Four Pulls</text>
-  <text class="tiny" x="600" y="594" text-anchor="middle">Firms want orders, governments want security, local communities want jobs, and customers want controllable backups.</text>
+  <rect class="band" x="386" y="526" width="428" height="112" rx="16"/>
+  <text class="label" x="600" y="562" text-anchor="middle">One Question, Four Pulls</text>
+  <text class="tiny" x="600" y="590" text-anchor="middle">Firms want orders; governments want security.</text>
+  <text class="tiny" x="600" y="612" text-anchor="middle">Communities want jobs; customers want backup capacity.</text>
 
   <path class="softLine" d="M600 450 L600 528"/>
 
@@ -75,5 +78,6 @@
   <rect class="chip" x="610" y="478" width="118" height="44" rx="10"/>
   <text class="tiny" x="669" y="506" text-anchor="middle">Power / cooling</text>
 
-  <text class="tiny" x="72" y="670">Taiwan.md Contributors self-made diagram. Arrows show capability and manufacturing-pressure directions, not complete company distribution or capacity share.</text>
+  <text class="caption" x="72" y="670">Taiwan.md Contributors self-made diagram. Arrows show capability and manufacturing-pressure directions,</text>
+  <text class="caption" x="72" y="688">not complete company distribution or capacity share.</text>
 </svg>

--- a/public/article-images/technology/ai-supply-chain-overseas-footprint.svg
+++ b/public/article-images/technology/ai-supply-chain-overseas-footprint.svg
@@ -10,11 +10,12 @@
       <path d="M2 2 L10 6 L2 10 Z" fill="#527174"/>
     </marker>
     <style>
-      .title { font: 700 34px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
-      .subtitle { font: 400 17px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
-      .label { font: 700 21px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
-      .small { font: 400 15px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #4d6366; }
-      .tiny { font: 400 13px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
+      .title { font: 700 38px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
+      .subtitle { font: 400 19px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
+      .label { font: 700 23px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #20393c; }
+      .small { font: 400 16px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #4d6366; }
+      .tiny { font: 400 14px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
+      .caption { font: 400 13px system-ui, -apple-system, BlinkMacSystemFont, "Noto Sans TC", sans-serif; fill: #607275; }
       .node { fill: #ffffff; stroke: #c7d9dc; stroke-width: 2; rx: 20; }
       .core { fill: #123f46; stroke: #123f46; }
       .coreText { fill: #ffffff; }
@@ -60,11 +61,12 @@
   <path class="line" d="M750 318 C821 282 835 244 864 232"/>
   <path class="line" d="M750 401 C824 433 836 489 862 493"/>
 
-  <rect class="band" x="402" y="528" width="396" height="98" rx="16"/>
-  <text class="label" x="600" y="565" text-anchor="middle">同一個問題，四種拉力</text>
-  <text class="tiny" x="600" y="594" text-anchor="middle">企業要訂單，政府要安全，地方要工作與基礎設施，客戶要可控的備援。</text>
+  <rect class="band" x="386" y="540" width="428" height="102" rx="18"/>
+  <text class="label" x="600" y="577" text-anchor="middle">同一個問題，四種拉力</text>
+  <text class="tiny" x="600" y="607" text-anchor="middle">企業要訂單，政府要安全，地方要工作與基礎設施，</text>
+  <text class="tiny" x="600" y="629" text-anchor="middle">客戶要可控的備援。</text>
 
-  <path class="softLine" d="M600 450 L600 528"/>
+  <path class="softLine" d="M600 450 L600 540"/>
 
   <rect class="chip" x="472" y="168" width="118" height="44" rx="10"/>
   <text class="tiny" x="531" y="196" text-anchor="middle">先進製程</text>
@@ -75,5 +77,6 @@
   <rect class="chip" x="610" y="478" width="118" height="44" rx="10"/>
   <text class="tiny" x="669" y="506" text-anchor="middle">電源散熱</text>
 
-  <text class="tiny" x="72" y="670">Taiwan.md Contributors 自製示意圖。箭頭表示供應鏈能力與設廠壓力的方向，不代表完整公司分布或產能比例。</text>
+  <text class="caption" x="72" y="682">Taiwan.md Contributors 自製示意圖。箭頭表示供應鏈能力與設廠壓力的方向，</text>
+  <text class="caption" x="72" y="700">不代表完整公司分布或產能比例。</text>
 </svg>

--- a/public/article-images/technology/reclaimed-water-semiconductor-loop-en.svg
+++ b/public/article-images/technology/reclaimed-water-semiconductor-loop-en.svg
@@ -2,8 +2,9 @@
   <title id="title">Reclaimed water and semiconductor manufacturing loop</title>
   <desc id="desc">A diagram showing how reservoir water, urban wastewater, reclaimed water plants, fabs and wastewater treatment form a water governance loop.</desc>
   <rect width="1400" height="900" fill="#f4f8fa"/>
-  <text x="88" y="92" font-family="Noto Sans TC, Arial, sans-serif" font-size="42" font-weight="700" fill="#1f2937">Reclaimed Water Links Fabs Back to the City Water Loop</text>
-  <text x="90" y="138" font-family="Noto Sans TC, Arial, sans-serif" font-size="22" fill="#52616f">Semiconductor water use is not one pipe; it is a loop of reservoirs, urban sewage, reclaimed-water plants, fabs, and local governance.</text>
+  <text x="88" y="92" font-family="Noto Sans TC, Arial, sans-serif" font-size="40" font-weight="700" fill="#1f2937">Reclaimed Water and Semiconductor Fabs</text>
+  <text x="90" y="136" font-family="Noto Sans TC, Arial, sans-serif" font-size="20" fill="#52616f">Semiconductor water use is a loop of reservoirs, urban sewage,</text>
+  <text x="90" y="164" font-family="Noto Sans TC, Arial, sans-serif" font-size="20" fill="#52616f">reclaimed-water plants, fabs, and local governance.</text>
   <defs>
     <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
       <path d="M2,2 L10,6 L2,10 Z" fill="#4f7f9a"/>
@@ -14,20 +15,21 @@
   </defs>
   <g font-family="Noto Sans TC, Arial, sans-serif" filter="url(#shadow)">
     <rect x="135" y="250" width="260" height="132" rx="22" fill="#d9ecf4"/>
-    <text x="181" y="307" font-size="28" font-weight="700" fill="#23495a">Reservoirs / Rivers</text>
-    <text x="178" y="345" font-size="19" fill="#52616f">Rain, drought, dispatch</text>
+    <text x="265" y="306" font-size="24" font-weight="700" fill="#23495a" text-anchor="middle">Reservoirs / Rivers</text>
+    <text x="265" y="344" font-size="17" fill="#52616f" text-anchor="middle">Rain, drought, dispatch</text>
     <rect x="570" y="215" width="260" height="132" rx="22" fill="#e6f0df"/>
-    <text x="622" y="272" font-size="28" font-weight="700" fill="#3d5b2e">Urban Sewage</text>
-    <text x="617" y="310" font-size="19" fill="#52616f">Sewers and treatment</text>
+    <text x="700" y="272" font-size="24" font-weight="700" fill="#3d5b2e" text-anchor="middle">Urban Sewage</text>
+    <text x="700" y="310" font-size="17" fill="#52616f" text-anchor="middle">Sewers and treatment</text>
     <rect x="1005" y="250" width="260" height="132" rx="22" fill="#dbe7f6"/>
-    <text x="1042" y="307" font-size="28" font-weight="700" fill="#284366">Reclaimed-Water Plants</text>
-    <text x="1038" y="345" font-size="19" fill="#52616f">Stable quality and pipelines</text>
+    <text x="1135" y="301" font-size="23" font-weight="700" fill="#284366" text-anchor="middle">Reclaimed-Water</text>
+    <text x="1135" y="329" font-size="23" font-weight="700" fill="#284366" text-anchor="middle">Plants</text>
+    <text x="1135" y="359" font-size="17" fill="#52616f" text-anchor="middle">Stable quality and pipelines</text>
     <rect x="786" y="562" width="300" height="142" rx="24" fill="#f2e7d5"/>
-    <text x="842" y="624" font-size="28" font-weight="700" fill="#63491f">Fabs</text>
-    <text x="833" y="665" font-size="19" fill="#52616f">Ultrapure, reuse, wastewater</text>
+    <text x="936" y="624" font-size="24" font-weight="700" fill="#63491f" text-anchor="middle">Fabs</text>
+    <text x="936" y="665" font-size="17" fill="#52616f" text-anchor="middle">Ultrapure, reuse, wastewater</text>
     <rect x="280" y="562" width="300" height="142" rx="24" fill="#eadfee"/>
-    <text x="330" y="624" font-size="28" font-weight="700" fill="#564063">Local Governance</text>
-    <text x="325" y="665" font-size="19" fill="#52616f">Data, contracts, drought response</text>
+    <text x="430" y="624" font-size="24" font-weight="700" fill="#564063" text-anchor="middle">Local Governance</text>
+    <text x="430" y="665" font-size="17" fill="#52616f" text-anchor="middle">Data, contracts, drought response</text>
   </g>
   <g fill="none" stroke="#4f7f9a" stroke-width="6" marker-end="url(#arrow)">
     <path d="M395 310 C465 260, 500 260, 570 280"/>
@@ -36,5 +38,6 @@
     <path d="M786 637 C690 660, 660 660, 580 638"/>
     <path d="M426 562 C352 505, 305 448, 270 382"/>
   </g>
-  <text x="88" y="820" font-family="Noto Sans TC, Arial, sans-serif" font-size="18" fill="#6b7280">Taiwan.md Contributors self-made diagram. This explains a water-governance loop, not a specific fab-site engineering plan.</text>
+  <text x="88" y="820" font-family="Noto Sans TC, Arial, sans-serif" font-size="18" fill="#6b7280">Taiwan.md Contributors self-made diagram. This explains a water-governance loop,</text>
+  <text x="88" y="844" font-family="Noto Sans TC, Arial, sans-serif" font-size="18" fill="#6b7280">not a specific fab-site engineering plan.</text>
 </svg>

--- a/public/article-images/technology/reclaimed-water-semiconductor-loop-en.svg
+++ b/public/article-images/technology/reclaimed-water-semiconductor-loop-en.svg
@@ -1,0 +1,40 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="900" viewBox="0 0 1400 900" role="img" aria-labelledby="title desc">
+  <title id="title">Reclaimed water and semiconductor manufacturing loop</title>
+  <desc id="desc">A diagram showing how reservoir water, urban wastewater, reclaimed water plants, fabs and wastewater treatment form a water governance loop.</desc>
+  <rect width="1400" height="900" fill="#f4f8fa"/>
+  <text x="88" y="92" font-family="Noto Sans TC, Arial, sans-serif" font-size="42" font-weight="700" fill="#1f2937">Reclaimed Water Links Fabs Back to the City Water Loop</text>
+  <text x="90" y="138" font-family="Noto Sans TC, Arial, sans-serif" font-size="22" fill="#52616f">Semiconductor water use is not one pipe; it is a loop of reservoirs, urban sewage, reclaimed-water plants, fabs, and local governance.</text>
+  <defs>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M2,2 L10,6 L2,10 Z" fill="#4f7f9a"/>
+    </marker>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="8" stdDeviation="9" flood-color="#1f2937" flood-opacity="0.12"/>
+    </filter>
+  </defs>
+  <g font-family="Noto Sans TC, Arial, sans-serif" filter="url(#shadow)">
+    <rect x="135" y="250" width="260" height="132" rx="22" fill="#d9ecf4"/>
+    <text x="181" y="307" font-size="28" font-weight="700" fill="#23495a">Reservoirs / Rivers</text>
+    <text x="178" y="345" font-size="19" fill="#52616f">Rain, drought, dispatch</text>
+    <rect x="570" y="215" width="260" height="132" rx="22" fill="#e6f0df"/>
+    <text x="622" y="272" font-size="28" font-weight="700" fill="#3d5b2e">Urban Sewage</text>
+    <text x="617" y="310" font-size="19" fill="#52616f">Sewers and treatment</text>
+    <rect x="1005" y="250" width="260" height="132" rx="22" fill="#dbe7f6"/>
+    <text x="1042" y="307" font-size="28" font-weight="700" fill="#284366">Reclaimed-Water Plants</text>
+    <text x="1038" y="345" font-size="19" fill="#52616f">Stable quality and pipelines</text>
+    <rect x="786" y="562" width="300" height="142" rx="24" fill="#f2e7d5"/>
+    <text x="842" y="624" font-size="28" font-weight="700" fill="#63491f">Fabs</text>
+    <text x="833" y="665" font-size="19" fill="#52616f">Ultrapure, reuse, wastewater</text>
+    <rect x="280" y="562" width="300" height="142" rx="24" fill="#eadfee"/>
+    <text x="330" y="624" font-size="28" font-weight="700" fill="#564063">Local Governance</text>
+    <text x="325" y="665" font-size="19" fill="#52616f">Data, contracts, drought response</text>
+  </g>
+  <g fill="none" stroke="#4f7f9a" stroke-width="6" marker-end="url(#arrow)">
+    <path d="M395 310 C465 260, 500 260, 570 280"/>
+    <path d="M830 280 C905 260, 935 270, 1005 310"/>
+    <path d="M1130 382 C1120 490, 1050 540, 1000 562"/>
+    <path d="M786 637 C690 660, 660 660, 580 638"/>
+    <path d="M426 562 C352 505, 305 448, 270 382"/>
+  </g>
+  <text x="88" y="820" font-family="Noto Sans TC, Arial, sans-serif" font-size="18" fill="#6b7280">Taiwan.md Contributors self-made diagram. This explains a water-governance loop, not a specific fab-site engineering plan.</text>
+</svg>


### PR DESCRIPTION
## What this PR does

This PR follows up on the merged AI hardware supply-chain series and fixes the SVG media assets used by the Chinese and English articles.

The original series added self-made SVG diagrams. After review, the English articles were still pointing at Chinese-language SVGs, and the newly split English SVGs needed their own layout instead of simply reusing the Chinese text positions. One Chinese diagram also had a small layout issue when rendered inside the article column.

## Changes

- Add English SVG variants for the AI hardware series:
  - `ai-hardware-supply-chain-flow-en.svg`
  - `ai-server-rack-stack-en.svg`
  - `ai-supply-chain-overseas-footprint-en.svg`
  - `reclaimed-water-semiconductor-loop-en.svg`
- Update English articles to reference the English SVGs instead of the Chinese originals.
- Reflow English SVG text with shorter titles, explicit multi-line labels, and adjusted row spacing.
- Refine the Chinese overseas manufacturing roadmap SVG:
  - slightly larger text hierarchy
  - more spacing between the lower chips and the "four pulls" panel
  - multi-line caption

## Why this matters

SVG text does not automatically wrap. Simply translating the visible text while keeping the Chinese layout can cause labels to overflow, collide, or become unreadable when the image is scaled inside the article. This PR keeps Chinese and English diagrams as separate source files so each language can have its own readable layout.

## Validation

Ran:

```bash
xmllint --noout public/article-images/technology/ai-hardware-supply-chain-flow-en.svg \
  public/article-images/technology/ai-server-rack-stack-en.svg \
  public/article-images/technology/ai-supply-chain-overseas-footprint-en.svg \
  public/article-images/technology/reclaimed-water-semiconductor-loop-en.svg \
  public/article-images/technology/ai-supply-chain-overseas-footprint.svg
```

Also checked that the English SVGs no longer contain visible Chinese text or Chinese punctuation.
