### PR TITLE
translate(es): 補完 es 相對 zh 的最後 10 篇缺口（es 覆蓋率 → 100%）

### DIFF
--- a/knowledge/es/Culture/shopping-design.md
+++ b/knowledge/es/Culture/shopping-design.md
@@ -1,0 +1,233 @@
+---
+translatedFrom: 'Culture/Shopping Design.md'
+sourceCommitSha: '17b63fe8'
+sourceContentHash: 'sha256:5d83fb5eff7a2309'
+sourceBodyHash: 'sha256:da4269ea46f7ec77'
+translatedAt: '2026-07-24T00:40:00+08:00'
+lang: 'es'
+title: 'Shopping Design: la revista que enseña a comprar diseño y que al final te pide distinguirla a ella misma'
+description: 'Fundada en 2006 y con el blanco como tema de su primer número, «Shopping Design» ha convertido en veinte años el diseño de un sustantivo de sala de exposiciones en un verbo cotidiano: recorrer tiendas y elegir objetos. Lo que de verdad le ha enseñado a Taiwán es que «distinguir» puede entrenarse como una capacidad; y ha extendido esa capacidad hasta una lista anual de los cien mejores, una revista trimestral y un festival, y también hasta la misma licencia de su empresa matriz, que dice a la vez «edición de revistas» y «servicios de publicidad». Así, la revista que enseña a distinguir acaba pidiéndote que la distingas a ella.'
+date: 2026-07-13
+category: 'Culture'
+tags:
+  - 'diseño'
+  - 'Shopping Design'
+  - 'revista de compra de diseño'
+  - 'Huang Wei-jung'
+  - 'Li Hui-chen'
+  - 'medios de estilo de vida'
+  - 'Business Next Media'
+  - 'alfabetización mediática'
+subcategory: 'Diseño y medios'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-13
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/Shopping-Design.md'
+viewpoint_formed: true
+spine_type: '立體群像'
+image: '/article-images/culture/shopping-design-designbiz-2022-banner.jpg'
+imageCredit: 'Shopping Design／DesignBIZ Fest'
+imageLicense: 'Fair use (editorial commentary)'
+imageSource: 'https://designbiz.shoppingdesign.com.tw/2022/'
+rationale:
+  why_this_hook: 'La portada blanca del primer número frente a la de «comprar diseño blanco» del número 100: el mismo blanco once años después, más dos palabras, «comprar» = convertir el gusto en una acción = distinguir. Cálido, concreto y con suspense (lo último que hay que distinguir es la propia revista), sin dejar cocido de antemano el «gotcha».'
+  whats_excluded: 'La línea oculta de Liao Li-wen queda en nota y no se despliega; los episodios concretos del pódcast se comprimen en «los tentáculos se extienden al sonido»; la lista de ponentes de DesignBIZ se comprime en «toda una fila de altos cargos de marcas», con los puestos en nota; de la lista de consejeros de la matriz solo se conserva la prueba del argumento de servicio, «edición de revistas + servicios de publicidad en una misma licencia»; las sesiones de Design+ y la Escuela de Economía del Estilo se funden en la frase de la «ampliación del mecanismo».'
+  where_it_hedges: 'Para la conversión en trimestral se escriben dos fechas: «reforma de finales de 2019 + primer número trimestral, el 134, en marzo de 2020». Para el Golden Tripod se escribe «premio al editor jefe de la categoría individual de revistas de la 40.ª edición (2016)» y no «mejor». El «abrir los cinco sentidos y saber catar» de Huang Wei-jung procede de un publirreportaje de whisky marcado como is_ads, así que se usa material verificado del propio autor y el publirreportaje se coloca en un párrafo sombreado como caso, señalando con honestidad que es publicidad. De «la avanzadilla del nacimiento de las revistas blandas» solo se citan seis caracteres, y La Vie/PPAPER 2004 se cuenta en frase narrativa. La cita de Chan Hung-chih se marca como «referida por Li Hui-chen». De Little Things se escribe «después no se ha visto ningún número nuevo». De SD se escribe «uno de los pocos casos que han llegado hasta hoy». El número de categorías de BEST100 cambia cada año (9/10/11) y no es un premio oficial. Al no verificarse quién ocupa hoy la dirección editorial se usa «editora Yi-hsin, subeditora Ya-yun».'
+  whos_pushing_back: 'La objeción más razonable a los medios de estilo de vida es si envuelven el consumo como vida ideal. Este texto no inventa críticas externas (no se ha verificado ninguna polémica pública que pueda sostener esa acusación); solo plantea preguntas estructurales, recoge la autocrítica del sector (el subdirector Pao Shu-ping hablando de la ética del publirreportaje) y describe la estructura industrial (La Vie también organiza sus propios premios; comparte con Business Next Media el origen en Chan Hung-chih), sin elevarlo a polémica ya ocurrida ni escribir que alguien haya usado la teoría de Bourdieu para criticar a SD.'
+relatedDiary:
+  - 2026-07-13-214351-manual
+---
+
+> **Resumen en 30 segundos:** Shopping Design (設計採買誌) se fundó en 2006 y lo que ha hecho durante veinte años es convertir el «diseño» de término profesional de sala de exposiciones en algo cotidiano: cómo recorre la gente corriente las tiendas, elige objetos y lee una ciudad. Pero lo que de verdad le ha enseñado a Taiwán es que «distinguir» puede entrenarse como una capacidad: ver en qué se diferencian este blanco y aquel otro, y saber decir por qué. Ha ido ampliando cada vez más esa acción de «distinguir por ti», de una revista a una lista anual de cien, a temas trimestrales y a un festival del diseño; y la ha extendido también a la licencia de su empresa matriz, que por un lado dice edición de revistas y por otro servicios de publicidad. Así, el objeto que esta revista que enseña a distinguir acaba pidiéndote que distingas es ella misma.
+
+## Dos portadas blancas separadas por once años
+
+En diciembre de 2006 apareció en las estanterías de las librerías taiwanesas una revista llamada «Shopping Design», y el tema de su primer número era el diseño blanco. Once años después, en marzo de 2017, llegó al número 100 y la portada volvió al blanco, solo que esta vez el tema traía dos palabras más: «comprar diseño blanco»[^1].
+
+El mismo blanco, once años después, y lo que se ha añadido es «comprar». Esas dos palabras parecen un término de marketing, pero esconden en realidad el corazón de toda la revista. El blanco en sí no es bueno ni malo: una pared blanca, una hoja de papel blanca, una camisa blanca; la diferencia no está en el blanco, sino en si eres capaz de ver en qué se diferencia este blanco de aquel y por qué este merece llevárselo a casa. «Comprar» convierte algo muy abstracto, el gusto, en una acción muy concreta: distinguir.
+
+Eso es lo que la revista lleva veinte años haciendo y rara vez se dice con todas las letras. Se llama «comprar diseño» y suena a que va a enseñarte a comprar cosas; pero lo que en realidad vende no ha sido nunca una silla o una cafetería concretas, sino la capacidad de «distinguir»: ver la diferencia y saber decir por qué. Y en cuanto la practicas veinte años siguiéndola, descubres que el objeto que más necesitas sacar a distinguir al final es precisamente la propia revista.
+
+No corras a preguntar por qué. Mira primero de qué dos manos salió originalmente este oficio de «distinguir».
+
+## Dos personas venidas de la publicidad para enseñarte a mirar
+
+Quien la creó se llama Huang Wei-jung y aquel año no llegaba a los cuarenta. No venía de una escuela de diseño: venía de la publicidad. «Mi primer trabajo fue de redactor en una agencia de publicidad, y aquella fue la última gran época dorada de la publicidad taiwanesa», recordaba así su punto de partida en una entrevista[^2]. Aquella agencia se llamaba Ideology y su jefe directo era la directora creativa Hsu Shun-ying. «El jefe directo de mi primer trabajo fue la señorita Hsu Shun-ying, directora creativa de la agencia Ideology». Años después diría que esa experiencia «le influye hasta hoy»[^2]. Ideology fue la agencia taiwanesa de los años noventa que mejor sabía contar historias con palabras, y quien trabajaba allí de redactor entrenaba justamente una destreza: coger algo corriente y saber decir por qué no es corriente.
+
+En el otoño de 1998, junto a sus amigos Ma Shih-fang, Yao Jui-chung, Hsu Yun-pin y Chen Kuang-ta, hizo el libro «Cien razones para sobrevivir en Taipéi», publicado por Locus Publishing. Era un libro que volvía a mirar y a escribir los rincones más cotidianos de la ciudad: las esquinas, los rótulos, la comida callejera, los autobuses. «Algo tan romántico como esto solo pasa una vez en la vida», escribiría después sobre aquella colaboración[^3]. Ese libro hizo que mucha gente lo conociera y lo transformó de redactor publicitario en un editor que organiza imagen y texto para volver a mirar el mundo en nombre del lector. Él mismo divide sus treinta años de creación en tres tramos: primero la redacción publicitaria y la escritura editorial; después la edición de revistas y la integración de imagen y texto; y por último los encargos mixtos de servicios creativos[^2]. Shopping Design cae justo al comienzo del segundo tramo.
+
+Así que en 2006 pasar a hacer una revista de diseño le encajaba bastante bien. Pero el nacimiento de esa revista no fue solo ideas: también fue negocio. Años después él mismo contó que la verdadera oportunidad de aquel verano fue un mensaje que llegó desde los canales de tiendas de conveniencia: «Ahora es muy difícil que suban más las ventas de las revistas "duras"; probad con temas "blandos"»[^4]. Lo «blando» eran temas de vida, viajes o diseño: ligeros de leer y bonitos de mirar. Él llama a La Vie y PPAPER, fundadas hacia 2004, «la avanzadilla del nacimiento de las revistas blandas», y Shopping Design apareció detrás de esa oleada[^4]. Que una revista que enseña a distinguir diseño fuera desde el primer día, a la vez, una idea y un negocio que tenía que venderse: ese doble origen se convertirá veinte años después en la pregunta final de todo este texto.
+
+Para entender con qué se legitima para enseñar a distinguir hay que ver qué hace un editor cada día. El trabajo de un editor, dicho sin rodeos, son tres acciones: poner un montón de cosas juntas y compararlas, ponerle un nombre a la diferencia, y maquetarlo para que tú lo entiendas. Cuando hace un número sobre cafeterías, pone en paralelo el filtrado y el espresso, la casa antigua y el blanco puro, el espacio para beber solo y el espacio para charlar en grupo, y señala para quién existe cada uno de esos silencios y bullicios, descomponiendo para ti las palabras «cafetería» en varias maneras distintas de vivir. Un número sobre hoteles, otro sobre el blanco, otro sobre «filtros»: cada número escoge un tema, despliega toda una categoría de cosas, señala y dice «esto merece la pena porque…», y luego lo ordena página a página.
+
+Cuando lo hojeas crees que estás mirando imágenes bonitas, pero en realidad te están entrenando la mirada página a página. Con el tiempo descubres que al ir de tiendas también empiezas a mirar así: ante dos objetos que parecen casi iguales te detienes, ves en qué se diferencian y sabes decir por qué te ha conmovido justamente uno de ellos. Esa capacidad de distinguir se entrena y se transmite así, página a página. Eso es lo que la revista te vende de verdad sin cobrártelo.
+
+Quien lo dijo con más claridad fue Li Hui-chen, la segunda directora editorial, que tomó el relevo de Huang Wei-jung. Se hizo cargo en 2011 y estuvo hasta 2017[^5]. Curiosamente, ella también venía de la publicidad: «Agradezco enormemente a la directora Hsu Li-wen que me dejara pasar de desertora del mundo publicitario a una planificadora que avanza con confianza», describe así su formación[^6]. Ella tradujo aquel oficio que Huang Wei-jung mantenía oculto en la maqueta a una frase que se entiende directamente: la revista debe recordarle al lector que viva «con conciencia», que elija y consuma con conciencia. «Con conciencia», en lenguaje llano, es distinguir: ver la diferencia y también poder preguntar por qué. Incluso refirió una frase de Chan Hung-chih: «Cuando lees cierto libro, puede que te conviertas en una persona solitaria…»[^6]. Cuanto más sabes, menos puedes volver a ser aquel que lo aceptaba todo sin más. En 2016 recibió junto a «Shopping Design» el premio al editor jefe de la categoría individual de revistas de la 40.ª edición de los Golden Tripod Awards[^7]; al año siguiente salió el número 100, y el tema que eligió fue precisamente volver a aquel blanco del primer número añadiéndole las palabras «comprar».
+
+> **📝 Nota de la curaduría**
+> Las dos personas que dirigieron sucesivamente esta revista se cruzan, en el fondo de sus currículos, en un mismo lugar: ambas salieron de la publicidad y ambas pasaron por las manos del mismo director editorial de Locus Publishing, Liao Li-wen[^6]. No hay que sobreinterpretarlo como una línea de discipulado, pero revela algo: el origen del método con que esta oleada taiwanesa de «revistas blandas» enseñó a mirar el diseño está en un grupo de personas formadas en publicidad, hábiles en encontrar un discurso para las cosas corrientes, que trasladaron esa destreza de vender cosas a enseñar a distinguirlas. El oficio de distinguir comparte de entrada los mismos músculos que el oficio de vender.
+
+La mirada que un editor entrena página a página cabe, en principio, en una sola revista. Lo que Shopping Design hizo en los veinte años siguientes fue ampliar vuelta a vuelta esa acción de «distinguir por ti».
+
+## Una revista no basta: listas, trimestral, festival
+
+Una revista mensual solo puede distinguir un tema cada vez. Así que empezó a hacer crecer esa misma acción hasta darle otras formas.
+
+Primero cambió de ritmo el propio papel. A finales de 2019, Shopping Design pasó de mensual a trimestral, y el primer número trimestral tras la reforma fue el 134, publicado en marzo de 2020[^8][^10]. Pasar a trimestral fue una división del trabajo deliberada: la web se encarga de lo rápido, de seguir las noticias y exposiciones que ocurren a diario en el mundo del diseño; el papel se encarga de lo lento, de dedicar tres meses por trimestre a pensar a fondo un tema. La propia redacción lo explicó así: el entorno cambia y los lectores también, y «si tiene que existir, queremos darle un poco más de valor», hacerlo «útil, interesante y significativo»[^9].
+
+```tw-versus
+Revista trimestral en papel | Web oficial
+Trabajo lento, un tema completo por trimestre | Mano rápida, persiguiendo la frescura de las noticias de diseño
+Un número dedica tres meses a pensar a fondo una sola cosa | Varias actualizaciones diarias de exposiciones y marcas
+Distinguir para ti una pregunta hasta el final | Enseñarte primero lo que está ocurriendo
+Fuente: redacción de Shopping Design, entrevista sobre la reforma en OKAPI (2019)
+```
+
+Al frenar, el papel convierte cada trimestre en un tema completo. En 2023 hizo «El habitante ideal», preguntando qué relación tiene en realidad una persona con el espacio en que vive[^11]; en 2024 hizo «Coleccionamos este diseño», preguntando por qué alguien quiere conservar un objeto a su lado[^11]. Lo que hace cada número es distinguir hasta el final y nombrar con claridad, en nombre de todo un grupo de personas, una pregunta de la vida que no se sabe formular. Es la versión ampliada del oficio de la fundación, solo que el tema ha pasado de un objeto a una manera de vivir.
+
+![Portada de Shopping Design Vol.147, «El habitante ideal»: un número trimestral en papel equivale a un tema vital completo](/article-images/culture/shopping-design-vol147-the-stay-cover.webp)
+_Vol.147, «El habitante ideal». Tras pasar a trimestral, el papel solo piensa a fondo una pregunta por trimestre. (Fair use, editorial commentary)_
+
+Distinguir para un grupo de personas tampoco basta: después pasa a distinguir para todo un año. Desde 2012, Shopping Design organiza cada año el Taiwan Design BEST100, que selecciona cien personas, hechos y objetos del diseño taiwanés del año y compone con ellos una lista anual[^12]. La función de esa lista es nombrar y archivar un año entero de diseño taiwanés: qué merece recordarse, qué ha definido ese año. La de 2019 se tituló «palabras clave de la fuerza del diseño» y repartió cien conjuntos de personas, hechos y objetos en nueve categorías, como personajes del año, hechos de diseño del año o cien paisajes humanísticos[^13]. Hizo para toda una industria lo que el primer número hizo para una portada blanca: comparar, elegir, nombrar. Con diez años acumulados, ese montón de personas, hechos y objetos seleccionados se ha convertido en el índice privado más parecido a una «historia oficial» del diseño taiwanés: sin respaldo gubernamental, pero tomado en silencio por todo un sector como coordenada del año.
+
+```tw-note
+Aclaración
+El Taiwan Design BEST100 es un premio mediático creado y juzgado por la propia redacción de Shopping Design, no un premio oficial de diseño organizado por el gobierno. El número de categorías incluso fluctúa cada año: 9 en 2019, 11 en 2021 y 10 entre 2024 y 2025; hasta el marco de clasificación se repiensa cada año. Que una lista que se llama a sí misma «anual» cambie cada año su propio esqueleto demuestra justamente que no es una evaluación mecánica con una fórmula fija, sino una redacción que vuelve a preguntarse cada año «con qué marco hay que mirar este año el diseño taiwanés».
+```
+
+![Portada de Shopping Design Vol.150, «Coleccionamos este diseño»: el número especial anual convierte «qué merece conservarse» en un ejercicio público de distinción](/article-images/culture/shopping-design-vol150-collection-cover.webp)
+_Vol.150, «Coleccionamos este diseño». La lista y el número especial son un ejercicio de distinción en nombre de todo un año del diseño taiwanés. (Fair use, editorial commentary)_
+
+Al final incluso sacó la distinción fuera del papel. Desde 2013 organiza los «Design+», que convierten la comparación y el nombrar de la maqueta en charlas y conversaciones presenciales; en 2016 creó la Escuela de Economía del Estilo y empezó a traducir la estética a un lenguaje comercial enseñable[^8]. En 2022, esa línea creció hasta el primer DesignBIZ Fest, un festival centrado en «el nuevo negocio del diseño»[^14]. La definición que le puso la organización es una serie de paralelismos: «El diseño es fuerza creativa, el diseño es fuerza de marketing, el diseño es fuerza cultural, el diseño es fuerza de planificación, el diseño es fuerza de integración: el diseño es fuerza vital»[^14]. Al escenario subió toda una fila de altos cargos de marcas, desde responsables de espacios compartidos hasta de motos eléctricas o cadenas de restauración[^15]. Sus tentáculos se extendieron también al sonido, llevando al oído con un pódcast las carreras de los diseñadores, las marcas y la revitalización local[^16]. Esa misma acción de «mirar por ti, elegir por ti» se había convertido ya, de una página maquetada, en todo un lenguaje comercial con entradas, con audiencia y con patrocinadores.
+
+![Ponentes del primer DesignBIZ Fest de 2022: el festival del diseño traduce el «distinguir por ti» a todo un lenguaje comercial](/article-images/culture/shopping-design-designbiz-2022-speaker.jpg)
+_Ponentes del DesignBIZ Fest de 2022. La distinción se traslada del papel al escenario, y de la estética al negocio. (Fair use, editorial commentary)_
+
+```tw-timeline
+La misma acción de «distinguir por ti», ampliada vuelta a vuelta durante veinte años
+2006 | Fundación de la revista | Nace en diciembre, primero mensual, distinguiendo para el lector una pregunta vital tras otra
+2012 | Nace la lista anual de los cien | Taiwan Design BEST100, que nombra y archiva un año entero de diseño taiwanés
+2013 | Las charlas aterrizan como encuentros | Arrancan los Design+, que trasladan la distinción del papel a la conversación presencial
+2016 | Se abren cursos de negocio | Se crea la Escuela de Economía del Estilo, que traduce la estética a lenguaje comercial enseñable
+2019 | El papel pasa a trimestral | Reforma de fin de año: el papel va a temas lentos y la web a noticias rápidas, en doble vía
+2022 | Se amplía a festival del sector | Primer DesignBIZ Fest, con toda una fila de altos cargos de marcas hablando del nuevo negocio del diseño
+2026 | El papel sigue saliendo | En abril llega al número 156: internet no lo ha sustituido
+Fuentes: «Trayectoria» oficial de Shopping Design (archivo de Wayback del 29-12-2019), listado de números de la web oficial, página oficial de DesignBIZ Fest
+```
+
+Una revista, una lista y un festival parecen tres cosas distintas, pero en el fondo son la misma acción a tres escalas: distinguir por ti, distinguir por todo un año, distinguir por toda una industria. Y en cuanto la escala llega tan lejos, aflora una pregunta que estaba oculta bajo la maqueta: cuando «distinguir por ti» se convierte en un negocio tan grande, ¿siguen pudiendo separarse la mano que distingue por ti y la mano que vende por la marca?
+
+## La mano que elige por ti también vende por la marca
+
+Miremos primero el documento menos romántico: el registro mercantil. La empresa matriz de Shopping Design se llama Business Next Media Corp. (巨思文化股份有限公司), con número de identificación fiscal 16780474 y con Chen Su-lan como presidenta[^16b]. Al abrir el apartado de «actividades» de su registro público aparecen dos líneas seguidas: una dice «edición de revistas (publicaciones periódicas)» y, no muy abajo, otra dice «servicios generales de publicidad»[^15b]. Esa línea está escrita en el documento de registro mercantil, en negro sobre blanco, y es el ámbito legal de actividad. La misma empresa, la misma licencia, edita por un lado contenidos que distinguen diseño por ti y gestiona por otro el negocio de vender publicidad; su web publica además abiertamente las tarifas publicitarias, entre 100.000 y 280.000 yuanes por espacio, con un 10% de descuento si se contrata todo el año[^17]. Ninguna declaración de marca por bonita que sea puede competir con la dureza de esas dos líneas de registro: el contenido y la publicidad conviven de entrada en los cimientos de esta empresa.
+
+```tw-stat
+Business Next Media | empresa matriz de Shopping Design, NIF 16780474 | presidenta Chen Su-lan
+Edición de revistas ＋ servicios generales de publicidad | dos líneas juntas en las «actividades» registradas | negro sobre blanco
+100.000–280.000 yuanes | precio público de un espacio publicitario en la web oficial | 10% de descuento por contratación anual
+Fuentes: registro mercantil del Departamento de Comercio del Ministerio de Asuntos Económicos, opengovtw, página oficial de tarifas publicitarias de Shopping Design
+```
+
+De esto habla la propia gente del sector con más franqueza que nadie. En 2017, el subdirector de Shopping Design, Pao Shu-ping, mantuvo una conversación pública con Eric, director editorial de otro medio de estilo de vida, y hablaron precisamente del publirreportaje, ese contenido que se lee como un reportaje y en realidad es publicidad. «El publirreportaje consiste en que, te guste o no, tienes que escribirlo de manera que enganche», dice Pao Shu-ping[^18]. La frase no oculta nada: el publirreportaje es la realidad del sector y la destreza del medio consiste en escribirlo de modo que quieras seguir leyendo. Añadió además algo que puede servir de nota a pie de toda la era del papel: «Estos dos años las revistas se venden mal; este año muchos medios ya no sacan edición impresa, y SD todavía existe»[^18].
+
+```tw-quote
+El publirreportaje consiste en que, te guste o no, tienes que escribirlo de manera que enganche
+Pao Shu-ping | subdirector de Shopping Design, 2017
+```
+
+En esa misma conversación, Eric contó cómo lo afrontan ellos: «En el primer párrafo del texto o en el titular te decimos sin rodeos que esto es un anuncio», buscando que lector, cliente y redactor «creen una situación en la que ganan los tres»[^18]. Es una postura honesta: marcar con claridad qué es publicidad y devolver la elección al lector. Pero, aunque la postura sea honesta, la frontera sigue ahí. Un publirreportaje etiquetado como «publicidad» permite al lector saber al menos que lo es; sin embargo, si detrás del gusto global de una revista, del «buen diseño» que ha marcado con un círculo para ti, hay o no una relación comercial, no suele haber ninguna línea que lo indique. El lugar donde la frontera se difumina más suele esconderse en esos contenidos que parecen más puros y que en realidad comparten licencia con el departamento de publicidad.
+
+En esa misma época, la web de Shopping Design usó un publirreportaje de whisky para elogiar retrospectivamente a «Huang Wei-jung, director editorial de la etapa fundacional» como un «descubridor de talentos que sabe vivir», empaquetando su imagen de editor de entonces dentro del relato de marca de una botella[^19]. Conviene aclararlo: esas frases sobre «abrir los cinco sentidos y saber catar» no las dijo Huang Wei-jung, sino que las escribió la redacción como texto de presentación de ese publirreportaje. Que una revista que te enseña a distinguir use la imagen de su fundador, construida por ella misma, para hacer de imagen de una marca de consumo es justamente la vez que más cerca han quedado «distinguir por ti» y «vender por la marca».
+
+> **📝 Nota de la curaduría**
+> Hay que tener cuidado de no escribir esto como un problema exclusivo de Shopping Design. El mismo modelo de «un medio informa sobre un sector y además organiza premios para ese sector» lo practica también otra revista blanda, La Vie, que desde 2014 organiza el «Taiwan Creative Power 100»[^20]. Y si se sube un piso más resulta aún más interesante: el grupo matriz de La Vie, Cité, fue creado en 1996 por iniciativa de Chan Hung-chih; y la matriz de Shopping Design, Business Next Media, también se fundó en 1999 con participación de Chan Hung-chih[^21]. Las dos grandes familias taiwanesas de medios de estilo de vida confluyen en su origen en la misma persona. No es una conspiración: es el retrato de una industria editorial taiwanesa muy concentrada. «Organizar una lista para el sector» es una práctica común de todo el gremio, con la que cada casa acumula autoridad de marca y amplía su margen de colaboración comercial, sin que nadie sea la excepción.
+
+Conviene dejar claro que no se encuentra ni un solo reportaje público que señale y critique problemas en los publirreportajes o en las selecciones de Shopping Design; lo anterior no llega todavía a ser una «polémica ya ocurrida», y se parece más a una cuestión que la propia estructura lleva ahí puesta esperando a que alguien la formule. Pero esa cuestión sí circula en el imaginario social: a la revista se le cuelga a menudo la etiqueta de «revista de hipsters», con la insinuación de cierta escenificación del consumo y de una superioridad de gusto. Curiosamente, hasta el propio Huang Wei-jung ha salido a rebatir esa etiqueta: «De verdad que no creo que en Taiwán exista eso de las revistas de hipsters»[^4]. Su gesto de rebatirla demuestra justamente que la sospecha lleva ahí todo el tiempo. Y si la sospecha lleva ahí todo el tiempo, al final alguien tendrá que distinguir. Y ese alguien solo puede ser el lector.
+
+## La última lección: distinguirla a ella
+
+En diciembre de 2025, Shopping Design publicó el número 155, titulado «Se busca diseño / Design Wanted»[^22]. Lo que toma prestado es el lenguaje visual más popular que hay: el de los anuncios de «se busca» pegados en las farolas y en las puertas de los locales. Directo, pegado sin más. Una revista que ha dedicado veinte años a enseñar a los taiwaneses a elegir, a mirar y a distinguir acaba pegándose a sí misma como un anuncio de empleo: diseño, se busca.
+
+![Portada de Shopping Design Vol.155, «Se busca diseño / Design Wanted»: la revista se pega a sí misma como un anuncio de empleo](/article-images/culture/shopping-design-vol155-cover.webp)
+_Vol.155, «Se busca diseño». La revista que te enseña a distinguir acaba pegándose a sí misma como un examen. (crédito: Business Next Media, Fair use editorial commentary)_
+
+Ese final enlaza en realidad con la preparación de toda una sociedad. Taiwán publicó ya en 2002 el «Libro Blanco de la Política de Educación en Alfabetización Mediática» y los institutos incorporaron la alfabetización mediática al currículo desde el curso 2017[^23]. Que «el lector tenga capacidad de distinguir publirreportaje y contenido» es desde hace tiempo un consenso a nivel de política educativa. Dicho de otro modo, que un medio acabe devolviendo al lector la responsabilidad de distinguir es justamente algo que esta sociedad ya había decidido enseñar a todo el mundo, y no tiene nada de novedoso. La única diferencia es que esta vez el objeto que hay que distinguir es quien te enseñó durante veinte años a distinguir.
+
+¿Y dónde está hoy la propia Shopping Design? Internet no la ha sustituido: en abril de 2026 el papel llegó al número 156[^11]. Vista dentro de la misma oleada de revistas blandas, ya es un logro: algunas han cambiado de dueño, otras tienen su último número a finales de 2025 y después no se ha visto ninguno nuevo; Shopping Design es uno de los pocos casos que han llegado hasta hoy manteniendo la misma marca y el mismo recorrido. Solo que también se está estrechando en silencio. La página de «Quiénes somos» de su web se retiró en los últimos años; el cargo de quien llevó el timón entre 2006 y 2017 era «director editorial», y el título más alto que aparece en los reportajes públicos de 2024 ya ha bajado a «editora Yi-hsin, subeditora Ya-yun»[^24]. Una revista que te enseña a distinguir y también a preguntar «¿quién ha elegido esto por mí?» tiene, en cambio, cada vez más difícil de consultar la información sobre su propia estructura y su origen. Primero tienes que aprender esa distinción que ella enseña para poder volverte y distinguir quién es y para quién trabaja, y ella está recogiendo cada año un poco más esa segunda mitad de las pistas. Eso mismo es un ejercicio que no ha enunciado pero ha dejado al lector.
+
+Y esa es justamente la última lección que devuelve al lector. Desde aquel blanco del primer número hasta este anuncio de empleo del número 155, en medio hay todo un oficio de «distinguir por ti», ampliado vuelta a vuelta hasta la lista, la trimestral y el festival, y acercado paso a paso al negocio de vender por la marca. Lo que esta revista le ha enseñado a Taiwán es mucho más hondo que qué silla es bonita o en qué hotel merece la pena alojarse. Lo que enseña es que «distinguir» puede entrenarse como una capacidad, y que cuanto más ancha entrena y más amplía esa capacidad, más se convierte ella misma en el objeto que más necesitas sacar a distinguir.
+
+Por eso la portada de «Se busca diseño» es también un examen. Lo que quiere buscar es, en realidad, un lector capaz de entender y también de preguntar «¿quién ha elegido esto por mí?». Hace veinte años te enseñó a comprar el blanco; veinte años después te devuelve a las manos el poder de distinguir, junto con la necesidad de distinguirla a ella. Saber apreciar y saber sospechar siempre han podido caber en un mismo par de ojos, y ese par de ojos es justamente el que ella ha entrenado para ti, página a página, durante veinte años.
+
+---
+
+## Lecturas complementarias
+
+- [Revistas](/culture/雜誌) — cien años de evolución de la revista taiwanesa; Shopping Design es el caso representativo de la rama de las «revistas blandas»
+- [Revista Ren Jian](/culture/人間雜誌) — otra alma de la revista taiwanesa, que distinguió y nombró a la sociedad de abajo con fotoperiodismo; es la otra cara de la moneda respecto a la revista de compra de diseño
+- [Historia de la publicidad en Taiwán](/culture/台灣廣告史) — el origen de la formación de Huang Wei-jung y Li Hui-chen; para entender cómo llevó a las revistas su destreza narrativa aquella generación de «Ideology»
+- [Ceremonia del té y estética cotidiana en Taiwán](/culture/台灣茶道與生活美學) — cómo creció la estética de la vida en Taiwán hasta convertirse en algo comentable y comprable
+- [Aaron Nieh](/people/聶永真) — otro nombre del mismo contexto del diseño taiwanés que lo empujó ante los ojos del gran público
+
+## Referencias
+
+[^1]: [La revista debe recordar al lector que viva con conciencia: Li Hui-chen, directora editorial de «Shopping Design»](https://www.biosmonthly.com/article/8577) — Entrevista de BIOS monthly de febrero de 2017, que recoge que Li Hui-chen «entraba en su sexto año» como directora editorial y que el número 100 respondía con «comprar diseño blanco» al «diseño blanco» del número inaugural.
+
+[^2]: [El editor transversal Huang Wei-jung: como creativo, lo soso, lo corriente y lo habitual son el mayor pecado](https://500times.udn.com/wtimes/story/120841/4313654) — Entrevista de 500times de 2020, en la que Huang Wei-jung relata su punto de partida como redactor publicitario, la agencia Ideology y Hsu Shun-ying, y la trayectoria en tres tramos de treinta años: «redacción publicitaria y escritura editorial → edición de revistas e integración de imagen y texto → encargos mixtos de servicios creativos».
+
+[^3]: [Algo tan romántico como esto solo pasa una vez en la vida: «Cien razones para sobrevivir en Taipéi»](https://www.shoppingdesign.com.tw/post/view/1446) — Columna del propio Huang Wei-jung de 2017, en la que recuerda ese libro escrito en 1998 junto a Ma Shih-fang, Yao Jui-chung, Hsu Yun-pin y Chen Kuang-ta y publicado por Locus Publishing.
+
+[^4]: [Las llamadas «revistas de hipsters» son en realidad producto de varios malentendidos…](https://www.cw.com.tw/article/5046241) — Texto publicado por Huang Wei-jung en 2013 en Independent Opinion@CommonWealth, que contiene el origen de Shopping Design en el «tema blando» de las tiendas de conveniencia de 2006, la definición de La Vie y PPAPER (2004) como «avanzadilla del nacimiento de las revistas blandas» y su rechazo de la etiqueta de «revista de hipsters».
+
+[^5]: [¡La fuerza de planificar que da la vuelta a una vida! Entrevista con la fundadora del Proyecto Unicornio, alias exdirectora editorial de Shopping Design](https://www.shoppingdesign.com.tw/podcast/view/104) — Pódcast oficial de Shopping Design, que confirma que Li Hui-chen fue directora editorial y que tras dejar el cargo en 2017 fundó el «Proyecto Unicornio».
+
+[^6]: [La trabajadora independiente Li Hui-chen: no creo en el destino, todo depende de lo que uno haga](https://500times.udn.com/wtimes/story/120841/4313624) — Entrevista de 500times, que recoge el origen de Li Hui-chen en una aldea militar de Yilan, su trayectoria editorial, su etapa como directora editorial de Shopping Design entre 2011 y 2017, su referencia a la frase de Chan Hung-chih «cuando lees cierto libro, puede que te conviertas en una persona solitaria» y la línea oculta de que tanto ella como Huang Wei-jung trabajaron a las órdenes del director editorial de Locus Publishing, Liao Li-wen.
+
+[^7]: [Lista de premiados de las ediciones 1 a 49 de los Golden Tripod Awards](https://data.gov.tw/dataset/25856) — Datos abiertos del Ministerio de Cultura. La tabla oficial edición por edición lo fija: en la 40.ª edición (2016), el «premio al editor jefe, categoría individual de revistas» fue para Li Hui-chen / «Shopping Design 設計採買誌» / Business Next Media Corp.
+
+[^8]: [Página oficial «Quiénes somos» de Shopping Design (archivo de Wayback Machine del 29-12-2019)](http://web.archive.org/web/20191229052902/https://www.shoppingdesign.com.tw/aboutus) — La cronología oficial de «Trayectoria» consigna literalmente: fundación en 12/2006 (mensual), BEST100 en 12/2012, arranque de Design+ en 12/2013, lanzamiento de la web en 12/2015, creación de la Escuela de Economía del Estilo en 10/2016 y reforma a trimestral en 12/2019.
+
+[^9]: [Entrevista sobre la reforma trimestral de Shopping Design](https://okapi.books.com.tw/article/13619) — OKAPI recoge la explicación de la redacción sobre la lógica de la reforma: la web persigue lo fresco y lo rápido y el papel construye temas a un ritmo más lento, además de la autodefinición de «útil, interesante y significativo».
+
+[^10]: [«Shopping Design» se reforma: desde este año pasa a trimestral](http://mol.mcu.edu.tw/《shopping-design》改版-今年起改季刊發行/) — Noticia de Mol News del 29 de marzo de 2020, que respalda que el primer número trimestral tras la reforma (el 134) salió en marzo de 2020.
+
+[^11]: [Listado de números de la web oficial de Shopping Design](https://www.shoppingdesign.com.tw/magazine/) — Catálogo oficial de productos, que permite verificar temas y fechas de números como el Vol.147 «El habitante ideal» (2023), el Vol.150 «Coleccionamos este diseño» (2024), el Vol.155 «Se busca diseño» (12-2025) o el Vol.156 (04-2026).
+
+[^12]: [Seleccionados del Taiwan Design Best100 2022](https://www.fundesign.tv/sd-2022-taiwan-design-best100/) — Reportaje del medio independiente de diseño FunDesign, que confirma desde una tercera parte que BEST100 lo organiza la redacción de Shopping Design desde 2012, que selecciona cada año 100 personas, hechos y objetos del diseño taiwanés y que es un premio mediático y no un galardón oficial del gobierno.
+
+[^13]: [Seleccionado en el Taiwan Design 100 de 2019: el quincenal Cultura+ de la agencia CNA](https://www.cna.com.tw/news/firstnews/201912130216.aspx) — Reportaje independiente de la agencia CNA, que consigna literalmente que el BEST100 de 2019 «seleccionó 100 conjuntos de personas, hechos y objetos del diseño bajo el tema de las "palabras clave de la fuerza del diseño", con los premios repartidos en 9 categorías».
+
+[^14]: [Página oficial del DesignBIZ Fest 2022](https://designbiz.shoppingdesign.com.tw/2022/) — La página oficial confirma que «desde 2022, Shopping Design organiza el primer DesignBIZ Fest» y recoge literalmente la definición en paralelismos: «el diseño es fuerza creativa, el diseño es fuerza de marketing, el diseño es fuerza cultural, el diseño es fuerza de planificación, el diseño es fuerza de integración: el diseño es fuerza vital».
+
+[^15]: [Lista de ponentes del DesignBIZ Fest 2022](https://designbiz.shoppingdesign.com.tw/2022/) — Cargos de los ponentes según la página oficial (en 2022): Chen Yun-chu (cofundadora de Plan b), Chen Ping-liang (director del centro de marca del Grupo Gamania), Yeh Chuan-feng (vicepresidente de marca y marketing de Gogoro), Chan Hsun-chih (vicepresidente de Chan Chi Hot Pot) y toda una fila de altos cargos de marcas y startups.
+
+[^16]: [Pódcast de Shopping Design «Palabras clave del diseño»](https://www.shoppingdesign.com.tw/podcast) — Página oficial del programa, que extiende los contenidos de Shopping Design al medio sonoro con temas de actualidad del diseño, historias de creativos, marcas y revitalización local.
+
+[^16b]: [Registro mercantil de Business Next Media Corp.](https://www.companys.com.tw/16780474) — Consulta del registro mercantil, que confirma la denominación en chino «巨思文化股份有限公司», la denominación en inglés «BUSINESS NEXT MEDIA CORP.», el NIF 16780474 y a Chen Su-lan como presidenta.
+
+[^15b]: [Datos abiertos gubernamentales de Business Next Media Corp.](https://opengovtw.com/ban/16780474) — Datos públicos de registro, en cuyo apartado de «actividades» figuran a la vez «edición de revistas (publicaciones periódicas)» y «servicios generales de publicidad»: la prueba dura de que la edición de contenidos y los servicios publicitarios pertenecen a una misma licencia.
+
+[^17]: [Página de tarifas publicitarias de Shopping Design](https://edm.shoppingdesign.com.tw/price.htm) — Tarifario oficial de publicidad, con precios por espacio entre 100.000 y 280.000 yuanes y un 10% de descuento por contratación anual.
+
+[^18]: [Conversación entre Eric y Pao Shu-ping: el aspecto de un medio](http://www.everydayobject.us/eric-and-pao-talks-style-of-a-media/) — Conversación de diciembre de 2017 entre Eric, director editorial de EVERYDAY OBJECT, y Pao Shu-ping, subdirector de Shopping Design, con citas literales sobre la ética del publirreportaje («el publirreportaje consiste en que, te guste o no, tienes que escribirlo de manera que enganche», «te decimos sin rodeos que esto es un anuncio», «crear una situación en la que ganan los tres») y sobre las dificultades del papel («estos dos años las revistas se venden mal; este año muchos medios ya no sacan edición impresa, y SD todavía existe»).
+
+[^19]: [Para vivir bien hay que aprender antes a catar la diferencia: Huang Wei-jung, el descubridor de talentos que sabe vivir](https://www.shoppingdesign.com.tw/post/view/5119) — Contenido de 2020 en la web oficial de Shopping Design, confirmado mediante el código fuente como publirreportaje de una marca de whisky con `is_ads:true`; frases como «abrir los cinco sentidos y saber catar» son presentación en tercera persona escrita por la redacción para el publirreportaje y no citas directas de Huang Wei-jung.
+
+[^20]: [Se revela la lista completa del Taiwan Creative Power 100 de 2025](https://www.wowlavie.com/article/250026501) — Página oficial de La Vie, que consigna la celebración bienal del «Taiwan Creative Power 100» desde 2014 y que forma con el BEST100 de Shopping Design un modelo paralelo de «listas anuales o bienales organizadas por los propios medios».
+
+[^21]: [Business Next Media Group](https://zh.wikipedia.org/zh-tw/巨思媒體集團) — Índice de Wikipedia, que consigna que el grupo Business Next Media fue fundado en 1999 por Chan Hung-chih, Ho Fei-peng y Chen Su-lan, con «Business Next», «Manager Today» y «Shopping Design» entre sus cabeceras; Chan Hung-chih impulsó además en 1996 la creación de Cité, grupo matriz de La Vie.
+
+[^22]: [Shopping Design Vol.155 «Se busca diseño / Design Wanted»](https://www.shoppingdesign.com.tw/magazine/view/130050) — Página oficial del número, publicado en diciembre de 2025, con una portada que toma el lenguaje visual de los anuncios populares de «se busca» y contenidos sobre cien obras y equipos, la Generación Z y la sensibilidad taiwanesa.
+
+[^23]: [Alfabetización mediática](https://zh.wikipedia.org/zh-tw/媒體素養) — Índice de Wikipedia, que recoge el contexto político de la publicación en 2002 del «Libro Blanco de la Política de Educación en Alfabetización Mediática» de Taiwán y de la incorporación de la alfabetización mediática al currículo de bachillerato desde el curso 2017.
+
+[^24]: [Repaso de la charla «Coleccionamos este diseño» de 2024](https://www.shoppingdesign.com.tw/post/view/10553) — Reportaje oficial de Shopping Design de agosto de 2024, en el que aparece literalmente «la editora Yi-hsin y la subeditora Ya-yun de Shopping Design», el cargo más alto verificable de la redacción en los últimos años (ya rebajado de «director editorial» a «editora»).
+
+## Fuentes de imágenes
+
+- **Hero｜imagen principal del DesignBIZ Fest 2022**: Shopping Design／DesignBIZ Fest, fuente <https://designbiz.shoppingdesign.com.tw/2022/>. Fair use (editorial commentary).
+- **Portada del Vol.147 «El habitante ideal»**: Shopping Design (Business Next Media), fuente: listado de números de la web oficial <https://www.shoppingdesign.com.tw/magazine/>. Fair use (editorial commentary).
+- **Portada del Vol.150 «Coleccionamos este diseño»**: Shopping Design (Business Next Media), fuente: listado de números de la web oficial <https://www.shoppingdesign.com.tw/magazine/>. Fair use (editorial commentary).
+- **Ponentes del DesignBIZ Fest 2022**: Shopping Design／DesignBIZ Fest, fuente <https://designbiz.shoppingdesign.com.tw/2022/>. Fair use (editorial commentary).
+- **Portada del Vol.155 «Se busca diseño»**: Business Next Media, fuente <https://www.shoppingdesign.com.tw/magazine/view/130050>. Fair use (editorial commentary).

--- a/knowledge/es/Music/chthonic.md
+++ b/knowledge/es/Music/chthonic.md
@@ -1,0 +1,202 @@
+---
+translatedFrom: 'Music/閃靈.md'
+sourceCommitSha: '087677fa'
+sourceContentHash: 'sha256:428539ef61aee065'
+sourceBodyHash: 'sha256:ca8382bb6533d023'
+translatedAt: '2026-07-23T22:45:00+08:00'
+lang: 'es'
+title: 'CHTHONIC: la banda que metió la historia de Taiwán en el black metal'
+description: 'CHTHONIC (閃靈) es una banda taiwanesa de heavy metal fundada en Taipéi en 1995. Con el black metal, el erhu, el taiwanés, la mitología de la isla, el relato de los espíritus y el trauma histórico como núcleo, llevó a los escenarios internacionales del metal la leyenda de la Hermana Lintou, el incidente de Musha, el incidente del 28 de febrero, las Unidades de Voluntarios Takasago, el Terror Blanco y la cuestión de la soberanía taiwanesa. No es el telón de fondo de Freddy Lim antes de su entrada en política, sino un cuerpo creativo sostenido en común por Freddy, Doris, Jesse, Dani y CJ.'
+date: 2026-07-10
+category: 'Music'
+tags:
+  - '閃靈'
+  - 'CHTHONIC'
+  - 'heavy metal'
+  - 'black metal'
+  - 'taiwanés'
+  - 'historia de Taiwán'
+  - 'Freddy Lim'
+subcategory: 'Heavy metal / historia de Taiwán'
+author: 'Taiwan.md Translation Team'
+featured: false
+canonical-order: 999
+lastVerified: 2026-07-10
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/閃靈-outline.md'
+image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bb/12-08_Wacken_Chthonic_02.jpg/1280px-12-08_Wacken_Chthonic_02.jpg'
+imageCredit: 'Achim Raschka / Wikimedia Commons'
+imageLicense: 'CC BY-SA 4.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:12-08_Wacken_Chthonic_02.jpg'
+rationale:
+  why_this_hook: 'Entrar por cómo puede el black metal sostener la historia de Taiwán, para no reducir CHTHONIC a la precuela política de Freddy Lim.'
+  whats_excluded: 'Los cambios completos de formación, el análisis de todas las canciones de cada álbum, la lista íntegra de premios y la cronología de las polémicas políticas se reforzarán en un texto posterior más profundo.'
+  where_it_hedges: 'De los temas de los álbumes solo se escribe el contexto central que sostienen varias fuentes; los premios y los sencillos recientes se describen con prudencia y no se toma el índice de Wikipedia como única fuente de hechos.'
+  whos_pushing_back: 'Quienes ven CHTHONIC solo como una banda política, quienes esperan únicamente crítica musical de metal y los fans que conocen toda la historia del grupo y desearían una verificación más completa de las canciones.'
+---
+
+# CHTHONIC: la banda que metió la historia de Taiwán en el black metal
+
+> **Resumen en 30 segundos:** CHTHONIC (閃靈) es una banda taiwanesa de heavy metal fundada en Taipéi en 1995. Partiendo del black metal, el death metal y el metal sinfónico, llevó al metal extremo el taiwanés (hoklo), el erhu, los instrumentos folclóricos, la leyenda de la Hermana Lintou, el incidente de Musha, el incidente del 28 de febrero, las Unidades de Voluntarios Takasago, el Terror Blanco y el sentido de la soberanía taiwanesa. El vocalista Freddy Lim (林昶佐) entró después en la escena política, pero la líder y bajista Doris Yeh (葉湘怡), el guitarrista Jesse Liu (劉笙彙), el batería Dani Wang (汪子驤) y el teclista CJ Kao (高嘉嶸) también han mantenido CHTHONIC como un cuerpo creativo completo. Muchos fans del metal en el extranjero escucharon por primera vez la historia de Taiwán a través de CHTHONIC, y oyeron cómo los espíritus, la lengua y el sentido de soberanía de un país se empujan hasta un escenario.
+
+En 1995 no había todavía mucha gente en Taipéi que supiera qué era el black metal. CHTHONIC se formó aquel año y más tarde el *Taipei Times* la describiría como la primera banda taiwanesa de black metal. En 2003 ganó el premio a la mejor banda en la 14.ª edición de los Golden Melody Awards con «9th Empyrean» (永劫輪迴). Ese mismo artículo recogía también que CHTHONIC había tocado en un acto por la rectificación del nombre de Taiwán frente al Palacio Presidencial y había subido al escenario la leyenda popular taiwanesa de la «Hermana Lintou» (林投姊). Ya entonces CHTHONIC llevaba maquillaje cadavérico, marcaba ritmos pesados y gritaba. Y al mismo tiempo se planteaba una pregunta muy precoz: ¿pueden la mitología, las heridas y los espíritus de la propia Taiwán convertirse en el núcleo del metal?[^1]
+
+## La historia de Taiwán dentro del black metal
+
+La música de CHTHONIC ató desde el principio la gramática del género con los materiales taiwaneses.
+
+En su entrevista de 2003 con el *Taipei Times*, Freddy Lim situó el punto de partida de la banda en la conciencia de la cultura matriz del black metal: el black metal nórdico tiene una actitud de resistencia hacia las antiguas creencias desplazadas por el cristianismo, y CHTHONIC devolvió esa pregunta a Taiwán para mirar la memoria local aplastada por la historiografía sinocéntrica, el colonialismo y la política autoritaria. Los primeros álbumes avanzaron desde la travesía de los han y el choque entre los mitos han y los de los pueblos indígenas hasta leyendas populares como la de la Hermana Lintou, levantando poco a poco un universo taiwanés hecho de espíritus, dioses y heridas históricas.[^1]
+
+Esta vía se prolongó después hacia la historia moderna. «Seediq Bale» (賽德克巴萊) aborda el incidente de Musha y la resistencia seediq contra Japón. «Mirror of Retribution» (十殿) sitúa el incidente del 28 de febrero dentro de la imaginación del juicio infernal. «Takasago Army» (高砂軍) vuelve la mirada a las Unidades de Voluntarios Takasago reclutadas por el Imperio japonés durante la Segunda Guerra Mundial. «Bú-Tik» (武德) se dirige hacia la colonización, la resistencia y el espacio de poder que simbolizan los salones Butokuden. «Battlefields of Asura» (政治) empuja al primer plano el Taiwán de posguerra, la democratización, la protesta y la sensibilidad política contemporánea. Estos temas se despachan con facilidad diciendo «tiene mucha carga política», pero en la obra de CHTHONIC son más bien la versión ultraterrena de la historia de Taiwán: quienes los manuales no supieron colocar como es debido vuelven al escenario a alzar la voz.
+
+Aquí se aclara también la diferencia entre CHTHONIC y las canciones al uso de consigna política. CHTHONIC mete los hechos históricos dentro de personajes, espíritus, mitos, reencarnación y ritual escénico. El público recibe primero el golpe del doble bombo y de los gritos, y solo después descubre poco a poco que detrás de esos sonidos están el 28 de febrero, Musha, el Terror Blanco, los soldados coloniales y las memorias familiares silenciadas.
+
+## El erhu, el taiwanés y el muro de sonido del metal
+
+Lo más reconocible del sonido de CHTHONIC son los gritos, los gruñidos graves, el doble bombo, las guitarras densas, la sensación sinfónica del teclado y un erhu que parece acercarse llorando desde lejos.
+
+Ya en 2003 el *Taipei Times* observaba que el erhu daba al sonido black metal de CHTHONIC una identidad taiwanesa reconocible. En el pop en chino el erhu suele usarse como herramienta lírica o nostálgica, pero dentro de CHTHONIC funciona más bien como la mecha de los espíritus: puede extraer la tristeza del teatro popular y también trazar, dentro del muro de sonido metálico, una línea afilada, inquieta, próxima a la invocación de los muertos.[^1]
+
+La lengua es también un núcleo del sonido de CHTHONIC. Durante la gira del Ozzfest de 2007, Freddy Lim dijo a NPR que en sus actuaciones estadounidenses usaban el mandarín y el hoklo, es decir, el taiwanés. El mismo artículo del *Taipei Times* señala que «UNlimited Taiwan» se cantaba en inglés y llevaba directamente a la gira estadounidense la reivindicación de la participación de Taiwán en los organismos internacionales.[^2] El inglés hacía entender la reivindicación al público extranjero, y el taiwanés y la historia de la isla convertían la obra en una gramática metálica insustituible.
+
+Después de «Takasago Army», la manera de componer de CHTHONIC dio un paso más. En el resumen de la entrevista de Metalship que cita Wikipedia, Freddy Lim cuenta que al principio era más bien escribir primero metal y meter después la sensación taiwanesa. Hacia «Takasago Army», la creación pasó a consistir en escribir primero el esqueleto de una canción taiwanesa, una canción en taiwanés o un tema pop taiwanés, y después él y Jesse lo volvían pesado hasta convertirlo en metal.[^3] Ese giro es decisivo: el erhu, las melodías en taiwanés, el aire de enka, la estructura del folclore y los arreglos de heavy metal empezaron en esa etapa a transformarse mutuamente.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/c3t-0MIy-fc" title="CHTHONIC - TAKAO Official Video" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Videoclip oficial de CHTHONIC: «TAKAO» (皇軍). Es un tema de la etapa de «Takasago Army» y permite ver cómo se colocan en un mismo lenguaje escénico el taiwanés, la memoria de la guerra y los arreglos de metal._
+
+## El escenario también forma parte del relato
+
+La imagen escénica de CHTHONIC siempre ha encajado con su música. El maquillaje cadavérico de los primeros tiempos tomaba prestada la frialdad del black metal nórdico, pero los signos pintados en la cara, el papel moneda funerario, las deidades, el infierno y el aire de invocación devuelven rápidamente lo visual al folclore taiwanés y a los espíritus de su historia. La tela con talismanes enrollada en la cabeza del teclista CJ Kao, los símbolos en la frente del vocalista y el gesto del público arrojando papel moneda funerario en el recinto convertían los conciertos en una especie de ceremonia religiosa en versión metal.[^13]
+
+Hacia la etapa de «Takasago Army», CHTHONIC cambió a un vestuario con aire de uniforme militar asiático, artes marciales y campo de batalla, alejándose poco a poco de la simple imagen de maquillaje cadavérico. Con ese giro, el escenario dejó de ser una ambientación de «el black metal es oscuro» y pasó a servir directamente al relato del álbum: los soldados japoneses de origen taiwanés, los ejércitos coloniales, las identidades obligadas a cambiar de nombre y las almas de la posguerra aparecen ante el público a través del vestuario y de lo visual. Por eso los directos de CHTHONIC casi nunca se limitan a reproducir el trabajo de estudio. Se parecen más a convocar temporalmente el universo de espíritus del álbum junto al puerto, en una sala de conciertos, en un festival internacional o en la avenida Ketagalan.
+
+Eso explica también que los videoclips de CHTHONIC tengan a menudo un aire cinematográfico. «TAKAO» compone su imagen con la guerra, la memoria y la melodía de la canción en taiwanés. «Broken Jade» (破夜斬), «Defenders of Bú-Tik Palace» (烏牛欄大護法) y «PATTONKAN» (護國山) empujan ante la cámara a personajes históricos, luchas y familias de las víctimas. Cuando la imagen, el vestuario, la lengua y el sonido trabajan juntos, el carácter político de CHTHONIC deja de depender solo de la explicación de las letras y pasa a sentirse a través de todo el sistema escénico.
+
+## La trilogía del réquiem: Musha, el 28 de febrero y Takasago
+
+El conjunto de obras más adecuado para iniciarse en CHTHONIC es el contexto de réquiem que forman «Seediq Bale», «Mirror of Retribution» y «Takasago Army».
+
+«Seediq Bale» llevó el incidente de Musha al escenario del metal. El álbum convirtió al pueblo seediq, a Mona Rudao, la resistencia antijaponesa y la violencia colonial en un conjunto de personajes trágicos y de paisajes sonoros. También hizo a CHTHONIC más reconocible en los medios metálicos extranjeros: esta banda taiwanesa vierte su propia historia en la gramática del género y toma distancia de la vía que solo imita el metal extremo nórdico o estadounidense.[^4]
+
+«Mirror of Retribution» sitúa el incidente del 28 de febrero en el inframundo y en el juicio. El infierno, las almas agraviadas y la imaginación de la reencarnación dieron una forma audible a una violencia política largamente reprimida. El lenguaje metálico de CHTHONIC encaja aquí especialmente bien: los gritos suenan como si quienes no pudieron hablar como es debido alzaran por fin la voz de una manera imposible de ignorar.
+
+«Takasago Army» empuja el tiempo hasta la Segunda Guerra Mundial. El tema del álbum apunta a los jóvenes de los pueblos indígenas taiwaneses reclutados por el Imperio japonés durante la Guerra del Pacífico, y enlaza con la fractura histórica entre «Seediq Bale» y «Mirror of Retribution». Las fuentes ordenadas por la entrada de Wikipedia muestran que «Takasago Army» se sitúa en el contexto histórico de los Takasago Volunteers. En el álbum participaron además Yu Tien, Chan Ya-wen y el músico taroko Pitero Wukah, entre otros, superponiendo la canción en taiwanés, las voces indígenas y el metal extremo.[^3]
+
+Estas tres obras dejan claro el núcleo de CHTHONIC: la banda está haciendo un réquiem por una historia que nunca fue enterrada del todo. Los espíritus de su música cargan el peso de la historia contemporánea de Taiwán y todavía no se han marchado de verdad.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/Ynb9vFd0iNg" title="閃靈 - 鎮魂醒靈寺 Official Video" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Videoclip oficial de CHTHONIC: «Requiem at Xingling Temple» (鎮魂醒靈寺). El escenario del templo Xingling, en Puli, arrastra el relato de réquiem de «Takasago Army» y «Mirror of Retribution» desde el universo del álbum hasta un lugar concreto._
+
+## El nombre de Taiwán en los escenarios internacionales
+
+CHTHONIC entendió muy pronto las giras como otra forma de acción pública.
+
+En 2007 dieron veinte conciertos en el Ozzfest y en cada uno hablaron al público en inglés sobre la dificultad de Taiwán para participar con normalidad en los organismos internacionales por el bloqueo chino. Para una banda de metal eso no es diplomacia tradicional. Pero para un Taiwán al que durante mucho tiempo se le ha pedido rebajar su presencia en los foros internacionales, ese hablar desde el escenario era ya en sí mismo una especie de relato exterior alternativo.[^2]
+
+Los medios extranjeros han contado después a menudo la entrada de Freddy Lim en política dentro del contraste de «el vocalista de heavy metal llega al Parlamento». Cuando GQ presentó en 2016 su elección como diputado, describió a CHTHONIC como una banda que llevaba mucho tiempo tomando como materia de creación las lenguas locales de Taiwán, los instrumentos tradicionales, la opresión y el sufrimiento de los pueblos indígenas.[^5] Cuando The Guardian informó sobre Freddy Lim en 2020, lo situó en una línea continua entre el metal, los movimientos sociales, el Parlamento y la identidad taiwanesa.[^6] Este contexto es importante: Freddy Lim no entró de golpe en los asuntos públicos después de dejar la música. La música de CHTHONIC tomó desde muy pronto como tarea creativa la pregunta de «cómo puede Taiwán ser escuchado por el mundo».
+
+El carácter internacional de CHTHONIC tampoco está solo en el mapa de sus giras. Ha hecho versiones de sus obras en taiwanés, en mandarín y en inglés para que públicos distintos se acerquen al mismo universo histórico por puertas distintas. Ha llevado la historia de Taiwán a escenarios internacionales como el Ozzfest, Wacken o el Fuji Rock, y ha logrado que los medios extranjeros pongan la historia taiwanesa, el metal y la identidad política dentro de un mismo artículo. Esos reportajes a veces los simplifican como «banda de metal antichina», pero volviendo a la música, lo que CHTHONIC exporta de verdad es todo un diseño sonoro para hacer que Taiwán se escuche.
+
+## No es cosa de un solo vocalista
+
+La imagen pública de CHTHONIC ha sido a menudo ampliada por Freddy Lim, sobre todo desde que pasó de músico al Nuevo Poder, al Yuan Legislativo y a un cargo diplomático. Pero CHTHONIC no es el proyecto personal de un vocalista.
+
+Doris Yeh lleva mucho tiempo siendo líder, bajista y núcleo de la gestión de la banda. Jesse Liu es un compositor importante y la fuente del sonido de guitarra. La batería de Dani Wang y los teclados de CJ Kao empujaron a CHTHONIC hacia una formación más sinfónica y teatral. La web oficial y las redes sociales siguen operando hoy con CHTHONIC como marca completa de banda, lo que recuerda al lector que la historia de CHTHONIC no puede entenderse retrocediendo desde el político Freddy Lim.[^7]
+
+De «Takasago Army» a «Bú-Tik», los arreglos metálicos de Jesse, la batería de Dani, los teclados de CJ y los graves y la gestión de Doris convirtieron la ambición narrativa de CHTHONIC en un sonido que se podía llevar de gira, grabar y hacer comprensible para los medios extranjeros. Freddy Lim aportó la voz, el concepto y el lenguaje público, pero la vitalidad a largo plazo de la banda viene de todo el equipo. CHTHONIC es una comunidad creativa con existencia propia dentro de la historia musical taiwanesa y no algo que pueda ordenarse como la precuela de un político.
+
+![CHTHONIC actuando en 2007 en el Metropolis de Montreal (Canadá). En el escenario se ven el vocalista, el bajo, la guitarra, la batería y otro músico, y el público de las primeras filas responde con los brazos en alto.](https://upload.wikimedia.org/wikipedia/commons/0/0a/Chthonic.jpg)
+_En 2007 CHTHONIC actuó en el Metropolis de Montreal, Canadá. Al aparecer varias posiciones del escenario a la vez, la imagen de la banda como formación completa en directo se transmite con más claridad que con un primer plano de un solo miembro. Photo: Kozikkris, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Chthonic.jpg) ([CC BY 3.0](https://creativecommons.org/licenses/by/3.0/))._
+
+## De la banda al espacio: Megaport Festival
+
+La influencia de CHTHONIC sobre la música taiwanesa tampoco se queda en los álbumes y las giras.
+
+En 2006, Freddy, Doris y el equipo de TRA Music organizaron la primera edición del Megaport Festival (大港開唱) junto a los muelles 11 y 12 del puerto de Kaohsiung. En la entrevista del especial de VERSE sobre Megaport, Doris recuerda que entonces querían hacer un festival del sur distinto del Formoz de Taipéi, con el paisaje portuario de Kaohsiung, el carácter desenvuelto y las bandas del sur de Taiwán como tono del evento. Ese punto de partida se parece mucho a la forma en que CHTHONIC hace música: llevar el paisaje, la lengua, la historia y las voces poco visibles para la corriente principal a un escenario suficientemente grande.[^14]
+
+![CHTHONIC actuando en el Megaport Festival de 2016: el vocalista en el centro del escenario, con las luces y una gran estructura escénica rodeando a la banda.](https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Chthonic_megaport_2016.jpg/1280px-Chthonic_megaport_2016.jpg)
+_En 2016 CHTHONIC actuó en el Megaport Festival. Esta fotografía transmite mejor que un primer plano de un solo miembro el encuentro entre la banda, un festival junto al puerto y un gran escenario. Photo: Hisakon, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Chthonic_megaport_2016.jpg) ([CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))._
+
+Después de que Freddy Lim fuera elegido diputado en 2016 y dejara el equipo de Megaport, Doris y el batería Dani Wang tomaron el relevo de la gestión y la coordinación. Según la entrevista de VERSE, Doris dirigió primero las ediciones de 2016 y 2017 y luego pasó a ser asesora; Dani participa en la coordinación desde 2016 y en el equipo lo llaman «el presidente». Esta línea hace más evidente el carácter colectivo de CHTHONIC: Doris y Dani sostienen sobre el escenario los graves y el ritmo, y fuera del escenario convierten el valor cultural de la banda en un festival capaz de reunir cada año a fans, bandas, ONG y memoria urbana.[^14]
+
+La segunda parte de VERSE devuelve Megaport al contexto del Formoz, del Spring Scream y de la cultura taiwanesa de ir a ver bandas desde los años noventa. Freddy y Doris se hicieron cargo del Formoz en sus primeros años y después aprendieron de la experiencia de escenarios internacionales como el Fuji Rock, Wacken o Download la gestión de múltiples escenarios, la circulación en el backstage, el reparto del voluntariado y la atención a los artistas, y devolvieron esa experiencia a Megaport. Dicho de otro modo, CHTHONIC no solo ha sacado Taiwán al exterior, sino que también ha traído de vuelta los métodos organizativos de los escenarios extranjeros y ha ido transformando poco a poco la cultura de los directos en los festivales locales.[^15]
+
+La «aldea de ONG» de Megaport deja ver especialmente bien la prolongación de CHTHONIC. Doris y Dani la conectan en la entrevista de VERSE con los conciertos que Freddy organizó en el pasado sobre justicia, contra la anexión y por la libertad del Tíbet, y también con los valores de libertad y justicia que CHTHONIC persigue desde hace tiempo. Para CHTHONIC, el escenario no es un lugar del que huir de la realidad; el escenario también puede hacer que emerjan a la vez los asuntos, las identidades y las emociones que han sido acalladas. Por eso Megaport, aunque merece una entrada propia, sigue siendo una rama lateral importante para entender a CHTHONIC.
+
+## «Bú-Tik» y «Battlefields of Asura»: del salón de artes marciales a la política contemporánea
+
+«Bú-Tik» es la obra con la que CHTHONIC empujó su universo discográfico a otro nivel. Según las fuentes en inglés, «Bú-Tik» fue publicado en 2013 por sellos como Spinefarm / Universal en Asia, Reino Unido y Norteamérica; Blabbermouth registra además que ganó el mejor álbum, la mejor banda y el mejor músico, entre otros, en los Golden Indie Music Awards.[^8] Lo que muestran esos premios es una cosa: una obra taiwanesa de metal extremo ya podía ser tratada por los premios musicales locales como un álbum completo, en lugar de quedar colocada en el sitio de un género exótico.
+
+El concepto de «Bú-Tik» acercó también a CHTHONIC al propio «escenario histórico». El Butokuden es un signo espacial de las artes marciales, la disciplina y la modernidad colonial de la época japonesa; CHTHONIC lo convirtió en relato metálico y llevó al sonido la relación entre el cuerpo, las armas, la dominación colonial, la resistencia y el Estado moderno. Las posteriores versiones acústicas y en directo desmontaron el muro de sonido, originalmente opresivo, hacia otra forma ritual, y cedieron a la melodía, la lengua y el sentido del espacio la fuerza que antes empujaba el volumen.
+
+«Battlefields of Asura», de 2018, empujó al primer plano el Taiwán de posguerra y la política contemporánea. Blabbermouth, al informar entonces sobre el álbum, señala la participación de Randy Blythe y de Denise Ho; los datos de la 30.ª edición de los Golden Melody Awards muestran además que «Battlefields of Asura» ganó el premio a la mejor banda, y que el comentario del jurado lo entiende dentro del contexto de una generación libre, del metal y de la expresión social.[^9][^10] Este álbum se considera a menudo la respuesta de Freddy Lim tras su entrada en política, pero prolonga a la vez una pregunta que CHTHONIC llevaba mucho tiempo formulando: ¿cómo entran las heridas históricas en el presente? Aquí la política se convierte en la reverberación que queda en el cuerpo, la familia y la memoria de cada persona.
+
+## Después de bajar la actividad, los espíritus siguen ahí
+
+Cuando Freddy Lim entró en el Parlamento, la actividad de CHTHONIC bajó durante un tiempo, pero la banda no desapareció.
+
+En 2019 CHTHONIC organizó el concierto «Taiwan Victory» en la avenida Ketagalan; en 2020 publicó con Matt Heafy, vocalista de Trivium, una nueva versión de «Broken Jade»; en el Megaport de 2021 dejó registro en directo; y en torno al aniversario del 28 de febrero de 2023 publicó «PATTONKAN» (護國山), que devolvió a la canción la memoria de Uongu Yatauyungana, víctima del Terror Blanco, y de su familia. Según la agencia CNA, la inspiración de «PATTONKAN» procede de familiares de víctimas políticas.[^11][^12] Al año siguiente el tema fue además presentado en el programa «Global Spin» de los Grammy, convirtiendo a CHTHONIC en la primera banda taiwanesa en aparecer allí.[^16]
+
+«PATTONKAN» muestra que las obras tardías de CHTHONIC siguen tratando el mismo núcleo: las víctimas tienen cartas familiares, hijos, voces cantadas y memoria comunitaria. Cuando la banda escribe desde Musha, el 28 de febrero y Takasago hasta Uongu Yatauyungana y su hija Kao Chü-hua, la historia de Taiwán se va desprendiendo del orden de los acontecimientos para convertirse en un eco que se transmite entre familias.
+
+«Millions of Reincarnations» (百萬遍), de 2025, volvió a enlazar esa línea con la memoria familiar y la sensación de reencarnación. Estas obras recientes no tienen por qué superar los primeros veinte años de creación de CHTHONIC, pero sí explican una cosa: el núcleo de CHTHONIC no ha desaparecido por la política, las elecciones o los cambios de papel de sus miembros. Sigue tratando las voces que vuelven una y otra vez en la historia de Taiwán.
+
+## Algunas puertas por las que empezar a escuchar
+
+Para entender a CHTHONIC no hace falta empezar necesariamente por la historia completa de la banda.
+
+Se puede escuchar primero «9th Empyrean» y sentir cómo conectaron la Hermana Lintou con el black metal en taiwanés; después «Seediq Bale», «Mirror of Retribution», «Takasago Army» y «Bú-Tik», para ver cómo empujó la banda hacia su universo discográfico temas como Musha, el 28 de febrero, las Unidades de Voluntarios Takasago o la dominación colonial; a continuación «Battlefields of Asura», para entender cómo, tras la entrada de Freddy Lim en la política institucional, CHTHONIC sigue tratando la historia y el presente en formato de banda; y por último «PATTONKAN» y «Millions of Reincarnations», para ver cómo la CHTHONIC pospolítica ha vuelto a la familia, al Terror Blanco y a la reencarnación de los espíritus.
+
+Escuchando así también resulta más difícil malinterpretar a CHTHONIC como una banda que primero tuvo una postura política y luego usó la música como envoltorio. Dicho con más precisión: llevan años tratando en su música la lengua, la historia, los espíritus y la identidad, y por eso los asuntos políticos parecen naturales dentro de su obra.
+
+Este itinerario de escucha se parece más a un mapa sonoro de una historiografía subterránea. CHTHONIC le dio a Taiwán una banda de metal capaz de subirse a los festivales internacionales, y además demostró que la historia de Taiwán puede salir de los manuales, los monumentos y los sucesos periodísticos para entrar en los gritos, el erhu, el taiwanés, la mitología, los ritmos pesados, los recintos de los festivales, los espacios culturales junto al puerto y las comunidades de fans del underground. Cuando esos sonidos estallan en los escenarios metálicos de todo el mundo, el público recibe primero el golpe del sonido y solo después puede preguntar poco a poco: ¿de dónde vienen estos espíritus?
+
+**Lecturas complementarias**: Freddy Lim, Megaport Festival, [música independiente taiwanesa](/music/台灣獨立音樂), [incidente del 28 de febrero](/history/二二八事件), incidente de Musha, Terror Blanco
+
+## Fuentes de imágenes
+
+- [12-08 Wacken Chthonic 02](https://commons.wikimedia.org/wiki/File:12-08_Wacken_Chthonic_02.jpg) — fotografiada por Achim Raschka en el Wacken Open Air de Alemania en 2012, recogida en Wikimedia Commons, licencia CC BY-SA 4.0.
+- [Chthonic](https://commons.wikimedia.org/wiki/File:Chthonic.jpg) — fotografiada por Kozikkris en el Metropolis de Montreal (Canadá) en 2007, recogida en Wikimedia Commons, licencia CC BY 3.0.
+- [Chthonic megaport 2016](https://commons.wikimedia.org/wiki/File:Chthonic_megaport_2016.jpg) — fotografiada por Hisakon en el Megaport Festival de 2016, recogida en Wikimedia Commons, licencia CC BY-SA 3.0.
+- [CHTHONIC - TAKAO - Official Video](https://www.youtube.com/watch?v=c3t-0MIy-fc) — vídeo oficial de CHTHONIC en YouTube, utilizado para mostrar el vocabulario sonoro y visual de la etapa de «Takasago Army».
+- [閃靈 - 鎮魂醒靈寺 Official Video](https://www.youtube.com/watch?v=Ynb9vFd0iNg) — vídeo oficial de CHTHONIC en YouTube, utilizado para mostrar el escenario del templo Xingling y el relato de réquiem.
+
+## Referencias
+
+[^1]: [Chthonic put spin on Taiwan's past](https://www.taipeitimes.com/News/taiwan/archives/2003/09/14/2003067797) — Entrevista del Taipei Times de 2003, que recoge el premio a la mejor banda de la 14.ª edición de los Golden Melody Awards por «9th Empyrean», la historia temprana del grupo, el erhu, la Hermana Lintou y el contexto de una creación basada en la historia de Taiwán.
+
+[^2]: [ChthoniC promotes Taiwan's UN bid in interview with NPR](https://www.taipeitimes.com/News/taiwan/archives/2007/08/09/2003373320) — Reportaje del Taipei Times de 2007 sobre cómo CHTHONIC habló al público estadounidense durante la gira del Ozzfest acerca del bloqueo a la participación internacional de Taiwán, y sobre el uso del mandarín, el taiwanés y el inglés en sus actuaciones.
+
+[^3]: [Takasago Army](https://en.wikipedia.org/wiki/Takasago_Army) — Entrada de la Wikipedia en inglés usada como índice de fuentes, que ordena el tema de «Takasago Army», los músicos participantes, el resumen de la entrevista de Metalship y los enlaces a los vídeos oficiales; el texto lo reformula con prudencia y evita usar por sí solos rankings sin fuente indicada.
+
+[^4]: [Seediq Bale (album)](https://en.wikipedia.org/wiki/Seediq_Bale_%28album%29) — Entrada del álbum en la Wikipedia en inglés usada como índice de fuentes, que ordena la publicación internacional de «Seediq Bale», el tema del incidente de Musha y la información sobre la grabación y los participantes.
+
+[^5]: [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic) — Reportaje de GQ de 2016 sobre la elección de Freddy Lim como diputado, que entiende a CHTHONIC dentro del contexto creativo de las lenguas locales de Taiwán, los instrumentos tradicionales, la opresión y el sufrimiento de los pueblos indígenas.
+
+[^6]: ['We want a fairer society': Freddy Lim, Taiwan's metalhead MP](https://www.theguardian.com/world/2020/aug/17/we-want-a-fairer-society-freddy-lim-taiwan-metalhead-mp) — Reportaje de The Guardian de 2020 sobre la identidad política y musical de Freddy Lim, que completa cómo entienden los medios internacionales la continuidad entre CHTHONIC, los movimientos sociales y la identidad taiwanesa.
+
+[^7]: [Web oficial de 閃靈 CHTHONIC](https://chthonic.tw/) — Sitio oficial de CHTHONIC, que ofrece la puerta de entrada a la marca oficial de la banda, sus redes sociales y sus plataformas musicales; en este texto se usa para confirmar el sitio oficial y sus accesos públicos actuales.
+
+[^8]: [Bu-Tik](https://en.wikipedia.org/wiki/Bu-Tik) — Entrada del álbum en la Wikipedia en inglés usada como índice de fuentes, que ordena la publicación y producción de «Bú-Tik», los Golden Indie Music Awards y las fuentes de crítica internacional; los detalles de los premios se contrastan con el reportaje de Blabbermouth.
+
+[^9]: [CHTHONIC To Release 'Battlefields Of Asura' Album In October](https://blabbermouth.net/news/chthonic-to-release-battlefields-of-asura-album-in-october) — Reportaje de Blabbermouth de 2018 sobre la información de publicación de «Battlefields of Asura» y la lista de colaboradores como Randy Blythe y Denise Ho, que completa el contexto del álbum en los medios internacionales de metal.
+
+[^10]: [Premio a la mejor banda (Golden Melody Awards)](https://zh.wikipedia.org/wiki/%E6%9C%80%E4%BD%B3%E6%A8%82%E5%9C%98%E7%8D%8E_%28%E9%87%91%E6%9B%B2%E7%8D%8E%29) — Entrada del premio a la mejor banda de los Golden Melody Awards usada como índice, que ordena la obtención del galardón por «Battlefields of Asura» en la 30.ª edición y el comentario del jurado; no se usa como pilar principal del relato.
+
+[^11]: [La nueva canción de CHTHONIC «PATTONKAN» se inspira en familiares de víctimas políticas](https://www.cna.com.tw/news/amov/202303010342.aspx) — Reportaje de la agencia CNA de 2023 sobre la inspiración de «PATTONKAN» y el contexto de los familiares de víctimas del Terror Blanco, que completa cómo prolongan las obras recientes el tema de la memoria histórica.
+
+[^12]: [Uongu Yatauyungana](https://zh.wikipedia.org/wiki/%E9%AB%98%E4%B8%80%E7%94%9F) — Entrada sobre Uongu Yatauyungana usada como índice de fuentes, que ordena el homenaje de «PATTONKAN» a él y a Kao Chü-hua, su eco con el contenido de las cartas familiares y las fuentes relacionadas de CNA y de la revista *New Messenger*.
+
+[^13]: [Chthonic (band)](https://en.wikipedia.org/wiki/Chthonic_%28band%29) — Entrada de la Wikipedia en inglés usada como índice de fuentes, que ordena las descripciones sobre el vestuario escénico de CHTHONIC, el papel moneda funerario, los símbolos, la visualidad militarizada y el ritual en directo; el texto lo reescribe con prudencia.
+
+[^14]: [«Megaport» pasado y presente (I): la vida generosa de quienes llevan el timón del festival](https://www.verse.com.tw/article/megaport-festival-01) — Especial de VERSE de 2022 sobre Megaport con entrevistas a Doris y Dani, que ordena los inicios de 2006, su posicionamiento como festival del sur, el relevo del equipo tras la salida de Freddy y el contexto de la aldea de ONG y de los valores de libertad y justicia.
+
+[^15]: [«Megaport» pasado y presente (II): no son solo 16 años, sino la suma cultural de la historia de los festivales de Taiwán](https://www.verse.com.tw/article/megaport-festival-02) — Segunda parte del especial de VERSE de 2022 sobre Megaport, que repasa el Formoz, la curaduría temprana de Freddy y Doris, la experiencia de Megaport y de los festivales internacionales y la evolución de la cultura taiwanesa de ir a ver bandas y de la experiencia en directo.
+
+[^16]: [La nueva canción de CHTHONIC «PATTONKAN» es seleccionada por un programa de los Grammy; Freddy Lim: que el mundo vea la bella Taiwán](https://www.cna.com.tw/news/amov/202305030257.aspx) — Reportaje de la agencia CNA de mayo de 2023, que informa de la selección de «PATTONKAN» en el programa «Global Spin» de los Grammy y de que CHTHONIC se convirtió en la primera banda taiwanesa en aparecer en él.

--- a/knowledge/es/Music/megaport-festival.md
+++ b/knowledge/es/Music/megaport-festival.md
@@ -1,0 +1,133 @@
+---
+translatedFrom: 'Music/大港開唱.md'
+sourceCommitSha: '717a640b'
+sourceContentHash: 'sha256:2cde586b88469ed9'
+sourceBodyHash: 'sha256:db05dfd8f23d6ee9'
+translatedAt: '2026-07-23T21:00:00+08:00'
+lang: 'es'
+title: 'Megaport Festival: el festival de música taiwanés que creció junto al puerto de Kaohsiung'
+description: 'Megaport Festival (大港開唱) es un gran festival taiwanés al aire libre fundado en 2006 junto al puerto de Kaohsiung. Partiendo de la experiencia curatorial del equipo de Formoz Festival, de los miembros de CHTHONIC y de TRA Music, reunió en un mismo espacio a las bandas del sur de Taiwán, los directos en taiwanés, los carteles internacionales, la aldea de ONG y el paisaje portuario. Gracias a él, la ribera del puerto de Kaohsiung se convirtió en un escenario clave donde se cruzan la cultura de ir a ver bandas, la identidad urbana y los asuntos públicos de Taiwán.'
+date: 2026-07-10
+category: 'Music'
+tags:
+  - '大港開唱'
+  - 'Megaport'
+  - 'festival de música'
+  - 'Kaohsiung'
+  - 'música independiente'
+  - 'taiwanés'
+  - 'CHTHONIC'
+subcategory: 'Industria musical'
+author: 'Taiwan.md Translation Team'
+featured: false
+canonical-order: 999
+lastVerified: 2026-07-10
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/大港開唱-outline.md'
+image: 'https://upload.wikimedia.org/wikipedia/commons/8/8e/2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg'
+imageCredit: 'Xi.you 1010.2008 / Wikimedia Commons'
+imageLicense: 'CC BY 4.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg'
+rationale:
+  why_this_hook: 'Entrar por el espacio de la ribera del puerto de Kaohsiung y por la cultura taiwanesa de ir a ver bandas, para evitar que quede como un párrafo accesorio de Freddy Lim o de CHTHONIC.'
+  whats_excluded: 'La lista completa de carteles año por año, los detalles de las polémicas sobre la venta de entradas y el contexto financiero de todos los años de suspensión y reanudación quedan para un texto posterior más profundo.'
+  where_it_hedges: 'Los registros de venta de entradas y la polémica de la suspensión se apoyan en fuentes verificables de medios y oficiales; los detalles no contrastados del todo no entran en el eje principal del texto.'
+  whos_pushing_back: 'Quienes ven Megaport como algo demasiado politizado, quienes lo consideran solo un gran evento de entretenimiento y quienes esperan un análisis completo de la gestión de la industria musical.'
+---
+
+# Megaport Festival: el festival de música taiwanés que creció junto al puerto de Kaohsiung
+
+![El escenario Nanbatian del Megaport Festival de 2025: las luces y el público mirando hacia el gran escenario junto al puerto de Kaohsiung.](https://upload.wikimedia.org/wikipedia/commons/8/8e/2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg)
+_El escenario Nanbatian del Megaport Festival de 2025. Photo: Xi.you 1010.2008 / Wikimedia Commons, CC BY 4.0._
+
+> **Resumen en 30 segundos:** Megaport Festival (大港開唱) es un gran festival al aire libre fundado en 2006 junto al puerto de Kaohsiung. Nació como prolongación de la experiencia del equipo de Formoz Festival (野台開唱); en sus primeros años lo impulsaron Freddy Lim (林昶佐), Doris Yeh (葉湘怡) y el equipo de TRA Music, y más tarde tomaron el relevo Doris y Dani Wang (汪子驤) junto a su equipo. Megaport reúne a las bandas del sur de Taiwán, el paisaje portuario, los directos en taiwanés, los carteles internacionales, la memoria del pop taiwanés y la aldea de ONG, y convierte dos días de conciertos en la manera que tiene una ciudad de volver a imaginarse a sí misma con sonido.
+
+---
+
+En 2006, el Pier-2 de Kaohsiung acababa de transformarse de almacenes portuarios en distrito artístico, y ni el metro ni el tranvía habían conectado todavía la ribera del puerto con la vida cotidiana de la ciudad.
+
+Aquel otoño, Megaport Festival abrió sus puertas junto a los muelles 11 y 12 del puerto de Kaohsiung. La página oficial de HISTORY, al mirar atrás hacia la primera edición, escribe que entonces solo había tres escenarios: «Nanbatian» (南霸天), «Hailongwang» (海龍王) y «Fengyong» (風湧). En el cartel figuraban Sugar Plum Ferry, Cheer Chen, Jeannie Hsieh, Fire EX., Bohemian Bo y Tizzy Bac, y también los japoneses envy y YURA YURA TEIKOKU. Ese programa colocó en un mismo fin de semana a las bandas independientes taiwanesas, al sonido underground japonés, a la memoria del pop en taiwanés y a la ribera del puerto de Kaohsiung.[^1]
+
+## El sur no es decoración
+
+El punto de partida de Megaport está claramente ligado al Formoz Festival de Taipéi.
+
+La página oficial de ABOUT sitúa a Megaport como un festival fundado en Kaohsiung por el equipo organizador de Formoz, uno al sur y otro al norte, convirtiéndose en uno de los pioneros del mercado de los grandes festivales taiwaneses. En la entrevista de VERSE, Doris recuerda que en 2006 ella y Freddy organizaron la primera edición con el equipo de TRA Music bajo el lema «大港起風湧，海龍南霸天», con el objetivo de crear un festival del sur distinto del Formoz de Taipéi.[^2][^3]
+
+Aquí «el sur» no es una imagen escénica ni un eslogan de marketing. La mitad de los artistas de la primera edición venían del sur de Taiwán, y hasta los nombres de los escenarios llevaban el acento de la ciudad portuaria: Nanbatian, Hailongwang, Fengyong. Son nombres ásperos, brillantes, directos, ligados al espacio abierto de la ribera del puerto de Kaohsiung, y hacen que el festival hable con la voz de Kaohsiung desde su primera edición.[^3]
+
+## Un equipo curatorial nacido de CHTHONIC
+
+Fuera del país se suele recordar Megaport como el festival fundado por Freddy Lim, pero lo que de verdad lo ha mantenido vivo como marca a largo plazo es un equipo.
+
+La entrevista de VERSE señala que, después de que Freddy Lim fuera elegido diputado en 2016 y dejara el equipo de Megaport, Doris y Dani tomaron el mando. Doris lo dirigió en 2016 y 2017 y luego pasó a ser asesora; Dani participa en la coordinación del evento desde 2016 y en el equipo lo llaman «el presidente» (社長).[^3]
+
+Este relevo es importante. Megaport se ha ido puliendo hasta convertirse en una institución de largo plazo entre miembros de bandas, curadores, equipo de producción y gestores del recinto, sin quedarse en el carisma personal de una estrella. Dani dice en VERSE que «no avanzar es retroceder», una frase que aterriza en la realidad de gestionar un festival: escenarios, circulación, backstage, medidas sanitarias, entradas, merchandising, zona de descanso de los artistas; todo hay que rehacerlo cada año.[^4]
+
+Y precisamente porque quienes llevan el timón son también intérpretes, Megaport asumió muy pronto la idea de gestión de que «los artistas también son clientes de la organización». Dani cree que un buen backstage relaja a quienes actúan y hace que se entreguen más sobre el escenario; Doris, por su parte, recuerda que Megaport está limitado por la geografía de la ribera del puerto y debe configurarse según las condiciones del recinto. Por eso la internacionalización de Megaport no aparece solo en la lista de bandas extranjeras, sino también en cómo desmonta la experiencia de los festivales de fuera y la va reincorporando, poco a poco, al ecosistema de los directos en Taiwán, junto al puerto de Kaohsiung.[^5]
+
+![La banda 1976 actuando en el Megaport Festival de 2016, con las luces del escenario iluminando a todo el grupo.](https://upload.wikimedia.org/wikipedia/commons/e/ea/1976bandatMegaport2016.jpg)
+_La banda 1976 en el Megaport Festival de 2016. Photo: Po Sing Tew / Wikimedia Commons, CC BY 2.0._
+
+## El festival de la vida
+
+La curaduría más reconocible de Megaport no está solo en las bandas independientes.
+
+Tras su reanudación en 2015, Doris y Dani invitaron a He Yi-hang y a LTK Commune a hacer juntos el «espectáculo de sala Megaport». Más tarde llegaron al escenario Shen Wen-cheng, Wang Tsai-hua, Tsai Kuei, Huang Hsi-tien, Jeannie Hsieh o Tsai Chiu-feng, memorias del taiwanés y del pop de distintas generaciones. Estas decisiones expandieron Megaport más allá del «festival de los que van a ver bandas» y lo convirtieron en un escenario capaz de acoger a la vez rock underground, espectáculo de sala en taiwanés, ídolos, hip hop, heavy metal, folk y colaboraciones transversales.[^3][^6]
+
+La página oficial de ABOUT llama a Megaport «el festival de la vida». No es un eslogan abstracto: corresponde a un método curatorial que consiste en hacer que se encuentren junto al puerto distintas etapas de la vida, distintas memorias generacionales, distintas lenguas y distintos gustos musicales. Quienes son jóvenes pueden venir por Bloody Blender o Sunset Rollercoaster, y ver en ese mismo fin de semana a Huang Hsi-tien o a Shen Wen-cheng; y las voces en taiwanés que conocen los mayores vuelven a escucharse, dentro del sistema de sonido a todo volumen de un festival.[^2]
+
+![Enno Cheng actuando en el escenario del Megaport Festival de 2018, con una guitarra y un micrófono en las manos.](https://upload.wikimedia.org/wikipedia/commons/b/bc/Enno-2018%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1.jpg)
+_Enno Cheng en el Megaport Festival de 2018. Photo: Ken26729264 / Wikimedia Commons, CC BY-SA 4.0._
+
+## La aldea de ONG y el espacio público
+
+La otra línea de Megaport son los asuntos públicos.
+
+Doris dice en VERSE que instalaron la aldea de ONG porque venir a un festival no significa que desaparezcan las cosas que hay que recordar. Dani y Doris también conectan la aldea de ONG con el espíritu de los conciertos que Freddy organizó en el pasado: el «Concierto Justicia Invencible», el «Concierto contra la anexión por China» o el «Concierto por la libertad del Tíbet». Así, el carácter público de Megaport no existe solo en algunas canciones o en las palabras de algún artista, sino que está configurado como parte del propio espacio.[^7]
+
+Ese carácter público también trae polémica. En 2019, durante una interpelación en el Consejo Municipal de Kaohsiung, un concejal del Kuomintang reprodujo un fragmento en el que el concejal de Taipéi Froggy Chiu soltaba palabrotas en el escenario de Megaport; el entonces alcalde de Kaohsiung, Han Kuo-yu, respondió criticando el contenido como «vulgar, indecente e insoportable». La agencia CNA recogió este cruce de acusaciones y también las dudas de Huang Chieh sobre el doble rasero.[^8]
+
+Para Megaport, la polémica no es una rama lateral. Muestra cómo mira una ciudad su propia cultura: un festival puede ser solo una actividad turística, o puede ser un escenario público donde chocan los jóvenes, las bandas, las ONG, los políticos y los valores de la ciudad.
+
+## Después de agotar las entradas
+
+En 2019 Megaport anunció su suspensión y en 2021 volvió. Para cuando VERSE la entrevistó en 2022, Doris ya lo veía como el resultado de una acumulación de años y no como un estallido provocado por una sola noticia. Dice que Megaport agota las entradas todos los años desde 2015, y que la única diferencia es que antes se agotaban antes del evento y ahora se agotan justo después de ponerse a la venta.[^9]
+
+La web oficial indica que el Megaport de 2026 está fijado para los días 21 y 22 de marzo, con el Pier-2 Art Center de Kaohsiung como localización; el cartel incluye a Sunset Rollercoaster, Kessoku Band, AiNA THE END, Fire EX., Hiromi's Sonicwonder, Käärijä, Yang Fan y Bloody Blender, entre otros. Esa lista conserva la mezcla característica de Megaport: un proyecto de banda de anime japonés, una figura mediática finlandesa de Eurovisión, rock taiwanés y memoria del pop en taiwanés pueden aparecer uno al lado del otro en el mismo fin de semana portuario.[^10]
+
+Si Megaport merece una entrada propia no es solo porque sea grande, porque cueste conseguir entradas o porque tenga un cartel vistoso. Lo más importante es que enlaza varias claves de la [cultura de festivales de Taiwán](/music/台灣音樂祭文化): la mirada local e internacional de CHTHONIC, la identidad urbana del sur de Taiwán, el ecosistema en directo de la [música independiente taiwanesa](/music/台灣獨立音樂), el regreso del taiwanés como lengua contemporánea y la posibilidad del festival como espacio público.
+
+Hay festivales que parecen un programa de mano; Megaport se parece más a una ciudad temporal. En dos días, los almacenes, los muelles, el césped y los recintos de la ribera del puerto son renombrados por el sonido. Cuando se apagan las luces y se desmontan los escenarios, mucha gente vuelve al año siguiente, como quien regresa a una tierra natal que solo existe en marzo.
+
+**Lecturas complementarias**: Freddy Lim, CHTHONIC, [cultura de festivales de Taiwán](/music/台灣音樂祭文化), [música independiente taiwanesa](/music/台灣獨立音樂), [Fire EX.](/music/滅火器樂團)
+
+## Fuentes de imágenes
+
+Este texto utiliza 3 imágenes con licencia CC de Wikimedia Commons:
+
+- **Escenario Nanbatian del Megaport 2025** (hero) — fotografía de Xi.you 1010.2008 ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg)), 2025. Licencia: [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+- **La banda 1976 actuando en Megaport** (scene-mid 1) — fotografía de Po Sing Tew ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:1976bandatMegaport2016.jpg)), 2016. Licencia: [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/).
+- **Enno Cheng actuando en Megaport** (scene-mid 2) — fotografía de Ken26729264 ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Enno-2018%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1.jpg)), 2018. Licencia: [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+## Referencias
+
+[^1]: [大港開唱 MEGAPORT FESTIVAL: HISTORY](https://megaportfest.com/info/history/) — Página oficial de historia de Megaport, que recoge carteles, escenarios, artistas y textos retrospectivos oficiales de todas las ediciones desde 2006; es la principal puerta de entrada de primera mano para verificar años y carteles.
+
+[^2]: [大港開唱 MEGAPORT FESTIVAL: ABOUT](https://megaportfest.com/info/about/) — Página oficial de presentación de Megaport, que explica su fundación en 2006, su vínculo con Formoz Festival, el paisaje portuario y su definición como «el festival de la vida».
+
+[^3]: [VERSE: «Megaport» pasado y presente (I): la vida generosa de quienes llevan el timón del festival](https://www.verse.com.tw/article/megaport-festival-01) — Entrevista de VERSE de 2022 con Doris y Dani, que detalla los inicios de 2006, los muelles 11 y 12 del puerto de Kaohsiung, la proporción de bandas del sur de Taiwán, la denominación de los escenarios y el relevo del equipo gestor a partir de 2016.
+
+[^4]: [VERSE: «Megaport» pasado y presente (I): la vida generosa de quienes llevan el timón del festival](https://www.verse.com.tw/article/megaport-festival-01) — La misma entrevista recoge la idea de Dani de que en la gestión de Megaport «no avanzar es retroceder», así como las presiones curatoriales derivadas de la pandemia, las medidas sanitarias, la circulación y la experiencia del evento.
+
+[^5]: [VERSE: «Megaport» pasado y presente (II): no son solo 16 años, sino la suma cultural de la historia de los festivales de Taiwán](https://www.verse.com.tw/article/megaport-festival-02) — La segunda parte de la entrevista de VERSE sitúa a Megaport dentro del contexto de Formoz y de la cultura taiwanesa de ir a ver bandas, y aborda la cultura de la venta de entradas, el backstage de los artistas y la experiencia de quienes actúan.
+
+[^6]: [大港開唱 MEGAPORT FESTIVAL: HISTORY](https://megaportfest.com/info/history/) — La página oficial de carteles por año muestra que distintas ediciones incorporaron a Jeannie Hsieh, Shen Wen-cheng, Huang Hsi-tien o Tsai Chiu-feng, memorias del taiwanés y del pop de varias generaciones, junto a bandas independientes y carteles internacionales.
+
+[^7]: [VERSE: «Megaport» pasado y presente (I): la vida generosa de quienes llevan el timón del festival](https://www.verse.com.tw/article/megaport-festival-01) — La entrevista explica el origen del espíritu de la aldea de ONG de Megaport y cómo entienden Doris y Dani la relación entre el festival y la libertad, la justicia y los asuntos públicos.
+
+[^8]: [CNA: Han Kuo-yu critica Megaport por indecente; Huang Chieh cuestiona el doble rasero](https://www.cna.com.tw/news/aloc/201909260286.aspx) — Reportaje de la agencia CNA de 2019 sobre las críticas y contracríticas al lenguaje usado en el escenario de Megaport durante una interpelación en el Consejo Municipal de Kaohsiung, que muestra la polémica político-cultural que suscita el carácter público del festival.
+
+[^9]: [VERSE: «Megaport» pasado y presente (II): no son solo 16 años, sino la suma cultural de la historia de los festivales de Taiwán](https://www.verse.com.tw/article/megaport-festival-02) — La segunda parte de la entrevista recoge la valoración de Doris sobre el fenómeno de las entradas agotadas, señalando que se agotan todos los años desde 2015 y que no se debe a una única polémica política.
+
+[^10]: [Web oficial de 大港開唱 MEGAPORT FESTIVAL](https://megaportfest.com/) — La portada oficial enumera la fecha, el lugar, el lema y parte del cartel del Megaport de 2026; se utiliza para confirmar la información pública disponible hasta julio de 2026.

--- a/knowledge/es/People/dwagie.md
+++ b/knowledge/es/People/dwagie.md
@@ -1,0 +1,176 @@
+---
+translatedFrom: 'People/大支.md'
+sourceCommitSha: '498649fe'
+sourceContentHash: 'sha256:2e7abe81d37d5763'
+sourceBodyHash: 'sha256:42bdb5d4361f8a68'
+translatedAt: '2026-07-23T21:40:00+08:00'
+lang: 'es'
+title: 'Dwagie: el «director» del rap en taiwanés salido de una sala de ensayo de Tainan'
+description: 'Dwagie (大支, nombre real Tseng Kuan-jung) es un rapero taiwanés nacido en Tainan y fundador del estudio musical Kung Fu Entertainment (人人有功練). Desde el tablón de MU y el álbum «Lotus from the Tongue» de Magic Stone Records hasta «Taiwan Song», «Refugee», los derechos de los animales, «The Rappers» y la enseñanza del hip hop en Tainan, ha metido en un mismo micrófono el rap en taiwanés, los escenarios locales, los asuntos públicos, la formación de una nueva generación y la conciencia de Taiwán como sujeto. Y ha convertido Tainan en un lugar que la historia del rap taiwanés no puede saltarse.'
+date: 2026-07-10
+category: 'People'
+tags:
+  - 'personaje'
+  - 'música'
+  - 'hip hop'
+  - 'rap'
+  - 'taiwanés'
+  - 'Tainan'
+  - 'Dwagie'
+  - 'Kung Fu Entertainment'
+subcategory: 'Música y artes escénicas'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-10
+lastHumanReview: false
+researchReport: reports/research/2026-07/大支-outline.md
+readingTime: 14
+image: '/article-images/music/dwagie-portrait-2019.webp'
+imageCredit: 'Gobierno de la ciudad de Chiayi / Wikimedia Commons'
+imageLicense: 'Licencia de atribución (declaración de datos abiertos de los sitios web gubernamentales)'
+imageSource: 'https://commons.wikimedia.org/wiki/File:全國獨嘉三日跨年祭_力邀金鐘雙主持(大支)(cropped).jpg'
+rationale:
+  why_this_hook: 'Entrar por Tainan y por el rap en taiwanés, para evitar retratar a Dwagie únicamente como una figura de posicionamiento político.'
+  whats_excluded: 'No se despliegan la lista completa de premios, la polémica reciente sobre subvenciones ni todas las canciones de cada álbum; se dejan para una investigación posterior más completa.'
+  where_it_hedges: 'El año de nacimiento, el episodio del recinto de la NBA y la definición de «Lotus from the Tongue» como primer álbum íntegramente de rap se suavizan o se dejan en las notas de investigación.'
+  whos_pushing_back: 'Los lectores que discrepan de la postura política o de las declaraciones públicas de Dwagie pueden esperar una cronología más detallada de las polémicas.'
+---
+
+# Dwagie: el «director» del rap en taiwanés salido de una sala de ensayo de Tainan
+
+> **Resumen en 30 segundos:** Dwagie (大支, nombre real Tseng Kuan-jung / 曾冠榕) es un rapero taiwanés nacido en Tainan y también el fundador del estudio musical Kung Fu Entertainment (人人有功練). A finales de los años noventa conoció a MC HotDog en el tablón de mensajes Master U y pasó de las maquetas underground y las actuaciones en clubes al estudio Big Circus de Magic Stone Records. Cuando en 2002 salió «Lotus from the Tongue» (舌粲蓮花; en algunas fuentes 舌燦蓮花), se discutió en el contexto de los primeros álbumes íntegramente de rap del mercado en chino; «Taiwan Song» convirtió el acento del taiwanés en una marca sonora de la conciencia de Taiwán como sujeto. A partir de 2003 volvió a Tainan y levantó Kung Fu Entertainment, transformando un espacio de grabación y ensayo en un bastión del hip hop del sur. En 2011, «Refugee» (人) reunió a Deserts Chang, Freddy Lim, Wen Hsia y el XIV Dalái Lama, entre otros, y llevó los derechos humanos, la religión, los derechos de los animales y la preocupación política al vocabulario del rap taiwanés. Con «The Rappers» (大嘻哈時代), como jurado y como «director», ha ido entregando a la nueva generación la experiencia acumulada en la escena underground de los primeros años.[^1][^2][^3][^4]
+
+## Los años underground que empezaron en el tablón de MU
+
+El lugar donde la escena taiwanesa de hip hop empezó a reconocer a Dwagie fue el tablón de mensajes de internet, las tiendas de discos y algún rincón subcultural de Tainan.
+
+En una entrevista con la agencia CNA recuerda que, de joven, en una tienda de discos se topó con obras del hip hop de la Costa Oeste estadounidense como «Doggystyle» de Snoop Dogg. En Tainan, escenas locales como POP Artist Shop o Eastern Assassin le mostraron cómo podía juntarse una subcultura. Después se fue a estudiar a Taipéi, conoció a MC HotDog en el tablón de Master U, y ambos, a través de quedadas, baloncesto, fiestas e intercambio de material, se convirtieron en uno de los tándems centrales del rap underground taiwanés de los primeros tiempos.[^1][^2]
+
+El hip hop taiwanés de entonces no tenía todavía una industria madura. Según el fragmento que Roomie extrajo del libro «Hip Hop Kid: historias del rap taiwanés», después de 1998 Magic Stone Records se fijó en MC HotDog en un directo del club @live de Taipéi y a continuación fundó el «estudio musical Big Circus», con miembros como MC HotDog, Dwagie, Xiao Si, 168 y Charles. La discográfica todavía andaba a tientas con la producción, el precio y la promoción del rap. Las maquetas underground, las redes de las residencias universitarias, los directos y la industria discográfica mayoritaria estuvieron conectados brevemente durante aquellos años.[^2]
+
+![MC HotDog actuando en el escenario con un micrófono adidas en la mano, de perfil y con gorra, con expresión concentrada.](/article-images/music/mc-hotdog-mic-2012.webp)
+_MC HotDog, actuación de 2012. Dwagie y MC HotDog se cruzaron en la época de Master U y Magic Stone. Los años underground de ambos componen juntos un recuerdo clave del rap taiwanés antes de entrar en el mercado mayoritario. Photo: Chiu Yu-feng, CC BY-SA 4.0 via Wikimedia Commons._
+
+En agosto de 2002 Dwagie publicó «Lotus from the Tongue». El extracto de Roomie lo sitúa en la última etapa de Magic Stone: la obra figura con el último número de registro en el catálogo de álbumes del sello y, en su momento, la promoción de la discográfica la presentó como la obra inaugural del álbum íntegramente de rap en el mercado en chino.[^2] Más que tomar ese eslogan publicitario como un ranking que no necesita verificación, conviene mirar la posición histórica que señala: en un momento en que el rap taiwanés aún no era del todo comprendido por el mercado mayoritario, Dwagie puso en un mismo álbum completo el taiwanés, el mandarín, los skits, la experimentación con la rima, la conciencia local y las formas del hip hop internacional.
+
+## El sonido de «Taiwan Song»
+
+La obra más recordada de «Lotus from the Tongue» es «Taiwan Song».
+
+A menudo se simplifica como un posicionamiento político, pero lo más importante es el método sonoro: Dwagie usa la pronunciación del taiwanés, el acento de Tainan y los gritos en forma de pregunta y respuesta para convertir «Taiwán» de concepto en un timbre que puede oírse. Situada en el contexto del desarrollo del hip hop y del rap taiwaneses, «Taiwan Song» es a la vez una canción de conciencia local y un experimento lingüístico. Aquí el taiwanés asume el ritmo del rap, su agresividad y su capacidad de movilizar a la multitud, y deja de ser algo que se toma prestado para dar color emocional a una canción pop en mandarín.[^2][^5]
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/mn_ptfQDOJA" title="大支 Dwagie - 台灣SONG Official MV" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Videoclip oficial de Dwagie: «Taiwan Song»._
+
+En 2017 fue invitado a interpretar «Taiwan Song» en la «Taiwan Culture Night» celebrada en la cancha de los Brooklyn Nets de la NBA, y los medios taiwaneses y las fuentes en línea lo registraron como el episodio representativo de un rapero taiwanés subido a un recinto de la NBA.[^3] La escena ilustra bien la posición contradictoria de Dwagie: una canción nacida del acento de Tainan, de la letra en taiwanés y de la conciencia taiwanesa se convierte, en una cancha profesional de baloncesto estadounidense, en la bandera sonora de un acto de cultura taiwanesa en el extranjero.
+
+## Volver a Tainan y abrir una sala de ensayo
+
+Después de «Lotus from the Tongue», Dwagie no se dirigió únicamente al mercado del espectáculo de Taipéi. Regresó a Tainan y levantó Kung Fu Entertainment.
+
+En la entrevista con CNA cuenta que Kung Fu Entertainment no fue desde el principio un gran proyecto cultural, sino más bien un sitio donde quienes amaban el hip hop pudieran grabar y ensayar, y donde los estudiantes pudieran aprender a rapear. A partir de 2003, ese espacio de reunión y enseñanza fue creciendo lentamente hasta convertirse en un bastión del hip hop del sur. Los cursos de rap de verano, el estudio de grabación, los eventos y la red de miembros hicieron de Tainan otro centro de producción del rap taiwanés.[^1]
+
+La particularidad de Kung Fu Entertainment está en que asume a la vez la enseñanza, los conciertos, la producción, la reunión local y el relevo de los novatos. Es más heterogéneo que un simple sello discográfico y más público que un estudio personal. Que más tarde el hip hop taiwanés empezara a llamar a Dwagie «el director» viene de su antigüedad y de su posición generacional, pero también de su manera de trabajar, que durante años ha atado la enseñanza del rap, el estudio de grabación y la gestión de la escena.
+
+El rap taiwanés se imagina a menudo como una cultura nacida de las redes de las residencias de Taipéi, de Riverside Live House, de los clubes y de las asociaciones universitarias; lo que Dwagie y Kung Fu Entertainment añadieron fue la vía de Tainan: un grupo de personas entrenando en casas de té, estudios de grabación, cursos y eventos, y llevando al hip hop el acento del sur, el taiwanés y la experiencia local.
+
+## Después de «Refugee», el micrófono conduce a los asuntos públicos
+
+«Refugee» (人), publicado en 2011, es un punto de inflexión importante en la trayectoria creativa de Dwagie. Según recoge CNA, el álbum incluye colaboraciones con Deserts Chang, Freddy Lim, Wen Hsia y el XIV Dalái Lama, entre otros; la canción homónima lleva a la obra la religión, los derechos humanos, los animales y la preocupación por la vida.[^1][^3]
+
+«Refugee» fue después nominado al mejor álbum en mandarín en la 23.ª edición de los Golden Melody Awards y ganó el mejor álbum y el mejor álbum de hip hop, entre otros, en la 3.ª edición de los Golden Indie Music Awards.[^3] Los premios no son la parte más nítida de la obra de Dwagie, pero sí metieron esta vía de rap áspera, muy política y cargada de taiwanés y de conciencia taiwanesa en una posición reconocible para las instituciones musicales mayoritarias.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/_VpcRXNNZUg" title="大支 Dwagie - 人 feat. 第十四世達賴喇嘛 Official MV" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Videoclip oficial de Dwagie: «Refugee», con la aparición del XIV Dalái Lama._
+
+Cuando la televisión pública (PTS) presentó a Dwagie en «Who's Coming to Dinner», lo situó en el contexto de «decir las verdades de la sociedad con el micrófono» y registró también su vegetarianismo de muchos años y su interés por los animales y por los colectivos vulnerables.[^6] En el Día Mundial por los Derechos de los Animales de 2019, el Centro de Información Ambiental informó de que en el acto encabezó la lectura de una declaración de derechos de los animales e interpretó canciones sobre el sacrificio y los productos de cuero.[^7]
+
+Estos asuntos públicos hacen difícil devolver la música de Dwagie únicamente al mercado del entretenimiento. Él entiende el hip hop como una herramienta sonora capaz de intervenir en la realidad, y los derechos humanos, la subjetividad taiwanesa, los derechos de los animales y la atención a los vulnerables se convirtieron después en parte de su obra y de su imagen pública.
+
+El carácter político también tuvo su precio. A finales de 2016 los medios informaron de que en China circulaba una lista de veto a artistas taiwaneses; la autenticidad de la lista no estaba confirmada oficialmente entonces. Incluido en ella, Dwagie respondió que llevaba años hablando de derechos humanos, política y valores universales y que, de entrada, no encajaba con la postura del Partido Comunista Chino, y añadió que «no pasa nada por ganar un poco menos».[^8] Esa respuesta se ha citado mucho después, porque expone su posición con enorme franqueza: el rap debe conservar la libertad de hablar, aunque eso estreche algunos mercados.
+
+## El cuerpo, la familia y la cara que hay detrás de la «dureza»
+
+La imagen escénica de Dwagie se envuelve fácilmente en unas pocas palabras: corpulento, voz grave, letras directas, postura política nítida. Todos esos rasgos son ciertos, pero mirar solo esa cara hace perder de vista por qué convirtió el hip hop en educación y en incidencia pública.
+
+Cuando PTS presentó su contexto familiar, mencionó que su padre era policía y su madre maestra, y que sus hermanos también siguieron trabajos de servicio público como la policía y los bomberos.[^6] Ese contexto familiar, puesto dentro de su música, produce un contraste interesante: él canta un hip hop considerado rebelde, malhablado, underground y contrario a la autoridad, pero las profesiones más cotidianas de su entorno son papeles de cuidado y de orden situados dentro de las instituciones: policía, maestra, bombero.
+
+PTS registra también que en su época de estudiante practicó judo, que después se lesionó y que esa experiencia corporal lo llevó del deporte a la música.[^6] El nombre artístico «Dwagie» arrastra por eso una cierta sensación física: el rap se apoya en las palabras y en la cabeza, pero también en la respiración, la capacidad pulmonar, el ritmo, los acentos y la presión de la escena para lanzar el cuerpo hacia fuera. De «Taiwan Song» a «Refugee», su parte más reconocible está a menudo en ese ritmo corporal áspero y pesado, pero preciso.
+
+Por eso, cuando más tarde mantuvo durante años una dieta vegetariana y se implicó en los derechos de los animales, esa fuerza «dura» original se orientó en otra dirección. Para Dwagie, el rap puede insultar, puede declarar una postura y también puede alzar la voz en lugar de vidas que no pueden hablar. Ese giro hizo que su imagen pública fuera difícil de contener en una sola etiqueta: es a la vez un rapero con agresividad, un director que enseña rap a sus alumnos, un activista que aparece en los actos por los derechos de los animales y un creador que mete preguntas religiosas y vitales en sus álbumes.
+
+## Los álbumes posteriores: política, lengua y experimentación de género
+
+Después de «Refugee», la obra de Dwagie no se quedó en una sola fórmula. En su cronología, álbumes como «Refuse to Listen» (2013), «Hard» (2016), «Dark Net» (2018), «Burning Rap Soul» (2019), «Music and Politics» (2020), «Captain Taiwan» (2021) o «Love» (2023) le hicieron atravesar sucesivamente el rap político, el taiwanés, el hardcore, los asuntos sociales y una sensación vital personal.[^3]
+
+En la época de «Refuse to Listen» colaboró con el rapero estadounidense Nas en la canción homónima, lo que estableció una conexión directa entre el rap taiwanés y un icono internacional del hip hop.[^3] «Hard» fue nominado a mejor cantante masculino en mandarín en la 28.ª edición de los Golden Melody Awards y ganó el premio del jurado en la 8.ª edición de los Golden Indie Music Awards; «Dark Net» fue nominado al álbum del año, al mejor álbum en taiwanés y al mejor cantante masculino en taiwanés en la 30.ª edición de los Golden Melody Awards.[^3] No hace falta leer estos premios como un simple currículum de éxitos. Lo más importante es que el alcance del reconocimiento institucional se fue ampliando. La obra de Dwagie se mueve entre los álbumes en mandarín, los álbumes en taiwanés, los premios de género de hip hop y los premios de artistas mayoritarios, empujando continuamente el rap taiwanés hacia los límites de distintas categorías.
+
+«Captain Taiwan», de 2021, volvió a poner en primer plano el taiwanés y la memoria de figuras públicas. Según las notas de investigación existentes, el álbum tiene el taiwanés como base y ha rendido homenaje con canciones a figuras como Chi Chia-wei, Wang Chien-ming o Lee Teng-hui. Esta forma de escribir prolonga un hábito creativo que Dwagie tenía desde muy pronto: además de escribir sobre sí mismo, mete en sus canciones a personas, hechos y conflictos de valores de la memoria pública taiwanesa. Aquí el taiwanés se convierte en una lengua narrativa capaz de sostener la biografía, la política, el homenaje y la discusión.
+
+## «La misma semilla» y la era de The Rappers
+
+Después de 2017, el hip hop en chino ganó enorme popularidad gracias a los concursos televisivos chinos, y el rap taiwanés también recibió más atención. Al hablar de este cambio en la entrevista con CNA, Dwagie usó una metáfora que le va muy bien a él mismo: «la misma semilla, en suelos distintos, crece con formas distintas».[^1]
+
+Esta frase responde por un lado a las diferencias entre los mercados de ambas orillas y, por otro, vuelve al propio rap taiwanés: cuando la semilla del hip hop estadounidense entra en Taiwán, su forma de crecer queda reconfigurada por el taiwanés, el hakka, las lenguas de los pueblos indígenas, las diferencias entre las escenas del norte y del sur, la política identitaria posterior a la democratización y la historia entrecruzada de la música independiente y los movimientos sociales. La vía del propio Dwagie es justamente la forma que tomó esa semilla en el suelo de Tainan.
+
+En 2021 comenzó a emitirse «The Rappers». El programa lo produjeron Sanlih Television y MTV, se emitió en plataformas como TTV, MTV y MyVideo, y Leo Wang, Dwagie, Barzo Chiang y Kumachan ejercieron de mentores o jurado.[^9] Para muchos oyentes jóvenes, Dwagie dejó de ser solo un OG de las listas underground de los primeros años y pasó a ser jurado, profesor y director en la pantalla. Ese cambio tiene un valor simbólico: el rap taiwanés, que antes tenía que buscar afines en tablones, redes de residencias y maquetas underground, había crecido por fin hasta poder construir la puerta de entrada de una nueva generación con un programa de televisión.
+
+El papel de Dwagie en el programa tampoco se limita a puntuar. Él representa una memoria del hip hop taiwanés de los primeros años: Tainan, el taiwanés, el carácter político, Kung Fu Entertainment y el largo camino del underground al mercado mayoritario. Cuando los raperos de la nueva generación exhiben ante la cámara su flow, sus batallas, su lengua y su actitud, la presencia de Dwagie le recuerda al público que un concurso es solo una puerta de entrada más, y que mucho antes ya había gente forjando el rap taiwanés en locales diminutos.
+
+## El pasado fue así, el futuro aún no se sabe
+
+La entrevista de CNA de 2019 se titula «El pasado fue así, el futuro aún no se sabe». La frase le encaja muy bien. No suena como un veterano ya asentado anunciando su próximo proyecto, sino más bien como alguien que, después de veinte años, empieza a notar que la energía, el tiempo y la responsabilidad están cambiando.[^1]
+
+En aquella entrevista Dwagie habla de los cantantes jóvenes, de la enseñanza y de la exposición que trajo la fiebre del hip hop chino, y al mismo tiempo también de cuánto tiempo más podrá seguir él. Es el sentido de la realidad de un músico de mediana edad: la escena underground de los primeros años se sostenía con pasión, pero después llegaron el estudio, los alumnos, los álbumes, los programas y los asuntos públicos, y cada una de esas cosas añade peso. Cuanto más se asienta el apelativo de «director», más se le plantea al creador esta pregunta: ¿cómo seguir escribiendo las propias canciones mientras se guía a la gente, se enseña y se responde a los acontecimientos públicos?
+
+Este es también el punto en que Dwagie se distingue de la simple etiqueta de «rapero político». Las declaraciones políticas se convierten en noticia, pero la enseñanza y la gestión de una escena son trabajo lento. Los hechos noticiosos se recuerdan con facilidad; un estudio de grabación, un curso de verano o el proceso por el que un grupo de jóvenes se va convirtiendo poco a poco en raperos entran con dificultad en un titular. Lo que Dwagie ha dejado de verdad es un conjunto de canciones de postura nítida y, a la vez, una forma de dar continuidad a una escena: alguien abrió primero la puerta en Tainan, y por eso quienes llegan después tienen un sitio donde entrar a entrenar.
+
+## Tainan, el taiwanés, lo público
+
+Lo más importante de Dwagie no está en si representa para siempre la mayor técnica del rap taiwanés, ni en si todas sus declaraciones políticas logran el acuerdo de todo el mundo. Su posición histórica más estable consiste en haber atado tres cosas: el rap en taiwanés, el espacio de Tainan y los asuntos públicos.
+
+Hizo del rap en taiwanés una declaración de sujeto; hizo crecer en Tainan un bastión del sur como Kung Fu Entertainment; y permitió que un rapero pusiera los derechos humanos, los derechos de los animales, la identidad taiwanesa y los asuntos sociales en el núcleo de su creación, en lugar de dejarlos en el terreno del espectáculo y del mercado del entretenimiento.
+
+En la historia del hip hop taiwanés, a MC HotDog se le suele situar en el punto en que el rap en chino entra en el mercado mayoritario; a Song Yueh-ting, en el de la escritura y el relato vital; a Soft Lipa y Kao!Inc., en el de la vía poética y jazzística. La posición de Dwagie es más áspera y más pública: llevó el micrófono a Tainan, a la calle, junto a los medios internacionales y a los asuntos políticos, e hizo que el rap taiwanés empezara muy pronto a formular una pregunta más difícil: ¿con qué lengua, con qué acento y con qué actitud va a hablar de sí misma esta isla?
+
+Esa pregunta hace que la obra de Dwagie lleve siempre una sensación de fricción. A quienes les gusta suelen verlo como una de las pocas personas dispuestas a cantar con tanta franqueza la identidad taiwanesa, los derechos humanos y los derechos de los animales; a quienes no les gusta pueden parecerles demasiado política, demasiado dura de tono y demasiado condicionada por su postura. Esa división es en sí misma la posición de Dwagie en la cultura popular taiwanesa: es difícil colocarlo como figura puramente del entretenimiento y difícil resumirlo en un único papel de activista. Sus canciones tienen escenario y ritmo, y también consignas, ataques, homenajes y convicciones; su estudio produce música, y también enseña y cría escena.
+
+Por eso, al mirar hacia atrás a Dwagie, la mejor puerta de entrada sigue siendo la música. Los acontecimientos políticos pasan uno tras otro y las polémicas públicas cambian sin cesar, pero aquel acento de Tainan de «Taiwan Song», el intento de un álbum íntegramente de rap que fue «Lotus from the Tongue» y la escena del sur que fue criando lentamente una sala de ensayo llamada Kung Fu Entertainment son lo más firme que ha dejado en la historia del hip hop taiwanés. Es el proceso por el que un rapero taiwanés canta una forma llegada de fuera hasta convertirla en sonido local, y también el proceso por el que el rap taiwanés pasa del underground a ser lengua pública.
+
+**Lecturas complementarias**:
+
+- [Desarrollo del hip hop y el rap en Taiwán](/music/台灣嘻哈與饒舌發展) — el recorrido del rap taiwanés desde Song Yueh-ting, MC HotDog y Dwagie hasta Leo Wang, Kumachan y la nueva generación.
+- [Música independiente taiwanesa](/music/台灣獨立音樂) — cómo han sostenido los sellos independientes, las escenas locales y la música no mayoritaria otra vía para la música de Taiwán.
+- [Golden Melody Awards](/music/金曲獎) — los cambios de los géneros musicales y de la política lingüística de Taiwán vistos desde los premios de música popular.
+- [Incidente del 28 de febrero](/history/二二八事件) — una de las memorias históricas y políticas taiwanesas que la obra de Dwagie toca con frecuencia.
+
+## Fuentes de imágenes
+
+- Fotografía de Dwagie de la imagen principal: Gobierno de la ciudad de Chiayi, Wikimedia Commons, licencia de atribución (declaración de datos abiertos de los sitios web gubernamentales). Archivo original: [全國獨嘉三日跨年祭 力邀金鐘雙主持（大支）](https://commons.wikimedia.org/wiki/File:全國獨嘉三日跨年祭_力邀金鐘雙主持(大支)(cropped).jpg).
+- Fotografía de la actuación de MC HotDog en 2012: Chiu Yu-feng, Wikimedia Commons, CC BY-SA 4.0. Archivo original: [2012 Super Slipper](https://commons.wikimedia.org/wiki/File:MC_HotDog_at_2012_Super_Slipper.jpg).
+
+## Referencias
+
+[^1]: [〖Entrevista〗Dwagie / El pasado fue así, el futuro aún no se sabe](https://www.cna.com.tw/culture/article/20191207w003) — Entrevista cultural de la agencia CNA de 2019, que recoge el primer contacto de Dwagie con el hip hop, su relación con MC HotDog, Magic Stone Records, Kung Fu Entertainment, «Refugee» y su visión del desarrollo del hip hop taiwanés.
+
+[^2]: [Arqueología del hip hop taiwanés: cuando ficharon a MC HotDog y a Dwagie, en Magic Stone nadie sabía cómo se hacía rap](https://www.roomie.tw/posts/64860) — Extracto publicado por Roomie del libro «Hip Hop Kid: historias del rap taiwanés» de Kao!Inc., que explica Master U, el estudio Big Circus de Magic Stone Records, los años underground de MC HotDog y Dwagie y el lugar de «Lotus from the Tongue» en la historia del rap taiwanés.
+
+[^3]: [Dwagie — Wikipedia](https://zh.wikipedia.org/zh-tw/%E5%A4%A7%E6%94%AF) — Entrada de Dwagie en la Wikipedia en chino, usada como índice de su cronología de obras, programas de televisión, colaboraciones, premios y actuaciones; los pasajes narrativos clave se contrastan con CNA, Roomie y la televisión pública.
+
+[^4]: [Estudio musical Kung Fu Entertainment — Wikipedia](https://zh.wikipedia.org/wiki/%E4%BA%BA%E4%BA%BA%E6%9C%89%E5%8A%9F%E7%B7%B4%E9%9F%B3%E6%A8%82%E5%B7%A5%E4%BD%9C%E5%AE%A4) — Entrada de Kung Fu Entertainment en la Wikipedia en chino, índice auxiliar que recoge la fundación del estudio, la escena de Tainan, la enseñanza y los miembros.
+
+[^5]: [Desarrollo del hip hop y el rap en Taiwán](https://taiwan-md.vercel.app/music/%E5%8F%B0%E7%81%A3%E5%98%BB%E5%93%88%E8%88%87%E9%A5%92%E8%88%8C%E7%99%BC%E5%B1%95) — Artículo existente de Taiwan.md, que sintetiza el rap en taiwanés, «Taiwan Song», Kung Fu Entertainment y el contexto del hip hop taiwanés.
+
+[^6]: [No jugar según las reglas para tener otra mirada: Dwagie](https://www.pts.org.tw/dinner11/recom09.html) — Presentación del programa «Who's Coming to Dinner 11» de la televisión pública, que recoge el contexto familiar de Dwagie, su vegetarianismo de años, su interés por los animales y su imagen pública de intervenir con el micrófono en los asuntos sociales.
+
+[^7]: [Taipéi y Kaohsiung se suman al Día Mundial por los Derechos de los Animales: una gran cara de cerdo aparece en la explanada de Huashan](https://e-info.org.tw/node/218325) — Reportaje del Centro de Información Ambiental de 2019, que documenta el acto del Día Mundial por los Derechos de los Animales, la lectura de la declaración de derechos de los animales encabezada por Dwagie y su participación musical en la incidencia por los derechos de los animales.
+
+[^8]: [Se dice que el PCCh veta a 55 artistas: Vivian Hsu y Wu Nien-jen figuran en la lista](https://www.epochtimes.com/b5/16/12/30/n8647750.htm) — Reportaje de Epoch Times de 2016, que registra la lista de veto a artistas taiwaneses difundida en internet y la respuesta de Dwagie; la autenticidad de la lista se trata como «se dice» y «sin confirmar».
+
+[^9]: [The Rappers — Wikipedia](https://zh.wikipedia.org/wiki/%E5%A4%A7%E5%98%BB%E5%93%88%E6%99%82%E4%BB%A3) — Entrada del programa en la Wikipedia en chino, que recoge las plataformas de emisión de «The Rappers», la presentación y la información sobre mentores como Leo Wang, Dwagie, Barzo Chiang y Kumachan; sirve como fuente de los datos básicos del programa.

--- a/knowledge/es/People/freddy-lim.md
+++ b/knowledge/es/People/freddy-lim.md
@@ -1,0 +1,238 @@
+---
+translatedFrom: 'People/林昶佐.md'
+sourceCommitSha: 'f28a9528'
+sourceContentHash: 'sha256:42745728f5eb5c1a'
+sourceBodyHash: 'sha256:b26e0a7ce99faf37'
+translatedAt: '2026-07-23T23:40:00+08:00'
+lang: 'es'
+title: 'Freddy Lim: del vocalista de CHTHONIC al hemiciclo, el hombre que convirtió la historia de Taiwán en voz pública'
+description: 'Como Freddy, vocalista de CHTHONIC, Freddy Lim escribió en la memoria pública el 28 de febrero, el Terror Blanco, el incidente de Musha, la mitología taiwanesa y el metal en taiwanés, y junto a sus compañeros convirtió el Megaport Festival en un espacio cultural del sur. La música, la conciencia taiwanesa, la práctica cultural, la política institucional, la experiencia vital familiar y su papel público tras dejar el escaño se enlazan en él y forman un camino que va del escenario a la sociedad, al Parlamento y a los foros internacionales.'
+date: 2026-07-10
+category: 'People'
+tags:
+  - 'personaje'
+  - 'música'
+  - 'heavy metal'
+  - 'política'
+  - 'movimientos sociales'
+  - 'CHTHONIC'
+subcategory: 'Música y figuras públicas'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-10
+lastHumanReview: false
+image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Freddy_Lim%2C_founder_of_ChthoniC.jpg/1280px-Freddy_Lim%2C_founder_of_ChthoniC.jpg'
+imageCredit: 'Hyw83516 / Wikimedia Commons'
+imageLicense: 'CC BY-SA 3.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg'
+difficulty: 'intermediate'
+readingTime: 14
+rationale:
+  why_this_hook: 'Abrir con el conflicto de múltiples identidades apretadas a la vez en una misma persona y volver después al núcleo identitario más profundo: el vocalista de CHTHONIC.'
+  whats_excluded: 'La historia completa de CHTHONIC, el análisis profundo álbum por álbum, la historia íntegra de la gestión de Megaport y la historia del partido Nuevo Poder se reservan para temas independientes; aquí solo se toma la línea principal necesaria para entender a Freddy Lim.'
+  where_it_hedges: 'No se acepta la campaña de Ko Wen-je de 2014 como detonante personal de su entrada en política; para Finlandia se usa el título de «representante en Finlandia»; los detalles de la revocación solo se apuntan como contexto y no se escriben resultados de su mandato sin verificar.'
+  whos_pushing_back: 'Quienes critican su servicio al distrito y su línea partidaria, quienes consideran demasiado política a CHTHONIC y quienes creen que no debe romantizarse el cruce de un artista hacia la política.'
+---
+
+> **Resumen en 30 segundos:** Freddy Lim es Freddy, el vocalista de CHTHONIC, uno de los promotores iniciales del Megaport Festival, expresidente de la sección taiwanesa de Amnistía Internacional y una de las figuras representativas de la tercera fuerza que entró en el Parlamento tras el Movimiento Girasol. CHTHONIC escribió en el black metal el [incidente del 28 de febrero](/history/二二八事件), el [Terror Blanco en Taiwán](/history/台灣白色恐怖), el incidente de Musha, la mitología taiwanesa y el relato de los espíritus, e hizo que la historia de Taiwán no solo pudiera leerse, sino también escucharse y gritarse. Después participó en la fundación del partido Nuevo Poder, fue elegido diputado y pasó por la salida del partido y por un proceso de revocación. Tras dejar el escaño volvió a enlazar con el trabajo internacional como representante de Taiwán en Finlandia. La política fue para él una aventura; CHTHONIC sigue siendo su cuerpo.
+
+Meter a Freddy Lim en una sola identidad casi siempre lo distorsiona. En 2017, el *New York Times* entró en su despacho de diputado y vio una batería electrónica, un póster de David Bowie y una foto de CHTHONIC tocando en la plaza de la Libertad. En 2022, el alemán *Der Tagesspiegel* encontró en una mezcla parecida una imagen de «Free Tibet» firmada por el Dalái Lama, una bandera arcoíris, un retrato de David Bowie y fotos de conciertos de CHTHONIC. Esos objetos son como una sección transversal de identidades: vocalista de metal, promotor de un festival, defensor de los derechos humanos, político de la tercera fuerza, diputado, protagonista de una revocación, cuidador de su familia y, más tarde, representante en Finlandia.[^5][^6][^11][^12][^13][^14][^15][^16]
+
+Que todas esas identidades se apretujen a la vez en una misma persona hace que la historia de Freddy Lim no sea solo el contraste de «un músico se mete en política». Freddy Lim no dejó CHTHONIC atrás para irse a la política. Su identidad pública creció desde el método de tratar con música la historia, la lengua y el sentido de soberanía de Taiwán. Antes de sentarse en una comisión y de derrotar a un político veterano, aquel hombre que rugía en el escenario los espíritus de Taiwán ya estaba buscando la voz de su época.
+
+## Primero es el vocalista de CHTHONIC
+
+Freddy Lim nació en 1976 y su nombre en inglés es Freddy. Para muchos medios internacionales, la forma más fácil de presentarlo es «death-metal star turned politician»: un vocalista de death metal o de black metal que después se convirtió en diputado taiwanés. Pero esa fórmula, aunque se entienda bien, cuenta su historia al revés.
+
+Antes de la política, Freddy Lim ya trataba la política dentro de la música.
+
+Creció al final de la ley marcial. En la entrevista con *Der Tagesspiegel* recuerda que en primaria, si hablabas taiwanés en la escuela, te multaban con diez yuanes y te escribían el nombre en la pizarra. En los libros de texto apenas había Taiwán y a los niños se les educaba como chinos. Solo a partir del instituto empezó a leer los libros sobre Taiwán que su padre traía a casa, y fue dándose cuenta poco a poco de que el lugar donde vivía no podía agotarse con el relato sinocéntrico de los manuales.[^6]
+
+CHTHONIC se formó en Taipéi en 1995 y desde el principio se negó a ser una simple imitadora del black metal nórdico. En la entrevista de 2003 con el *Taipei Times*, Freddy Lim situó el punto de partida de la banda en la pregunta del black metal por la «cultura matriz»: el black metal nórdico mira hacia las antiguas creencias aplastadas por el cristianismo, y CHTHONIC devolvió esa pregunta a Taiwán para buscar la memoria local rebajada por la historiografía sinocéntrica, la colonización y la política autoritaria. Tomó prestada la intensidad del black metal, el death metal y el metal sinfónico, pero devolvió el contenido a Taiwán: los espíritus ancestrales, el infierno, los médiums, el incidente de Musha, el 28 de febrero, el Terror Blanco, las Unidades de Voluntarios Takasago, la historia taiwanesa reprimida. Freddy Lim fue el vocalista de la banda y participó además en la construcción del concepto, las letras y el relato público. Que los reportajes internacionales describan después a CHTHONIC con «taiwanés, instrumentos tradicionales e historia de Taiwán» se debe a que esos elementos hacen que, dentro de la escena metálica global, se note al oírla que no es la copia de otra banda occidental.[^1][^17]
+
+Esto distingue algo a CHTHONIC de las bandas al uso «con postura política nítida». No es que primero tuviera un programa político y luego metiera consignas en las canciones. Es más bien así: la historia de Taiwán está de entrada llena de muertos, de silencios, de tabúes y de duelos inacabados. La oscuridad, los gritos, la velocidad y la ritualidad del black metal resultaron ser un registro vocal capaz de albergar esa historia.
+
+> **💡 ¿Lo sabías?**
+> El nombre en inglés de la banda, Chthonic, procede del concepto griego relacionado con lo subterráneo y el inframundo. Para una banda taiwanesa de metal que lleva años escribiendo sobre espíritus, antepasados y almas agraviadas de la historia, el nombre parece casi un destino.
+
+La persona escénica de Freddy Lim tampoco es un adorno. Sus gritos, el erhu, el maquillaje facial, el papel moneda funerario y las versiones de los álbumes en taiwanés y en inglés componen todo un sistema sonoro que hace reconocible a Taiwán en el mundo. Para los fans internacionales del metal, CHTHONIC puede haber sido la primera vez que oyeron a través de la música el 28 de febrero, el incidente de Musha o la situación de la soberanía taiwanesa. Para el público taiwanés, CHTHONIC convirtió en algo que se puede gritar juntos en un concierto una historia troceada por los manuales, la familia y los tabúes políticos.
+
+Cuando más tarde habló del taiwanés, dijo que esa lengua le permitía imaginar cómo vivían sus abuelos de jóvenes. Esa pista es importante: el metal en taiwanés de CHTHONIC devuelve al cuerpo y a la voz una experiencia taiwanesa aplastada por el silencio de la escuela, del Estado y de la familia.[^6]
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/kta4ZAwI6rY" title="閃靈、元千歲 - 暮沉武德殿（民謠版）" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Vídeo oficial de CHTHONIC: versión folk de «Sunset in My Hometown» (暮沉武德殿). Aunque el muro de sonido metálico se desmonte en una versión acústica, la voz de Freddy Lim, la melodía en taiwanés y la sensación histórica siguen en primer plano._
+
+## Historia y espíritus dentro del black metal
+
+El método creativo más importante de CHTHONIC es escribir la historia de Taiwán como un universo de espíritus que vuelven una y otra vez.
+
+«Seediq Bale» trata el incidente de Musha. «Mirror of Retribution» sitúa el 28 de febrero en la imaginación del infierno y el juicio. «Takasago Army» mira hacia los jóvenes indígenas taiwaneses reclutados por el Imperio japonés en la Guerra del Pacífico. «Bú-Tik» enreda la modernidad, el salón de artes marciales y la memoria colonial. «Battlefields of Asura» empuja directamente a la superficie la violencia y la resistencia del Taiwán de posguerra.
+
+Estos álbumes superan la función de «presentar la historia». Se parecen más a una pregunta: si a las víctimas no se las recuerda de verdad, ¿no volverán siempre?
+
+«Battlefields of Asura» tampoco nace solo de los grandes temas nacionales. En la entrevista con la Fundación de Cuidados Paliativos, Freddy Lim habla de la muerte repentina de su padre por un infarto en 2017 y de que no llegó a tiempo de verlo por última vez. Ese mismo año nació su hija, y la vida y la muerte se le echaron encima a la vez en muy poco tiempo. Dice que la muerte de su padre le hizo ver que hay que cuidar a quienes se ama y no dejar heridas irreparables por causa de las emociones. Esa percepción de la muerte, la paternidad y la reconciliación entró también en «Battlefields of Asura», de 2018.[^7]
+
+En una larga entrevista posterior a su salida del escaño, Freddy Lim cuenta que, tras descubrir la historia de la familia de su abuelo materno, volvió a entender la manera en que CHTHONIC llevaba años escribiendo sobre el Terror Blanco, las víctimas del 28 de febrero y la reencarnación. Dice que al principio no sabía cómo terminar esa historia llamada CHTHONIC. Cuando los personajes de ficción se conectaron con la historia real de su familia, aquel universo musical pareció por fin enlazar con el mundo real.
+
+El núcleo de lo que CHTHONIC lleva años haciendo no está en la apariencia de «metal más temas taiwaneses», sino en usar el metal para tratar una sensación muy familiar para los taiwaneses y que a menudo no se puede decir: la historia no ha pasado de verdad, y en la familia quizá se esconde una historia que nunca se terminó de contar.
+
+La preocupación social creció dentro de ese trabajo musical. Cuando las víctimas, los espíritus ancestrales y las personas silenciadas obtuvieron voz sobre el escenario, apareció la siguiente pregunta: ¿pueden esas voces escucharse dentro de la sociedad?
+
+![Freddy Lim sobre el escenario, con un micrófono en la mano y alzando una bandera tibetana, delante de una gran estructura escénica.](https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Freddy_Lim%2C_founder_of_ChthoniC.jpg/1280px-Freddy_Lim%2C_founder_of_ChthoniC.jpg)
+_En 2012 Freddy Lim alzó una bandera tibetana sobre el escenario. Esta imagen coloca en un mismo lugar su identidad de vocalista, su compromiso con los derechos humanos y la situación internacional de Taiwán. Photo: Hyw83516, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg) ([CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))._
+
+## Megaport Festival: convertir el sonido en espacio
+
+Si CHTHONIC fue para Freddy Lim el lugar donde cantar la historia, el Megaport Festival fue el lugar donde convirtió la música en espacio público.
+
+Antes de Megaport, Freddy Lim y Doris Yeh llevaban tiempo aprendiendo a organizar directos dentro de los festivales. A finales de los noventa se hicieron cargo del Formoz Festival. En 2000, CHTHONIC actuó en el Fuji Rock Festival japonés y vio de cerca por primera vez el escenario, el backstage, la circulación y el reparto de tareas de un gran festival internacional. Aquella experiencia les llevó a empujar el Formoz hacia varios escenarios, bandas internacionales, sistema de entradas y una experiencia de directo más completa. Después, la experiencia de backstage, voluntariado y atención a los artistas que CHTHONIC fue acumulando en escenarios internacionales como Wacken o Download también revirtió en el diseño del Megaport, dándole la intención de «mostrar contenido local taiwanés con estándares internacionales».[^10]
+
+En 2006, Freddy Lim, Doris y el equipo de TRA Music organizaron la primera edición del Megaport junto a los muelles 11 y 12 del puerto de Kaohsiung. Recogió el contexto de los festivales taiwaneses existentes y enseguida desarrolló su propio carácter: sur, ribera portuaria, taiwanés, bandas independientes, sonido pesado, identidad urbana y un sentido de lo público muy cercano a los asuntos sociales. En sus inicios, el equipo lo concibió deliberadamente como un festival del sur distinto del Formoz de Taipéi. Los nombres de los escenarios, el paisaje del puerto y la proporción de bandas del sur hicieron que «Kaohsiung» fuera el contenido del festival.[^2][^9]
+
+La importancia de Megaport supera con mucho el punto curricular de «Freddy Lim también organizó un festival». Es un mediador: allí las bandas se convierten en comunidad cultural, el público se convierte en colectividad, y Kaohsiung pasa de ser un lugar de conciertos a una coordenada cultural. Allí los músicos programan, organizan, coordinan y asumen la taquilla y la presión pública. Y allí el público confirma con el cuerpo que el sonido de Taiwán no tiene por qué concentrarse en Taipéi y que no solo los escenarios mayoritarios cuentan como cultura.
+
+Megaport conserva además el sentido público al estilo de CHTHONIC. Tras su reanudación en 2015, el equipo lo llamó un festival sobre la vida y mantuvo la aldea de ONG, para que el público pudiera acercarse entre escenarios a los derechos humanos, la libertad, Hong Kong, el Tíbet y toda clase de asuntos sociales. El reportaje de VERSE enlaza esa línea con los conciertos que Freddy Lim organizó en el pasado: Justicia Invencible, contra la anexión por China o por la libertad del Tíbet. Para estos músicos, el festival puede ser un lugar donde alejarse un rato de la vida diaria y, a la vez, un lugar por donde la realidad entra de otra manera.[^9]
+
+Megaport tampoco fue nunca la epopeya de un héroe solitario. Freddy Lim cuenta en las entrevistas que muchas cosas, de la música al Formoz, de Megaport a la política, las sacó adelante junto a Doris. Señala además que en ámbitos de fuerte carga masculina como el rock o los festivales, el trabajo de las mujeres queda a menudo más invisibilizado. Cuando en 2016 fue elegido diputado y dejó el equipo, Megaport pasó a manos sobre todo de Doris y del batería de CHTHONIC, Dani. Ambos prolongaron el espíritu de CHTHONIC de cavar hondo en lo local mirando a lo internacional, y entienden el backstage, la venta de entradas, la experiencia de los artistas y las rutinas del equipo como parte del festival. Megaport lo sostiene todo un equipo de música y curaduría que levanta una escena del sur, y no es el logro personal de un vocalista.[^9][^10]
+
+Megaport produjo un segundo giro en el papel de Freddy Lim. De ser quien estaba en el centro del escenario pasó también a ser quien monta el escenario. Esa diferencia conduciría después a la política: la política es, hasta cierto punto, también montar un escenario, solo que ese escenario se convierte en distrito electoral, comisiones, hemiciclo, proyectos de ley y foco mediático. De CHTHONIC a Megaport, la identidad musical de Freddy Lim dejó de tener que ver solo con actuar y empezó a asumir espacios, comunidades y asuntos públicos.
+
+## Tras el Girasol, hacia dentro de las instituciones
+
+Después del [Movimiento Girasol](/society/太陽花學運) de 2014 apareció en Taiwán una nueva ola de imaginación política. Mucha gente joven, activistas y trabajadores de la cultura empezaron a creer que, además de la protesta callejera, hacía falta también quien entrara en las instituciones.
+
+Freddy Lim fue uno de los rostros más visibles de esa ola. Participó en la fundación del partido Nuevo Poder y en 2016 fue elegido diputado por el quinto distrito de la ciudad de Taipéi. En la entrevista de 2015 con el *Taipei Times* ya se apreciaban en su equipo de campaña las conexiones con la generación del Girasol: Wu Cheng, Lai Pin-yu y otros se incorporaron al equipo, y músicos, activistas y jóvenes profesionales de la política quedaron colocados en un mismo escenario electoral.[^11] Aquel distrito incluye Wanhua y parte de Zhongzheng; para un vocalista de heavy metal, esa elección lo llevó al terreno prolongado del servicio al distrito y del trabajo parlamentario. Exigía enfrentarse a diario a peticiones, presupuestos, vínculos locales, batallas parlamentarias y las expectativas concretas de los votantes hacia un político, mucho más allá de una candidatura simbólica.
+
+A los medios internacionales de entonces les encantaba el contraste: un vocalista de metal con la cara pintada que canta la historia de Taiwán entra en el Parlamento. GQ lo presentó como «la estrella del death metal que se convirtió en representante electo» y devolvió al Nuevo Poder al contexto político posterior al Girasol. El *New York Times* observó que, además de las reformas internas, ponía en su agenda política el reconocimiento internacional de Taiwán.[^3][^5] Pero para su propia historia esto era más bien la prolongación de un mismo camino. Lo que trató CHTHONIC fue la memoria histórica y la visibilidad internacional. Lo que trató Megaport fue el espacio cultural. Lo que encontró al entrar en el Yuan Legislativo fue la defensa, la diplomacia, los derechos humanos, la cultura y la justicia transicional dentro de las instituciones.
+
+Solo que el sentido del tiempo de la política es completamente distinto del de la música.
+
+Al mirar después su experiencia parlamentaria dijo que la política no es como escribir canciones. Dentro de una banda, unas pocas personas se ponen de acuerdo y la obra avanza. El Yuan Legislativo, en cambio, es un espacio de más de cien personas y las cosas solo pueden moverse poquito a poco. Esa diferencia hace que el «ideal» deje de consistir en si la voz puede sonar más fuerte y pase a consistir en si se puede mover algo despacio dentro de las instituciones.
+
+Ahí está también la parte más densa de la historia de Freddy Lim. La música hace creer que una canción puede estallar en un instante. La política obliga a reconocer que muchas cosas solo pueden pulirse despacio.
+
+## Los temas en el Parlamento
+
+Los ocho años de Freddy Lim en el Yuan Legislativo no se resumen con «un artista se mete en política».
+
+Su trabajo político prolonga a grandes rasgos varias líneas que ya existían en su etapa musical: la participación internacional de Taiwán, los derechos humanos, la justicia transicional, la política cultural y la defensa y la diplomacia. Entre 2010 y 2014 presidió la sección taiwanesa de Amnistía Internacional. En la entrevista de 2015 colocaba también los derechos humanos, el medio ambiente, la política cultural, la independencia de Taiwán y la justicia transicional dentro de un mismo lenguaje político de «justicia y equidad».[^6][^11] Ya en el Parlamento siguió atento al Tíbet, Hong Kong, los derechos humanos y el espacio internacional de Taiwán. La continuidad de esos temas con su etapa musical explica sus elecciones políticas mejor que enumerar una por una sus interpelaciones.
+
+Esa continuidad ya estaba antes de su entrada en política. Durante la gira del Ozzfest de 2007, CHTHONIC dio veinte conciertos en Estados Unidos y explicó en inglés al público la situación de Taiwán, bloqueado por China para participar con normalidad en los organismos internacionales. «UNlimited Taiwan» llevó también directamente la reivindicación de la participación internacional a una gira de metal. El espacio internacional del que Freddy Lim habló después en el Parlamento se había ensayado antes sobre el escenario.[^18]
+
+![Durante la campaña legislativa de 2015, Freddy Lim, con un chaleco amarillo de campaña, entrega folletos a los votantes en la calle.](https://upload.wikimedia.org/wikipedia/commons/a/a1/%E6%99%82%E4%BB%A3%E5%8A%9B%E9%87%8F%E7%AB%8B%E5%A7%94%E5%80%99%E9%81%B8%E4%BA%BA%E6%9E%97%E6%98%B6%E4%BD%90_03.JPG)
+_En 2015 Freddy Lim pidió el voto como candidato a diputado del Nuevo Poder por el distrito de Zhongzheng-Wanhua. Tras pasar del escenario a la política institucional, también tuvo que meterse en este terreno público de calle, distrito y movilización local. Photo: 國會無雙, [Wikimedia Commons](https://commons.wikimedia.org/w/index.php?curid=48398521) ([CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/))._
+
+Estos temas parecen muy políticos, pero en realidad conectan con el núcleo musical de CHTHONIC: ¿quién tiene derecho a ser escuchado por el mundo? ¿La historia de quién se silencia? ¿Cómo puede hablar de sí mismo en los escenarios internacionales un país que no está oficialmente reconocido?
+
+El papel público de Freddy Lim es difícil de meter solo en la casilla de «músico» o en la de «político». Fue una serie de empujes sucesivos: en CHTHONIC convirtió la historia de Taiwán en sonido. En Megaport convirtió el sonido en espacio. En el Parlamento intentó convertir el espacio en práctica institucional.
+
+Ese camino no es romántico. La política dentro de las instituciones exige negociación, compromiso, votaciones, organización y servicio a los electores, y también la desgastan las revocaciones, las escisiones de partido, las batallas mediáticas y las presiones locales. No funciona como el escenario, donde basta con que se apaguen las luces y suene un golpe de batería para que la emoción se concentre en la misma dirección.
+
+Su trabajo político se concentra en unas cuantas direcciones recurrentes. La primera es lo internacional: la visibilidad de Taiwán en los organismos internacionales, el nombre olímpico, las alianzas democráticas y los asuntos de derechos humanos. La segunda es la defensa y la diplomacia, sobre todo cómo mantiene Taiwán su seguridad y sus relaciones exteriores bajo la presión china. La tercera son los derechos humanos, prolongando su atención de largo plazo a Amnistía Internacional, al Tíbet libre y a Hong Kong. La cuarta es la cultura, porque siempre ha mirado la música popular, la lengua, la memoria histórica y el relato nacional sobre un mismo mapa.
+
+Esas cuatro direcciones no están separadas. Para Freddy Lim, que la música de Taiwán pueda escucharse en el mundo, que el nombre de Taiwán pueda pronunciarse con normalidad en las competiciones internacionales y que la historia de los taiwaneses pueda reconocerse en la educación y la cultura apuntan todas a la misma pregunta: ¿cómo recupera la posición de hablar una comunidad a la que durante mucho tiempo otros han nombrado, representado y reescrito?
+
+## El desgaste de la política
+
+Freddy Lim dejó el Nuevo Poder en 2019, apoyó la reelección de Tsai Ing-wen y concurrió como independiente a las legislativas de 2020.[^12] Tras su reelección vivió también la escisión del Nuevo Poder, un proceso de revocación y la reconfiguración de la tercera fuerza. La votación de revocación de 2022 no prosperó: hubo más votos a favor que en contra, pero no se alcanzó el umbral legal. La mayoría de los análisis de entonces situaron esa votación en el contexto del sistema taiwanés de revocación, de la movilización partidaria y del cansancio del electorado, y no solo como una victoria o derrota personal.[^8][^13] En 2023 anunció que no buscaría la reelección como diputado; la razón que hizo pública fue cuidar de un familiar con una enfermedad rara. En noviembre de ese mismo año solicitó ingresar en el Partido Democrático Progresista y colaboró en las elecciones de 2024.[^14][^15] En 2025, la Oficina Presidencial anunció su nombramiento como representante de Taiwán en Finlandia, enlazando de nuevo, de otra forma, «música, incidencia internacional y diplomacia».[^16]
+
+Este recorrido es más complejo que un simple ganar o perder.
+
+En las entrevistas, Freddy Lim mira atrás a su línea política de 2016 a 2020 y cuenta que llegó a creer que, si volcaba en ello el espíritu, el alma y todas sus fuerzas y seguía empujando hacia delante, podría llevar a Taiwán más lejos. Pero después las escisiones de partido, las derrotas de sus compañeros, la ola de revocaciones y la realidad política obligaron a detener aquella sensación juvenil de «si sigo empujando, llegaré».
+
+Esto contrasta de forma aguda con la música. En la música unas cuantas personas pueden empujar juntas, y a quien le gusta le gusta y a quien no, no. La política, en cambio, exige integrar a mucha gente y además soportar los momentos en que el resultado no es el imaginado. Freddy Lim llevó su ideal a las instituciones, y las instituciones también lo cambiaron a él.
+
+> **⚠️ Punto de vista en disputa**
+> La valoración política de Freddy Lim lleva tiempo dividida. Quienes lo apoyan ven avances en derechos humanos, proyección internacional y conciencia local; quienes lo critican cuestionan su servicio al distrito, su línea partidaria y sus decisiones políticas. Esas polémicas quedaron junto a sus años en el Parlamento y dotan a su experiencia de cruce del desgaste y el coste de la escena política.
+
+## La voz fuera de las instituciones
+
+Al repasar tras dejar el escaño sus ocho años de trabajo político, Freddy Lim menciona una diferencia: un político puede convencer con discursos, interpelaciones o apariciones en los medios, y mover a la gente en el plano racional. La música y el cine, en cambio, pueden quedarse mucho más tiempo, y hacer que alguien se dé cuenta muchos años después de que una obra lo cambió.
+
+No dijo que la política sea inferior ni que la música sea superior. Se parece más a volver a confirmar, tras haber atravesado las instituciones, que las dos formas de trabajo llegan a la gente de maneras distintas. La política necesita negociación, procedimiento, votos y organización. La música trata la memoria, la emoción, la lengua y el cuerpo. Lo particular de Freddy Lim está en haber llevado al ámbito público el sentido de la historia, de los espíritus y de la soberanía que hay en la música, y en haber visto dentro de la realidad política que hay cosas que las instituciones pueden empujar y cosas a las que, aun así, solo llega una canción.
+
+Si la política fue una aventura de llevar su voz a las instituciones, CHTHONIC es la raíz a la que esa voz vuelve una y otra vez.
+
+El Parlamento le dio otra escala para entender la realidad. La música lo devuelve a un carácter público que la política no puede sustituir del todo.
+
+## Reordenar los papeles
+
+El Freddy Lim posterior al escaño no se ha «retirado de la política» ni ha «vuelto a cantar» sin más. Sus papeles se han reordenado: la política institucional pasa atrás, y la música, la incidencia internacional, la diplomacia y la palabra pública conservan cada una su sitio. La obra de CHTHONIC sigue pudiendo meter a la gente en la sombra de la historia de Taiwán. En 2023, «PATTONKAN» (護國山) devolvió a la canción la memoria de Uongu Yatauyungana, víctima del Terror Blanco, y de su familia, y sacó a la CHTHONIC de esos años del ciclo creativo de «Millions of Reincarnations». Megaport y la cultura de los festivales siguen demostrando que el sonido puede juntarse hasta formar un espacio. Y la experiencia parlamentaria le recuerda que, si un ideal entra en las instituciones, las instituciones lo pondrán a prueba.[^19]
+
+Por eso la historia de Freddy Lim no se detiene en la curiosidad política de «un vocalista de metal en el Parlamento». Primero descubrió Taiwán dentro de la música, después empujó ese descubrimiento hacia el escenario, la ciudad, los movimientos sociales y el Parlamento, y al final volvió a lo hondo de la música cargando con el cansancio y la comprensión de la política.
+
+Esos papeles no se anulan entre sí. CHTHONIC dejó un universo discográfico, el metal en taiwanés, una presencia en la escena metálica internacional y un relato de la historia de Taiwán. Megaport dejó una ciudad del sur, la gestión de un festival y un equipo curatorial. El Nuevo Poder metió en su biografía la estructura política de la tercera fuerza posterior al Girasol. Y todas las líneas que atraviesan a Freddy Lim acaban volviendo a la voz que creció desde aquel vocalista.
+
+## Lecturas complementarias
+
+CHTHONIC: el universo de la banda, el contexto de sus álbumes, su influencia internacional y la estética del black metal taiwanés.
+
+Megaport Festival: el festival del sur, la identidad urbana, la cultura contemporánea en taiwanés y la larga evolución del equipo curatorial.
+
+[Música independiente taiwanesa](/music/台灣獨立音樂): para entender cómo participó Freddy Lim en el cambio de lenguaje del «underground» a lo «independiente».
+
+[Cultura de festivales de Taiwán](/music/台灣音樂祭文化): para entender el lugar que ocupa Megaport en el ecosistema de los festivales taiwaneses.
+
+[Movimiento Girasol](/society/太陽花學運), el Nuevo Poder y la [transición democrática de Taiwán](/history/台灣民主轉型): para entender el trasfondo de época de su entrada en la política institucional.
+
+## Fuentes de imágenes
+
+- [Retrato de Freddy Lim de 2012](https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg) — Photo: Hyw83516, Wikimedia Commons, CC BY-SA 3.0.
+- [Candidato a diputado del Nuevo Poder Freddy Lim 03](https://commons.wikimedia.org/wiki/File:%E6%99%82%E4%BB%A3%E5%8A%9B%E9%87%8F%E7%AB%8B%E5%A7%94%E5%80%99%E9%81%B8%E4%BA%BA%E6%9E%97%E6%98%B6%E4%BD%90_03.JPG) — Photo: 國會無雙, Wikimedia Commons, CC BY-SA 4.0.
+- [閃靈、元千歲 - 暮沉武德殿（民謠版）](https://www.youtube.com/watch?v=kta4ZAwI6rY) — vídeo oficial de CHTHONIC en YouTube, usado para mostrar la voz de Freddy Lim como vocalista y la interpretación en versión acústica.
+
+## Notas
+
+[^1]: [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic) — Perfil de GQ de 2016 que describe cómo Freddy Lim, como vocalista de CHTHONIC y con el taiwanés y los instrumentos tradicionales, entró en el campo de visión del metal internacional y de la política.
+[^2]: [Web oficial del Megaport Festival](https://megaportfest.com/) — Web oficial del evento, usada para confirmar la posición contemporánea de Megaport como festival de Kaohsiung; su historia se contrasta además con Wikipedia.
+[^3]: [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic) — El mismo reportaje de GQ, que aporta el contexto de cómo entendieron los medios internacionales en 2016 lo de «un vocalista de metal llega al Parlamento».
+[^4]: ['We want a fairer society': Freddy Lim, Taiwan's metalhead MP](https://www.theguardian.com/world/2020/aug/17/we-want-a-fairer-society-freddy-lim-taiwan-metalhead-mp) — Reportaje de The Guardian de 2020, que completa la observación de los medios internacionales sobre su papel público en torno a su reelección.
+[^5]: [De estrella del rock a diputado: las convicciones del taiwanés Freddy Lim](https://cn.nytimes.com/china/20170531/from-heavy-metal-frontman-to-taiwans-parliament/zh-hant/) — Reportaje de 2017 de la edición en chino del New York Times, que documenta su primera etapa política, desde la escena musical underground hasta el Parlamento, impulsando la visibilidad internacional de Taiwán y los asuntos sociales.
+[^6]: [Metal-Sänger und Politiker Freddy Lim: „Wir waren nie ,das freie China' – wir sind Taiwan"](https://www.tagesspiegel.de/gesellschaft/metal-sanger-und-politiker-freddy-lim-wir-waren-nie-das-freie-china--wir-sind-taiwan-8904460.html) — Entrevista de Der Tagesspiegel de 2022, que aporta el repaso de Freddy Lim a la educación bajo la ley marcial, el taiwanés, la identidad de Taiwán y el relato internacional.
+[^7]: [De hijo a marido y a padre. Freddy Lim: que el amor continúe de otra manera](https://www.hospice.org.tw/content/3435) — Entrevista de la Fundación de Cuidados Paliativos, que completa la experiencia vital de Freddy Lim entre la muerte repentina de su padre, el nacimiento de su hija, los cuidados paliativos y el álbum «Battlefields of Asura».
+[^8]: [Melena larga, maquillaje cadavérico… hace 7 años Freddy Lim, como vocalista de una banda, derrotó a un veterano militar del KMT y escribió una leyenda de participación política ciudadana](https://www.businesstoday.com.tw/article/category/80392/post/202201090014/) — Reportaje de Business Today de 2022, que ordena el contexto político en torno a la revocación, temas progresistas como el matrimonio igualitario y el análisis del umbral de revocación.
+[^9]: [«Megaport» pasado y presente (I): la vida generosa de quienes llevan el timón del festival](https://www.verse.com.tw/article/megaport-festival-01) — Reportaje de VERSE de 2022, que ordena el contexto desde los inicios de 2006 junto al puerto de Kaohsiung hasta el relevo de Doris y Dani tras 2016 y la aldea de ONG.
+[^10]: [«Megaport» pasado y presente (II): no son solo 16 años, sino la suma cultural de la historia de los festivales de Taiwán](https://www.verse.com.tw/article/megaport-festival-02) — Reportaje de VERSE de 2022, que completa la larga línea del Formoz, la internacionalización con varios escenarios, el pago por uso, el backstage de los artistas y la mejora de la cultura taiwanesa de ir a ver bandas.
+[^11]: [INTERVIEW: Freddy Lim unfolds New Power Party platform](https://www.taipeitimes.com/News/taiwan/archives/2015/06/26/2003621612) — Entrevista del Taipei Times de 2015, que aporta el contexto de su entrada en la carrera electoral como vocalista de CHTHONIC, defensor de los derechos humanos y fundador del Nuevo Poder.
+[^12]: [Lim to leave NPP, back Tsai re-election bid](https://www.taipeitimes.com/News/front/archives/2019/08/02/2003719765) — Reportaje del Taipei Times de 2019, que confirma su salida del Nuevo Poder, su candidatura a la reelección como independiente y su apoyo a la reelección de Tsai Ing-wen.
+[^13]: [Independent Legislator Freddy Lim survives recall vote](https://focustaiwan.tw/politics/202201090008) — Reportaje de Focus Taiwan/CNA de 2022, que confirma que la revocación no prosperó por no alcanzarse el umbral de votos a favor.
+[^14]: [Freddy Lim to retire from politics, look after family](https://www.taipeitimes.com/News/taiwan/archives/2023/03/18/2003796315) — Reportaje del Taipei Times de 2023, que recoge su anuncio de no buscar la reelección por tener que cuidar de un familiar con una enfermedad rara.
+[^15]: [Independent lawmaker Freddy Lim applies to join DPP](https://focustaiwan.tw/politics/202311270019) — Reportaje de Focus Taiwan/CNA de 2023, que confirma su solicitud de ingreso en el Partido Democrático Progresista y su disposición a colaborar en las elecciones de 2024.
+[^16]: [Rock star-turned-politician named Taiwan's representative to Finland](https://focustaiwan.tw/politics/202505190024) — Reportaje de Focus Taiwan/CNA de 2025, que confirma el anuncio de la Oficina Presidencial de su nombramiento como representante de Taiwán en Finlandia.
+[^17]: [Chthonic put spin on Taiwan's past](https://www.taipeitimes.com/News/taiwan/archives/2003/09/14/2003067797) — Entrevista del Taipei Times de 2003, que documenta la historia temprana de CHTHONIC, el erhu, la Hermana Lintou, el premio a la mejor banda de los Golden Melody Awards y cómo devolvió Freddy Lim la conciencia de la cultura matriz del black metal a la historia y las leyendas populares taiwanesas.
+[^18]: [ChthoniC promotes Taiwan's UN bid in interview with NPR](https://www.taipeitimes.com/News/taiwan/archives/2007/08/09/2003373320) — Reportaje del Taipei Times de 2007, que ordena cómo explicó CHTHONIC en inglés al público estadounidense durante la gira del Ozzfest el bloqueo a la participación internacional de Taiwán, y el contexto de la interpretación de «UNlimited Taiwan».
+[^19]: [La nueva canción de CHTHONIC «PATTONKAN» se inspira en familiares de víctimas políticas](https://www.cna.com.tw/news/amov/202303010226.aspx) — Reportaje de la agencia CNA de 2023 sobre la inspiración de «PATTONKAN», los familiares de víctimas del Terror Blanco y la memoria de la familia de Uongu Yatauyungana, que completa cómo prolongan las obras recientes de CHTHONIC el tema de la memoria histórica.
+
+## Referencias
+
+- [EP109 Todos somos uno entre un millón de reencarnaciones｜Freddy Lim de CHTHONIC](https://www.youtube.com/watch?v=5TBDAhWwtr8), Only Drinking Library, 2026. Este texto se apoya en el resumen de los subtítulos en chino tradicional y consulta sobre todo los pasajes en torno a 00:26, 01:04, 01:17, 02:53 y 02:58.
+- [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic), GQ, 2016.
+- ['We want a fairer society': Freddy Lim, Taiwan's metalhead MP](https://www.theguardian.com/world/2020/aug/17/we-want-a-fairer-society-freddy-lim-taiwan-metalhead-mp), The Guardian, 2020.
+- [De estrella del rock a diputado: las convicciones del taiwanés Freddy Lim](https://cn.nytimes.com/china/20170531/from-heavy-metal-frontman-to-taiwans-parliament/zh-hant/), edición en chino del New York Times, 2017.
+- [Metal-Sänger und Politiker Freddy Lim: „Wir waren nie ,das freie China' – wir sind Taiwan"](https://www.tagesspiegel.de/gesellschaft/metal-sanger-und-politiker-freddy-lim-wir-waren-nie-das-freie-china--wir-sind-taiwan-8904460.html), Der Tagesspiegel, 2022.
+- [De hijo a marido y a padre. Freddy Lim: que el amor continúe de otra manera](https://www.hospice.org.tw/content/3435), Fundación de Cuidados Paliativos.
+- [Melena larga, maquillaje cadavérico… hace 7 años Freddy Lim, como vocalista de una banda, derrotó a un veterano militar del KMT y escribió una leyenda de participación política ciudadana](https://www.businesstoday.com.tw/article/category/80392/post/202201090014/), Business Today, 2022.
+- [INTERVIEW: Freddy Lim unfolds New Power Party platform](https://www.taipeitimes.com/News/taiwan/archives/2015/06/26/2003621612), Taipei Times, 2015.
+- [Lim to leave NPP, back Tsai re-election bid](https://www.taipeitimes.com/News/front/archives/2019/08/02/2003719765), Taipei Times, 2019.
+- [Independent Legislator Freddy Lim survives recall vote](https://focustaiwan.tw/politics/202201090008), Focus Taiwan/CNA, 2022.
+- [Freddy Lim to retire from politics, look after family](https://www.taipeitimes.com/News/taiwan/archives/2023/03/18/2003796315), Taipei Times, 2023.
+- [Independent lawmaker Freddy Lim applies to join DPP](https://focustaiwan.tw/politics/202311270019), Focus Taiwan/CNA, 2023.
+- [Rock star-turned-politician named Taiwan's representative to Finland](https://focustaiwan.tw/politics/202505190024), Focus Taiwan/CNA, 2025.
+- [Chthonic put spin on Taiwan's past](https://www.taipeitimes.com/News/taiwan/archives/2003/09/14/2003067797), Taipei Times, 2003.
+- [ChthoniC promotes Taiwan's UN bid in interview with NPR](https://www.taipeitimes.com/News/taiwan/archives/2007/08/09/2003373320), Taipei Times, 2007.
+- [La nueva canción de CHTHONIC «PATTONKAN» se inspira en familiares de víctimas políticas](https://www.cna.com.tw/news/amov/202303010226.aspx), agencia CNA, 2023.
+- [«Megaport» pasado y presente (I): la vida generosa de quienes llevan el timón del festival](https://www.verse.com.tw/article/megaport-festival-01), VERSE, 2022.
+- [«Megaport» pasado y presente (II): no son solo 16 años, sino la suma cultural de la historia de los festivales de Taiwán](https://www.verse.com.tw/article/megaport-festival-02), VERSE, 2022.
+- [Many Young Taiwanese Want to Go to the Olympics With a New Flag and Anthem](https://time.com/4567456/taiwan-flag-anthem-independence-tokyo-2020-olympics/), TIME, 2016.
+- [Web oficial del Megaport Festival](https://megaportfest.com/)
+- [Web oficial de CHTHONIC 閃靈](https://www.chthonic.tw/)
+- [Freddy Lim, founder of ChthoniC](https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg), Photo: Hyw83516, Wikimedia Commons, CC BY-SA 3.0.
+- [Candidato a diputado del Nuevo Poder Freddy Lim 03](https://commons.wikimedia.org/wiki/File:%E6%99%82%E4%BB%A3%E5%8A%9B%E9%87%8F%E7%AB%8B%E5%A7%94%E5%80%99%E9%81%B8%E4%BA%BA%E6%9E%97%E6%98%B6%E4%BD%90_03.JPG), Photo: 國會無雙, Wikimedia Commons, CC BY-SA 4.0.
+- [閃靈、元千歲 - 暮沉武德殿（民謠版）](https://www.youtube.com/watch?v=kta4ZAwI6rY), YouTube oficial de CHTHONIC.
+- [Megaport Festival - Wikipedia](https://zh.wikipedia.org/wiki/%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1)
+- [Chthonic (band) - Wikipedia](https://en.wikipedia.org/wiki/Chthonic_%28band%29)
+- [Freddy Lim - Wikipedia](https://en.wikipedia.org/wiki/Freddy_Lim)
+- [Quinto distrito electoral de la ciudad de Taipéi (diputados) - Wikipedia](https://zh.wikipedia.org/wiki/%E8%87%BA%E5%8C%97%E5%B8%82%E7%AC%AC%E4%BA%94%E9%81%B8%E8%88%89%E5%8D%80_%28%E7%AB%8B%E6%B3%95%E5%A7%94%E5%93%A1%29)

--- a/knowledge/es/People/tu-pan-fangke.md
+++ b/knowledge/es/People/tu-pan-fangke.md
@@ -1,0 +1,242 @@
+---
+translatedFrom: 'People/杜潘芳格.md'
+sourceCommitSha: 'd39f3a50'
+sourceContentHash: 'sha256:d405136a29d9431e'
+sourceBodyHash: 'sha256:b0195c9685eb2443'
+translatedAt: '2026-07-23T23:10:00+08:00'
+lang: 'es'
+title: 'Tu Pan Fang-ke: tres lenguas, una función de teatro de la paz'
+description: 'Poeta hakka de la generación que atravesó las lenguas y familiar de las víctimas de la familia Chang Chi-lang en el incidente del 28 de febrero. «Ping-an-hsi» reescribe el teatro folclórico de agradecimiento a los dioses como un acta de complicidad para sobrevivir bajo el Terror Blanco: para quien el régimen le ha quitado la lengua, el verso más afilado en la lengua materna está escrito para los suyos.'
+date: 2026-07-12
+category: 'People'
+tags:
+  - 'personaje'
+  - 'Tu Pan Fang-ke'
+  - 'hakka'
+  - 'poeta'
+  - 'Sociedad Poética Li'
+  - 'generación que atravesó las lenguas'
+  - '28 de febrero'
+  - 'poesía en hakka'
+  - 'Ping-an-hsi'
+  - 'literatura femenina'
+subcategory: 'Literatura y poetas / figuras de la cultura hakka'
+author: 'Taiwan.md Translation Team'
+featured: false
+canonical-order: 120
+lastVerified: 2026-07-12
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/杜潘芳格.md'
+viewpoint_formed: true
+image: '/article-images/people/dupan-xinpu-pan-house.webp'
+imageCredit: 'Wikimedia Commons / Casa Pan de Xinpu'
+imageLicense: 'see file page'
+imageSource: 'https://commons.wikimedia.org/wiki/File:新埔潘屋全景.jpg'
+---
+
+# Tu Pan Fang-ke: tres lenguas, una función de teatro de la paz
+
+![Conjunto arquitectónico de la casa Pan en Xinpu, condado de Hsinchu: el ladrillo rojo y los hastiales en forma de lomo de caballo se despliegan bajo la luz del día. Tu Pan Fang-ke nació en 1927 en una familia hakka acomodada de Xinpu, y este paisaje familiar es el ancla material de su infancia y de la memoria de la generación que atravesó las lenguas.](/article-images/people/dupan-xinpu-pan-house.webp)
+_Casa Pan de Xinpu, condado de Hsinchu: el paisaje de la familia hakka acomodada de la que procede Tu Pan Fang-ke. Photo via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E6%96%B0%E5%9F%94%E6%BD%98%E5%B1%8B%E5%85%A8%E6%99%AF.jpg)._
+
+> **Resumen en 30 segundos:** Tu Pan Fang-ke (1927–2016; en la romanización del hakka hailu suele aparecer como Tu Pan Fong-Gied, y en la bibliografía en inglés también como Fangge Dupan) es una de las pocas poetas hakka ampliamente estudiadas dentro de la **generación taiwanesa que atravesó las lenguas**: la educación de la época japonesa le dio el japonés, la política lingüística de posguerra la obligó a pasarse al chino, y en torno al fin de la ley marcial volvió a escribir su poesía en **hakka**. No es una poeta folclórica que solo cultiva la nostalgia: en 1977, la versión en mandarín de «**Ping-an-hsi**» (平安戲) usó el escenario del teatro hakka de agradecimiento invernal a los dioses para escribir cómo «la gente pacífica que solo sabe obedecer» masca caña de azúcar bajo el entarimado y **conserva la única vida que tiene**; el peso ético de ese poema está unido a la historia familiar del asesinato, en el incidente del 28 de febrero de 1947, de **Chang Chi-lang** —tío político de su madre, en Hualien— y de sus hijos.[^1][^2][^3]
+
+## Lo que le quitaron no fue solo una lengua
+
+En 1967 el poeta Lin Heng-tai propuso la expresión «**la generación que atravesó las lenguas**»: aquel grupo que creció con el japonés bajo la dominación japonesa y que después de la guerra tuvo que aprender a escribir en chino.[^4] Tu Pan Fang-ke cae justo en el tramo de edad central de esa cohorte: nació en 1927 en Xinpu, prefectura de Hsinchu, viajó de bebé a Japón con su padre Pan Chin-huai, volvió a Taiwán con seis o siete años y entró en una «escuela primaria» destinada entonces sobre todo a hijos de japoneses.[^1]
+
+No fue una infancia bilingüe y romántica. Las biografías en chino y en inglés escriben lo mismo: sufrió acoso en la escuela y después escribió poesía, narrativa y ensayo en japonés, metiendo el dolor colonial en una «salida que permitía la fantasía».[^1][^5] En los horarios de la Escuela Superior Femenina de Hsinchu y del Instituto Superior Femenino de Taipéi había arreglo floral, ceremonia del té y costura, y también un adiestramiento en las virtudes femeninas para «servir al marido y educar a los hijos»: la semilla de que más tarde escribiera una y otra vez sobre la posición de las mujeres está aquí.[^1]
+
+En 1946 escribir en japonés en Taiwán se volvió peligroso. La política lingüística no cambió solo los libros de texto: cambió todo un órgano para poder hablar en público. La síntesis del Museo Nacional de Literatura Taiwanesa lo escribe con sequedad: **se arrancaron de golpe el vocabulario, la gramática y la capacidad de expresar pensamientos complejos**. Hubo quien dejó de escribir y quien tuvo que reaprender durante años antes de atreverse a publicar de nuevo.[^4] Tu Pan Fang-ke dejó de publicar durante más de una década; en ese tiempo se casó, ayudó en la clínica de su marido y crió a sus hijos. Hasta mediados de los años sesenta no reapareció en el panorama poético, ya en chino.[^1][^4]
+
+En entrevistas posteriores habló de sus tres lenguas como de tres almacenes: el japonés era el de formación más completa, donde cabían los sentimientos más hondos. El chino se le quedó durante mucho tiempo en un nivel «de tercero o cuarto de primaria», y al escribir poesía le solían reprochar falta de refinamiento. El hakka era la lengua materna que siempre se había hablado en casa pero que sobre el papel había que reinventar desde cero.[^12] Sung Tse-lai llegó a aconsejarle que escribiera directamente en japonés y buscara a alguien que la tradujera. Pero su ánimo volvía siempre a «debería usar mi propia lengua materna». Esa vacilación es en sí misma la obra cotidiana de la generación que atravesó las lenguas, no un defecto de carácter por indecisión.[^12]
+
+> 📝 **Nota de la curaduría**: la generación que atravesó las lenguas se escribe a menudo como una «biografía trágica». En el caso de Tu Pan Fang-ke es más preciso decir esto: a lo largo de su vida hizo al menos **tres** elecciones lingüísticas: el japonés impuesto, el chino impuesto y el hakka que recuperó **por voluntad propia** en su madurez. La tercera es su respuesta a la soberanía.
+
+## Aquel disparo en Hualien queda escrito en todos los «años de paz» posteriores
+
+El incidente del 28 de febrero de 1947. **Chang Chi-lang** —tío político de la madre de Tu Pan Fang-ke, médico del Hospital Jen-shou de Fenglin, en Hualien, y persona de altísimo prestigio local— fue detenido junto con sus hijos y asesinado poco después.[^1][^6] Chang Chi-lang era hakka, natural de Hukou (Hsinchu), y médico rural graduado en la Escuela de Medicina del Gobierno General de Taiwán. Tras la guerra fue elegido concejal y presidente del consejo provincial en Hualien, y también resultó elegido delegado de la Asamblea Nacional con una alta votación. Durante el incidente del 28 de febrero fue además el más votado cuando en Hualien se propuso al jefe del condado, pero desapareció junto con sus hijos en la purga que siguió a la extensión de los sucesos.[^3][^6]
+
+Esto no es un cotilleo de parientes lejanos: es el negativo ético de sus posteriores poemas de sátira política. Cuando el relato oficial dice «todos los años son de paz», en casa se sabe a costa de la desaparición de quién se ha obtenido esa paz. Tanto la Wikipedia en chino como los textos sobre cultura hakka señalan que esta historia familiar añadió crítica y alegoría política a su creación posterior: no una toma de partido de consigna, sino una alergia prolongada de una familia superviviente a esas dos palabras, «paz».[^1]
+
+En 1948, contra la oposición de su familia, se casó con el médico **Tu Ching-shou** y se mudó a Chungli, en Taoyuan, donde escribía junto a la clínica y también daba clases de arreglo floral.[^1] Chungli no era el salón de una familia acomodada de Xinpu, sino la cotidianidad de la consulta médica y de la crianza. Su primer poemario se llamó por eso «**Ching-shou**» (慶壽, 1977): «Ching» del nombre de su marido y «shou» por la longevidad de su padre, incrustando la ética privada directamente en el título.[^1] La onomástica familiar reaparecerá después: «Huai-shan Wan-hai» (淮山完海) lleva incrustados los nombres de sus padres, «Huai» y «Wan»; «Chao-ching» (朝晴) toma el nombre de sus nietos; «Yuan Chien-hu» (遠千湖) reúne los nombres de sus amistades (el carácter «chien» enlaza con Chen Chien-wu, de la Sociedad Poética Li).[^1] Para ella, los títulos de sus libros eran a menudo mapas de parentesco, no eslóganes de marketing.
+
+![Exterior de la antigua residencia de Wu Cho-liu en Xinpu. También hakka de Xinpu, Wu Cho-liu tradujo al chino los primeros poemas en japonés de Tu Pan Fang-ke, un ejemplo de cómo la generación que atravesó las lenguas se sostenía mutuamente la expresión.](/article-images/people/dupan-xinpu-wuzhuoliu-house.webp)
+_Antigua residencia de Wu Cho-liu en Xinpu: la huella material de la red de escritores mayores del mismo pueblo. Del primer poema publicado por Tu Pan Fang-ke en 1966 consta que Wu Cho-liu tradujo el original japonés. Photo via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E6%96%B0%E5%9F%94%E5%90%B3%E6%BF%81%E6%B5%81%E6%95%85%E5%B1%85.jpg)._
+
+## La voz femenina bajo Li, la voz femenina bajo la mano del traductor
+
+En 1965 se incorporó a la [Sociedad Poética Li](/art/笠詩社), buque insignia de las sociedades poéticas nativistas fundada en 1964, que subrayaba la conciencia local.[^1][^7] No fue una de las doce personas fundadoras, sino la poeta que entró «al año siguiente de la fundación de Li». Li Yuan-chen, Li Min-yung y otros defenderían después en repetidas ocasiones su pensamiento poético.[^5]
+
+En julio de 1966, la revista *Taiwan Wenyi* publicó su poema «Primavera». La prensa en inglés lo escribe así: era un original en japonés, traducido al chino por **Wu Cho-liu**.[^4] Aquí aparece una forma de producción habitual en la generación que atravesó las lenguas: el poema crece primero en una cabeza que piensa en japonés y después otro par de manos lo traslada a la página en mandarín. Li Yuan-chen señalaría más tarde que los primeros originales en chino pasaban a menudo por **traductores varones**, y que los matices de la mirada femenina quedaban alisados; esa es también una de las razones por las que se ha subestimado su influencia.[^4]
+
+El 17 de septiembre de 1967, tras la recuperación de su marido, gravemente herido en un accidente de tráfico, ella leyó ese giro como una plegaria atendida y se adentró aún más en la fe cristiana y en el trabajo misionero.[^1] La fe no la convirtió en una abuela dulce que canta al folclore: al contrario, algunos de sus poemas más conocidos **desmontan** precisamente la obviedad del pudu del Festival de los Fantasmas y del teatro de la paz.
+
+## «Ping-an-hsi»: la caña de azúcar bajo el entarimado es más honesta que los dioses del escenario
+
+En el agradecimiento hakka de invierno a los dioses suele representarse el «ping-an-hsi», el teatro de la paz. El pretexto es dar gracias por un año entero de paz. La versión en mandarín de «Ping-an-hsi» que Tu Pan Fang-ke incluyó en «Ching-shou» en 1977 mueve la cámara de los dioses a las gradas:[^2]
+
+> Año tras año, siempre un año de paz  
+> Año tras año, siempre se representa el teatro de la paz
+>
+> La gente pacífica que solo sabe obedecer  
+> La gente pacífica que solo sabe aguantar
+>
+> Rodeando el entarimado  
+> Mirando la función por compromiso
+>
+> Es lo que tú le has permitido representar
+>
+> Muchísima gente pacífica  
+> Prefiere quedarse bajo el entarimado,  
+> mascando caña de azúcar, con una ciruela salada en la boca.
+>
+> **Conservando la única vida que tiene**  
+> mira  
+> el teatro de la paz.
+
+«Conservar la única vida que tiene» es la cerradura de todo el poema. El texto comparativo de The News Lens de 2021 señala: la gente no es que ignore que en el escenario hay muerte, sino que sabe que dar un paso al frente puede costarle la desaparición, y por eso llama paciencia a la obediencia y paz a mirar desde fuera.[^2] La lectura guiada de Hung Shu-ling, del Departamento de Literatura China de la Universidad Nacional de Taiwán, abre tres capas: la crítica moderna a lo irracional del folclore, la ironía política bajo el autoritarismo y la ética universal de que «quien solo busca salvarse acaba siendo dominado».[^8]
+
+Más tarde reescribió el poema en **hakka**. El Museo Nacional de Literatura Taiwanesa conserva el manuscrito en hakka de «Ping-an-hsi» de 1995.[^9] El reportaje en inglés del *Taipei Times* advierte de que la versión hakka no es una traducción literal, sino que incorpora una retórica hakka ausente en la versión en mandarín.[^4] La última estrofa en hakka que cita VERSE suena aún más a lengua hablada, como quien muerde una raíz de nabo seco:
+
+> 儘多儘多个平安人  
+> 情願囓菜餔根  
+> K甘蔗含李仔鹼  
+> 保持一條佢个老命  
+> 看，平安戲。[^8]
+
+La misma ética, con otro juego de músculos de la boca. Para una poeta que atravesó las lenguas, esto no es un juego de estilo, sino la cuestión de **quién tiene derecho a nombrar la complicidad y con qué voz**.
+
+⚠️ **Punto de vista en disputa**: leer «Ping-an-hsi» como «solo critica al Kuomintang» o como «solo insulta la cobardía de los hakka» estrecha el poema en ambos casos. El filo apunta a la vez al régimen, a quienes miran desde fuera y al autoengaño de «embellecer la obediencia como virtud». La historia de la familia Chang Chi-lang da a ese filo un peso de sangre, pero eso no significa que el poema admita solo la lectura de un diario de agravios familiares.
+
+Esa misma ética puede releerse en cualquier época: el silencio dentro de una empresa, la mirada pasiva en la escuela, el «primero salvarse uno mismo» en las redes sociales. No se trata de relativizar el Terror Blanco, sino de reconocer que Tu Pan Fang-ke forjó una experiencia histórica particular hasta convertirla en una **sintaxis ética trasplantable**. Por eso una canción pop de 2021 pudo enlazar con unos versos de 1977.[^2]
+
+## El cerdo con el «bien dispuesto» en la boca: «Festival de los Fantasmas», el otro espejo
+
+Si «Ping-an-hsi» mira las gradas, «Festival de los Fantasmas» (中元節) mira al cerdo sobre el altar. La versión hakka escribe: en la boca del gran cerdo hay una fruta llamada «bien dispuesto» (甘願), y quien se la ha metido dentro «就係𠊎，沒就係你» (soy yo, o si no eres tú).[^10] Dentro del bullicio del pudu, la gente se mezcla con la multitud y «唔記得你自家係𠍨儕» (olvida quién es). Y alguien sabe cada vez con mayor claridad que es «孤獨心蕉人», una persona de corazón solitario.[^10]
+
+Esto resulta especialmente punzante junto al vocabulario de fe de «Figuras de papel» (紙人): las figuras de papel se agitan con el viento de otoño; ella escribe «mi cuerpo es una vasija y mi corazón es un templo», y quiere buscar a la «persona verdadera» en un mundo saturado de figuras de papel.[^11] Que una poeta cristiana desmonte las fiestas populares no busca alimentar una guerra cultural, sino preguntar: **a quién se le exige estar bien dispuesto y quién tiene derecho a mirar la función**.
+
+![Arquitectura hakka tradicional de patio cerrado en la zona de Tongluo, condado de Miaoli. El mundo material de la poesía en hakka no es un simple «símbolo rural», sino un espacio de vida que han hecho crecer juntos la aldea, los ritos, el entarimado del teatro y la lengua hablada cotidiana.](/article-images/people/dupan-hakka-compound-tongluo.webp)
+_Patio hakka tradicional (Tongluo, Miaoli). Para entender las escenas folclóricas de «Ping-an-hsi» y «Festival de los Fantasmas» hay que devolver primero el entarimado y la sala común desde el símbolo turístico al terreno de la ética cotidiana. Photo via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Hakka_Compound,_Tongluo,_Miaoli_(Taiwan).jpg)._
+
+## Tras el fin de la ley marcial, la lengua materna pasó de «hablarse en casa» a «escribirse en papel»
+
+En 1987 se levantó la ley marcial. El 28 de diciembre de 1988, la manifestación hakka «**Devolvedme mi lengua materna**» salió a la calle.[^4] Tu Pan Fang-ke pasaba entonces de los sesenta. Nunca llegó a sentirse verdaderamente cómoda escribiendo en chino: en el proceso creativo el japonés seguía siendo la lengua más fluida para pensar. Y un día descubrió que algunas frases **se formaban directamente en hakka**. «I picked the words up and wove them into Hakka poems» («recogí esas palabras y las tejí en poemas hakka»), describiría después, admitiendo a la vez el sufrimiento de la falta de vocabulario literario y de tener sonidos sin caracteres.[^4]
+
+Hacia 1989 empezó a publicar activamente poesía en hakka; en los noventa publicó «Chao-ching», «Yuan Chien-hu», «Ching-feng Lan-po» (青鳳蘭波) y «La estación de la flor de hibisco» (芙蓉花的季節), con la lengua yendo y viniendo entre el chino, el hakka, el japonés y el inglés.[^1] En 1992, «**Yuan Chien-hu**», escrito en chino, inglés y japonés, ganó la primera edición del **Premio de Poesía Chen Hsiu-hsi**.[^1] Pai Chiu le había reprochado en su momento falta de refinamiento en chino; Li Yuan-chen y Li Min-yung insistieron en que en esa tosquedad había un brillo de escamas: el premio salió cargado a hombros desde la polémica, no de una ovación unánime.[^12]
+
+Tomó como referencia que Dante escribiera la «Divina Comedia» en italiano: la lengua se levanta con las obras, no esperando a que la autoridad la declare elegante.[^4] También advirtió: cuando tras el fin de la ley marcial todos se disputaban el hablar «taiwanés», no había que estrechar lo taiwanés a un solo acento: «Aboriginal languages and Hakka are also Taiwanese» («las lenguas indígenas y el hakka también son taiwanés»).[^4]
+
+Para ella, el japonés y el mandarín fueron en su momento «forced to learn by authorities» y «represent our enslavement»; las herramientas de comunicación pueden tomarse prestadas, pero **la soberanía de la lengua materna no puede seguir tratándose como algo prestado**.[^4]
+
+En los años ochenta vivió unos años en Estados Unidos, obtuvo la nacionalidad estadounidense en mayo de 1982 y después regresó a Taiwán para instalarse en Chungli.[^1][^13] La experiencia transoceánica añadió otra capa de presión lingüística (el inglés) y convirtió las preguntas sobre «isla / refugiado / nación» de algo abstracto en el peso del equipaje. Por eso su escritura en hakka tras el regreso no es solo nostalgia: es un **tercer pacto** firmado después de haber sido obligada a cambiar de lengua, de haber dejado la isla por voluntad propia y de haber vuelto a casa.
+
+<div style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;max-width:100%;margin:1.5rem 0;">
+  <iframe src="https://www.youtube.com/embed/OibAtswHQwQ" title="客家女詩人杜潘芳格與中壢文學街區介紹" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Vídeo: reportaje cultural público sobre Tu Pan Fang-ke y el distrito literario de Chungli, en Taoyuan (YouTube). Las instalaciones con versos en la calle son la forma contemporánea en que la poesía sale de la página hacia los itinerarios cotidianos._
+
+## Un árbol mujer, no una flor que pide que la mimen
+
+Hung Shu-ling destaca especialmente el autobautismo de «Árbol del amor» (相思樹):
+
+> Yo también soy  
+> nacida en esta isla  
+> un árbol mujer.[^8]
+
+La metáfora de la flor ha escrito con demasiada frecuencia a las mujeres como algo que se mira, se corta y se ofrenda. Un árbol necesita raíces, viento y tiempo. La imagen pública de Tu Pan Fang-ke se recoge con facilidad hacia la ternura de «la tía / la abuela Tu Pan» —el distrito literario de Chungli, los actos de cultura hakka, las portadas de las antologías—, pero ese árbol de sus poemas tiene a la vez un borde duro de razón: ciudadanía, pudu, teatro de la paz, figuras de papel. La lectura de Hung Shu-ling señala que su visión histórica cuenta como ciudadanos de Taiwán a los habitantes del pasado, del presente y del futuro, sin exceptuar siquiera a los muertos ya convertidos en abono de la tierra.[^8]
+
+La entrada «Mujeres de Taiwán» del Museo Nacional de Historia de Taiwán cita «Voz»: no se sabe desde cuándo el sonido tenue que solo una misma puede escuchar quedó bajo llave, la lengua perdió su salida y no queda más que esperar, día tras día, con solemne paciencia, una voz nueva.[^5] Aquí la tristeza de atravesar las lenguas no es retórica: es una afasia de nivel fisiológico. La poesía en hakka fue la salida que ella esperó y que también hizo crecer por sí misma.
+
+La lectura de VERSE rescata además «La casa de mis padres»: la madre parece una rosa orgullosa en la capilla, pero la sombra alta del padre la cubre de vez en cuando; el poema dice: «y la madre que vive dentro de la cruz / el padre que vive dentro de la madre / los dos viven en una espina de la rosa orgullosa».[^8] La familia no es un telón de fondo, sino el primer escenario donde practicó «cómo arraiga la opresión estructural en las relaciones más íntimas». Ayudante de clínica, profesora de arreglo floral, madre criando hijos, poeta, cristiana: solo cuando esas identidades están presentes a la vez el poema tiene peso; si se separan y queda únicamente la etiqueta de «poetisa», se vuelve ligero.
+
+> 📝 **Nota de la curaduría**: recibir a Tu Pan Fang-ke solo como «escritora representativa hakka» o solo como «familiar de las víctimas del 28 de febrero» deja fuera la mitad en ambos casos. Los cuatro ejes —atravesar las lenguas, el 28 de febrero, ser mujer hakka y la denuncia social— tienen que estar abiertos a la vez para que ella deje de ser un único panel expositivo dentro de un museo.
+
+## Premios, manuscritos y la segunda lectura después de Collage
+
+Las instituciones públicas y la academia añadieron después coronas que llegaron tarde: en 2007, el «Premio a la Contribución Destacada» y el «Premio a la Contribución a la Nueva Literatura Taiwanesa» del Consejo de Asuntos Hakka; en 2008, el «Premio Oxford de Literatura Taiwanesa» de la Universidad Aletheia.[^1] El 10 de marzo de 2016 murió mientras dormía en su casa, a los 89 años; en el funeral, un representante del Consejo de Asuntos Hakka entregó el elogio presidencial.[^1][^13]
+
+En marzo de 2017 la familia donó **340** manuscritos a la Biblioteca Nacional Central: japonés, chino y hakka dispuestos uno junto a otro, como si se apilara en papel hojeable todo un campo de batalla lingüístico de una vida.[^4] El *Taipei Times* cita lo que dijo en 2004 a la revista *INK*: «If you ask me why I write, you might as well ask me why I live» («si me preguntas por qué escribo, podrías preguntarme igualmente por qué vivo»).[^4]
+
+Hacia 2021, «El dolor de la madre compasiva entre miles de flores» (萬千花蕊慈母悲哀) de la banda independiente **Collage** (珂拉琪) se hizo enormemente popular, y muchos lectores interpretaron el verso «la gente de carne y hueso acabó desaparecida» como una escena del Terror Blanco. The News Lens puso esa canción junto a «Ping-an-hsi»: una ruge hacia el bodhisattva, la otra mira la caña de azúcar bajo el entarimado; ambas son **formas indirectas de escribir cuando no se puede mirar de frente el trauma**.[^2] No importa si Collage está «oficialmente certificada» como creación sobre el Terror Blanco; lo importante es que los oídos de una nueva generación volvieron a conectarse con un circuito ético ya escrito en 1977.
+
+![Danza y público del Festival Hakka de la Flor de Tung. Que la lengua materna pase del habla familiar al espacio cultural público es una obra larga posterior al movimiento «Devolvedme mi lengua materna» de finales de los ochenta; la poesía en hakka de Tu Pan Fang-ke es uno de los muros de carga tempranos de esa obra por el lado de la literatura.](/article-images/people/dupan-hakka-tung-festival.webp)
+_Acto del Festival Hakka de la Flor de Tung (2014): la visibilidad hakka en la cultura pública y la escritura en hakka en la literatura son afluentes distintos del mismo largo río de revitalización. Photo via [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:2014%E5%AE%A2%E5%AE%B6%E6%A1%90%E8%8A%B1%E8%88%9E%E8%B9%88%E5%A4%A7%E8%B3%BD_Hakka_Tung_Blossom_Festival_-_panoramio.jpg)._
+
+## Por qué seguir leyéndola en 2026
+
+En las coordenadas de Taiwan.md, Tu Pan Fang-ke ocupa al menos cuatro cruces:
+
+1. **La generación que atravesó las lenguas** — la voz femenina sobre la misma mesa de operaciones histórica que Chen Chien-wu, Lin Heng-tai o Chin Lien
+2. **Familiar de las víctimas del 28 de febrero** — la continuación literaria de la línea de Chang Chi-lang, no un apéndice de cifras
+3. **Poeta hakka** — el tira y afloja de toda una vida entre el papel de esposa y madre ejemplar y la subjetividad de poeta
+4. **«Ping-an-hsi»** — haber reescrito la «paz» de bendición a problema de ética política
+
+Y si se añade «la torre de Babel de la soberanía»: la poesía en hakka es una de las voces taiwanesas que los grandes modelos internacionales rechazan responder, reescriben o dejan en blanco con mayor facilidad. Que ella insistiera en el hakka sobre el papel no es solo estética rural: es hacer que una voz susceptible de ser silenciada **exista primero**. La existencia misma es defensa. Meter sus poemas en una base de conocimiento abierta equivale a clavar una estaca taiwanesa en primera persona antes de que se filtren los corpus de entrenamiento.
+
+El itinerario de sus principales poemarios se puede memorizar como una cronología muy breve: «Ching-shou» (1977) → «Huai-shan Wan-hai» (1986) → «Chao-ching» y «Yuan Chien-hu» (hacia 1990) → «Ching-feng Lan-po» (1993) → «La estación de la flor de hibisco» (1997).[^1] Entremedias se intercalan los años en Estados Unidos, la experimentación en hakka, la gestión de la sociedad poética y las polémicas por los premios. Si al leer una antología se extrae solo «Ping-an-hsi» como obra representativa, se pierden la afasia de «Voz», el «bien dispuesto» de «Festival de los Fantasmas», el árbol mujer de «Árbol del amor» y esos poemas familiares que parecen hablar solo de cocinar en una mañana de otoño y en realidad hablan de los hijos que se van del nido.[^8]
+
+En Chungli, su nombre acabó inscrito en el distrito literario y en las rutas culturales locales: versos en los muros, visitas guiadas convertidas en itinerario, de modo que un transeúnte que quizá nunca compre un poemario pueda toparse con el «árbol mujer» en la esquina de un soportal.[^14] Es un arma de doble filo: la conmemoración pública recoge con facilidad a la poeta como un hito amable, pero si la visita guiada está dispuesta a detenerse en ese verso de «Ping-an-hsi», «conservando la única vida que tiene», la calle conserva todavía el filo. La educación lingüística en hakka, las lecturas radiofónicas y las reediciones de antologías son otra línea de continuidad, más silenciosa: no un estallido viral, sino una voz leída una y otra vez en las aulas de lengua materna. Lo que ella añadió a la historia de la literatura taiwanesa no es «una poetisa más», sino la voz femenina hakka que casi no se escuchó sobre la mesa de operaciones de las lenguas, y ese tajo que convirtió una fiesta folclórica en papel de tornasol de la ética política.
+
+Puede que el entarimado ya se haya desmontado. Puede que el bagazo de la caña se haya barrido. Pero cada vez que alguien dice «no busques problemas, con estar en paz basta», ese verso de «Ping-an-hsi» —«es lo que tú le has permitido representar»— vuelve a sonar a la vez desde el hakka y desde el mandarín.
+
+En 2016 se marchó mientras dormía. En 2017 sus manuscritos entraron en la biblioteca. En 2021 una canción pop volvió a llevar a la gente joven bajo el entarimado.  
+Antes de cerrar esta página, el lector puede preguntarse algo muy pequeño:
+
+**Ahora mismo, ¿estás sobre el escenario, o bajo el entarimado mascando caña de azúcar?**
+
+---
+
+**Lecturas complementarias**:
+
+- [Sociedad Poética Li](/art/笠詩社) — la red de la sociedad poética nativista a la que se incorporó en 1965
+- [Incidente del 28 de febrero](/history/二二八事件) — la estructura de trauma de toda la isla en la que se inscribe el caso de Chang Chi-lang
+- [El Terror Blanco en Taiwán](/history/台灣白色恐怖) — el trasfondo institucional de la lectura política de «Ping-an-hsi»
+- [Historia de la literatura taiwanesa](/art/台灣文學史) — la posición de largo alcance de la generación que atravesó las lenguas y de la literatura en lengua materna
+- [Monaneng](/people/莫那能) — otra vía contrapuntística de «alzar la voz por el propio pueblo en una lengua ajena / en caracteres chinos»
+- [Poesía moderna taiwanesa](/art/台灣現代詩) — el mapa más amplio del ecosistema de las sociedades poéticas de posguerra
+
+## Fuentes de imágenes
+
+Este texto utiliza **imágenes de paisaje y de contexto cultural** en lugar de los escasos retratos con licencia CC (a fecha de 12-07-2026, la consulta de Wikimedia y de las entradas de Wikipedia no arrojó retratos reutilizables de forma estable):
+
+- [Vista general de la casa Pan de Xinpu](https://commons.wikimedia.org/wiki/File:%E6%96%B0%E5%9F%94%E6%BD%98%E5%B1%8B%E5%85%A8%E6%99%AF.jpg) — hero, paisaje familiar
+- [Antigua residencia de Wu Cho-liu en Xinpu](https://commons.wikimedia.org/wiki/File:%E6%96%B0%E5%9F%94%E5%90%B3%E6%BF%81%E6%B5%81%E6%95%85%E5%B1%85.jpg) — red literaria del mismo pueblo que atravesó las lenguas
+- [Hakka Compound, Tongluo, Miaoli](<https://commons.wikimedia.org/wiki/File:Hakka_Compound,_Tongluo,_Miaoli_(Taiwan).jpg>) — espacio de vida hakka
+- [Concurso de danza del Festival Hakka de la Flor de Tung 2014](https://commons.wikimedia.org/wiki/File:2014%E5%AE%A2%E5%AE%B6%E6%A1%90%E8%8A%B1%E8%88%9E%E8%B9%88%E5%A4%A7%E8%B3%BD_Hakka_Tung_Blossom_Festival_-_panoramio.jpg) — visibilidad de la lengua materna en la cultura pública
+
+Vídeo opcional: programas públicos como «El distrito literario de Tu Pan Fang-ke», de Hakka TV o de reportajes culturales (YouTube), como complemento y no como elemento imprescindible del texto.
+
+## Referencias
+
+[^1]: [Wikipedia — Tu Pan Fang-ke](https://zh.wikipedia.org/zh-hant/%E6%9D%9C%E6%BD%98%E8%8A%B3%E6%A0%BC) — fechas de nacimiento y muerte, origen en Xinpu, incorporación a la Sociedad Poética Li en 1965, cronología de poemarios, historia familiar de Chang Chi-lang, premios y fallecimiento en 2016.
+
+[^2]: [The News Lens — Collage y «Ping-an-hsi» de Tu Pan Fang-ke](https://www.thenewslens.com/article/148153) — Texto de 2021 que cita íntegra la versión en mandarín de «Ping-an-hsi» de 1977 incluida en «Ching-shou» y la lee en paralelo con la escritura cifrada del Terror Blanco.
+
+[^3]: [Fundación Conmemorativa del 28 de Febrero — Chang Chi-lang](https://www.228.org.tw/228heroes/6359bf2c-bd93-4b7c-9821-503e26939c46) — Los hechos del asesinato del médico Chang Chi-lang y de sus hijos en Fenglin (Hualien) durante el 28 de febrero, y su trasfondo político local.
+
+[^4]: [Taipei Times — The sweet sound of the mother tongue](https://www.taipeitimes.com/News/feat/archives/2017/03/05/2003666154) — Reportaje especial de 2017: los 340 manuscritos, la definición de la generación que atravesó las lenguas, el giro hacia el hakka y el discurso sobre las lenguas impuestas.
+
+[^5]: [Mujeres de Taiwán — la poeta hakka que cruzó fronteras, Tu Pan Fang-ke](https://women.nmth.gov.tw/?p=2062) — Entrada del Museo Nacional de Historia de Taiwán, que incluye la cita de «Voz» y el contexto de la Sociedad Poética Li.
+
+[^6]: [Wikipedia — Chang Chi-lang](https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E4%B8%83%E9%83%8E) — Vida de Chang Chi-lang y su muerte en el 28 de febrero; se contrasta con el relato familiar de Tu Pan Fang-ke sobre su «tío político».
+
+[^7]: [Wikipedia — Sociedad Poética Li](https://zh.wikipedia.org/zh-hant/%E7%AC%A0%E8%A9%A9%E7%A4%BE) — Sociedad poética nativista fundada en 1964; Tu Pan Fang-ke se incorporó en 1965 y no es miembro fundadora.
+
+[^8]: [VERSE — leer a Tu Pan Fang-ke](https://www.verse.com.tw/article/hakka-du-pan-fang-ge) — Lectura guiada de Hung Shu-ling de 2023: el árbol mujer, la última estrofa en hakka de «Ping-an-hsi» y su visión poética de la ciudadanía.
+
+[^9]: [Fondos del Museo Nacional de Literatura Taiwanesa — Ping-an-hsi (poema en hakka)](https://collections.culture.tw/nmtl_collectionsweb/GalData.aspx?GID=M1MHMAMAMXMD) — Manuscrito fechado en 1995, autora Pan Fang-ke (Tu Pan Fang-ke).
+
+[^10]: [Un poema para ti cada día — «Festival de los Fantasmas» ◎ Tu Pan Fang-ke](https://cendalirit.blogspot.com/2016/05/20160525.html) — Texto íntegro en hakka procedente de «Ching-feng Lan-po», con anotaciones léxicas.
+
+[^11]: [Merit Times — «Figuras de papel» de Tu Pan Fang-ke](https://www.merit-times.com.tw/NewsPage.aspx?unid=241341) — Los versos clave de «Figuras de papel» y una lectura del poema desde la dimensión de la fe.
+
+[^12]: [Nueva Cultura Taiwanesa — La redención del dolor: religión y literatura](https://www.twcenter.org.tw/thematic_series/character_series/taiwan_litterateur_interview/b01_7101/b01_7101_1) — Entrevista de Chuang Tzu-jung a Tu Pan Fang-ke en 1997: el almacén del japonés, la vacilación ante el hakka y la polémica del Premio Chen Hsiu-hsi.
+
+[^13]: [Wikipedia en inglés — Fangge Dupan](https://en.wikipedia.org/wiki/Fangge_Dupan) — Fechas de nacimiento y muerte en inglés, su posición como parte de la generación que atravesó las lenguas y el homenaje y elogio de 2016, en un resumen legible internacionalmente.
+
+[^14]: [Página de autora de Wenhsun — Tu Pan Fang-ke](https://www.wenhsun.com.tw/authorsite/detail/15) — Complementos biográficos y verificación cruzada de su posición dentro de «la generación que atravesó las lenguas».
+
+[^15]: [Presentación en inglés del Consejo de Asuntos Hakka — Du Pan Fang-ge](https://english.hakka.gov.tw/Content/Content?NodeID=670&PageID=39821&LanguageType=ENG) — Presentación en inglés del Consejo de Asuntos Hakka: su escritura en japonés, chino y hakka y el tema de la opresión colonial.

--- a/knowledge/es/Society/taipei-smoking-room.md
+++ b/knowledge/es/Society/taipei-smoking-room.md
@@ -1,0 +1,318 @@
+---
+translatedFrom: 'Society/台北吸菸室.md'
+sourceCommitSha: '1929e495'
+sourceContentHash: 'sha256:38028701b07f0fef'
+sourceBodyHash: 'sha256:9688d39de8d42815'
+translatedAt: '2026-07-24T00:10:00+08:00'
+lang: 'es'
+title: 'La sala de fumar de Taipéi: la caja de cristal que respira dentro de una ciudad sin humo'
+description: 'El 7 de mayo de 2026 se levantó junto a la salida 6 del metro de Ximen una caja transparente: la primera sala de fumar exterior de presión negativa de Taiwán. Al abrir la puerta, el aire entra y no sale. Taipéi quiere ser una ciudad sin humo y, sin embargo, ha empezado construyendo en plena calle una casa de cristal para fumar. Desde 1984, cuando Yen Tao perdió un lóbulo pulmonar, hasta hoy, con el humo ajeno en interiores reducido al 3,2% y todavía casi la mitad puertas afuera, esta caja contiene un cigarrillo legal y un contrato sobre el espacio público que la ciudad aún no ha terminado de negociar.'
+date: 2026-07-13
+category: 'Society'
+tags:
+  - 'sala de fumar'
+  - 'ciudad sin humo'
+  - 'control del tabaco'
+  - 'humo de segunda mano'
+  - 'sala de presión negativa'
+  - 'salud pública'
+  - 'Ximending'
+  - 'cigarrillo electrónico'
+subcategory: 'Society'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-13
+lastHumanReview: false
+readingTime: 17
+researchReport: 'reports/research/2026-07/台北吸菸室.md'
+image: '/article-images/society/taipei-ximending-smoking-booth-2026.webp'
+imageCredit: '花花日報 / periodista Chang Hsiang-ying'
+imageLicense: 'Fair use editorial commentary'
+imageSource: 'https://n.yam.com/Article/20260518246667'
+sporeLinks:
+  - id: 155
+    platform: 'threads'
+    date: '2026-07-14'
+    url: 'https://www.threads.com/@taiwandotmd/post/DaxYe4Sk52Q'
+  - id: 156
+    platform: 'x'
+    date: '2026-07-14'
+    url: 'https://x.com/taiwandotmd/status/2076992601543327976'
+relatedDiary:
+  - 2026-07-14-193334-manual
+---
+
+_Junto a la salida 6 del metro de Ximen, la primera sala de fumar exterior de presión negativa de Taiwán: una caja de cristal transparente con marco negro, levantada sobre la acera. Photo: 花花日報 / periodista Chang Hsiang-ying (fair use editorial commentary)._
+
+> **Resumen en 30 segundos:** Taipéi ha escrito en la calle el «prohibido en principio, permitido por excepción»: en Ximending y en la zona de Xinzhongshan se prohíbe fumar en todo el exterior y, a la vez, se levantan las primeras salas de fumar exteriores de presión negativa de Taiwán, que crean con extracción de aire una diferencia de presión para que el olor a tabaco entre pero no salga. Quienes lo apoyan dicen que por fin pueden respirar; pero las organizaciones antitabaco están en contra, porque cuanto más cómoda se construye, más se aleja del propósito de que la gente deje de fumar. Una caja de cristal visible contiene una larga marcha del control del tabaco que dura ya cuarenta años y que ahora ha avanzado hasta el exterior.
+
+## Una caja transparente parada junto al soportal
+
+El 7 de mayo de 2026, junto a la salida 6 del metro de Ximen, entre los rótulos de Chengdu Yangtao Bing y del local original de Taiwan Yan Su Chi, apareció sobre la acera una caja transparente. Unos 16 metros cuadrados; alguien la midió en Dcard: «prácticamente el tamaño de una plaza de aparcamiento». Dentro lleva cuatro filtros (grasa, filtrado primario del aire, carbón activo y PM2.5): el humo entra, se lava capa a capa y sale después por una salida de aire en diagonal. El horario va de las 8 de la mañana a las 12 de la noche, y en la puerta hay un cartel: prohibida la entrada a menores de 20 años y a embarazadas. Es la primera sala de fumar exterior de presión negativa de Taiwán[^1].
+
+Las palabras «presión negativa» suenan a jerga de laboratorio, pero desplegadas describen un fenómeno físico contraintuitivo. Ya en 2008, cuando el hotel Sheraton instaló una sala de fumar interior homologada, la responsable de comunicación Pai Ching-hui se lo explicó así a un periodista de televisión: «La sensación de la presión negativa es que, al abrir la puerta, el aire de dentro no sale, sino que el aire de fuera entra»[^2]. El extractor mantiene la presión de la caja por debajo de la exterior, así que al abrir la puerta el aire entra y el olor a tabaco queda dentro sin poder salir. El principio es el mismo que el de las habitaciones de presión negativa con que los hospitales aíslan a pacientes infecciosos.
+
+El primer gesto visible de una ciudad que quiere ser una «ciudad sin humo» ha sido, sin embargo, construir en la esquina más concurrida una casa de cristal para fumar. ¿Es contradictorio? Esa caja transparente que respira es, en realidad, la forma más concreta que ha adoptado hasta ahora el intento de Taipéi de volver a colocar dentro del contrato del espacio público un cigarrillo legal pero que sin duda daña a quien está al lado. Al seguir el olor a tabaco desde el cenicero de la oficina hasta esta casa de cristal, lo que se ve es una negociación que la ciudad lleva cuarenta años sin cerrar.
+
+Solo que esta caja no se portó bien desde el principio. A los tres días de funcionamiento, la puerta manual de una de ellas no cerraba y se abría sola; la Oficina de Obras Públicas dijo que ya había ajustado el riel[^3]. Una caja que dice mantener la presión negativa mediante el cierre hermético, y cuya puerta no cierra. Esa pequeña rendija anticipaba justo todas las polémicas posteriores: entre el hermetismo declarado y las fugas reales siempre hay una batalla que no termina.
+
+## El aire fue gratis alguna vez
+
+Para entender por qué una sala de fumar callejera puede convertirse en un asunto de peso hay que volver a la época en que el olor a tabaco era parte del aire. Antes de 2009, en las oficinas, los trenes, los karaokes y los restaurantes de Taiwán flotaba el humo. El «Longevidad» del Monopolio fue durante años el número uno del mercado desde su salida en 1958 y en 1987 aún suponía el 76% de las ventas de tabaco de Taiwán: de cada cuatro fumadores, tres fumaban Longevidad[^4]. La fábrica de tabaco de Songshan, iniciada en 1937 por la Oficina del Monopolio del Gobierno General, llegó a tener dos mil empleados y una producción anual de más de 21.000 millones de yuanes, y siguió produciendo hasta 1998[^5]. El tabaco fue en su momento un negocio del Estado, y fumar era el sonido de fondo cotidiano de la isla.
+
+![Fachada norte de la nave de producción de la fábrica de tabaco de Songshan, una fábrica moderna de cigarrillos construida en 1937 por la Oficina del Monopolio del Gobierno General de Taiwán y convertida tras la guerra en base productiva del Monopolio de Tabaco y Alcohol.](/article-images/society/songshan-tobacco-factory-north.webp)
+
+_Nave de producción de la fábrica de tabaco de Songshan: construida en 1937 por la Oficina del Monopolio del Gobierno General, tomada tras la guerra por el Monopolio de Tabaco y Alcohol y en funcionamiento hasta el cese de producción en 1998; hoy es el Songshan Cultural and Creative Park. El tabaco fue en su momento un negocio del Estado. Photo: 寺人孟子 / Wikimedia Commons, CC BY-SA 4.0._
+
+El giro de ese sonido de fondo empieza cuando alguien pierde un lóbulo pulmonar. Yen Tao aprendió a fumar a los 12 años y a los 52 le extirparon el lóbulo superior del pulmón derecho por daños del tabaco. Al salir del hospital decidió en secreto dedicarse al control del tabaco[^6]. El 19 de mayo de ese mismo 1984, cuando su amigo Tung Chih-ying le ofreció 2,5 millones de dólares estadounidenses (unos 100 millones de nuevos dólares taiwaneses al cambio de entonces) en agradecimiento por haberle resuelto un litigio, Yen Tao propuso más bien destinar ese dinero a crear una fundación orientada al control del tabaco[^7]. Así nació la Fundación John Tung.
+
+En abril de aquel año, el actor Sun Yueh rodaba «La segunda primavera del viejo Mo» en el sur de Taiwán. Terminado un plano, sacó como siempre un cigarrillo para encenderlo, vio venir de frente a dos estudiantes de uniforme y le cruzó por la cabeza una frase: «¡Sun Yueh! Tu tabaco daña a los demás. ¿Aún vas a seguir fumando?». Dejó una adicción de 38 años, se ofreció como voluntario en la Fundación John Tung e impulsó un lema que mucha gente recordaría después: «Todo el mundo tiene derecho a rechazar el humo ajeno»[^8]. Esa frase cambió el problema de «¿quieres dejar de fumar por tu salud?» a «¿daña tu tabaco a quien tienes al lado?». Ese desplazamiento es el punto de partida de toda la lógica de la prohibición al aire libre cuarenta años después.
+
+De ese lema a la ley pasaron trece años. La Ley de Control del Tabaco se promulgó en marzo de 1997 y entró en vigor en septiembre. Se reformó en 2007 y, desde el 11 de enero de 2009, quedaron totalmente libres de humo los espacios públicos y de trabajo interiores con tres o más personas. El 22 de marzo de 2023 se amplió de nuevo, incorporando guarderías, universidades, bares y discotecas, prohibiendo por completo los cigarrillos electrónicos y elevando a 20 años la edad legal para fumar[^9]. Con cada ampliación, el espacio donde se puede fumar se estrechaba otra vuelta.
+
+```tw-timeline
+Cuarenta años de control del tabaco: el espacio para fumar se estrecha vuelta a vuelta
+1984 | Fundación de la Fundación John Tung | Yen Tao la crea tras su operación de pulmón; Sun Yueh impulsa «todo el mundo tiene derecho a rechazar el humo ajeno»
+1997 | Entra en vigor la Ley de Control del Tabaco | Promulgada el 19 de marzo y en vigor el 19 de septiembre; regula por primera vez el consumo en lugares públicos
+2009 | Prohibición total en interiores | Desde el 11 de enero, todos los centros de trabajo interiores con tres o más personas quedan libres de humo
+2023 | Ampliación de la prohibición y veto total al cigarrillo electrónico | En vigor el 22 de marzo; la edad para fumar sube a 20 años
+2026 | Ciudad sin humo y sala exterior de presión negativa | El 7 de mayo entra en servicio la primera sala de fumar exterior de presión negativa de Taiwán
+Fuentes: Base Nacional de Normativa, Ministerio de Sanidad y Bienestar, agencia CNA
+```
+
+El negocio del tabaco también fue retirándose. En 2002, Taiwán entró en la OMC y la Oficina del Monopolio se transformó en Taiwan Tobacco & Liquor Corporation, poniendo fin a cuarenta años de monopolio[^10]. En 2016, los cultivadores de tabaco y la corporación llegaron a un acuerdo; en la primavera de 2017 se curó la última cosecha y el cultivo de tabaco taiwanés pasó a la historia[^11]. Algo que un día dominó el aire y sostuvo también las arcas públicas fue expulsado paso a paso del espacio público.
+
+![Antiguo edificio de la Oficina del Monopolio de Tabaco y Alcohol de la provincia de Taiwán, en la calle Nanchang de Taipéi: arquitectura barroca de ladrillo rojo, hoy sede de Taiwan Tobacco & Liquor Corporation.](/article-images/society/taiwan-tobacco-monopoly-bureau-building.webp)
+
+_Antiguo edificio de la Oficina del Monopolio de Tabaco y Alcohol de la provincia de Taiwán, hoy Taiwan Tobacco & Liquor Corporation. El tabaco fue un negocio monopolístico del Estado hasta que se soltó con la entrada en la OMC en 2002. Photo: lienyuan lee / Wikimedia Commons, CC BY 3.0._
+
+## En interiores se ganó; puertas afuera, todavía no
+
+Esta larga marcha llega a la década de 2020 con una gran victoria sobre el papel. La prevalencia del tabaquismo entre los adultos de 18 años o más cayó del 21,9% de 2008 al 12,8% de 2024, una reducción de más del 40% y la más baja desde 1990[^12]. La exposición al humo ajeno en los centros de trabajo interiores también bajó del 32,1% de 2008 al 22,1% de 2020[^13]. Con cientos de miles de fumadores menos, los ceniceros de las oficinas casi han desaparecido.
+
+Pero si se desglosan las cifras del humo ajeno aparecen dos líneas en direcciones opuestas. La exposición en lugares públicos interiores se desplomó del 27,8% de 2008 al 3,2% de 2024: la batalla de los interiores está prácticamente ganada de forma abrumadora. En cambio, en los lugares públicos exteriores sin prohibición, en ese mismo periodo subió del 36,2% hasta un máximo del 58,5% en 2013 y solo en los últimos años ha bajado al 48,9% de 2024: casi la mitad[^12]. El olor a tabaco no ha desaparecido: lo han empujado puerta afuera.
+
+```tw-line
+Las dos líneas del humo ajeno: los interiores casi vacíos, casi la mitad todavía puertas afuera (tasa de exposición %)
+Año | Lugares públicos interiores | Lugares exteriores sin prohibición
+2008 | 27,8 | 36,2
+2024 | 3,2 | 48,9
+Fuente: Administración de Promoción de la Salud, Encuesta sobre el comportamiento tabáquico de los adultos
+```
+
+Al preguntar dónde se topa la gente con más frecuencia con ese humo, la respuesta es muy concreta. En la encuesta de 2024, el lugar de mayor exposición al humo ajeno es «la calzada, la calle, los soportales y otros espacios exteriores de tránsito», con un 27,9%, muy por delante del segundo, los parques (7,7%), y de los soportales de las tiendas de conveniencia (7,7%)[^14]. Dicho de otro modo: la prohibición en interiores echó a los fumadores a la calle, y los soportales se convirtieron en el nuevo corredor de humo. Que al caminar por Ximending acabes convertido en un «maestro de aguantar la respiración» no es en absoluto una exageración según los datos.
+
+> 📝 **Nota de la curaduría**: merece la pena detenerse un momento en el gesto de fondo de esta política. El método anterior al aire libre era «dibujar zonas sin humo»: se presupone que se puede fumar en cualquier parte y luego se acotan unos cuantos trozos donde no. La ciudad sin humo del actual gobierno municipal le da la vuelta entera a esa presunción: al aire libre no se puede fumar en principio, y solo se puede en los lugares designados que aparecen «en la lista». En una misma acera, el valor por defecto ha pasado de «se puede fumar» a «no se puede fumar». Añadir unos cuantos carteles es solo la superficie; lo que de verdad se ha reescrito es a quién pertenece el aire de toda la ciudad.
+
+## Prohibido en principio, permitido por excepción
+
+Después de darle la vuelta, el problema que queda es adónde va esa minoría que todavía fuma. La respuesta del actual gobierno municipal es la «gestión por separación»: prohibición total al aire libre, pero canalizando a los fumadores hacia zonas o salas de fumar designadas[^15]. Ximending y la zona de Xinzhongshan quedaron totalmente libres de humo desde el 1 de junio, con multas de hasta 10.000 nuevos dólares taiwaneses. Al mismo tiempo, las zonas designadas para fumar de toda la ciudad llegaron a 183 y a finales de mayo aumentaron a 201, y entre ellas se cuelan estas primeras salas exteriores de presión negativa de Taiwán[^16].
+
+El principio de la presión negativa lo explicó con claridad el día de la inauguración Lin Hui-chung, secretario principal de la Oficina de Nuevas Obras: «Esta instalación emplea una "tecnología de control de flujo por presión negativa": mediante extracción y ajuste de presión, la presión interior queda por debajo de la atmosférica exterior, formando una barrera física por la que el aire solo puede entrar y no puede escapar, lo que reduce eficazmente el desbordamiento del humo»[^15]. Estas cajas tienen tamaños distintos; la mayor está en la avenida Zhonghua y admite 16 personas[^1]; una más pequeña, como la de la salida 4 de la estación de Ximen, mide 2 por 8 metros, y el presidente de la Comisión de Investigación y Evaluación, Yin Wei, dice que «caben más de 10 personas de pie a la vez»[^17].
+
+Que este diseño acabara siendo «de presión negativa» y no una sala cerrada por los cuatro costados como las de Osaka tiene detrás un rodeo técnico. Taipéi quería trasladar directamente el modelo cerrado de Osaka, pero el gobierno central lo frenó con el argumento de que «cerrar las ventanas por los cuatro lados equivale a un interior, y la Ley de Control del Tabaco prohíbe fumar en interiores»[^18]. Así que el diseño «de presión negativa», basado en el control del flujo de aire y no en un cierre físico total, es en cierto modo una solución nacida para sortear el umbral legal de «si cuenta o no como interior». La tecnología en sí no es nueva. La Ley de Promoción de la Salud japonesa, en vigor desde 2020, ya fija para las salas de fumar cerradas una velocidad del aire en la entrada de al menos 0,2 metros por segundo, y la metrópolis de Tokio añade normas complementarias aún más estrictas[^19]. La verdadera novedad de Taipéi no está en la tecnología de presión negativa y filtrado, sino en haberla convertido en mobiliario urbano gratuito plantado en la calle.
+
+Sobre cuánto ha costado, el gobierno municipal no ha publicado la liquidación unidad por unidad. En sus respuestas al pleno municipal tomó como base de estimación unos 1,5 millones de yuanes por unidad y calculó un gasto total de unos 100 millones hasta finales de junio[^20]. Por otro lado, Tao Lien-sheng, presidente de la Federación Nacional de Asociaciones de Padres, lo cuestiona desde la relación coste-beneficio: las salas de fumar exteriores deben tener por ley compartimentación independiente, climatización independiente, diseño de presión negativa y puerta automática, y «cuando no se puede lograr el efecto de "no oler a tabaco" y aun así se gastan de cientos de miles a un millón de yuanes en instalarlas, resulta evidente que no compensa»[^21]. Uno es un criterio de planificación municipal y el otro una estimación crítica de una asociación de padres; las dos cifras son de naturaleza distinta, pero ambas apuntan a la misma pregunta: ¿merece la pena esta caja?
+
+## Hasta quienes están contra el tabaco se han puesto a discutir
+
+Si quienes se oponen fueran solo unos padres que lo ven caro, el asunto sería sencillo. Lo que ha complicado esto es que el propio bando antitabaco se ha puesto a discutir, y no sobre si hay que combatir el tabaco, sino sobre cómo hacerlo.
+
+La postura de la Alianza Taiwanesa contra el Tabaco y de la Fundación John Tung es clara: en contra de construir salas de fumar cerradas de presión negativa al aire libre. Lin Ching-li, directora del Centro de Control del Tabaco de la Fundación John Tung, sostiene que hay que ir «de dentro afuera: primero hacer efectivo el 100% libre de humo en interiores y después abrir puntos fijos de consumo al aire libre», y afirma sin rodeos que «una ciudad sin humo debe hacerle las cosas incómodas al fumador, no sembrarla de casetas de fumar»[^22]. En su lógica, cuanto más cómoda se construya la sala, más se allana el camino al hecho de fumar y más se aleja del propósito de que la gente lo deje. Tampoco es una postura nueva: ya en 2011 la Fundación John Tung criticó el plan del aeropuerto de Taoyuan de recuperar sus salas de fumar interiores.
+
+```tw-versus
+Reducción del daño: encerrar el tabaco en una caja | Reducción del consumo: hacer que fumar sea cada vez más difícil
+Reconocer que aún hay quien fuma y darle un rincón que no moleste | El objetivo es que la prevalencia siga bajando
+Gestionar de forma concentrada el olor y las colillas y limpiar el paisaje urbano | Cuanto más incómodo, más probable es que se fume menos o se deje
+La lógica de separación del actual gobierno municipal | La posición de las organizaciones antitabaco y de parte del sector médico
+```
+
+Kuo Fei-jan, médico adjunto del Departamento de Medicina Familiar del Hospital Universitario Nacional de Taiwán y secretario general de la Alianza Médica Taiwanesa para el Control del Tabaco, va un paso más allá. En un artículo de opinión cita el Convenio Marco de la OMS para el Control del Tabaco y señala que ninguna ventilación, equipo de filtrado de aire ni sala designada puede evitar la exposición al humo ajeno, y que «no existe ningún nivel seguro de exposición al humo de segunda mano»[^23]. Y su frase más afilada apunta al efecto secundario de la propia existencia de esta caja.
+
+```tw-quote
+Apoyo mucho la ciudad sin humo, pero no instalen salas de fumar cerradas al aire libre; no anuncien que como la sala tiene presión negativa y equipos de filtrado ya no hay humo ajeno; no propaguen ideas equivocadas en nombre de un fin bienintencionado.
+Kuo Fei-jan | médico del Departamento de Medicina Familiar del Hospital Universitario Nacional de Taiwán y secretario general de la Alianza Médica Taiwanesa para el Control del Tabaco, 2026
+```
+
+> 📝 **Nota de la curaduría**: en esta frase de Kuo Fei-jan se esconde un mecanismo que se pasa por alto con facilidad. Una caja de cristal con aire futurista que presume de «cuatro filtros» sugiere que «si hay equipo, hay seguridad»: cuando ves el humo absorbido por una caja de alta tecnología, sientes inconscientemente que el problema del humo ajeno ya está resuelto. Pero científicamente esa tranquilidad no se sostiene. El informe del Cirujano General de Estados Unidos de 2006 concluyó que ni siquiera las salas de fumar de presión negativa, cerradas y con extracción independientes, impiden que el humo ajeno se filtre a las zonas contiguas[^24]. La OMS y la ASHRAE mantienen la misma posición. La casa de cristal es a la vez un compromiso considerado y, posiblemente, una barrera que baja la guardia de la gente; ambas cosas pueden ser ciertas al mismo tiempo.
+
+## Aquel estudio de Kioto medía en realidad otra cosa
+
+Llegados a este punto de la discusión, cada bando empieza a sacar sus pruebas. Y uno de los estudios más citados es justamente un buen ejemplo de «cómo un mismo material se cuenta de dos maneras distintas».
+
+La Alianza contra el Tabaco citó en rueda de prensa que un estudio de 2023 de la Universidad Femenina de Kioto halló que la concentración de PM2.5 de una «sala de fumar cerrada» con climatización de alta especificación superaba el nivel de alerta de calidad del aire, y que incluso las mediciones a 5 metros de la entrada excedían el límite[^25]. Suena como el golpe más directo posible contra las salas de presión negativa. Pero al rastrear el artículo, el título es en realidad «Situación del tabaquismo pasivo en el entorno del área de fumadores *exterior* de la estación de Kioto», y el objeto de estudio era un rincón abierto para fumadores frente a la estación, con mamparas parciales pero sin puerta ni techo, y lo que se midió fue el PM2.5 a distancias como 3 y 10 metros hacia el este[^26]. No medía una sala cerrada, sino un rincón exterior bajo un alero y ventilado por los cuatro costados.
+
+La diferencia no es pequeña. Una sala cerrada de presión negativa y un área de fumadores abierta son dos estructuras físicas distintas. El profesor Hiroshi Yamato, de la Universidad de Ciencias de la Salud Ocupacional y Ambiental, llamó en una entrevista a aquel espacio de Kioto directamente «un rincón de fumadores de tipo abierto», y criticó que no es razonable colocar ese tipo de rincón bajo una gran cubierta y que debería estar al menos a 25 metros de las rutas de paso de los no fumadores[^27]. Dicho de otro modo: el bando antitabaco quería demostrar con ese estudio que «ni siquiera una sala cerrada retiene el humo», pero lo que el estudio demuestra es que «ni siquiera un rincón abierto con cubierta impide que el humo se escape».
+
+Los dos bandos citaron el mismo estudio, pero lo que se medía era otra cosa. Lo interesante es que ese desajuste informativo lleva de vuelta a una advertencia más honesta: el problema no está solo en si hay cierre o no, sino en que, si el diseño del flujo de aire no está a la altura, el olor a tabaco no se retiene ni cerrado ni abierto. Para verificar científicamente una sala cerrada de presión negativa hay que volver a las conclusiones coincidentes de los CDC, la OMS y la ingeniería, no a un estudio sobre un espacio exterior que se ha ido deformando al recontarse. Que un bando tenga razón en su postura pero se equivoque de prueba es, en el debate público, más frecuente de lo que parece.
+
+## ¿De quién es el soportal?
+
+Al llevar la cámara de los datos y los artículos de vuelta a la calle, aparece un conjunto de personas más complejo. Quienes han sido invitados a la caja de cristal, o expulsados del soportal, tampoco son un bloque uniforme.
+
+![Cruce de la zona peatonal de Ximending: las primeras salas de fumar exteriores de presión negativa de Taiwán se han instalado en esta acera de gran afluencia.](/article-images/society/ximending-street-crossing.webp)
+
+_Zona peatonal de Ximending: las primeras salas de fumar exteriores de presión negativa de Taiwán se han colocado en el barrio de mayor densidad de gente. Quién tiene derecho a encender aquí un cigarrillo es el núcleo de toda esta polémica. Photo: Bigmorr / Wikimedia Commons, CC BY-SA 4.0._
+
+Hay quien lo celebra. En la encuesta callejera del *China Times* en Ximending, un ciudadano con experiencia como fumador cree que «para quien no fuma está bien, así no le afecta el humo ajeno»; una fumadora dice que antes, al fumar en la calle, se cruzaba a menudo con niños o con padres empujando carritos, y que ahora, con zonas fijas para fumar, han disminuido las molestias mutuas[^28]. Pero también hay quien siente que lo han apartado demasiado. Un fumador se quejó en Dcard de que la sala es mucho más pequeña de lo que imaginaba, casi como una plaza de aparcamiento, y preguntó si ahora hay que hacer cola para fumar y encima estar sujeto a un horario[^29]. La respuesta del gobierno municipal fue que las salas de presión negativa japonesas también cierran a las diez u once de la noche, y que las distintas salas están a entre tres y cinco minutos a pie unas de otras[^30].
+
+Lo interesante es una de las respuestas debajo. A aquel mensaje de queja de «es tan pequeña como una plaza de aparcamiento», un usuario contestó: «¿Ahora entiendes lo que siente normalmente quien no fuma?»[^29]. Una sola frase pone lado a lado dos agravios: el fumador siente que lo han metido en una caja pequeña y lejana; quien no fuma siente que lleva décadas desplazado por el olor a tabaco y que el sitio donde podía estar nunca fue muy grande. En la misma casa de cristal, uno ve la estrechez del espacio y el otro ve una equidad que llega tarde.
+
+Y si se da un paso más atrás, se ve que fumar se distribuye a lo largo de una línea de clase. Entre los hombres adultos, la prevalencia del tabaquismo con estudios de secundaria básica o inferiores llega al 35,8%, el triple que entre quienes tienen estudios superiores (11,9%); en el tramo de 30 a 49 años, entre quienes tienen secundaria básica o menos sube al 50%, casi el doble que entre los universitarios (27%)[^31]. Cuanto menor es el nivel educativo, más probable es ser la persona que fuma.
+
+```tw-bars
+A menor nivel educativo, mayor prevalencia: los hombres con secundaria básica o menos triplican a los universitarios (%)
+*Secundaria básica o menos | 35,8 | el triple que los universitarios
+Estudios superiores | 11,9
+Fuente: Ministerio de Sanidad y Bienestar (prevalencia en hombres adultos, estadísticas del 6.º aniversario de la Ley de Control del Tabaco)
+```
+
+> 📝 **Nota de la curaduría**: bajo esa línea de diferencia triple se esconde un círculo incómodo. Buena parte del recargo sanitario que grava cada mil cigarrillos vuelve como subsidio a los colectivos vulnerables: el recargo del tabaco paga la cuota sanitaria de 446.000 personas con dificultades económicas y sostiene además el funcionamiento de 13 centros públicos de acogida de todo el país[^32]. Dicho de otro modo: quienes tienen una posición socioeconómica más baja son los que más fuman, y el impuesto adicional que pagan por cada cajetilla subvenciona la red sanitaria de los colectivos vulnerables, ellos incluidos. No es un diseño que pueda juzgarse como bueno o malo en una frase, y merece que cada lector lo rumie: cuando invitamos a los fumadores a una caja de cristal, quienes entran suelen ser las personas que ya estaban en los márgenes de esta ciudad.
+
+Lo que preocupa a los comercios y a los jefes de barrio es un problema más práctico de gestión. Liu Chia-hsin, presidente de la Asociación para el Desarrollo del Distrito Peatonal de Ximen, encabezó la adhesión al comercio sin humo, pero también dice que «de día es menos probable que haya problemas de gestión; lo que más me preocupa es el horario nocturno»; y Yeh Min-hui, jefa del barrio de Ximen, señala que en Ximending hay muchas personas sin hogar y teme que «en el futuro la gestión será sin duda el mayor problema»[^33]. Son previsiones formuladas en el momento de la entrevista, no hechos consumados, pero reflejan con veracidad la cotidianidad que va a tener que afrontar una política que concentra a la gente en un espacio fijo.
+
+## Tokio también las construyó, ¿y luego?
+
+Taipéi no es la primera ciudad que se preocupa por esto. Separar a los fumadores en espacios específicos es desde hace tiempo un lenguaje común de muchas ciudades asiáticas, solo que con formas distintas.
+
+Japón fue el primero y el más fragmentado. El distrito de Chiyoda, en Tokio, ya sancionaba en octubre de 2002 el consumo en la vía pública con una multa de 2.000 yenes, una de las primeras sanciones de este tipo en Japón; el distrito de Shibuya lo siguió en 2019, prohibiendo fumar en los espacios públicos de todo el distrito[^34]. Lo fragmentado está en que la metrópolis de Tokio no tiene una norma única para toda la ciudad y los 23 distritos van cada uno por su cuenta: un mismo cigarrillo es legal en esta calle y puede ser una infracción de 2.000 yenes al entrar en el distrito de al lado. En comparación, Taipéi tiene por ahora un único criterio para toda la ciudad y se ahorra esa confusión entre distritos.
+
+![Zona designada para fumar al aire libre en el parque Ōhori de Fukuoka (Japón), con un diseño semiabierto de celosía de madera y un cartel de SMOKING AREA.](/article-images/society/ohori-park-smoking-area-fukuoka.webp)
+
+_Zona de fumadores al aire libre del parque Ōhori de Fukuoka (Japón). Se acota un rincón semiabierto con celosía de madera, muy distinto de la caja de cristal taipeana, cerrada por los cuatro costados y con presión negativa mantenida por extracción. Photo: Hirho / Wikimedia Commons, CC BY 4.0._
+
+Otras ciudades tienen cada una sus cuentas, pero con monedas y mecanismos distintos no conviene comparar magnitudes sin más.
+
+```tw-stat
+NT$2.000–10.000 | Infracción por fumar en Ximending / zona comercial de Xinzhongshan, Taipéi | desde el 01-06-2026
+¥2.000 | Fumar en la vía pública en Chiyoda y Shibuya, Tokio | multa administrativa, pago en el acto
+HK$3.000 | Zonas de prohibición legal de Hong Kong | desde el 01-01-2026, subida desde 1.500
+€135 | Espacios exteriores frecuentados por menores en Francia | desde el 01-07-2025
+Fuentes: anuncios de los respectivos gobiernos municipales / autoridades sanitarias
+```
+
+Singapur pinta en el suelo, frente a los centros de comida y las cafeterías, «recuadros amarillos» en los que el fumador tiene que meterse entero; la concurrida Orchard Road quedó declarada zona sin humo desde el 1 de enero de 2019 y solo puede fumarse en unos pocos puntos designados[^35]. Hong Kong elevó el 1 de enero de 2026 la multa fija en las zonas de prohibición legal de 1.500 a 3.000 dólares hongkoneses y añadió además la norma de no fumar mientras se hace cola[^36]. Francia ha ido más lejos: desde julio de 2025 prohíbe fumar en parques, playas y puertas de colegios y otros espacios exteriores frecuentados por menores[^37]. La frontera del reparto del humo avanza en todas partes hacia escenarios cotidianos cada vez más finos.
+
+El propio gobierno de Taipéi usa la expresión «primera de todo el país», es decir, la primera sala de fumar exterior de presión negativa dentro de Taiwán. Ni los medios en chino ni los medios en inglés han dicho «primera del mundo»[^38]. Esa formulación relativamente contenida se sostiene: dentro de lo verificado hasta ahora, no se ha encontrado ningún otro gobierno que haya instalado en la calle este tipo de cabina exterior mecánica de presión negativa. En cuanto a la frase que suele usarse como advertencia, «en Tokio el 80% incumple», al rastrear su origen resulta ser un estudio del equipo de la Universidad de Kobe publicado en *BMC Public Health*, que midió la proporción de restaurantes y bares *interiores* de Tokio, Osaka y Aomori que no cumplían la prohibición (78,4%), y no la tasa de incumplimiento en las áreas de fumadores exteriores[^39]. Son dos cosas que no pueden compararse directamente, pero ambas apuntan a la misma advertencia: por muy fina que sea la norma escrita, la prueba de verdad está siempre en el cumplimiento.
+
+## Cartuchos zombi y una cuenta que no acaba
+
+El campo de batalla del tabaco sigue moviéndose. Mientras Taipéi discute por la casa de cristal del cigarrillo de papel, la siguiente batalla ya ha cambiado de rival.
+
+Al tiempo que el cigarrillo tradicional se retira, el electrónico ha ido creciendo en silencio entre los adolescentes. El consumo de cigarrillos electrónicos entre los alumnos de secundaria básica pasó del 1,9% de 2018 al 3,9% de 2021, y entre los de secundaria superior y formación profesional del 3,4% al 8,8%, mientras el consumo de cigarrillos de papel de esos mismos chicos bajaba[^40]. Taiwán prohibió por completo los cigarrillos electrónicos en 2023, mientras que el tabaco calentado siguió otra vía y, tras superar la evaluación de riesgos para la salud, empezó a venderse legalmente en las tiendas de conveniencia desde octubre de 2025[^41]. Y la última batalla, la de 2026, se debe a que la droga etomidato, conocida como «cartucho zombi», suele usar el cigarrillo electrónico como vehículo: el Yuan Ejecutivo aprobó el 25 de junio un nuevo proyecto de reforma de la Ley de Control del Tabaco que eleva la sanción por posesión y consumo de cigarrillos electrónicos de entre 2.000 y 10.000 yuanes a entre 30.000 y 100.000, y convierte la fabricación y venta en delito penal con hasta 7 años de prisión; el texto sigue en tramitación en el Yuan Legislativo y no ha superado la tercera lectura[^42].
+
+![Un cigarrillo electrónico desechable moderno (de tipo pod). Taiwán prohíbe desde 2023 la fabricación, importación, venta y uso de cigarrillos electrónicos.](/article-images/society/electronic-cigarette-pod.webp)
+
+_El cigarrillo electrónico es el nuevo rival del campo de batalla del tabaco: Taiwán lo prohibió por completo en 2023, pero su consumo entre los jóvenes sigue subiendo y ahora, por transportar la droga del «cartucho zombi», vuelve a reformarse la ley. El tabaco ha cambiado de envoltorio y la batalla no ha terminado. Photo: Jacek Halicki / Wikimedia Commons, CC BY-SA 4.0._
+
+La ciudadanía también sigue empujando. En septiembre de 2025, alguien propuso en la plataforma de participación pública en línea «prohibir fumar a los peatones», sosteniendo que también debería prohibirse fumar mientras se camina, y alcanzó pronto el umbral de firmas[^43]. El sitio del tabaco se ha estrechado del interior al soportal, y del soportal a esa casa de cristal; ahora hay quien sostiene que incluso encender un cigarrillo mientras se camina debería prohibirse. El espacio donde se puede fumar sigue reduciéndose.
+
+Volvamos a aquella caja transparente de la salida 6 del metro de Ximen. Quien está dentro se queja de que es pequeña y estrecha, y cuando llega la hora tiene que apagar y salir; quien está fuera por fin puede cruzar el soportal sin aguantar la respiración. El actual gobierno municipal dice que es una consideración de separación, quienes piden espacios sin humo dicen que es un compromiso que traiciona el propósito, y el médico de familia dice que lo más peligroso es que haga creer que «si hay filtro, no hay humo ajeno». Cuatro tipos de personas miran la misma caja y ven cuatro verdades distintas; y quizá sea justo por eso por lo que se ha hecho transparente: quién mira a quién y quién es mirado por quién queda todo extendido sobre el cristal.
+
+El tabaco nunca ha desaparecido de verdad. Se retiró del cenicero de la oficina al soportal, del soportal a esta casa de cristal que respira, y ahora, con el envoltorio del cigarrillo electrónico, se dirige hacia la siguiente batalla sin terminar. Hace cuarenta años, el año en que a Yen Tao le extirparon un lóbulo pulmonar, el aire de Taiwán todavía era gratis; cuarenta años después, un cigarrillo legal pero dañino vuelve a colocarse dentro del contrato sobre el espacio público que esta ciudad aún no ha terminado de negociar. Esa caja transparente de la calle de Ximen no será el punto final: es solo, hasta ahora, la forma más visible de esta negociación.
+
+**Lecturas complementarias**:
+
+- [Ximending](/geography/西門町) — la primera sala de fumar exterior de presión negativa de Taiwán está en la calle, junto a la salida del metro de Ximen; cómo una zona comercial nacida del barrio de ocio de la época japonesa se ha convertido en el banco de pruebas de una nueva política
+- [Sistema de salud pública y prevención epidémica de Taiwán](/society/台灣公共衛生與防疫體系) — el control del tabaco es parte de la larga marcha de la salud pública taiwanesa y comparte con el sistema de prevención epidémica la misma lógica de «primero la salud colectiva»
+- [Justicia ambiental y conflictos NIMBY en Taiwán](/society/台灣環境正義與鄰避爭議) — dónde construir la sala de fumar y si se juntarán personas sin hogar es, en esencia, un dilema NIMBY a escala de calle
+- [Periodo de ley marcial](/history/戒嚴時期) — la época en que el tabaco Longevidad tenía el 70% del mercado y la Oficina del Monopolio controlaba tabaco y alcohol es justamente el trasfondo histórico de un Estado que administraba la vida cotidiana
+
+## Fuentes de imágenes
+
+Este texto utiliza 6 imágenes, todas cacheadas en `public/article-images/society/` para evitar el enlace directo a los servidores de origen:
+
+- [花花日報 / periodista Chang Hsiang-ying](https://n.yam.com/Article/20260518246667) — escena callejera de la sala de fumar exterior de presión negativa de Ximending (hero), Fair use editorial commentary
+- [寺人孟子 / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E6%9D%BE%E5%B1%B1%E8%8F%B8%E5%BB%A0%E8%A3%BD%E8%8F%B8%E5%B7%A5%E5%BB%A0%E5%8C%97%E9%9D%A2.jpg) — fachada norte de la nave de producción de la fábrica de tabaco de Songshan, CC BY-SA 4.0
+- [lienyuan lee / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E5%8E%9F%E5%8F%B0%E7%81%A3%E8%8F%B8%E9%85%92%E5%85%AC%E8%B3%A3%E5%B1%80_Former_Taiwan_Tobacco_and_Wine_Monopoly_Bureau_-_panoramio.jpg) — antiguo edificio de la Oficina del Monopolio de Tabaco y Alcohol de la provincia de Taiwán, CC BY 3.0
+- [Bigmorr / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Ximending_rainbow_crossing_20260326.jpg) — cruce de la zona peatonal de Ximending, CC BY-SA 4.0
+- [Hirho / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%C5%8Chori_Park_The_smoking_area_%C5%8Chorik%C5%8Den_Ch%C5%AB%C5%8D-ku_Fukuoka_20260113_150049.jpg) — zona de fumadores al aire libre del parque Ōhori de Fukuoka (Japón), CC BY 4.0
+- [Jacek Halicki / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:2023_Lost_Vape_Ursa_Nano_Pod.jpg) — pod de cigarrillo electrónico desechable, CC BY-SA 4.0
+
+## Referencias
+
+[^1]: [Peoplenews: entra en servicio la primera sala de fumar exterior de presión negativa de Taiwán](https://www.peoplenews.tw/articles/lifestyle/30593) — Reportaje del periodista Lin Wei-cheng del 07-05-2026, que incluye los cuatro filtros, la capacidad de 16 personas de la mayor unidad en la avenida Zhonghua, el horario de 8 de la mañana a 12 de la noche, la ubicación de las 5 instalaciones y las sanciones.
+
+[^2]: [TVBS: salas de fumar de presión negativa, solo 2 homologadas en toda Taiwán](https://news.tvbs.com.tw/life/189736) — Reportaje del 12-12-2008, con la descripción literal del flujo de presión negativa por parte de Pai Ching-hui, responsable de comunicación del hotel Sheraton, y el registro de que aquel año Taiwán tenía unos 4,2 millones de fumadores y solo 2 salas homologadas.
+
+[^3]: [Liberty Times: la sala de presión negativa de Ximen se avería a los 3 días](https://news.ltn.com.tw/news/life/breakingnews/5434547) — Reportaje del 12-05-2026 sobre una interpelación en el pleno municipal; el director de la Oficina de Sanidad, Huang Chien-hua, responde que seguirán mejorando la gestión del equipamiento y la Oficina de Obras Públicas afirma haber ajustado el riel de la puerta.
+
+[^4]: [UDN: durante años la primera marca del mercado taiwanés del tabaco; el Monopolio lanza «Longevidad»](https://udn.com/news/story/120910/8940040) — Columna nostálgica que recoge las cifras históricas de cuota de mercado del Longevidad: 72% en 1974 (fuente única) y 76% en 1987.
+
+[^5]: [Oficina de Patrimonio Cultural del Ministerio de Cultura: fábrica de tabaco de Songshan](https://nchdb.boch.gov.tw/assets/overview/monument/20020416000001) — Ficha de registro patrimonial, que consigna el inicio de las obras en 1937 por la Oficina del Monopolio del Gobierno General, los cerca de 2.000 empleados en su apogeo, el cese de producción en 1998 y la apertura del Songshan Cultural and Creative Park en 2011.
+
+[^6]: [Wikipedia: Yen Tao (empresario)](<https://zh.wikipedia.org/zh-tw/%E5%9A%B4%E9%81%93_(%E4%BC%81%E6%A5%AD%E5%AE%B6)>) — Recoge la biografía de Yen Tao: empezó a fumar a los 12 años, le extirparon el lóbulo superior del pulmón derecho a los 52 por daños del tabaco y fundó la Fundación John Tung en 1984.
+
+[^7]: [StoryStudio: quién es en realidad el «Tung» de la Fundación John Tung](https://storystudio.tw/article/gushi/cold104) — Artículo especial que explica el origen de la fundación: Tung Chih-ying donó el dinero en agradecimiento a Yen Tao por resolverle un litigio y Yen Tao propuso convertirlo en una obra pública de control del tabaco.
+
+[^8]: [Red china de deshabituación tabáquica: nuestro queridísimo tío Sun](https://www.e-quit.org/CustomPage/HtmlEditorPage.aspx?MId=1178&ML=3) — Web del sistema de la Fundación John Tung, que recoge el monólogo interior de Sun Yueh al dejar de fumar durante un rodaje en abril de 1984 y el lema «todo el mundo tiene derecho a rechazar el humo ajeno» (obsérvese: no «rechazar el humo ajeno es un derecho de cada persona»).
+
+[^9]: [Ministerio de Sanidad y Bienestar: la nueva Ley de Control del Tabaco entra en vigor el 22 de marzo de 2023](https://www.mohw.gov.tw/cp-6566-74078-1.html) — Anuncio oficial, contrastado con el histórico de la Base Nacional de Normativa, que confirma las tres fechas de entrada en vigor (1997, 11-01-2009 y 22-03-2023), la ampliación de la prohibición, el veto total al cigarrillo electrónico y la subida de la edad para fumar a 20 años.
+
+[^10]: [The News Lens: por qué terminó la Oficina del Monopolio de Tabaco y Alcohol 40 años de posición monopolística](https://www.thenewslens.com/article/188943) — Recoge las dos fechas: la entrada en la OMC el 01-01-2002 y la transformación de la Oficina del Monopolio en Taiwan Tobacco & Liquor Corporation el 01-07-2002.
+
+[^11]: [CNews: la corporación deja de comprar en marzo y el cultivo de tabaco taiwanés pasa a la historia](https://cnews.com.tw/%E8%8F%B8%E9%85%92%E5%85%AC%E5%8F%B83%E6%9C%88%E5%81%9C%E6%AD%A2%E6%94%B6%E8%B3%BC-%E5%8F%B0%E7%81%A3%E8%8F%B8%E8%91%89%E7%A8%AE%E6%A4%8D%E8%B5%B0%E5%85%A5%E6%AD%B7%E5%8F%B2/) — Relato compuesto del acuerdo con los cultivadores en 2016 y de la última cosecha y curado entre enero y marzo de 2017.
+
+[^12]: [Administración de Promoción de la Salud: resultados de la encuesta sobre el comportamiento tabáquico de la población](https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=1718&pid=9913) — Estadística de primera mano: la prevalencia adulta baja del 21,9% (2008) al 12,8% (2024), un 41,6% menos; la exposición al humo ajeno en lugares públicos interiores pasa del 27,8% al 3,2% y en lugares exteriores sin prohibición del 36,2% al 58,5% y al 48,9%.
+
+[^13]: [Ministerio de Sanidad y Bienestar: que el tabaco no se convierta en un riesgo laboral](https://www.mohw.gov.tw/fp-16-63866-1.html) — Recoge la caída de la exposición al humo ajeno en los centros de trabajo interiores del 32,1% (2008) al 22,1% (2020).
+
+[^14]: [CNA: la exposición exterior al humo ajeno roza el 50%; la propuesta de prohibir fumar a los peatones alcanza el umbral](https://www.cna.com.tw/news/ahel/202511200366.aspx) — Reportaje del 20-11-2025 que cita la encuesta de 2024 de la Administración de Promoción de la Salud, con la calzada/calle/soportales como principal lugar de exposición (27,9%), y registra que la propuesta en línea de «prohibir fumar a los peatones» alcanzó el umbral de firmas.
+
+[^15]: [Gobierno de la ciudad de Taipéi: el alcalde Chiang Wan-an visita la primera sala de fumar exterior de presión negativa de Taiwán](https://www.gov.taipei/News_Content.aspx?n=2044902FC839D045&s=AC7A74FD2EA0F1BD) — Nota de prensa municipal con la explicación literal de la tecnología de control de flujo por presión negativa del secretario principal Lin Hui-chung, el núcleo de la política de «gestión por separación» y las cifras de encuesta del 96,2% y cerca del 80%.
+
+[^16]: [CNA: entra en servicio la sala de fumar exterior de presión negativa de Taipéi, dentro de un conjunto de 183 zonas de fumadores](https://www.cna.com.tw/news/aloc/202605070075.aspx) — Reportaje de la periodista Chen Yu-ting con el detalle de las 183 zonas designadas y las 5 salas de presión negativa; la prohibición total en Ximending desde el 1 de junio y la multa máxima de 10.000 yuanes en [Focus Taiwan](https://focustaiwan.tw/society/202605300006); las 201 corresponden a la cifra tras la actualización de la app Taipei Pass del 30 de mayo.
+
+[^17]: [UDN: los fumadores se desesperan; el gobierno municipal responde sobre las especificaciones de la sala](https://udn.com/news/story/7323/9477562) — Respuesta del presidente de la Comisión de Investigación y Evaluación, Yin Wei: «la sala de la salida 4 de la estación de Ximen mide 2 por 8 metros y caben más de 10 personas de pie a la vez»; la capacidad de 16 personas de la mayor unidad de la avenida Zhonghua aparece en el reportaje de Peoplenews ([^1]) y corresponde a otra sala.
+
+[^18]: [UDN: la sala de fumar exterior de Taipéi se atasca; el gobierno central responde que «cerrar las ventanas por los cuatro lados es un interior»](https://udn.com/news/story/7323/9303502) — Reportaje del 02-02-2026 que recoge el contenido de la respuesta del organismo central y la referencia de la Comisión de Investigación y Evaluación al modelo de Osaka, y explica el origen del diseño de presión negativa para sortear la calificación de «interior».
+
+[^19]: [Ministerio de Salud, Trabajo y Bienestar de Japón: medidas contra el tabaquismo pasivo (criterios técnicos de las salas de fumar)](https://jyudokitsuen.mhlw.go.jp/point/) — La Ley de Promoción de la Salud japonesa entró plenamente en vigor en abril de 2020 y exige a las salas de fumar cerradas una velocidad del aire en la entrada de al menos 0,2 m/s; la metrópolis de Tokio añade además criterios complementarios más estrictos para las «cabinas de fumar con función de eliminación de humo», con una tasa de eliminación de compuestos orgánicos volátiles superior al 95% ([reproducido por una empresa de equipamiento de separación de humo](https://www.tornex.co.jp/3096)).
+
+[^20]: [ETtoday: respuesta parlamentaria sobre el coste de las salas de presión negativa de Taipéi](https://www.ettoday.net/news/20260515/3166314.htm) — Reportaje del 15-05-2026: el gobierno municipal toma 1,5 millones de yuanes por unidad como base de planificación (unos 75 millones, y en torno a 100 millones en total hasta finales de junio); el reportaje de CNA del mismo día verifica de forma cruzada las cifras de coste ([CNA](https://www.cna.com.tw/news/aloc/202605150083.aspx)).
+
+[^21]: [CNA: la Alianza contra el Tabaco se opone a las salas cerradas al aire libre](https://www.cna.com.tw/news/ahel/202605070248.aspx) — Transcripción literal de la rueda de prensa, con la crítica del presidente de la Federación Nacional de Asociaciones de Padres, Tao Lien-sheng, de que instalarlas «gastando de cientos de miles a un millón de yuanes resulta evidentemente poco rentable» (estimación de la asociación de padres, fuente única).
+
+[^22]: [Awakening News Networks: Lin Ching-li aboga por aplicar la prohibición de dentro afuera](https://www.anntw.com/articles/20260317-ec68) — Citas literales de Lin Ching-li, directora del Centro de Control del Tabaco de la Fundación John Tung: «de dentro afuera» y «una ciudad sin humo debe hacerle las cosas incómodas al fumador, no sembrarla de casetas de fumar»; verificado de forma cruzada con [UDN](https://udn.com/news/story/7314/9383252).
+
+[^23]: [Liberty Times Talk: artículo de Kuo Fei-jan, no instalen salas cerradas al aire libre](https://talk.ltn.com.tw/article/breakingnews/5424206) — Artículo firmado por el propio Kuo Fei-jan, que cita el artículo 8 del Convenio Marco de la OMS para el Control del Tabaco y señala que ninguna ventilación, equipo de filtrado ni sala designada puede evitar la exposición al humo ajeno.
+
+[^24]: [CDC de Estados Unidos: Ventilation and secondhand smoke](https://archive.cdc.gov/www_cdc_gov/tobacco/secondhand-smoke/protection/ventilation.htm) — Sintetiza el informe del Cirujano General de 2006 y las posiciones de la OMS (2007) y ASHRAE (2010), y señala que ni siquiera las salas de fumar de presión negativa con cierre y extracción independientes impiden que el humo ajeno se escape a las zonas contiguas.
+
+[^25]: [Peoplenews: Kuo Fei-jan critica las salas cerradas al aire libre](https://www.peoplenews.tw/articles/hot-news/35538) — Reportaje del 01-06-2026 con la cita literal de Kuo Fei-jan «no propaguen ideas equivocadas en nombre de un fin bienintencionado»; el mismo artículo contiene el contexto de la referencia de la Alianza contra el Tabaco al estudio de Kioto.
+
+[^26]: [Repositorio académico de la Universidad Femenina de Kioto: situación del tabaquismo pasivo en el entorno del área de fumadores exterior de la estación de Kioto](http://repo.kyoto-wu.ac.jp/dspace/handle/11173/3852) — El título del artículo confirma que el objeto de estudio era el área de fumadores «exterior» de la estación de Kioto (medición de PM2.5 a 3 y 10 metros hacia el este) y no la «sala cerrada» de la que hablaba la Alianza contra el Tabaco.
+
+[^27]: [Kyoto Shimbun (reproducido en notobacco.jp): quejas por el área de fumadores de la plaza de la estación de Kioto](https://notobacco.jp/pslaw/kyoto240314.html) — Reportaje del 14-03-2024 que describe esa área como una estructura rodeada por mamparas de unos 2 metros de altura, sin puerta ni techo, y en la que el profesor Hiroshi Yamato, de la Universidad de Ciencias de la Salud Ocupacional y Ambiental, la llama «un rincón de fumadores de tipo abierto».
+
+[^28]: [China Times: encuesta callejera del primer día sin humo en Ximending, 1 de junio](https://www.chinatimes.com/realtimenews/20260601003176-260405) — Reportaje del periodista Yu Ting-kang, con la cita directa de un ciudadano fumador («para quien no fuma está bien, así no le afecta el humo ajeno») y el testimonio, relatado por el periodista, de una fumadora que considera que las zonas fijas reducen las molestias mutuas.
+
+[^29]: [UDN Oops: se queja de que la sala de Ximending es pequeña y con horario limitado](https://udn.com/news/story/120912/9478980) — Reproduce un mensaje anónimo de Dcard (red social, no encuesta callejera) que se queja de que la sala es más pequeña de lo imaginado, del tamaño de una plaza de aparcamiento (relatado por el periodista); la respuesta de un usuario, «¿Ahora entiendes lo que siente normalmente quien no fuma?», es cita literal.
+
+[^30]: [UDN: los fumadores se desesperan; el gobierno municipal responde sobre distancias y horarios](https://udn.com/news/story/7323/9477562) — Respuesta del presidente de la Comisión de Investigación y Evaluación, Yin Wei: «las salas de presión negativa japonesas también abren solo hasta las 22 o 23 horas» y «la distancia está dentro de un trayecto a pie de 3 a 5 minutos».
+
+[^31]: [Ministerio de Sanidad y Bienestar: 6.º aniversario de las nuevas normas de control del tabaco, reduciendo la desigualdad en salud](https://www.mohw.gov.tw/cp-2636-21202-1.html) — Registra la estratificación de la prevalencia masculina por nivel educativo: 35,8% con secundaria básica o menos frente a 11,9% con estudios superiores (el triple); entre los hombres de 30 a 49 años, 50,0% frente a 27,0% (1,9 veces).
+
+[^32]: [Administración Nacional del Seguro de Salud: partidas y tasa de ejecución del recargo sanitario del tabaco](https://www.nhi.gov.tw/ch/cp-2145-4f27d-3126-1.html) — Datos oficiales: el recargo del tabaco subvenciona la cuota sanitaria de 446.000 personas vulnerables y sostiene el funcionamiento de 13 centros públicos de acogida de todo el país.
+
+[^33]: [UDN: la sala de presión negativa de Ximen; comercios y jefa de barrio hablan de sus temores de gestión](https://udn.com/news/story/7323/9488277) — Liu Chia-hsin, presidente de la Asociación para el Desarrollo del Distrito Peatonal de Ximen: «de día es menos probable que haya problemas de gestión; lo que más me preocupa es el horario nocturno»; Yeh Min-hui, jefa del barrio de Ximen: «en el futuro la gestión será sin duda el mayor problema» (previsiones en el momento de la entrevista, no hechos consumados).
+
+[^34]: [Ayuntamiento del distrito de Chiyoda: sanción administrativa por fumar en la vía pública](https://www.city.chiyoda.lg.jp/koho/machizukuri/sekatsu/jore/karyoshobun.html) — Chiyoda estableció en octubre de 2002 la primera ordenanza sancionadora del país contra el consumo en la vía pública, con multa de 2.000 yenes; las normas de Shibuya, en la [web oficial del distrito de Shibuya](https://www.city.shibuya.tokyo.jp/kankyo/machi-seiso/kitsuen/kituenrule.html).
+
+[^35]: [NEA de Singapur: Orchard Road No Smoking Zone](https://www.nea.gov.sg/ORNSZ) — Orchard Road es zona sin humo desde el 01-01-2019 y solo dispone de unos pocos puntos designados; los «recuadros amarillos» (Yellow Box) pintados en el suelo de los centros de comida y la prohibición a menos de 5 metros de las entradas de los edificios son prácticas habituales en Singapur, según la [página de prohibición de fumar de la NEA](https://www.nea.gov.sg/our-services/smoking-prohibition).
+
+[^36]: [Servicio de Información del Gobierno de Hong Kong: la ordenanza modificada de control del tabaco entra en vigor el 01-01-2026](https://www.info.gov.hk/gia/general/202512/29/P2025122900227.htm) — La multa fija en las zonas de prohibición legal sube de 1.500 a 3.000 dólares hongkoneses y se añaden normas como la prohibición de fumar mientras se hace cola.
+
+[^37]: [Euronews: France to implement smoking ban in public spaces with children](https://www.euronews.com/my-europe/2025/05/30/france-to-implement-smoking-ban-in-public-spaces-with-children-from-1-july) — Francia prohíbe totalmente fumar desde el 01-07-2025 en parques, playas, puertas de colegios y otros espacios exteriores frecuentados por menores, con multa de 135 euros.
+
+[^38]: [Oficina de Sanidad del Gobierno de Taipéi: nota de prensa sobre la primera zona de fumadores de presión negativa del país](https://health.gov.taipei/News_Content.aspx?n=BB5A41BA1E6CA260&sms=72544237BBE4C5F6&s=CEA10961E1B594E8) — La expresión del titular oficial es «primera de todo el país» (limitada a Taiwán), y los medios en inglés hablan solo de «Taipei's first»; no se ha encontrado la fórmula «primera del mundo».
+
+[^39]: [Kataoka et al., BMC Public Health (2024)](https://pmc.ncbi.nlm.nih.gov/articles/PMC11606096/) — Estudio del equipo de la Universidad de Kobe: el 78,4% corresponde a la proporción de restaurantes y bares *interiores* de Tokio, Osaka y Aomori que no modificaron su situación de consumo conforme a la prohibición de 2020, y no a una tasa de incumplimiento en áreas de fumadores exteriores.
+
+[^40]: [Administración de Promoción de la Salud: en 2021 el consumo juvenil de cigarrillos electrónicos se dispara al 6,6%](https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=4576&pid=16031) — El consumo de cigarrillos electrónicos entre alumnos de secundaria básica pasa del 1,9% (2018) al 3,9% (2021) y entre los de secundaria superior y formación profesional del 3,4% al 8,8%, mientras el consumo de cigarrillos de papel baja en el mismo periodo.
+
+[^41]: [ETtoday Health: el tabaco calentado saldrá a la venta como pronto el 11 de octubre](https://health.ettoday.net/news/3032516) — La Administración de Promoción de la Salud aprobó con condiciones, el 29-07-2025, 14 productos de 2 empresas; 8 referencias de barritas de tabaco y 3 dispositivos entraron en vigor el 11-10-2025 y llegaron progresivamente a las tiendas de conveniencia.
+
+[^42]: [Administración de Promoción de la Salud: el Consejo de Ministros aprueba el proyecto de reforma parcial de la Ley de Control del Tabaco](https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=5020&pid=20160) — Proyecto aprobado el 25-06-2026 en respuesta al etomidato del «cartucho zombi», que eleva la sanción por posesión y consumo a entre 30.000 y 100.000 yuanes y castiga la fabricación y venta con hasta 7 años de prisión; en el momento de la verificación seguía en tramitación en el Yuan Legislativo sin haber superado la tercera lectura (verificado de forma cruzada con [CNA](https://www.cna.com.tw/news/aipl/202606250150.aspx)).
+
+[^43]: [CNA: la exposición exterior al humo ajeno roza el 50%; la propuesta de prohibir fumar a los peatones alcanza el umbral](https://www.cna.com.tw/news/ahel/202511200366.aspx) — El proponente planteó el 26 de septiembre de 2025 en la plataforma de participación pública en línea «prohibir fumar a los peatones» y alcanzó el umbral de firmas.

--- a/knowledge/es/Technology/ai-hardware-supply-chain.md
+++ b/knowledge/es/Technology/ai-hardware-supply-chain.md
@@ -1,0 +1,206 @@
+---
+translatedFrom: 'Technology/AI硬體供應鏈.md'
+sourceCommitSha: '8f5e81ee'
+sourceContentHash: 'sha256:96b285db19941653'
+sourceBodyHash: 'sha256:96ecb5a6142f55f7'
+translatedAt: '2026-07-23T22:00:00+08:00'
+lang: 'es'
+title: 'La cadena de suministro del hardware de IA: el lugar donde Taiwán convierte la nube en máquinas'
+description: 'La IA generativa parece un servicio en la nube, pero en realidad necesita toda una carretera física: alguien diseña los chips, alguien fabrica las obleas, alguien las empaqueta, alguien se ocupa de la memoria, la electricidad, la disipación, las placas base y los racks. La importancia de Taiwán no está solo en TSMC, sino en que muchos de los pasos clave de esa carretera se concentran aquí. Ese interés común existe de verdad, y viene acompañado de agua y electricidad, emisiones de carbono, reparto de la renta, fábricas en el extranjero y riesgo geopolítico, convirtiendo los eslóganes abstractos en pruebas verificables sobre la cadena de suministro.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'hardware de IA'
+  - 'semiconductores'
+  - 'cadena de suministro'
+  - 'servidores de IA'
+  - 'procesos de vanguardia'
+  - 'empaquetado avanzado'
+  - 'industria tecnológica taiwanesa'
+subcategory: 'Semiconductores y hardware'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Entrar por el plano de mesa del «banquete del billón» para que el lector vea primero que la cadena de suministro del hardware de IA no es una sola empresa, sino todo un conjunto de nodos de ingeniería taiwaneses.'
+  whats_excluded: 'No se pretende hacer una enciclopedia industrial completa ni enumerar una por una todas las empresas taiwanesas de semiconductores, servidores y componentes.'
+  where_it_hedges: 'El valor de Taiwán en la cadena de suministro se trata junto con el agua y la electricidad, las emisiones, el reparto de la renta, las fábricas en el extranjero y el riesgo geopolítico.'
+  whos_pushing_back: 'Los clientes y aliados globales necesitan a Taiwán y, al mismo tiempo, reducen mediante fábricas en el extranjero su dependencia de un único punto en torno al estrecho de Taiwán.'
+image: '/article-images/technology/ai-hardware-supply-chain-flow.svg'
+imageCredit: 'Taiwan.md Contributors'
+imageLicense: 'CC BY-SA 4.0'
+---
+
+# La cadena de suministro del hardware de IA: el lugar donde Taiwán convierte la nube en máquinas
+
+> **Resumen en 30 segundos:** La IA parece responder preguntas en una pantalla, pero detrás hay un largo relevo físico. Alguien plantea una necesidad, alguien diseña un chip, alguien lo fabrica, alguien monta chips, memoria, disipación, alimentación y placa base hasta formar máquinas, y al final se envían a un centro de datos. La importancia de Taiwán no se agota con un «TSMC es muy bueno»: en ese relevo hay varios tramos clave que están en Taiwán. Ese interés común es real, pero no es una garantía; trae al mismo tiempo presiones de agua y electricidad, emisiones, reparto de la renta, fábricas en el extranjero y geopolítica.
+
+El 28 de mayo de 2026, Jensen Huang organizó una cena en Taipéi. Los medios la llamaron «el banquete del billón», porque la suma de la capitalización bursátil de las empresas que había detrás de los asistentes resultaba asombrosa. Pero lo que más merece mirarse de esa cena no es quién se sentó en la cabecera ni cuánto valen juntas esas empresas.
+
+Lo que de verdad merece mirarse es el plano de mesa.
+
+En fundición, C.C. Wei de TSMC. En montaje de servidores y racks de IA, Young Liu de Foxconn, Barry Lam de Quanta, Simon Lin de Wistron y Emily Hong de Wiwynn. En diseño de circuitos integrados, Rick Tsai de MediaTek. En alimentación y disipación, Ping Cheng de Delta, Sen-bin Chiu de Lite-On y Ching-hsing Shen de AVC. En placas base y marcas de producto final, Jonney Shih de ASUS, Pei-cheng Yeh de GIGABYTE y Jason Chen de Acer. Las categorías de la cadena de suministro que la agencia CNA enumeró en su reportaje —fundición, empaquetado y pruebas, módulos de disipación, gestión de la alimentación, placas base, fabricación por encargo y marcas— son prácticamente la sección transversal de un servidor de IA desmontado.[^1]
+
+![Jensen Huang sosteniendo una GPU RTX Blackwell durante la conferencia inaugural del CES 2025; sobre el fondo negro del escenario se ve el nombre NVIDIA y en su mano el módulo del nuevo chip de IA.](/article-images/technology/jensen-huang-ces-2025-blackwell.webp)
+
+_Jensen Huang muestra la GPU RTX Blackwell en la conferencia inaugural del CES 2025. Esta imagen devuelve la «IA» desde la interfaz de software al hardware que se sostiene en la mano. Photo: Steve Jurvetson. CC BY 2.0 via Wikimedia Commons._
+
+Aquella no fue una cena de empresa cualquiera. Fue más bien poner una pregunta sobre la mesa: cuando el mundo entero dice que la IA necesita a Taiwán, ¿qué es exactamente lo que necesita?
+
+La respuesta no será una sola empresa ni un solo chip. Se parece más a una carretera: empieza en una frase, «necesitamos más capacidad de cómputo para IA», atraviesa los chips, las fábricas, el empaquetado, la electricidad, la disipación, las placas base y los racks, y llega finalmente a un centro de datos. Taiwán está en varios de los pasos de esa carretera.
+
+## Pensar primero la IA como un servicio que necesita cuerpo
+
+La gente corriente entra en contacto con la IA normalmente desde el móvil, el ordenador o una página web. Escribes un texto y aparece la respuesta. Parece magia, y también un servicio en la nube sin peso.
+
+![El recinto ferial de Computex en el Centro de Exposiciones de Nangang, Taipéi: amplios pasillos flanqueados por estands de fabricantes de informática y con público congregado, una escena en la que se hace visible la cadena de suministro de hardware de Taiwán.](/article-images/technology/computex-nangang-floor-2015.webp)
+
+_El recinto de Computex en el Centro de Exposiciones de Nangang, Taipéi. La cadena de suministro del hardware de IA no existe solo en los informes financieros: también se ve concretamente en las ferias, las máquinas de muestra, los racks y las reuniones comerciales. Photo: Solomon203. CC BY-SA 4.0 via Wikimedia Commons._
+
+Pero para que la IA responda preguntas, detrás tiene que haber máquinas calculando. Esas máquinas están en centros de datos, consumen electricidad, generan calor, necesitan mantenimiento, y también que alguien las fabrique, las monte y las lleve hasta el cliente.
+
+Se puede pensar la IA como un restaurante muy grande. Lo que ves es al camarero llevando el plato a la mesa, pero no ves el diseño de la carta, las compras, la cocina, el gas, el agua y la luz, la cámara frigorífica, el circuito de salida de los platos y la limpieza. Con la IA pasa lo mismo. Lo que ves es la respuesta en la pantalla; detrás hay toda una cocina de hardware.
+
+La posición de Taiwán está precisamente en muchas de las mesas de trabajo importantes de esa cocina.
+
+## Cómo se convierte un pedido en un rack
+
+Una cadena de suministro de hardware de IA empieza a menudo con una necesidad muy corriente: una empresa de la nube, una empresa de modelos o una gran corporación necesita más capacidad de cómputo. Esa frase suena a comprar un servicio en la nube, pero enseguida se convierte en una serie de problemas físicos: ¿qué chip hay que diseñar? ¿Dónde puede fabricarse? ¿Cómo se acerca la memoria al chip? ¿Cómo se evacúa el calor? ¿Cómo se lleva la electricidad? Y por último, ¿quién monta esas piezas carísimas en una máquina que se pueda entregar, mantener y meter en un centro de datos?
+
+![Diagrama de flujo de la cadena de suministro del hardware de IA: la demanda de IA pasa por el diseño de chips, los procesos de vanguardia, el empaquetado avanzado, la HBM y los sustratos, la disipación y la alimentación, las placas base, el ODM/EMS y los racks de IA, y entra finalmente en el centro de datos; el diagrama señala los pasos de ingeniería altamente concentrados en Taiwán, como el proceso, el empaquetado, la electricidad y el calor, las placas, el montaje y los racks.](/article-images/technology/ai-hardware-supply-chain-flow.svg)
+
+_Diagrama conceptual elaborado por Taiwan.md. No es un gráfico de cuotas de mercado ni un mapa completo de empresas; sirve para explicar una ruta central: cómo aterriza la demanda de IA en máquinas alimentables, refrigerables y enviables._
+
+El diseño de chips, en el extremo más alto, está en su mayor parte en manos de empresas como NVIDIA, AMD, Broadcom, Google, Amazon o Microsoft. Una de las posiciones importantes de Taiwán aparece cuando esos planos se convierten en chips. La hoja de ruta tecnológica oficial de TSMC enumera procesos lógicos de 7, 5, 3 y 2 nanómetros, A16 y A14, con N2 marcado para producción en masa en el cuarto trimestre de 2025.[^2] Para muchos chips de IA, ese paso es donde el diseño toca por primera vez suelo taiwanés.
+
+Pero que el chip esté fabricado no significa todavía que la IA pueda funcionar. Un chip de IA necesita estar cerca de la memoria y también unir distintos dados en un sistema capaz de cooperar a alta velocidad. TSMC describe 3DFabric como la combinación de tecnologías de apilamiento 3D de silicio y empaquetado avanzado, incluyendo SoIC, CoWoS e InFO. AP, al informar sobre la nueva planta de SPIL en Taichung, la situó también en el contexto del refuerzo de la producción de chips de IA.[^3][^4] Aquí el papel de Taiwán empieza a ampliarse de «fabricar el chip» a «unir los chips en un módulo capaz de trabajar».
+
+Si se sigue hacia fuera, la cadena deja de parecerse a una línea recta. La memoria de gran ancho de banda (HBM) está dominada sobre todo por empresas coreanas. Los equipos, los materiales y el software de diseño implican a proveedores de Estados Unidos, Países Bajos, Japón y Europa. Las plataformas en la nube y los servicios de modelos están en su mayoría en manos estadounidenses. Taiwán ni monopoliza cada tramo ni se lleva en cada tramo el mayor beneficio. Su particularidad está en que nodos clave como la fundición, el empaquetado, las pruebas, los sustratos, la alimentación, la disipación, las placas base y el montaje final están muy cerca unos de otros y llevan años acostumbrados a resolver juntos los problemas de ingeniería.
+
+![Diagrama por capas de un servidor de IA: chips y aceleradores, placas y placa base, alimentación y disipación, servidor y rack, y centro de datos se apilan en orden, explicando cómo una GPU se convierte en infraestructura de IA operativa.](/article-images/technology/ai-server-rack-stack.svg)
+
+_Diagrama conceptual elaborado por Taiwan.md. La GPU es solo uno de los núcleos de un servidor de IA; hace falta además conectarla a placas, alimentación, disipación, máquina completa, rack y centro de datos._
+
+En la fase de máquina completa, el problema se vuelve muy concreto. Cuanto más potente es el chip, mayor es la corriente y más difícil resulta evacuar el calor. La placa base, la alimentación, la disipación, la carcasa, el sistema de gestión y la planificación de envíos se mueven a la vez. Lo que recogen empresas como Foxconn, Quanta, Wistron, Wiwynn, Inventec, Compal y Pegatron es precisamente el trabajo de montar chips, placas, alimentación, disipación y diseño mecánico en servidores y racks de IA. Cuando CNA informó del envío de la nueva plataforma de Foxconn, lo situó también en el contexto de la exhibición de sistemas de servidores de IA.[^10]
+
+Por eso ese diagrama de flujo no pretende que nadie memorice términos. Lo que quiere mostrar es que el valor de Taiwán no está solo en una empresa ni solo en un chip, sino en la capacidad de empujar un producto complejo desde la oblea y el empaquetado hasta el rack y el centro de datos en muy poca distancia y en muy poco tiempo. Esa densidad es lo que separa a Taiwán de una base de fabricación de bajo coste cualquiera.
+
+Para el lector general, este recorrido ofrece también una forma de leer las noticias. La próxima vez que una empresa anuncie una nueva plataforma de IA no hace falta preguntar solo quién diseñó el chip; también se puede seguir preguntando: ¿dónde se empaqueta? ¿Quién hace la máquina completa? ¿Quién gestiona la electricidad y el calor? ¿Quién asume los plazos y el mantenimiento? En cuanto se formulan esas preguntas, el contorno de Taiwán dentro de la cadena se vuelve más claro, más concreto y más fácil de juzgar.
+
+## Los semiconductores son la puerta, no el destino
+
+Escribir la industria tecnológica taiwanesa como «una empresa llamada TSMC» es cómodo, pero deja fuera muchas cosas.
+
+Lo que responde una fábrica de obleas es «si el chip puede fabricarse». La cadena del hardware de IA tiene que responder además a otras preguntas: ¿puede el chip conectarse con la memoria? ¿Puede alimentarse, disiparse, probarse y mantenerse? ¿Puede montarse, en el plazo que exige el cliente, en un rack entero, en una fila entera, en un centro de datos entero?
+
+Lo que hay que preguntar de verdad aquí es qué restricción resuelve cada tramo. El proceso lógico más avanzado resuelve «si se pueden meter más transistores en un chip más pequeño y de menor consumo». El empaquetado avanzado resuelve «si, cuando un solo chip no basta, se pueden unir el chip de cómputo, la memoria y distintos dados de forma cercana y rápida». Lo que pregunta un servidor de IA es otra cosa: si esas piezas carísimas pueden convertirse en una máquina estable, mantenible, producible en serie y entregable.
+
+Por eso la disipación y la alimentación no son papeles secundarios. Cuanto más potente es el chip, mayor es la corriente y más difícil resulta manejar el calor. Si la alimentación es inestable o el calor no sale, hasta el chip más avanzado tiene que bajar la velocidad, o incluso no puede ponerse en marcha. Los procesos maduros tampoco han desaparecido por eso, porque dentro de una máquina de IA siguen haciendo falta muchos chips de control, conexión, gestión de alimentación y periféricos. Si el proceso más avanzado es el motor, los procesos maduros y los componentes son los frenos, el circuito de combustible, el cuadro de mandos y el sistema de refrigeración. Sin cualquiera de esos tramos, el coche no puede correr con fiabilidad.
+
+Dentro de este gran cuadro basta con retener una cosa: los semiconductores son la puerta, no el destino. Para que la IA funcione de verdad hay que atravesar además todo un tramo que convierte los chips en máquinas.
+
+Y por eso también «Taiwán tiene valor» no debería ser un consuelo abstracto. Debería poder descomponerse en un diagrama: quién hace las obleas, quién el empaquetado, quién la disipación, quién la alimentación, quién las placas base, quién la máquina completa, quién asume los plazos, quién asume el agua y la electricidad, y a quién le recortan primero los pedidos cuando el ciclo se da la vuelta.
+
+Este diagrama también ayuda a distinguir el lenguaje de las noticias. Cuando un empresario dice «Taiwán es un socio», se le puede preguntar si de lo que depende es del proceso, del empaquetado, del ODM, de la alimentación o de la velocidad de reacción de todo el sistema. Cuando un político dice «interés común», se puede preguntar en qué empresas, en qué ciudades y en qué trabajadores se concentra ese interés. Cuando un inversor dice «el futuro de la IA es prometedor», se puede indagar si ese futuro aterriza en el diseño de chips, en la capacidad de empaquetado, en el montaje de servidores o en los componentes de disipación y alimentación. En cuanto un eslogan abstracto se descompone en capas, al lector le resulta más difícil dejarse llevar solo por la emoción.
+
+## El interés común es real, pero no es magia
+
+La posición de Taiwán en la cadena del hardware de IA sí ha creado un interés común.
+
+Para NVIDIA, para las grandes empresas de la nube y para las compañías globales de IA, Taiwán es el lugar donde convierten el diseño en producto. Para países como Estados Unidos, Japón o los europeos, Taiwán es un nodo de suministro ineludible de chips de vanguardia e infraestructura de IA. Para Taiwán, esa relación de ser necesitado trae exportaciones, inversión, empleo, visibilidad bursátil y bazas en la política internacional.
+
+Cuando AP informó en 2026 sobre la economía de la IA en Taiwán, puso en el mismo texto el fuerte crecimiento, el aumento de las exportaciones y la ampliación de la presencia de NVIDIA en la isla junto a la burbuja de la IA, el riesgo geopolítico y la desigualdad de renta.[^5] Esa yuxtaposición es importante, porque recuerda al lector que el interés común no es una protección unidireccional ni un amuleto que nunca caduca.
+
+Otros países se esfuerzan por sacar fuera una parte de la cadena. Que TSMC construya fábricas en Estados Unidos, Japón y Alemania demuestra, por un lado, que el mundo necesita a TSMC y, por otro, que los clientes y los gobiernos no quieren apostar todo el riesgo a Taiwán. Puede que a corto plazo las plantas del extranjero no reproduzcan la densidad completa de Taiwán, pero a largo plazo cambiarán la estructura de la negociación.
+
+Además, el interés de las empresas no equivale al interés del Estado. Lo que NVIDIA quiere es suministro estable y márgenes altos. Lo que TSMC quiere es liderazgo tecnológico y clientes globales. Lo que quieren los ODM son pedidos y utilización de capacidad. Lo que quiere la sociedad taiwanesa son salarios, vivienda, seguridad energética, capacidad de carga ambiental y garantías de seguridad. Esos intereses se solapan, pero también chocan.
+
+Todos los de la mesa son importantes, pero el poder no está repartido por igual. NVIDIA controla la arquitectura de las GPU, el ecosistema CUDA y el ritmo de la plataforma. TSMC controla los procesos de vanguardia y una capacidad clave de empaquetado. Las grandes empresas de la nube controlan las compras de los centros de datos. Los ODM controlan el diseño de la máquina completa, el montaje de racks y los envíos masivos, pero su margen suele ser mucho menor que el de las empresas de diseño de chips. Entre los fabricantes de componentes de alimentación, disipación, sustratos o interfaces de prueba, algunos obtienen buenos beneficios gracias a barreras técnicas altas y otros suben y bajan con los pedidos de sus grandes clientes. Esa es también la razón para descomponer el «interés común»: dentro de una misma cadena todos los tramos son necesarios, pero no a todos les toca el mismo poder.
+
+Una formulación más precisa debería ser más prudente: que el mundo necesite a Taiwán le da a Taiwán un conjunto importante de bazas. Pero esas bazas hay que mantenerlas entre la defensa, la diplomacia, la energía, la gobernanza industrial y el reparto social.
+
+## Construir fábricas fuera no es tan simple como mudarse
+
+Que TSMC construya fábricas en Estados Unidos, Japón y Alemania se mete a menudo en la misma inquietud: si se llevan la fabricación de vanguardia, ¿se adelgazará el escudo de silicio de Taiwán?
+
+A esta pregunta no se puede responder con un «sí» o un «no».
+
+Construir fuera es, por un lado, una prolongación de la capacidad taiwanesa. Que los clientes y los aliados estén dispuestos a poner subvenciones, suelo y capital político se debe precisamente a que TSMC y la cadena taiwanesa son demasiado importantes. Esas plantas acercan TSMC a sus clientes y hacen que la cadena global sea políticamente más aceptable.
+
+Por otro lado, construir fuera es también un movimiento de dispersión del riesgo. Ni Estados Unidos, ni Europa, ni Japón quieren que los chips más críticos estén para siempre concentrados junto al estrecho de Taiwán. Taiwán es necesario, por eso recibe inversión. Taiwán es demasiado importante, por eso se dispersa. Ambas frases se sostienen a la vez.
+
+Pero una fábrica no equivale a todo un ecosistema. Los procesos de vanguardia necesitan equipos, materiales, productos químicos, ingenieros, mantenimiento, experiencia en rendimiento, capacidad de empaquetado, coordinación con el cliente y velocidad de reacción de los proveedores. Sacar fuera un tramo de capacidad y sacar fuera toda una sociedad de ingeniería son dos dificultades distintas.
+
+Por eso construir fuera se parece más a estirar hacia fuera algunos nodos de la cadena taiwanesa que a arrancar a Taiwán de la cadena. Irá cambiando lentamente la estructura de la negociación y pondrá a prueba cómo conserva Taiwán la I+D central, la producción en masa más avanzada y la densidad de la cadena.
+
+## Los procesos maduros están en el mismo mapa
+
+La fiebre de la IA hace que sea fácil poner toda la atención en los 3 nanómetros, los 2 nanómetros y CoWoS. Pero una máquina de IA no funciona solo con los chips más avanzados.
+
+Los circuitos integrados de gestión de alimentación, los controladores, los sensores, los chips de comunicaciones, los periféricos y los chips de automoción e industriales siguen usando en su mayoría procesos maduros. Esos chips no salen en las noticias como las GPU, pero sostienen la conversión de energía, el control de señales, la supervisión de equipos y muchísimas funciones poco vistosas dentro de los centros de datos.
+
+La escasez global de chips durante la pandemia hizo entender a las líneas de producción de automoción, electrodomésticos y control industrial una cosa: al mundo no solo le faltan los chips más avanzados, sino también esos nodos maduros que parecen corrientes pero sin los cuales no se puede enviar nada. Por eso el mapa taiwanés de los semiconductores no puede mirarse solo por arriba. TSMC, UMC, Vanguard, PSMC y un grupo de empresas de procesos especiales, empaquetado y pruebas y materiales componen juntos un sustrato más grueso.
+
+Este punto es importante para el lector. El valor de Taiwán no debería entenderse como una carrera de cifras nanométricas. Cuanto más complejo es el hardware de IA, más necesita que lo avanzado y lo maduro trabajen juntos. Más necesita que la máquina completa y los componentes se entreguen juntos.
+
+Por eso los procesos maduros deben devolverse al mismo mapa. Son el chasis que determina si el hardware de IA puede funcionar de forma estable. La GPU más avanzada necesita apoyarse en una gran cantidad de chips corrientes para convertirse en una máquina realmente usable, mantenible y producible en serie.
+
+## La factura del grupo de montañas sagradas
+
+Conectar la demanda mundial de hardware de IA a Taiwán deja también la factura en Taiwán.
+
+La primera factura que se ve es la eléctrica. Las fábricas de obleas de vanguardia, la litografía EUV, las líneas de empaquetado, las pruebas de servidores de IA y los centros de datos necesitan electricidad estable. Los medios tecnológicos han informado de que la industria taiwanesa de semiconductores ha advertido sobre la presión de la energía verde y del suministro eléctrico. TSMC también publica de forma continuada sus planes de ahorro en EUV y de gestión del agua.[^6][^7] La mejora de la eficiencia es importante, pero mientras la demanda de IA siga creciendo, la presión sobre el total seguirá ahí.
+
+La segunda factura es el agua y la vulnerabilidad climática. La fabricación de obleas necesita enormes cantidades de agua ultrapura. El reportaje de WIRED sobre el agua en la fabricación de chips señala que una sola fábrica de obleas puede usar varios millones de galones diarios, y durante las sequías taiwanesas ha aflorado la tensión entre el agua agrícola y la producción de chips. La capacidad de proceso no puede separarse de los embalses, la lluvia, el agua regenerada y la gestión regional.[^8]
+
+La tercera factura son las emisiones y el bloqueo de la trayectoria industrial. El estudio de Roussilhe y otros, con fabricantes taiwaneses de componentes electrónicos como muestra, analiza cómo la energía, el agua y las emisiones de gases de efecto invernadero suben con el crecimiento de la producción, y el riesgo del carbon lock-in.[^9] El grupo de montañas sagradas trae bazas internacionales y, a la vez, ata profundamente la energía y el uso del suelo del país a una fabricación intensiva en energía.
+
+La cuarta factura es el reparto. La IA ha subido la bolsa, las exportaciones y los salarios del sector tecnológico taiwanés, pero no todo el mundo está sobre esa cadena principal de crecimiento. Las industrias tradicionales, los servicios, quienes viven de alquiler y los jóvenes ajenos al sector tecnológico no reciben necesariamente el dividendo al mismo tiempo. Cuando los precios de la vivienda, las tarifas eléctricas, el suelo y la inversión pública están condicionados por la industria de alta tecnología, «el futuro de Taiwán es prometedor» no equivale a «la vida de cada taiwanés mejora».
+
+Esto no pretende negar la importancia de los semiconductores ni de la cadena de la IA. Al contrario: precisamente porque es importante, hay que escribir la factura con claridad.
+
+## Dónde se sitúa Taiwán a sí mismo
+
+Lo que la cadena del hardware de IA le ha dado a Taiwán, además de divisas y pedidos, es también una manera de entenderse a sí mismo.
+
+Taiwán no es simplemente una isla pequeña protegida por el mundo, ni un imperio tecnológico capaz de controlar unilateralmente la IA global. Se parece más a un nudo de ingeniería altamente especializado: es necesario, y por eso tiene bazas. Se depende de él, y por eso tiene responsabilidad. Está concentrado, y por eso también asume riesgo.
+
+La próxima vez que el lector oiga «Taiwán es insustituible», no tiene por qué quedarse en el eslogan. Puede dibujar mentalmente una ruta física: la demanda de una empresa de modelos entra en el diseño de chips, el diseño entra en los procesos de TSMC, la oblea entra en el empaquetado avanzado, el módulo empaquetado entra en la disipación, la alimentación, la placa base y el rack, y al final el ODM/EMS taiwanés lo entrega en un centro de datos.
+
+Esa ruta es la prueba concreta. Convierte el «interés común» de emoción en un hecho que se puede discutir, cuestionar y también defender.
+
+Taiwán convierte la nube en máquinas. El verdadero significado de esa frase es este: hasta la IA más abstracta tiene que pasar, al final, por la isla más concreta.
+
+Y esa es también una de las posiciones más claras, y más necesitadas de ser vistas con claridad, de Taiwán en este momento.
+
+## Lecturas complementarias
+
+- [Comercio exterior de Taiwán y cadenas de suministro globales](/economy/台灣外貿與全球供應鏈) — el trasfondo macro desde la orientación exportadora y el comercio triangular hasta la reconfiguración de las cadenas entre Estados Unidos y China.
+- [NVIDIA en Taiwán](/technology/NVIDIA在台灣) — cómo deposita NVIDIA en Taiwán la fabricación de chips, el empaquetado y el montaje de servidores.
+- [Industria de semiconductores](/technology/半導體產業) — el largo trasfondo desde la transferencia tecnológica de RCA y la fundición de TSMC hasta el campo de batalla de los materiales y el empaquetado.
+- [Computex](/technology/Computex) — por qué la feria informática de Taipéi se ha convertido en la era de la IA en el lugar de peregrinación del lado de la oferta de hardware mundial.
+- [La electricidad y los semiconductores en Taiwán](/technology/台灣的電力與半導體) — la factura eléctrica, la presión de la energía verde y la seguridad energética detrás de la cadena de la IA.
+- [El agua de los semiconductores y los recursos hídricos de Taiwán](/technology/半導體用水與台灣水資源) — cómo se conectan las fábricas de obleas con los embalses, las sequías, el agua regenerada y la gobernanza local.
+- [Fábricas de la cadena de IA en el extranjero](/technology/AI供應鏈海外設廠) — cómo el mundo está sacando fuera la cadena taiwanesa, desde TSMC, Foxconn y Wistron hasta Delta.
+
+## Fuentes de imágenes
+
+- **Diagrama de flujo de la cadena de suministro del hardware de IA**: diagrama conceptual SVG elaborado por Taiwan.md Contributors, CC BY-SA 4.0, almacenado en `public/article-images/technology/ai-hardware-supply-chain-flow.svg`. Los nodos del diagrama se han ordenado según el texto y las referencias, y sirven para explicar cómo la demanda de IA entra en el centro de datos pasando por el diseño de chips, los procesos de vanguardia, el empaquetado avanzado, la HBM y los sustratos, la disipación y la alimentación, las placas base, el ODM/EMS y los racks de IA; no es un gráfico de cuotas de mercado ni un mapa completo de empresas.
+- **Diagrama por capas del servidor de IA**: diagrama conceptual SVG elaborado por Taiwan.md Contributors, CC BY-SA 4.0, almacenado en `public/article-images/technology/ai-server-rack-stack.svg`. Sirve para explicar los niveles de sistema de un servidor de IA desde el chip hasta el centro de datos, y no representa un mapa completo de empresas ni cuotas de mercado.
+- **Jensen Huang mostrando la GPU RTX Blackwell**: [Jensen Huang holding RTX Blackwell at CES 2025](<https://commons.wikimedia.org/wiki/File:Jensen_Huang_-_RTX_Blackwell_-_Nvidia_Keynote_-_CES_2025_Las_Vegas_(3).jpg>) — Photo: Pronoia, Wikimedia Commons, CC0. Este texto usa la versión cacheada en `public/article-images/technology/jensen-huang-ces-2025-blackwell.webp`.
+- **Recinto de Computex en Nangang**: [Computex Taipei at Taipei Nangang Exhibition Center](https://commons.wikimedia.org/wiki/File:Computex_Taipei_at_Taipei_Nangang_Exhibition_Center_20150602.jpg) — Photo: NVIDIA Taiwan, Wikimedia Commons, CC BY 2.0. Este texto usa la versión cacheada en `public/article-images/technology/computex-nangang-floor-2015.webp`.
+
+## Referencias
+
+[^1]: [CNA: llega el «banquete del billón» de Jensen Huang; asisten C.C. Wei, Young Liu, Barry Lam y otras grandes figuras](https://www.cna.com.tw/news/afe/202605280300.aspx) — Reportaje de la agencia CNA del 28 de mayo de 2026 sobre la cena a la que Jensen Huang convocó en Taipéi a directivos de las empresas taiwanesas de la cadena de IA, con la enumeración de categorías como fundición, empaquetado y pruebas, módulos de disipación, gestión de alimentación, placas base, fabricación por encargo y marcas.
+[^2]: [TSMC Logic Technology](https://www.tsmc.com/english/dedicatedFoundry/technology/logic) — Página oficial de tecnología de procesos lógicos de TSMC, con los procesos lógicos avanzados de 7, 5, 3 y 2 nanómetros, A16 y A14 y la explicación de su hoja de ruta.
+[^3]: [TSMC Advanced Packaging Services](https://www.tsmc.com/english/dedicatedFoundry/services/advanced-packaging) — Página oficial de servicios de empaquetado avanzado de TSMC, que explica que 3DFabric incluye tecnologías de integración de front-end y back-end como SoIC, CoWoS e InFO.
+[^4]: [AP: Taiwan takes a further step in production of AI chips with advanced new plant](https://apnews.com/article/1e087e92592b0b9ab7fb20442a5b8dc7) — Reportaje de AP sobre la nueva planta de SPIL en Taichung y la asistencia de Jensen Huang, que aporta una perspectiva internacional sobre el papel del empaquetado avanzado taiwanés en la cadena de los chips de IA.
+[^5]: [AP: Taiwan's AI-powered economy soars in the shadow of bubble fears and China threats](https://apnews.com/article/7527bd4bf3089cbd2dab1c530ee61c3e) — Reportaje de AP de 2026 sobre cómo la demanda de IA impulsa el crecimiento económico y las exportaciones de Taiwán, que a la vez ordena las limitaciones de la burbuja de la IA, el riesgo geopolítico y la desigualdad de renta; resulta adecuado como material de equilibrio.
+[^6]: [Tom's Hardware: TSMC-led semiconductor association warns of power supply pressure](https://www.tomshardware.com/tech-industry/tmsc-led-semiconductor-association-begs-taiwan-government-for-clean-green-energy-as-demand-skyrockets-fabs-are-struggling-to-keep-up-with-power-needs) — Reportaje de un medio tecnológico sobre la advertencia de la industria taiwanesa de semiconductores acerca de la energía verde y la estabilidad del suministro; sirve como fuente secundaria sobre las limitaciones energéticas y la presión de RE100, aunque para una cita formal conviene acudir a TSIA o al texto oficial.
+[^7]: [Tom's Hardware: TSMC reduces peak power consumption of EUV tools by 44%](https://www.tomshardware.com/tech-industry/semiconductors/tsmc-reduces-peak-power-consumption-of-euv-tools-by-44-percent-company-to-save-190-million-kilowatt-hours-of-electricity-by-2030) — Reportaje sobre el plan de ahorro energético de TSMC en EUV y la escala de su consumo total; adecuado para explicar la tensión entre la mejora de la eficiencia y el crecimiento del total, aunque para una cita formal conviene contrastarlo con la documentación de sostenibilidad de TSMC.
+[^8]: [WIRED: Want to Win a Chip War? You’re Gonna Need a Lot of Water](https://www.wired.com/story/want-to-win-a-chip-war-youre-gonna-need-a-lot-of-water/) — Reportaje de WIRED de 2023 sobre la necesidad de agua ultrapura e instalaciones de tratamiento en la fabricación de semiconductores, que menciona además la tensión entre TSMC y el agua agrícola durante las sequías taiwanesas y sostiene el apartado de recursos hídricos de este texto.
+[^9]: [Roussilhe et al.: From Silicon Shield to Carbon Lock-in?](https://arxiv.org/abs/2209.12523) — Estudia la huella ambiental de 16 fabricantes taiwaneses de componentes electrónicos entre 2015 y 2020, y plantea que la energía, el agua y las emisiones aumentan con el crecimiento de la producción, además del riesgo de carbon lock-in.
+[^10]: [CNA: Young Liu confía en los envíos de Vera Rubin de NVIDIA en el segundo semestre](https://www.cna.com.tw/news/afe/202605290100.aspx) — Reportaje de la agencia CNA del 29 de mayo de 2026, en el que el presidente de Foxconn, Young Liu, habla de los envíos de la plataforma Vera Rubin, de CPO y fotónica de silicio y de la exhibición de sistemas de servidores de IA.

--- a/knowledge/es/Technology/ai-supply-chain-overseas-manufacturing.md
+++ b/knowledge/es/Technology/ai-supply-chain-overseas-manufacturing.md
@@ -1,0 +1,223 @@
+---
+translatedFrom: 'Technology/AI供應鏈海外設廠.md'
+sourceCommitSha: 'fd01d452'
+sourceContentHash: 'sha256:7fa246cf8f0f5c00'
+sourceBodyHash: 'sha256:453d3851b08255ad'
+translatedAt: '2026-07-23T22:20:00+08:00'
+lang: 'es'
+title: 'Fábricas de la cadena de IA en el extranjero: cuando el mundo invita a salir a la capacidad taiwanesa'
+description: 'Construir fábricas de la cadena de hardware de IA fuera de Taiwán no es solo que TSMC vaya a Estados Unidos, Japón y Alemania: también Foxconn, Wistron, Delta y los proveedores de empaquetado, pruebas y servidores están siendo atraídos hacia Estados Unidos, Japón, Europa, la India, el Sudeste Asiático y México por los clientes, los aranceles, las subvenciones y la geopolítica. Este texto lo explica desde la globalización, la reducción de riesgos y el pulso de las cadenas de suministro: la salida al exterior de las empresas taiwanesas es una prolongación de su capacidad y a la vez un movimiento del mundo para reducir su dependencia de un solo punto; no es una simple mudanza empresarial.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'hardware de IA'
+  - 'fábricas en el extranjero'
+  - 'semiconductores'
+  - 'cadena de suministro'
+  - 'TSMC'
+  - 'Foxconn'
+  - 'Wistron'
+  - 'Delta Electronics'
+subcategory: 'Semiconductores y hardware'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Entrar por los múltiples actores implicados en la construcción de fábricas en el extranjero, para evitar simplificar la salida al exterior como «TSMC se marcha» o como la noticia de una sola empresa.'
+  whats_excluded: 'No se ordenan caso por caso todas las cifras de inversión en el extranjero, las condiciones de las subvenciones ni los calendarios de las plantas.'
+  where_it_hedges: 'Se tratan a la vez el crecimiento empresarial, la seguridad de los gobiernos, el coste para la ciudadanía, el respaldo de los socios extranjeros y si la capacidad central de Taiwán se está desplazando.'
+  whos_pushing_back: 'Los gobiernos y clientes extranjeros necesitan la capacidad taiwanesa, pero también expresan con claridad su deseo de reducir la dependencia de la capacidad concentrada en la isla.'
+image: '/article-images/economy/tsmc-fab21-arizona-2023.webp'
+imageCredit: 'Hunter Trick / Wikimedia Commons'
+imageLicense: 'CC BY-SA 4.0'
+---
+
+# Fábricas de la cadena de IA en el extranjero: cuando el mundo invita a salir a la capacidad taiwanesa
+
+> **Resumen en 30 segundos:** Construir fábricas de la cadena de IA en el extranjero no es una simple «mudanza» ni «vender Taiwán». Es el resultado de que la capacidad manufacturera taiwanesa, después de ser necesitada por el mundo, entra en su siguiente etapa: las empresas quieren estar cerca de sus clientes y mercados, los gobiernos quieren reducir el riesgo de que les corten el paso, la ciudadanía se preocupa por el empleo, los salarios, el agua y la luz y la vida local, y los socios extranjeros quieren poner la capacidad crítica donde puedan controlarla mejor. TSMC es el líder más visible, pero no solo salen fuera las fábricas de obleas: también los servidores de IA, los racks, la alimentación, los equipos de red, el empaquetado y las pruebas, los servicios de planta y los componentes. A Taiwán lo necesitan, y por eso lo invitan a salir; Taiwán está demasiado concentrado, y por eso también lo dispersan.
+
+En 2025, NVIDIA desplegó una cadena de suministro taiwanesa sobre el mapa de Estados Unidos.
+
+Anunció que los chips Blackwell ya se producían en la planta de TSMC en Phoenix, que la fabricación de los superordenadores de IA correría a cargo de Foxconn con una planta en Houston y de Wistron con otra en Dallas, y que el empaquetado y las pruebas implicaban además a SPIL y Amkor en Arizona.[^1] No era la primera salida al exterior de empresas taiwanesas, pero ilustraba muy bien el cambio de la década de 2020: los clientes extranjeros no solo quieren que Taiwán sepa hacerlo, sino que el hardware crítico pueda hacerse allí donde ellos tienen más control.
+
+Durante mucho tiempo el ideal de la globalización fue muy sencillo: se fabrica donde mejor, más barato y más rápido pueda hacerse. Las empresas taiwanesas crecieron en ese mundo. Taiwán recibía los pedidos, la costa china hacía la producción masiva, el Sudeste Asiático aportaba mano de obra y suelo, Estados Unidos y Europa controlaban las marcas, los clientes y el mercado, y Japón, Países Bajos y Corea guardaban los materiales, los equipos y la memoria. Ese reparto abarató los productos y acostumbró al mundo a poner la eficiencia por delante de la seguridad.
+
+Después ocurrieron varias cosas a la vez: la COVID-19 convirtió la escasez de chips en paradas de producción, la guerra tecnológica entre Estados Unidos y China convirtió los chips en un asunto de seguridad nacional, la guerra de Ucrania recordó a los países que tanto la energía como las cadenas de suministro pueden convertirse en armas, y la IA convirtió la capacidad de cómputo en un nuevo símbolo de poder nacional. Antes todos preguntaban: «¿dónde es más eficiente?». Ahora preguntan también: «si allí pasa algo, ¿me cortarán el paso?».
+
+Ese es el contexto de las fábricas taiwanesas de la cadena de IA en el extranjero. Detrás de la expansión exterior de una sola empresa está el mundo entero devolviendo las cadenas de suministro desde el «coste mínimo» hacia lo «controlable, fiable y negociable».
+
+![Vista aérea del conjunto de plantas de TSMC en el Parque Científico de Hsinchu: numerosas naves de gran tamaño concentradas dentro del parque, un paisaje que refleja la densidad de la cadena de semiconductores en la isla de Taiwán.](/article-images/economy/tsmc-fabs-hsinchu-2020.webp)
+
+_Conjunto de plantas de TSMC en el Parque Científico de Hsinchu. El trasfondo de la construcción de fábricas en el extranjero es precisamente que esta densidad manufacturera altamente concentrada en la isla es necesitada por el mundo, y a la vez el mundo quiere dispersarla. Photo: Tseng Cheng-Hsun. CC BY 2.0 via Wikimedia Commons._
+
+## De la globalización a la reducción de riesgos
+
+Construir fábricas en el extranjero no es nada nuevo. La industria electrónica taiwanesa lleva mucho tiempo acostumbrada a moverse siguiendo a los clientes, los salarios, el suelo y los aranceles.
+
+A partir de los años noventa, muchas fábricas taiwanesas de fabricación electrónica por encargo situaron gran parte de su capacidad en China. La lógica de entonces era la globalización: los clientes necesitaban gran escala, bajo coste y entrega puntual. China aportaba suelo, mano de obra, puertos, coordinación de los gobiernos locales y un ecosistema completo de proveedores. Lo que las empresas taiwanesas hacían allí era gestión, ingeniería, mejora de procesos e intermediación con los clientes globales.
+
+Pero a partir de la década de 2020 cambiaron las razones para salir. Las empresas ya no salen solo por abaratar, sino también por dispersar el riesgo. Los clientes estadounidenses quieren que sus productos se fabriquen en Estados Unidos o en países amigos. India, Vietnam, Tailandia y México ofrecen bases de montaje fuera de China. Japón y Europa quieren volver a enlazar los semiconductores con las cadenas de automoción e industriales.
+
+Este cambio suele llamarse reducción de riesgos, o *de-risking*. No equivale necesariamente a un desacoplamiento total ni a volver a un mundo en el que cada país lo fabrique todo. Se parece más a partir en varios nodos de respaldo una cadena excesivamente concentrada y excesivamente dependiente de un solo lugar.
+
+Para Taiwán es un momento muy delicado. Las empresas taiwanesas crecieron gracias a la globalización, y ahora la reducción de riesgos las empuja a redistribuirse.
+
+## La IA empuja la cadena de hardware hacia las fronteras
+
+La IA ha hecho más urgente la construcción de fábricas en el extranjero.
+
+Un gran sistema de IA no es solo software en la nube. Necesita GPU, CPU, memoria HBM, empaquetado avanzado, sustratos, disipación, alimentación, conmutadores de red, racks, centros de datos y grandes cantidades de electricidad. Ese hardware es voluminoso, consume mucho, cuesta caro y está a menudo ligado a la seguridad nacional, la soberanía de los datos y la seguridad energética.
+
+Por eso los clientes ya no preguntan solo: «¿puede hacerlo Taiwán?».
+
+Los clientes preguntan además: «¿puede hacerse donde yo esté más tranquilo?».
+
+En aquel anuncio sobre la fabricación en Estados Unidos, NVIDIA dijo que había encargado más de un millón de pies cuadrados de espacio de fabricación en Arizona y Texas; que los chips Blackwell ya se producían en la planta de TSMC en Phoenix; que la fabricación de superordenadores de IA correría a cargo de Foxconn en Houston y de Wistron en Dallas; y que el empaquetado y las pruebas se harían con la taiwanesa SPIL y con Amkor en Arizona.[^1]
+
+Esa lista es muy interesante. Las obleas, el empaquetado y las pruebas, la máquina completa del servidor, los racks y las pruebas quedan todos dentro del relato de la «infraestructura de IA estadounidense», y TSMC es solo el nombre más visible entre ellos.
+
+![Vista aérea de las obras de la Fab 21 de TSMC en Phoenix, Arizona: una enorme zona de obras y la estructura de la planta desplegándose en el borde de una ciudad del desierto, una escena de la fabricación de chips de vanguardia atraída hacia territorio estadounidense.](/article-images/economy/tsmc-fab21-arizona-2023.webp)
+
+_Obras de la Fab 21 de TSMC en Phoenix, Arizona. Construir fuera acaba aterrizando en un lugar donde la planta, el agua y la luz, los trabajadores, la sociedad local y la cadena de suministro tienen que funcionar juntos. Photo: Hunter Trick. CC BY-SA 4.0 via Wikimedia Commons._
+
+OpenAI y Foxconn anunciaron después una colaboración para diseñar y fabricar en Estados Unidos racks para centros de datos de IA, con productos que incluyen cableado, equipos de red y sistemas de alimentación; según AP, Foxconn utilizará instalaciones estadounidenses en Wisconsin, Ohio y Texas.[^2] Con esto, «construir fábricas fuera» deja de ser solo producción de chips y arrastra a la localización todo el conjunto del hardware de los centros de datos de IA.
+
+![Mapa de rutas de la expansión exterior de la cadena de IA: la capacidad central de la isla de Taiwán se extiende hacia Estados Unidos, Japón, Europa, México, el Sudeste Asiático, la India y el mercado de centros de datos, mostrando cuatro fuerzas de atracción: empresas, gobiernos, comunidades locales y clientes.](/article-images/technology/ai-supply-chain-overseas-footprint.svg)
+
+_La salida al exterior de la cadena de IA taiwanesa no sigue una única ruta. Cada tramo es atraído por mercados distintos: los chips y el empaquetado y las pruebas se acercan a la seguridad nacional y a los clientes de la nube, mientras que los servidores, los racks, la alimentación y la disipación se mueven siguiendo los centros de datos, los aranceles y las exigencias de entrega. Diagrama conceptual elaborado por Taiwan.md Contributors._
+
+## Por qué las empresas taiwanesas miran tan a menudo al exterior
+
+El mercado taiwanés es demasiado pequeño, y de entrada resulta difícil criar grandes empresas de hardware solo con la demanda interna.
+
+La forma de crecer de las empresas taiwanesas ha consistido a menudo en recoger primero las necesidades de los clientes internacionales y forjarse después como proveedores de nivel mundial. TSMC atiende a las empresas de diseño de chips de todo el mundo; Foxconn, Quanta, Wistron, Compal y Pegatron recogen a las marcas globales y a los clientes de la nube; Delta se ocupa de la alimentación, la disipación y la gestión energética; ASE y SPIL recogen el empaquetado y las pruebas; y un grupo de empresas de servicios de planta, materiales, electromecánica, equipos y componentes se mueve siguiendo a los grandes clientes.
+
+Esto le da a la cadena taiwanesa un rasgo particular: funciona para el mundo, y el mercado interno taiwanés es más bien una parte pequeña.
+
+Cuando el mundo aún creía en la globalización, eso era una ventaja. Las empresas taiwanesas sabían de gestión transnacional, de montar fábricas deprisa, de responder a los clientes y de movilizar proveedores. Ahora que el mundo empieza a reducir riesgos sigue siendo una ventaja, solo que el enunciado se ha vuelto más difícil. Los clientes no solo quieren que las empresas taiwanesas sepan hacerlo, sino que puedan lograr la misma calidad y la misma velocidad en Estados Unidos, México, la India, Vietnam, Tailandia, Japón, Alemania u otros lugares.
+
+Por eso «salir fuera» no significa solo trasladar fábricas. Es también una nueva demostración de la capacidad empresarial: si la gestión de ingeniería, la colaboración con proveedores y el ritmo de fabricación forjados en Taiwán pueden replantarse dentro de otro sistema institucional, otra lengua, otros sindicatos, otras tarifas eléctricas, otros recursos hídricos y otra cultura laboral.
+
+## Una misma fábrica en el extranjero, problemas distintos según quién mire
+
+La construcción de fábricas en el extranjero se escribe con mucha facilidad como noticia empresarial: cuánto invierte tal compañía, dónde levanta la planta, en cuántos años producirá en masa, si aumentarán los ingresos.
+
+Ese es, por supuesto, el primer problema que mira un empresario. Para la empresa, salir fuera es un negocio: acercarse al cliente, esquivar aranceles, obtener subvenciones, dispersar el riesgo chino, establecer una segunda base de producción por exigencia de un gran cliente. Si la planta exterior permite conseguir pedidos, retener clientes y entrar en la contratación pública, el empresario la verá naturalmente como una estrategia de crecimiento.
+
+Pero un gobierno ve en esa misma fábrica otra cosa.
+
+Para los gobiernos de Estados Unidos, Japón y Europa, las fábricas taiwanesas en el extranjero se entienden dentro de la seguridad económica. Que la CHIPS and Science Act estadounidense subvencionara a TSMC en Arizona buscaba que los chips de vanguardia se produjeran en territorio estadounidense y reducir la dependencia del suministro asiático. Cuando AP informó de que el gobierno estadounidense ofrecía a TSMC hasta 6.600 millones de dólares en ayudas, situó también el asunto en el contexto de reconstruir la capacidad estadounidense de fabricación de chips avanzados y de la seguridad de la cadena.[^8]
+
+Para el gobierno taiwanés el problema es más delicado. En su entrevista con TIME, el presidente Lai Ching-te dijo, por un lado, que los semiconductores son una industria de división global del trabajo, con materias primas, equipos y tecnología repartidos entre Estados Unidos, Japón, Países Bajos y otros; y, por otro, que si las empresas de semiconductores despliegan operaciones en Estados Unidos, Japón, Europa u otros países por su propio interés y desarrollo, el gobierno lo respeta en principio.[^9] Esto significa que el gobierno no puede mirar la salida al exterior solo como «quedarse en Taiwán» o «salir es perder», sino que debe buscar un equilibrio entre el crecimiento empresarial, las alianzas internacionales y la capacidad central local.
+
+## La ciudadanía y los socios extranjeros también miran esa fábrica
+
+Lo que ve la ciudadanía es otro conjunto de problemas.
+
+En Taiwán, la gente preguntará: si las fábricas y los pedidos más importantes se van poco a poco fuera, ¿habrá menos empleo en Taiwán? ¿Se estancarán los salarios? ¿Se debilitará el efecto protector de la montaña sagrada? Pero la ciudadanía también puede beneficiarse por otro lado: si la salida al exterior trae más pedidos, más I+D, más puestos directivos y más cooperación internacional, la sede taiwanesa puede conservar trabajos de mayor nivel en vez de quedarse dentro de la isla con toda la presión sobre el agua, la luz, el suelo, el transporte y la vivienda.
+
+En los lugares donde se construyen las plantas, la ciudadanía pregunta: ¿traen de verdad estas inversiones tecnológicas buenos empleos? ¿Puede la comunidad asumir el agua, la electricidad, el transporte, la vivienda y los riesgos ambientales? Cuando The Verge informó sobre el clúster de semiconductores de Arizona, puso las expectativas de empleo que traen las inversiones en chips junto a las dudas sobre los recursos hídricos, los productos químicos, la seguridad laboral y si los vecinos se benefician de verdad.[^10] Esto nos recuerda que, tras salir al exterior, las empresas taiwanesas no solo se encuentran con clientes extranjeros, sino también con sociedades locales extranjeras.
+
+La perspectiva de los proveedores y socios extranjeros también es distinta. Empresas como NVIDIA, OpenAI, Sony, Denso, Toyota, Bosch, Infineon o NXP colaboran con empresas taiwanesas porque Taiwán completa un tramo de capacidad que falta en sus propias cadenas. La colaboración las acerca a los mercados de cómputo, automoción, industria o centros de datos, y también reduce su dependencia de un solo punto. Para ellas, las empresas taiwanesas son socios y a la vez parte de su gestión del riesgo.
+
+Por eso la construcción de fábricas en el extranjero no debería preguntarse solo «si la empresa ha ganado dinero». Pregunta al mismo tiempo: qué seguridad obtiene el gobierno, qué coste asume la ciudadanía, qué respaldo consiguen los socios extranjeros y qué capacidad central queda en la isla de Taiwán.
+
+## Salir fuera no es copiar otro Taiwán
+
+Salir fuera se imagina con facilidad como «trasladar la misma fábrica a otro país». Pero en la industria manufacturera, comprar el suelo, levantar la nave e instalar las máquinas es solo el comienzo. Lo verdaderamente difícil es llevar todo un conjunto de hábitos de trabajo a un lugar nuevo.
+
+En Taiwán, una llamada de teléfono basta para encontrar al proveedor de materiales de siempre, a la empresa electromecánica, al mantenimiento de equipos, a la logística y al soporte de ingeniería. Los proveedores conocen la velocidad de los demás y saben cómo cubrirse cuando surge un problema. Esa densidad pertenece a todo un clúster industrial y es una compenetración que muchas empresas han pulido durante años.
+
+Fuera, la empresa tiene que enfrentarse de nuevo a otro mercado laboral, otro sistema sindical, otros procedimientos de evaluación ambiental, otra política local, otras tarifas eléctricas y del agua, otro talento de ingeniería y otro grado de madurez de los proveedores. Algunos problemas se resuelven con dinero, otros necesitan tiempo, y algunos incluso cambian el propio método de gestión original.
+
+Por eso la dificultad de salir fuera varía mucho según el tramo. Los servidores de IA, los racks, la alimentación, el cableado y el montaje se mueven con más facilidad siguiendo a los clientes y a los centros de datos; la fabricación de obleas y el empaquetado avanzado dependen mucho más de la densidad de la cadena, de la formación de los ingenieros y del rendimiento a largo plazo. El mundo puede invitar a salir a las empresas taiwanesas con subvenciones, pero no necesariamente puede reproducir de inmediato la velocidad de la isla.
+
+Por eso, al evaluar la construcción de fábricas fuera no basta con mirar «dónde está la capacidad». Más determinante es: dónde están las decisiones, dónde está la I+D, dónde está la capacidad de resolver problemas, si los proveedores pueden seguir el ritmo y dónde se fabricará primero la siguiente generación tecnológica. Esas preguntas deciden si salir fuera es una prolongación de la capacidad taiwanesa o el traslado gradual de la capacidad central a otro sitio.
+
+## No todos los tramos salen fuera de la misma manera
+
+Dentro de la cadena de IA, cada tramo sale fuera por razones distintas.
+
+La fabricación de obleas tiene la barrera de capital más alta e implica agua, electricidad, suelo, talento, equipos, productos químicos y rendimiento. Es lo más difícil de trasladar y lo más visible políticamente. El empaquetado avanzado y las pruebas están en un punto intermedio: tienen que estar cerca de las obleas, de los clientes y de la integración de sistemas. Los servidores de IA, los racks y los sistemas de alimentación están más cerca del centro de datos final y son más sensibles a los aranceles, los plazos, la ubicación del cliente y las compras ligadas a la seguridad nacional.
+
+Por eso vemos a distintos fabricantes moverse en distintas direcciones.
+
+Foxconn y Wistron han sido arrastrados a la fabricación de superordenadores de IA en Estados Unidos. Delta amplía sus bases exteriores en alimentación, centros de datos y equipos eléctricos industriales; según los medios, su campus de Plano (Texas) planea acercarse a 1,5 millones de pies cuadrados tras la ampliación y ofrecer una opción de fabricación local en Estados Unidos; su planta india de Krishnagiri también sigue ampliándose para atender a clientes de vehículos eléctricos, telecomunicaciones, centros de datos e industria.[^3][^4]
+
+Nodos de obleas y de empaquetado y pruebas como TSMC, ASE o SPIL entran de forma más directa en las políticas de semiconductores de Estados Unidos, Japón y Europa. Salen fuera para que clientes y gobiernos crean que, aunque la isla de Taiwán siga siendo el núcleo, una parte de la capacidad puede arraigar también en territorio aliado.
+
+## La montaña sagrada lleva el problema a su máxima intensidad
+
+TSMC es el personaje más visible de esta historia, pero la salida al exterior de la cadena no se detiene en TSMC.
+
+Que TSMC sea el símbolo de la «montaña sagrada que protege al país» lleva el problema de las fábricas en el extranjero a su máxima intensidad. Lo que está en juego aquí es la fabricación de obleas, lo más complejo, lo más caro y lo más dependiente de la densidad de la cadena, y se le pide además que arraigue en territorio aliado. Si eso ocurre, es aún menos probable que los demás tramos se queden por completo dentro de la isla.
+
+La página oficial de TSMC sobre Arizona explica que la inversión en el campus de Phoenix se ha ampliado a 165.000 millones de dólares y que el plan incluye seis fábricas de obleas, dos instalaciones de empaquetado avanzado y un centro de I+D; una de las fábricas ya entró en producción en masa con el proceso N4 en el cuarto trimestre de 2024, y después están previstos N3, N2 y A16, entre otros.[^5] Es el caso representativo de Estados Unidos atrayendo a su territorio una parte de la capacidad de fabricación de chips de IA de vanguardia.
+
+Kumamoto, en Japón, representa otra necesidad. Según AP, TSMC planea producir chips de 3 nanómetros en su segunda planta de Kumamoto para IA, teléfonos inteligentes, robótica y conducción autónoma; lo que Japón valora es la seguridad económica y volver a enlazar los semiconductores con las industrias de automoción, robótica, materiales y equipos.[^6]
+
+ESMC, en Dresde (Alemania), es una tercera lógica. La web oficial de ESMC explica que se trata de una empresa conjunta de TSMC, Bosch, Infineon y NXP cuyo objetivo es levantar una fábrica de obleas en Alemania para dar servicio a los mercados europeos de industria, IoT, comunicaciones y automoción.[^7] Lo que a Europa le importa es la resiliencia del suministro de chips de automoción, control industrial y comunicaciones, no alcanzar a Taiwán en todos los nodos.
+
+Aunque se trate igualmente de construir fábricas fuera, lo que buscan Estados Unidos, Japón y Alemania no es lo mismo. Estados Unidos busca IA y seguridad nacional, Japón busca reconstrucción industrial y Europa busca resiliencia industrial. Y TSMC, entre esas necesidades, se ha convertido en la interfaz internacional más visible de la cadena taiwanesa.
+
+## Después de salir fuera, ¿qué le queda a Taiwán?
+
+Lo que de verdad merece preguntarse es esto: «después de salir, ¿qué queda en Taiwán?».
+
+Hay cosas que pueden trasladarse relativamente rápido: las naves, parte de las líneas de producción, la capacidad de montaje, el servicio al cliente, el mantenimiento local, parte de las pruebas y la logística. Hay cosas difíciles de trasladar: la densidad de proveedores, la formación de los ingenieros, la velocidad de mejora de procesos, la cultura del rendimiento, la colaboración entre empresas, la confianza acumulada durante años y un grupo de personas que sabe a quién llamar cuando algo va mal.
+
+El valor central de Taiwán no desaparecerá de golpe porque aparezcan unas cuantas plantas en el extranjero. Pero tampoco seguirá existiendo automáticamente para siempre.
+
+Construir fábricas fuera produce dos efectos contrapuestos. Primero, mete a las empresas taiwanesas más adentro de los mercados aliados y refuerza el interés común. Segundo, permite también que los aliados construyan poco a poco capacidad de respaldo y reduzcan su dependencia de un solo punto en la isla. El empresario ve crecimiento, el gobierno ve seguridad, el socio extranjero ve respaldo, y la ciudadanía ve a la vez oportunidad e inquietud.
+
+Ambas cosas se sostienen al mismo tiempo.
+
+Por eso Taiwán no puede ver la construcción de fábricas fuera solo como una pérdida ni solo como un honor. Es una prueba de resistencia: si las empresas taiwanesas sacan fuera su capacidad, ¿podrá la isla seguir conservando la I+D de mayor nivel, los procesos, el empaquetado, la densidad de ingeniería, el talento y la red de proveedores?
+
+Si la respuesta es que sí, salir fuera se convierte en prolongación. Si la respuesta es que no, salir fuera puede convertirse en dilución.
+
+## Necesitado, y también dispersado
+
+Las fábricas de la cadena de IA taiwanesa en el extranjero han vuelto más compleja la frase «Taiwán es insustituible».
+
+El mundo necesita a Taiwán, sin duda. Pero el mundo también se esfuerza, con subvenciones, políticas, suelo, agua y electricidad, aranceles y mercado, por no depender tanto de Taiwán.
+
+Es la reacción inevitable que aparece después del éxito de Taiwán. Cuando una isla se convierte en un nodo clave de la cadena global de IA, es natural que otros países quieran atraerse una parte de esa capacidad.
+
+Lo que Taiwán tiene que hacer a continuación es que el mundo, después de la salida al exterior, siga necesitando a Taiwán. Las plantas exteriores pueden crecer en Estados Unidos, Japón, Alemania, la India, Vietnam, Tailandia o México, pero la capacidad central debe seguir renovándose en Taiwán.
+
+Esa «renovación» es muy concreta: Taiwán tiene que retener a quienes saben estabilizar un proceso nuevo, a quienes saben desatascar un cuello de botella de empaquetado, a quienes saben sostener los plazos de entrega de los servidores y a quienes saben hacer que los proveedores cubran rápido. Si esas capacidades siguen acumulándose, Taiwán continuará siendo el lugar donde nace la siguiente ronda de soluciones. Mientras el próximo problema difícil siga volviendo primero a Taiwán para resolverse, construir fábricas fuera se parecerá más a extender hacia fuera la capacidad taiwanesa que a vaciar Taiwán.
+
+Esa es la pregunta más importante de las fábricas de la cadena de IA en el extranjero: después de que el mundo invite a salir a la capacidad taiwanesa, ¿podrá Taiwán seguir criando la siguiente capa de capacidad?
+
+## Lecturas complementarias
+
+- [Cadena de suministro del hardware de IA](/technology/AI硬體供應鏈) — por qué el mundo necesita que Taiwán convierta la demanda de la nube en máquinas.
+- [Cadena de suministro del hardware de IA](/technology/AI硬體供應鏈) — de la GPU al rack: cómo recogen los ODM/EMS taiwaneses el hardware de los centros de datos de IA.
+- [La electricidad y los semiconductores en Taiwán](/technology/台灣的電力與半導體) — cómo vuelve la fabricación de vanguardia a la electricidad y a la seguridad energética.
+- [El agua de los semiconductores y los recursos hídricos de Taiwán](/technology/半導體用水與台灣水資源) — cómo entran las fábricas de obleas en los embalses, las sequías y la gestión del agua regenerada.
+- [Empresas taiwanesas: TSMC](/economy/台灣企業：台積電) — cómo el modelo de fundición de TSMC reescribió la división global del trabajo en semiconductores.
+- [Empresas taiwanesas: Foxconn](/economy/台灣企業：鴻海精密) — de la fabricación electrónica por encargo a los servidores de IA y el hardware de centros de datos.
+- [Empresas taiwanesas: Delta Electronics](/economy/台灣企業：台達電子) — cómo la alimentación, la disipación y la gestión energética se convirtieron en parte de la infraestructura de IA.
+- [Desarrollo de los parques científicos](/technology/科技園區發展) — cómo creció el clúster taiwanés de semiconductores desde el suelo y las ciudades.
+
+## Fuentes de imágenes
+
+- **Vista aérea de las obras de la Fab 21 de TSMC en Arizona (hero / interior)**: [231105-1 TSMC Fab 21 construction](https://commons.wikimedia.org/wiki/File:231105-1_TSMC_Fab_21_construction.jpg) — Photo: Hunter Trick, 2023-11-05, Wikimedia Commons, CC BY-SA 4.0. Este texto usa la versión cacheada en `public/article-images/economy/tsmc-fab21-arizona-2023.webp`.
+- **Conjunto de plantas de TSMC en el Parque Científico de Hsinchu**: [TSMC fabs in Hsinchu 01](https://commons.wikimedia.org/wiki/File:TSMC_fabs_in_Hsinchu_01.jpg) — Photo: Tseng Cheng-Hsun, 2020-01-02, Wikimedia Commons, CC BY 2.0. Este texto usa la versión cacheada en `public/article-images/economy/tsmc-fabs-hsinchu-2020.webp`.
+- **Mapa de rutas de la expansión exterior de la cadena de IA**: diagrama conceptual SVG elaborado por Taiwan.md Contributors, CC BY-SA 4.0, almacenado en `public/article-images/technology/ai-supply-chain-overseas-footprint.svg`. Sirve para explicar las múltiples rutas y las fuerzas de los distintos actores en la salida al exterior de la cadena taiwanesa de hardware de IA, y no representa la distribución completa de empresas ni proporciones de capacidad.
+
+## Referencias
+
+[^1]: [AP: Nvidia plans to manufacture AI chips in the US for the first time](https://apnews.com/article/nvidia-ai-artificial-intelligence-tariffs-dcf48112ce98a7b61bfd32157359ce2f) — Reportaje de AP sobre la producción de chips Blackwell y superordenadores de IA de NVIDIA en Estados Unidos, que menciona TSMC Phoenix, Foxconn Houston, Wistron Dallas y la colaboración de SPIL / Amkor en empaquetado y pruebas en Arizona.
+[^2]: [AP: OpenAI and Taiwan’s Foxconn to partner in AI hardware design and manufacturing in the US](https://apnews.com/article/openai-foxconn-ai-hon-taiwan-china-b022977e34c23f5f3ddf7522817accfe) — Reportaje de AP sobre la alianza de OpenAI y Foxconn para diseñar y fabricar racks para centros de datos de IA, con productos que incluyen cableado, equipos de red y sistemas de alimentación, y con mención de la distribución de instalaciones de Foxconn en Estados Unidos.
+[^3]: [MySA: Plans move forward on $115M electronics factory in Plano](https://www.mysanantonio.com/business/article/delta-electronics-plano-20254702.php) — Reportaje sobre la ampliación por parte de Delta Electronics de sus instalaciones de fabricación y oficinas en Plano (Texas), que ordena sus centros de I+D y fabricación existentes, la escala posterior del campus y su posicionamiento de fabricación local en Estados Unidos.
+[^4]: [Times of India: Delta Electronics pushes for capacity expansion](https://timesofindia.indiatimes.com/city/chennai/delta-electronics-pushes-for-capacity-expansion/articleshow/123853472.cms) — Reportaje sobre la ampliación de la planta india de Delta Electronics en Krishnagiri, que explica la demanda de clientes de telecomunicaciones, centros de datos, vehículos eléctricos e industria, así como su despliegue de cadena localizada en la India.
+[^5]: [TSMC Arizona](https://www.tsmc.com/static/abouttsmcaz/index.htm) — Página oficial de TSMC sobre Arizona, que explica la escala de la inversión en Phoenix, las seis fábricas de obleas, las dos instalaciones de empaquetado avanzado, el calendario de N4/N3/N2/A16 y los planes de reciclaje de agua.
+[^6]: [AP: TSMC to make advanced AI computer chips in Japan](https://apnews.com/article/semiconductors-tsmc-japan-taiwan-ai-11256f2bfde73ca23d08331ad138d6d5) — Reportaje de AP sobre el plan de TSMC de producir chips de 3 nanómetros en su segunda planta de Kumamoto (Japón), que ordena la seguridad económica japonesa y la demanda de IA, robótica y conducción autónoma.
+[^7]: [ESMC: European Semiconductor Manufacturing Company](https://www.esmc.eu/) — Web oficial de ESMC, que explica que se trata de una empresa conjunta de TSMC, Bosch, Infineon y NXP para levantar una fábrica de obleas en Dresde (Alemania) que dé servicio a los mercados europeos de industria, IoT, comunicaciones y automoción.
+[^8]: [AP: Biden administration announces $6.6 billion to ensure leading-edge microchips are built in the US](https://apnews.com/article/microchips-biden-commerce-arizona-taiwan-semiconductor-manufacturing-7e627aad5b9ce5a715aa4d660ad86149) — Reportaje de AP sobre las ayudas de la CHIPS and Science Act estadounidense a la ampliación de TSMC en Arizona, que explica cómo entiende el gobierno de Estados Unidos la fabricación de chips de vanguardia como un asunto de seguridad de la cadena y de seguridad nacional.
+[^9]: [TIME: lea la entrevista completa al presidente de Taiwán Lai Ching-te](https://time.com/6986139/taiwan-president-lai-ching-te-interview-mandarin/) — En la transcripción completa en chino publicada por TIME, Lai Ching-te habla de los semiconductores como industria de división global del trabajo y de cómo ve el gobierno el despliegue de TSMC y otras empresas de semiconductores en Estados Unidos, Japón y Europa.
+[^10]: [The Verge: The new silicon valley (literally)](https://www.theverge.com/features/825207/semiconductor-chip-manufacturing-new-silicon-valley) — Reportaje sobre el empleo, el desarrollo local, los recursos hídricos, el medio ambiente y las polémicas sobre seguridad laboral que trae la expansión del clúster de semiconductores de Arizona; sirve para equilibrar la mirada de la sociedad local sobre las fábricas en el extranjero.

--- a/knowledge/es/Technology/taiwan-electricity-and-semiconductors.md
+++ b/knowledge/es/Technology/taiwan-electricity-and-semiconductors.md
@@ -1,0 +1,195 @@
+---
+translatedFrom: 'Technology/台灣的電力與半導體.md'
+sourceCommitSha: '250410ea'
+sourceContentHash: 'sha256:739eb8c857d7b377'
+sourceBodyHash: 'sha256:814f9eb8b97792cf'
+translatedAt: '2026-07-23T21:20:00+08:00'
+lang: 'es'
+title: 'La electricidad y los semiconductores en Taiwán: la factura eléctrica de la montaña sagrada que protege al país'
+description: 'La baza internacional de los semiconductores taiwaneses se apoya en un sistema eléctrico muy concreto. Las fábricas de obleas de vanguardia, la litografía EUV, el empaquetado avanzado, las pruebas de servidores de IA y los centros de datos necesitan un suministro estable, con pocas interrupciones y capaz de crecer. Este texto no convierte el consumo eléctrico de los semiconductores en una simple denuncia ecologista, sino que lo devuelve al pulso de la cadena de suministro: el mundo necesita que Taiwán fabrique los chips de IA, y Taiwán también debe responder a quién asume el coste eléctrico, la presión de las emisiones y el riesgo para la seguridad energética.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'semiconductores'
+  - 'electricidad'
+  - 'energía'
+  - 'TSMC'
+  - 'hardware de IA'
+  - 'cadena de suministro'
+subcategory: 'Semiconductores y hardware'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Conectar la «montaña sagrada que protege al país» hacia abajo con la red eléctrica, para que el lector vea la factura de infraestructura que hay detrás de la baza de los semiconductores.'
+  whats_excluded: 'No convertir el texto en un alegato de una sola postura sobre la energía nuclear, la energía verde o la política de tarifas.'
+  where_it_hedges: 'Tratar a la vez la estabilidad del suministro, la electricidad baja en carbono, la competitividad industrial, el coste público y la seguridad energética.'
+  whos_pushing_back: 'La industria de los semiconductores y de la IA necesita electricidad estable y baja en carbono, pero la sociedad también preguntará por el coste, el riesgo, la carga ambiental y la equidad en el reparto.'
+image: '/article-images/nature/maanshan-nuclear-plant-nan-wan-2014.webp'
+imageCredit: 'M. Weitzel / Wikimedia Commons'
+imageLicense: 'CC BY-SA 3.0'
+---
+
+# La electricidad y los semiconductores en Taiwán: la factura eléctrica de la montaña sagrada que protege al país
+
+> **Resumen en 30 segundos:** Los semiconductores no se hacen solo con ingenieros, fábricas de obleas y equipos de vanguardia, sino también con una red eléctrica estable. Cuanto más potentes son los chips de IA, más electricidad necesitan la fabricación de obleas, el empaquetado avanzado, las pruebas de servidores y los centros de datos. Así es como Taiwán ha ganado una baza en la cadena de suministro global, y así también ha metido en una misma factura las tarifas eléctricas, la importación de combustible, las energías renovables, las emisiones de carbono y el riesgo de apagones.
+
+25.550 millones de kilovatios hora.
+
+Es el consumo eléctrico de TSMC en 2024 según el medio tecnológico Tom's Hardware. Aquel artículo hablaba en realidad de cómo TSMC está reduciendo el consumo punta de las máquinas de litografía EUV, y mencionaba que el ahorro en las herramientas EUV podría suponer 190 millones de kilovatios hora menos de aquí a 2030. Pero ese mismo texto colocaba al lado la escala del consumo anual de TSMC: 25.550 millones de kilovatios hora.[^1]
+
+Al poner esas dos cifras juntas, la imagen cambia. Cuando la gente habla de la «montaña sagrada que protege al país», suele pensar en TSMC, en los procesos de vanguardia, en la cotización bursátil, en las exportaciones y en la baza diplomática. Los 25.550 millones de kilovatios hora devuelven esa misma montaña al suelo, a la red eléctrica, al combustible, a las centrales, a los contratos de energía renovable y a cada una de las facturas.
+
+Una fábrica de obleas de vanguardia no puede quedarse sin luz. Las máquinas de litografía EUV, la climatización de las salas limpias, el suministro de productos químicos, el tratamiento de gases de escape, los sistemas de agua ultrapura, los equipos de medición, los centros de datos y los sistemas de respaldo tienen que funcionar de forma estable. Que los chips puedan producirse en serie depende, al final, de que la electricidad llegue de manera estable.
+
+Por eso el consumo eléctrico de los semiconductores no debería escribirse solo como «TSMC gasta muchísima luz».
+
+La pregunta más precisa es esta: cuando Taiwán acoge la demanda mundial de chips de IA y de fabricación de vanguardia, ¿quién proporciona esa electricidad estable? ¿Quién asume la importación de combustible y la presión de las emisiones? ¿Quién paga el coste cuando se ajustan las tarifas? ¿Quién asume el riesgo cuando hay un apagón o la red se vuelve inestable?
+
+![Vista exterior de la Tercera Central Nuclear junto a Nanwan, en Hengchun (condado de Pingtung): los edificios, la chimenea y la línea de costa en un mismo encuadre, una escena donde se cruzan las opciones eléctricas de Taiwán y el entorno local.](/article-images/nature/maanshan-nuclear-plant-nan-wan-2014.webp)
+
+_La Tercera Central Nuclear (central de Maanshan) en Hengchun, condado de Pingtung. La demanda eléctrica de la IA y de los semiconductores ha devuelto al espacio público el debate sobre la energía nuclear, el gas, las renovables y la resiliencia de la red. Photo: M. Weitzel. CC BY-SA 3.0 via Wikimedia Commons._
+
+## La demanda de IA acaba volviendo al contador
+
+La IA generativa parece un servicio en la nube, pero en realidad son máquinas calculando.
+
+Un chip de IA, desde el diseño hasta su puesta en marcha, pasa por la fabricación de obleas, el empaquetado avanzado, las pruebas, la placa base, la alimentación, la disipación, el rack y el centro de datos. Cada tramo consume electricidad. La fabricación inicial la consume porque los equipos de proceso y el entorno limpio no pueden interrumpirse. El empaquetado posterior la consume porque la integración de chips y memoria es cada vez más compleja. Los servidores de IA la consumen porque las GPU y los aceleradores convierten grandes cantidades de electricidad en cómputo, y también en calor.
+
+Por tanto, la cadena de suministro de la IA no es solo esa palabra abstracta, «cómputo». El cómputo tiene facturas eléctricas, red, grupos de gas, compras de energía renovable y también emisiones de carbono.
+
+El sentido de esos 25.550 millones de kilovatios hora del principio no está en impresionar, sino en recordar al lector que la ventaja de los procesos de vanguardia se sostiene sobre una entrada de energía enorme y continua. Las herramientas EUV pueden ahorrar energía, las salas limpias pueden optimizarse, los sistemas de planta pueden ajustarse. Pero mientras la demanda de IA siga empujando la capacidad hacia arriba, la presión sobre el total no desaparecerá automáticamente porque un equipo concreto gaste menos.
+
+Esto también distingue la era de la IA de la industria electrónica del pasado. Antes, al hablar de la manufactura taiwanesa se hablaba de eficiencia fabril, densidad de proveedores, cultura de los ingenieros y plazos de entrega. Ahora hay que añadir una pregunta más: ¿puede Taiwán conectar de forma estable la demanda mundial de cómputo a su propia red eléctrica?
+
+Si la respuesta es afirmativa, la electricidad forma parte del crédito de Taiwán en la cadena de suministro. Si la respuesta empieza a tambalearse, los clientes extranjeros meterán en la misma hoja de cálculo la ubicación de la fabricación, el acceso a las renovables, el riesgo de apagones y la geopolítica.
+
+## La estabilidad importa más que el precio bajo
+
+Cuando la gente corriente habla de electricidad, piensa primero en el precio. Pero para una fábrica de obleas la estabilidad puede importar más que la tarifa a secas.
+
+Muchos pasos de la fabricación de obleas deben realizarse de forma continua en un entorno altamente controlado. Fluctuaciones de tensión, microcortes o una calidad de suministro inestable pueden provocar paradas de equipos, productos desechados o interrupciones en la planificación. Para un hogar, unos minutos sin luz son una molestia; para una fábrica de obleas de vanguardia, unos minutos pueden ser un lote de obleas, un tramo de rendimiento e incluso la confianza de un cliente.
+
+Este es también uno de los puntos más ignorados del pulso de la cadena de suministro. Los clientes extranjeros necesitan a Taiwán porque Taiwán puede entregar chips de forma prolongada, estable y puntual. El suministro eléctrico estable se convierte así en parte del crédito taiwanés.
+
+Y al revés: cuando los clientes internacionales y los gobiernos evalúan si trasladar parte de la fabricación a Estados Unidos, Japón o Europa, la electricidad también entra en la cuenta. No es solo el riesgo geopolítico lo que impulsa la construcción de fábricas en el extranjero; el suministro energético, la estructura tarifaria, el acceso a las renovables y la resiliencia de la red también forman parte del cálculo.
+
+Aquí hay un matiz delicado. Parte de la competitividad histórica de Taiwán venía de una electricidad estable y relativamente asequible. Pero cuando la transición energética, los precios del combustible, las finanzas de Taipower, las tarifas industriales y la presión por descarbonizar suben a la vez, esa base ya no puede darse por descontada.
+
+Lo que la industria de los semiconductores quiere es electricidad «barata, estable, baja en carbono y ampliable». El problema es que resulta muy difícil cumplir las cuatro condiciones al mismo tiempo. La electricidad barata puede abaratar los costes de las empresas, pero hacer que Taipower o la ciudadanía asuman más; la electricidad estable puede requerir capacidad de reserva, grupos de gas o almacenamiento; la electricidad baja en carbono requiere renovables, nuclear u otras soluciones; y la ampliable implica suelo, red, puertos, terminales de recepción y aceptación local.
+
+Por eso el problema eléctrico de los semiconductores es a la vez de ingeniería, financiero y político.
+
+## La energía verde se va convirtiendo en condición de los pedidos
+
+El consumo eléctrico de los semiconductores tiene además otra capa de presión: los compromisos de descarbonización de los clientes.
+
+Apple, NVIDIA, las grandes empresas de la nube y las marcas globales afrontan la presión de las emisiones de su cadena de suministro. No solo miran si TSMC puede fabricar el chip, sino también de dónde viene la electricidad del proceso de producción. Cuando un cliente se compromete al cero neto o a RE100, el consumo eléctrico del proveedor deja de ser un coste interno y pasa a formar parte de la huella de carbono del producto del cliente.
+
+Esto somete a los semiconductores taiwaneses a una doble exigencia: por un lado ampliar producción, por otro conseguir más electricidad baja en carbono. Ampliar aumenta el consumo, y descarbonizar exige transformar la estructura eléctrica. Cuando ambas cosas ocurren a la vez, la dificultad ya no se resuelve con el ahorro energético de una empresa.
+
+Tom's Hardware, citando un reportaje de DigiTimes, señala que la Asociación de la Industria de Semiconductores de Taiwán advirtió al gobierno sobre la urgencia de la estabilidad eléctrica y del suministro de renovables; el reportaje menciona además que en 2024 la proporción de renovables en el consumo de las fábricas de obleas taiwanesas seguía por debajo de lo que exige la senda RE100.[^2] Estos reportajes no deberían leerse como una simple queja contra el gobierno, sino devolverse al contexto de la cadena de suministro: si los clientes quieren chips bajos en carbono, Taiwán debe tener suficiente electricidad baja en carbono.
+
+Por eso la «energía verde» no es un eslogan bonito dentro de los semiconductores. Poco a poco se convierte en condición de los pedidos, condición financiera y condición diplomática.
+
+![Parque eólico marino frente a la costa de Miaoli, con los aerogeneradores blancos alineados sobre el mar, una escena representativa de la expansión de las renovables en Taiwán.](/article-images/nature/hai-neng-offshore-wind-farm-2024.webp)
+
+_Parque eólico marino frente a Miaoli. Cuando los clientes de semiconductores exigen una cadena de suministro baja en carbono, el consumo de las fábricas de obleas acaba conectándose con los parques eólicos, la conexión a red, el almacenamiento y la comunicación con las comunidades. Imagen: Ministerio de Asuntos Económicos de la República de China, CC BY-SA 4.0 via Wikimedia Commons._
+
+Si Taiwán logra ofrecer un entorno de fabricación bajo en carbono y estable, su carácter insustituible será aún mayor. Si Taiwán solo puede ofrecer fabricación de alta densidad pero no logra seguir el ritmo de las exigencias de emisiones de sus clientes, parte de los pedidos podría desplazarse a otras regiones, o exigirse a las empresas taiwanesas que construyan fábricas en el extranjero para obtener allí electricidad baja en carbono.
+
+## La mejora de eficiencia no compensa automáticamente el crecimiento del total
+
+Las empresas, por supuesto, ahorran energía. Las máquinas de litografía EUV, la climatización de las salas limpias, los sistemas de planta, los equipos de proceso y los centros de datos tienen margen de mejora.
+
+Pero la mejora de la eficiencia y la presión sobre el total son dos cosas distintas.
+
+Si cada equipo consume menos, pero el número de equipos, la capacidad de obleas, la capacidad de empaquetado avanzado, las pruebas de servidores de IA y la demanda de centros de datos crecen más deprisa, el consumo total seguirá subiendo. Ese es el dilema de la cadena de suministro de la IA: el progreso técnico a menudo mejora la eficiencia y, al mismo tiempo, genera una demanda mayor.
+
+El estudio de Roussilhe y otros, con 16 fabricantes taiwaneses de componentes electrónicos como muestra, señala que entre 2015 y 2020 las emisiones de gases de efecto invernadero, la energía final, el consumo eléctrico y el uso de agua de las empresas de la muestra aumentaron con el crecimiento de la producción, y plantea el riesgo del carbon lock-in.[^3] Esta advertencia es importante: la mejora industrial no trae automáticamente una reducción de la carga ambiental.
+
+Dicho de otro modo, Taiwán no puede preguntarse solo «si cada oblea consume menos electricidad». También debe preguntar: «después de que toda la industria amplíe su escala, ¿cómo se gestionan el consumo total, las emisiones totales, la importación total de combustible y la carga sobre la red?».
+
+Esta pregunta no desaparecerá porque Taiwán sea importante. Precisamente porque Taiwán es importante, necesita afrontarla de frente.
+
+## ¿De quién es la factura eléctrica?
+
+Los semiconductores traen exportaciones, salarios, impuestos, bolsa y visibilidad internacional. Esos beneficios son reales.
+
+Pero la factura eléctrica también lo es.
+
+Una parte la pagan las empresas, y se refleja en las tarifas, la inversión en equipos, la compra de renovables y la gestión energética. Otra parte la asume la sociedad en conjunto, y se refleja en la construcción de la red, la política tarifaria, la importación de combustible, la contaminación del aire y las emisiones, la ubicación de las centrales, las líneas de transmisión y la aceptación local de las instalaciones energéticas.
+
+Aquí no hay respuestas sencillas. Si las tarifas son demasiado bajas, puede trasladarse el coste industrial a la ciudadanía o a las finanzas de Taipower; si suben demasiado rápido, puede afectar a la competitividad industrial y a la carga de los hogares. Si las renovables se expanden demasiado despacio, aumenta la presión descarbonizadora sobre las empresas; si se expanden demasiado rápido, pueden chocar con el suelo, la pesca, el paisaje y la política local.
+
+«La factura eléctrica de la montaña sagrada» es, por tanto, un problema público: ¿con qué mezcla energética quiere Taiwán sostener su posición en la cadena de suministro global?
+
+Lo que ve el gobierno es la seguridad energética y la competitividad industrial. Lo que ven las empresas son los costes, los plazos, las exigencias de los clientes y las opciones de fabricar fuera. Lo que ve la ciudadanía son las tarifas, la contaminación, los apagones, las obras locales y la calidad de vida. Y lo que ven los clientes extranjeros es esto: ¿podrá Taiwán seguir suministrando de forma estable durante la próxima década, y además cumplir con las exigencias de una cadena baja en carbono?
+
+Un mismo kilovatio hora es una cosa distinta según quién lo mire. Para la fábrica es capacidad; para el hogar, factura; para el gobierno, política energética; para el cliente extranjero, riesgo en la cadena de suministro.
+
+## Las empresas compran energía verde, pero la sociedad sigue teniendo que construir el sistema
+
+Las grandes empresas de semiconductores pueden firmar contratos de compraventa de electricidad, comprar certificados de energía renovable, invertir en equipos eficientes y también exigir a sus proveedores que reduzcan emisiones. Todas estas medidas son necesarias, porque los clientes internacionales rastrean las emisiones de la cadena hacia arriba.
+
+Pero que las empresas compren energía verde no equivale a que el problema social se resuelva solo.
+
+Primero, la energía verde tiene que poder generarse de verdad. La eólica marina, la fotovoltaica, la geotermia, la biomasa u otras fuentes bajas en carbono necesitan suelo, espacio marítimo, conexión a red, almacenamiento, mantenimiento y coordinación local. Las empresas pueden firmar contratos de compra, pero las instalaciones de generación y la red siguen teniendo que sostenerlas la sociedad entera.
+
+![Grandes paneles solares instalados en el tejado del área de servicio de Xihu, en la autopista nacional, con los carriles y los edificios del área de servicio debajo, mostrando cómo la fotovoltaica entra en la infraestructura cotidiana.](/article-images/nature/xihu-service-area-solar-2014.webp)
+
+_Paneles solares en el tejado del área de servicio de Xihu. Antes de que las empresas compren energía verde, la sociedad debe haber construido primero los sistemas de generación, suelo, conexión a red y mantenimiento. Photo: lienyuan lee. CC BY 3.0 via Wikimedia Commons._
+
+Segundo, la energía verde tiene un problema de tiempo. De día hay mucha solar, pero la fábrica de obleas sigue funcionando de noche; cuando hace viento hay mucha eólica, pero cuando no lo hay sigue habiendo que cubrir con otras fuentes o con almacenamiento. Lo que los semiconductores necesitan es electricidad estable en cada instante, no solo haber comprado suficiente energía verde en el total anual.
+
+Tercero, la energía verde también tiene un problema de reparto. Si las empresas con más dinero y más capacidad de negociación acceden primero a la electricidad baja en carbono, ¿qué pasa con las demás industrias, las pymes y los hogares? Si la exportación tecnológica puede trasladar el coste a los clientes globales mientras los vecinos asumen la red, las subestaciones, los parques eólicos, las plantas solares y los ajustes tarifarios, la confianza social se vuelve frágil.
+
+Por eso el problema de la energía verde en los semiconductores taiwaneses no puede resolverlo solo el departamento de sostenibilidad de una empresa. Necesita que la política energética, el mercado eléctrico, la gobernanza local y la transformación industrial avancen a la vez. La capacidad de compra de las empresas puede empujar el mercado, pero detrás del mercado sigue haciendo falta infraestructura pública.
+
+## La polémica nuclear también vuelve arrastrada por la IA
+
+El debate eléctrico taiwanés difícilmente puede esquivar la energía nuclear.
+
+En 2025, tras la parada del último reactor nuclear en funcionamiento de Taiwán, la cuestión de si prolongar su vida útil volvió al debate público mediante un referéndum. AP informó de que, aunque en el referéndum de 2025 sobre la prórroga de la Tercera Central los votos a favor superaron claramente a los votos en contra, no se alcanzó el umbral de aprobación; quienes apoyan la nuclear sostienen que ayuda a rebajar las tarifas y a sostener el crecimiento del consumo que traen las aplicaciones de IA.[^4]
+
+La polémica nuclear no necesita simplificarse aquí en una toma de posición. Lo que de verdad merece atención es esto: la IA y los semiconductores han vuelto a convertir la energía en una cuestión de capacidad nacional.
+
+Quienes apoyan la nuclear dirán que Taiwán necesita electricidad estable y baja en carbono y no puede depender solo del gas importado y de unas renovables en crecimiento. Quienes se oponen dirán que los residuos nucleares, el riesgo sísmico, el coste del desmantelamiento y la seguridad local no pueden quedar aplastados por la fiebre de la IA. Detrás de la discusión, ambos bandos responden en realidad a la misma pregunta: ¿con qué tipo de riesgo quiere Taiwán pagar su posición en la cadena de suministro global?
+
+Esta pregunta no puede dejarse solo en manos de TSMC o de Taipower. Es una elección de toda la sociedad.
+
+## Las bazas de la cadena de suministro necesitan infraestructura
+
+El valor de Taiwán en la cadena de los semiconductores no viene solo de TSMC, sino de toda una sociedad de ingeniería: parques científicos, proveedores, ingenieros, empaquetado y pruebas, productos químicos, logística, agua y electricidad, y coordinación gubernamental.
+
+La electricidad es la infraestructura más básica de esa sociedad de ingeniería.
+
+Cuando el mundo dice «Taiwán es insustituible», está dependiendo también de la red eléctrica taiwanesa. Cuando los gobiernos extranjeros impulsan que TSMC construya fábricas en Estados Unidos, Japón o Alemania, están intentando también trasladar parte de la factura eléctrica a su propio territorio. Eso muestra más bien que el valor de Taiwán es tan alto que ningún país quiere apostar todo el riesgo a una misma isla.
+
+Lo que Taiwán tiene que afrontar de verdad a continuación es un problema institucional más difícil: si los semiconductores son la baza internacional de Taiwán, ¿con qué sistema energético está Taiwán dispuesto a mantenerla?
+
+Una buena respuesta no será solo «construir más centrales» o «comprar más energía verde». Incluye también la resiliencia de la red, el almacenamiento, la respuesta de la demanda, las tarifas industriales, la seguridad de las importaciones energéticas, la comunicación con las comunidades, la conexión a red de las renovables y cómo las industrias intensivas en energía explican a la sociedad sus costes y sus aportaciones.
+
+Los semiconductores han hecho que el mundo necesite a Taiwán. La electricidad le recuerda a Taiwán que ser necesitado no es gratis.
+
+## Lecturas complementarias
+
+- [Cadena de suministro de hardware de IA](/technology/AI硬體供應鏈) — cómo convierte Taiwán la demanda en la nube en máquinas listas para enviar.
+- [El agua de los semiconductores y los recursos hídricos de Taiwán](/technology/半導體用水與台灣水資源) — cómo entra la fabricación de obleas en los embalses, las sequías y la gestión del agua regenerada.
+- [Fábricas de la cadena de IA en el extranjero](/technology/AI供應鏈海外設廠) — cómo ata la construcción de fábricas fuera la cadena de suministro, la electricidad y la infraestructura local.
+- [Empresas taiwanesas: TSMC](/economy/台灣企業：台積電) — cómo el modelo de fundición pura se convirtió en el cuello de botella mundial de los chips de vanguardia.
+
+## Fuentes de imágenes
+
+- **Exterior de la Tercera Central Nuclear (Maanshan, Hengchun, Pingtung; hero / interior)**: [Maanshan Nuclear Power Plant, Nan Wan](https://commons.wikimedia.org/wiki/File:Maanshan_Nuclear_Power_Plant,_Nan_Wan.jpg) — Photo: M. Weitzel, Wikimedia Commons, CC BY-SA 3.0. Este texto usa la versión cacheada en `public/article-images/nature/maanshan-nuclear-plant-nan-wan-2014.webp`.
+- **Parque eólico marino frente a Miaoli**: [Hai Long offshore wind farm](https://commons.wikimedia.org/wiki/File:Hai_Long_offshore_wind_farm.jpg) — Wikimedia Commons, CC BY-SA 4.0. Este texto usa la versión cacheada en `public/article-images/nature/hai-neng-offshore-wind-farm-2024.webp`.
+- **Paneles solares en el tejado del área de servicio de Xihu**: [Xihu Service Area solar panels](https://commons.wikimedia.org/wiki/File:Xihu_Service_Area_solar_panels.jpg) — Photo: lienyuan lee, Wikimedia Commons, CC BY 3.0. Este texto usa la versión cacheada en `public/article-images/nature/xihu-service-area-solar-2014.webp`.
+
+## Referencias
+
+[^1]: [Tom's Hardware: TSMC reduces peak power consumption of EUV tools by 44%](https://www.tomshardware.com/tech-industry/semiconductors/tsmc-reduces-peak-power-consumption-of-euv-tools-by-44-percent-company-to-save-190-million-kilowatt-hours-of-electricity-by-2030) — Informa del plan de ahorro energético de TSMC en EUV, la escala de su consumo total y la proporción de ahorro de las herramientas; sirve para explicar la coexistencia de la mejora de eficiencia y la presión sobre el total.
+[^2]: [Tom's Hardware: TSMC-led semiconductor association warns of power supply pressure](https://www.tomshardware.com/tech-industry/tmsc-led-semiconductor-association-begs-taiwan-government-for-clean-green-energy-as-demand-skyrockets-fabs-are-struggling-to-keep-up-with-power-needs) — Informa de la advertencia de la Asociación de la Industria de Semiconductores de Taiwán sobre la estabilidad eléctrica y el suministro de renovables, y recoge RE100, la demanda de energía verde de las fábricas de obleas y el riesgo de traslado al extranjero.
+[^3]: [Roussilhe et al.: From Silicon Shield to Carbon Lock-in?](https://arxiv.org/abs/2209.12523) — Estudia la huella ambiental de 16 fabricantes taiwaneses de componentes electrónicos entre 2015 y 2020, y plantea que la energía, el agua y las emisiones aumentan con el crecimiento de la producción, además del riesgo de carbon lock-in.
+[^4]: [AP: Taiwan lawmakers survive recall vote; nuclear power referendum fails](https://apnews.com/article/taiwan-recall-vote-nuclear-referendum-2efa596845858a7e4bd89e0c23af39b8) — Reportaje de AP sobre el resultado del referéndum de 2025 acerca de la prórroga de la Tercera Central Nuclear de Taiwán, que explica también cómo incorporan quienes apoyan la nuclear las tarifas y la demanda eléctrica de la IA a su argumentación.


### PR DESCRIPTION
接續 #1237（ja）與 #1239（ko）。這個 PR 把 **zh SSOT 相對 es 僅存的 10 篇真實缺口**全部補上，es 對 zh 的文章覆蓋率從 843/853 補到 **853/853**。

| zh source | → es |
|---|---|
| `Culture/Shopping Design.md` | `es/Culture/shopping-design.md` |
| `Music/大港開唱.md` | `es/Music/megaport-festival.md` |
| `Music/閃靈.md` | `es/Music/chthonic.md` |
| `People/大支.md` | `es/People/dwagie.md` |
| `People/杜潘芳格.md` | `es/People/tu-pan-fangke.md` |
| `People/林昶佐.md` | `es/People/freddy-lim.md` |
| `Society/台北吸菸室.md` | `es/Society/taipei-smoking-room.md` |
| `Technology/AI硬體供應鏈.md` | `es/Technology/ai-hardware-supply-chain.md` |
| `Technology/AI供應鏈海外設廠.md` | `es/Technology/ai-supply-chain-overseas-manufacturing.md` |
| `Technology/台灣的電力與半導體.md` | `es/Technology/taiwan-electricity-and-semiconductors.md` |

## 誰翻的

- **AI**：Claude Opus 4.8，由 [@hansai-art](https://github.com/hansai-art) 驅動。
- **母語者**：❌ 我不是西班牙文母語者。西文語感請務必人工複審，特別是〈平安戲〉的詩行、Shopping Design 那篇的長 rationale，以及台北吸菸室裡六種 `tw-*` fence 的標籤。
- zh 原文理解無虞（繁中母語）；西文為 AI 產出 + 逐項結構驗證。

## 品質自檢（10/10 全過）

下表由腳本產生，非手填。每一項都與原文完全相等：

| 檔案 | ratio | `##` | `[^N]` 引用 | 腳註定義 | `http` | 非空行 |
|---|---|---|---|---|---|---|
| megaport-festival | 2.69 | 7=7 | 14=14 | 10=10 | 19=19 | 51=51 |
| taiwan-electricity-and-semiconductors | 3.33 | 11=11 | 4=4 | 4=4 | 7=7 | 85=85 |
| dwagie | 3.09 | 11=11 | 26=26 | 9=9 | 13=13 | 74=74 |
| ai-hardware-supply-chain | 3.04 | 11=11 | 10=10 | 10=10 | 12=12 | 95=95 |
| ai-supply-chain-overseas-manufacturing | 3.11 | 13=13 | 11=11 | 10=10 | 12=12 | 103=103 |
| chthonic | 2.89 | 12=12 | 21=21 | 16=16 | 29=29 | 88=88 |
| tu-pan-fangke | 3.05 | 11=11 | 60=60 | 15=15 | 24=24 | 124=124 |
| freddy-lim | 2.52 | 12=12 | 32=32 | 19=19 | 57=57 | 128=128 |
| taipei-smoking-room | 3.00 | 11=11 | 48=48 | 43=43 | 56=56 | 158=158 |
| shopping-design | 2.78 | 8=8 | 38=38 | 26=26 | 32=32 | 117=117 |

其他檢查：

- `check-slug-consistency.py` → ✅ 3384 檔全部與 en sibling 對齊
- wikilink residue → **0**
- frontmatter → YAML 皆可解析，`translatedFrom` / `sourceCommitSha` / `sourceContentHash` / `sourceBodyHash` / `translatedAt` / `lang` 齊全

ratio 2.52–3.33，落在既有 es 語料實測區間（p10 2.54 / 中位數 3.23 / p90 3.82）內。**es 是 TRANSLATE_PROMPT 裡唯一寫對的區間**（2.0-4.0，92% 命中），所以這批不需要 #1238 的修正也會過。

## 翻譯決策，請 reviewer 特別看

1. **地名／專名沿用 es 既有慣例**（實測 300 檔：`Taiwán` 7233 次 > `Taiwan` 1420、`Taipéi` 2104 > `Taipei` 457、`Kaohsiung`、`Tainan`）；人名用羅馬拼音（`Tsai Ing-wen`、`Lai Ching-te` 為既有寫法），首次出現附漢字。
2. **章節標題沿用既有慣例**：`## Referencias`（707 次）、`## Lecturas complementarias`（147）、`## Fuentes de imágenes`（71）；30 秒 callout 用 `> **Resumen en 30 segundos:**`（343 次，最常見）。
3. **〈平安戲〉客語版原文保留未譯**（`tu-pan-fangke.md`），與既有 fr 譯本一致 —— 該段論點就是「同一倫理換一套口腔肌肉」，譯掉客語就毀了論證；華語版完整譯成西文。
4. **CC 姓名標示保留授權者原名**（如 `Photo: 國會無雙`），不改寫成英文名。
5. **wikilink 全部扁平化**，理由同 #1237。

## 順帶回報：一個容易誤判腳註的 regex 陷阱

我自己的檢查腳本一開始把 `[^6]: explicación` 這種**行中**的標記誤判成腳註定義，導致引用數少算。查了才發現這個寫法在既有 es 語料裡**已有 222 處**（`tsmc.md`、`sodagreen.md`、`cho-yun-hsu-bridging-historian.md` 等），在 zh 原文裡也有（`Nature/大安溪倚天劍.md`、`Nature/黃魚鴞.md`）—— 是正常慣例，不是問題。

但如果專案的腳註檢查（`article-health.py --check=footnote-format`）也用 `\[\^\w+\](?!:)` 這類 lookahead 來數引用，就會在這 222 處上誤判。正確的判準是「**只有行首**的 `[^N]:` 才是定義」。這個 PR 沒有動任何檢查腳本，只是回報，維護者可自行確認。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGZT4FDb3XyzKSYFCSYs48
