### PR TITLE
translate(fr): 補完 fr 相對 zh 的最後 10 篇缺口（fr 覆蓋率 → 100%）

### DIFF
--- a/knowledge/fr/Culture/shopping-design.md
+++ b/knowledge/fr/Culture/shopping-design.md
@@ -1,0 +1,233 @@
+---
+translatedFrom: 'Culture/Shopping Design.md'
+sourceCommitSha: '17b63fe8'
+sourceContentHash: 'sha256:5d83fb5eff7a2309'
+sourceBodyHash: 'sha256:da4269ea46f7ec77'
+translatedAt: '2026-07-24T04:05:00+08:00'
+lang: 'fr'
+title: 'Shopping Design : la revue qui apprend à acheter du design et qui, à la fin, vous demande de la distinguer elle-même'
+description: 'Fondée en 2006 avec le blanc pour thème de son premier numéro, « Shopping Design » a transformé en vingt ans le design, de substantif de salle d’exposition en verbe du quotidien : arpenter les boutiques et choisir des objets. Ce qu’elle a vraiment appris à Taïwan, c’est que « distinguer » peut s’entraîner comme une capacité ; et elle a étendu cette capacité jusqu’à un palmarès annuel de cent, une revue trimestrielle et un festival, ainsi qu’à la licence unique de sa maison mère, qui mentionne à la fois « édition de revues » et « services publicitaires ». Ainsi, la revue qui enseigne à distinguer finit par vous demander de la distinguer, elle.'
+date: 2026-07-13
+category: 'Culture'
+tags:
+  - 'design'
+  - 'Shopping Design'
+  - 'revue d’achat de design'
+  - 'Huang Wei-jung'
+  - 'Li Hui-chen'
+  - 'médias de style de vie'
+  - 'Business Next Media'
+  - 'éducation aux médias'
+subcategory: 'Design et médias'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-13
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/Shopping-Design.md'
+viewpoint_formed: true
+spine_type: '立體群像'
+image: '/article-images/culture/shopping-design-designbiz-2022-banner.jpg'
+imageCredit: 'Shopping Design／DesignBIZ Fest'
+imageLicense: 'Fair use (editorial commentary)'
+imageSource: 'https://designbiz.shoppingdesign.com.tw/2022/'
+rationale:
+  why_this_hook: 'La couverture blanche du premier numéro face à celle « acheter du design blanc » du numéro 100 : le même blanc onze ans plus tard, plus deux mots, « acheter » = transformer le goût en action = distinguer. Chaleureux, concret, avec du suspense (ce qu’il reste à distinguer, c’est la revue elle-même), sans « gotcha » préparé d’avance.'
+  whats_excluded: 'La ligne cachée de Liao Li-wen reste en note et n’est pas déployée ; les épisodes précis du podcast sont comprimés en « les tentacules s’étendent au son » ; la liste des intervenants de DesignBIZ est comprimée en « toute une rangée de dirigeants de marques », les fonctions passant en note ; de la liste des administrateurs de la maison mère, on ne conserve que la preuve de l’argument de service, « édition de revues + services publicitaires sous une même licence » ; les séances de Design+ et l’École d’économie du style sont fondues dans la phrase de l’« élargissement du mécanisme ».'
+  where_it_hedges: 'Pour le passage au trimestriel, deux dates sont écrites : « refonte de fin 2019 + premier numéro trimestriel, le 134, en mars 2020 ». Pour le Golden Tripod, on écrit « prix du rédacteur en chef, catégorie individuelle revues, 40e édition (2016) » et non « meilleur ». Le « ouvrir les cinq sens et savoir déguster » de Huang Wei-jung provient d’un publireportage de whisky marqué is_ads : on utilise donc du matériel vérifié de l’auteur lui-même et le publireportage est placé dans un paragraphe grisé comme cas d’étude, en signalant honnêtement qu’il s’agit de publicité. De « l’avant-garde de la naissance des revues molles », on ne cite que six caractères, et La Vie/PPAPER 2004 est raconté en phrase narrative. La citation de Chan Hung-chih est signalée comme « rapportée par Li Hui-chen ». De Little Things, on écrit « aucun nouveau numéro n’a été vu depuis ». De SD, on écrit « l’un des rares cas parvenus jusqu’à aujourd’hui ». Le nombre de catégories du BEST100 change chaque année (9/10/11) et ce n’est pas un prix officiel. Faute de vérification sur la direction éditoriale actuelle, on écrit « rédactrice Yi-hsin, rédactrice adjointe Ya-yun ».'
+  whos_pushing_back: 'L’objection la plus raisonnable aux médias de style de vie est de savoir s’ils emballent la consommation en vie idéale. Ce texte n’invente pas de critiques extérieures (aucune polémique publique vérifiable ne peut soutenir une telle accusation) ; il ne pose que des questions structurelles, rapporte l’autocritique du secteur (le rédacteur adjoint Pao Shu-ping sur l’éthique du publireportage) et décrit la structure industrielle (La Vie organise elle aussi ses propres prix ; elle partage avec Business Next Media une origine chez Chan Hung-chih), sans en faire une polémique déjà survenue ni écrire que quelqu’un aurait utilisé la théorie de Bourdieu pour critiquer SD.'
+relatedDiary:
+  - 2026-07-13-214351-manual
+---
+
+> **En 30 secondes :** Shopping Design (設計採買誌) est née en 2006 et ce qu’elle a fait pendant vingt ans, c’est transformer le « design » de terme professionnel de salle d’exposition en quelque chose de quotidien : comment les gens ordinaires arpentent les boutiques, choisissent des objets et lisent une ville. Mais ce qu’elle a vraiment appris à Taïwan, c’est que « distinguer » peut s’entraîner comme une capacité : voir en quoi ce blanc-ci diffère de ce blanc-là, et savoir dire pourquoi. Elle a élargi de plus en plus cette action de « distinguer pour vous », d’une revue à un palmarès annuel de cent, à des thèmes trimestriels et à un festival du design ; et elle l’a étendue jusqu’à la licence de sa maison mère, qui d’un côté indique l’édition de revues et de l’autre les services publicitaires. Ainsi, ce que cette revue qui enseigne à distinguer finit par vous demander de distinguer, c’est elle-même.
+
+## Deux couvertures blanches séparées par onze ans
+
+En décembre 2006, une revue intitulée « Shopping Design » paraissait sur les rayons des librairies taïwanaises, et le thème de son premier numéro était le design blanc. Onze ans plus tard, en mars 2017, elle atteignait le numéro 100 et la couverture revenait au blanc, sauf que le thème comportait cette fois deux mots de plus : « acheter du design blanc »[^1].
+
+Le même blanc, onze ans plus tard, et ce qui s’ajoute, c’est « acheter ». Ces deux mots ressemblent à un terme de marketing, mais ils cachent en réalité le cœur de toute la revue. Le blanc en soi n’est ni bon ni mauvais : un mur blanc, une feuille blanche, une chemise blanche ; la différence n’est pas dans le blanc, mais dans votre capacité à voir en quoi ce blanc-ci diffère de celui-là et pourquoi celui-ci mérite d’être rapporté chez vous. « Acheter » transforme quelque chose de très abstrait, le goût, en une action très concrète : distinguer.
+
+C’est ce que la revue fait depuis vingt ans sans que cela soit souvent dit clairement. Elle s’appelle « acheter du design » et semble vouloir vous apprendre à acheter des choses ; mais ce qu’elle vend réellement n’a jamais été telle chaise ou tel café, c’est la capacité de « distinguer » : voir la différence et savoir dire pourquoi. Et dès lors que vous l’exercez vingt ans en la suivant, vous découvrez que l’objet qu’il vous faut le plus sortir pour le distinguer, à la fin, c’est justement la revue elle-même.
+
+Ne demandez pas tout de suite pourquoi. Regardez d’abord de quelles deux mains est né à l’origine ce métier de « distinguer ».
+
+## Deux personnes venues de la publicité pour vous apprendre à regarder
+
+Celui qui l’a créée s’appelle Huang Wei-jung et il n’avait pas quarante ans cette année-là. Il ne venait pas d’une école de design mais de la publicité. « Mon premier emploi était rédacteur dans une agence de publicité, et c’était le dernier âge d’or de la publicité taïwanaise », se rappelait-il ainsi dans un entretien[^2]. Cette agence s’appelait Ideology et son supérieur direct était la directrice de création Hsu Shun-ying. « Le supérieur direct de mon premier emploi était Mme Hsu Shun-ying, directrice de création de l’agence Ideology. » Des années plus tard, il dira que cette expérience « l’influence encore aujourd’hui »[^2]. Ideology fut l’agence taïwanaise des années 1990 la plus habile à raconter des histoires avec des mots, et y être rédacteur revenait à exercer une adresse précise : prendre une chose ordinaire et savoir dire pourquoi elle ne l’est pas.
+
+À l’automne 1998, avec ses amis Ma Shih-fang, Yao Jui-chung, Hsu Yun-pin et Chen Kuang-ta, il réalise « Cent raisons de survivre à Taipei », publié par Locus Publishing. C’était un livre qui regardait et écrivait à nouveau les coins les plus quotidiens de la ville : les carrefours, les enseignes, la cuisine de rue, les bus. « Une chose aussi romantique, cela n’arrive qu’une fois dans une vie », écrira-t-il plus tard à propos de cette collaboration[^3]. Ce livre l’a fait connaître à beaucoup de gens et l’a transformé, de rédacteur publicitaire, en éditeur qui organise images et textes pour regarder à nouveau le monde à la place du lecteur. Il divise lui-même ses trente ans de création en trois segments : d’abord la rédaction publicitaire et l’écriture d’édition, puis l’édition de revues et l’intégration image-texte, enfin les missions mixtes de services créatifs[^2]. Shopping Design tombe justement au début du deuxième segment.
+
+Qu’il aille en 2006 faire une revue de design s’enchaîne donc assez naturellement. Mais la naissance de cette revue ne tenait pas qu’à des idées : il y avait aussi le commerce. Des années plus tard, il raconte lui-même que la véritable occasion, cet été-là, fut un message venu des réseaux de supérettes : « les ventes des revues "dures" sont désormais très difficiles à faire monter, essayez donc des sujets "mous" »[^4]. Les sujets « mous », ce sont la vie, les voyages, le design : légers à lire et beaux à regarder. Il appelle La Vie et PPAPER, fondées autour de 2004, « l’avant-garde de la naissance des revues molles », Shopping Design arrivant derrière cette vague[^4]. Qu’une revue apprenant à distinguer le design ait été dès le premier jour à la fois une idée et un commerce devant se vendre : cette double naissance deviendra, vingt ans plus tard, la question finale de tout ce texte.
+
+Pour comprendre au nom de quoi elle enseigne à distinguer, il faut voir ce que fait un rédacteur au quotidien. Le travail d’un rédacteur, à vrai dire, tient en trois gestes : mettre un tas de choses côte à côte pour les comparer, donner un nom à la différence, puis la mettre en pages pour que vous compreniez. Pour un numéro sur les cafés, il place côte à côte le filtre et l’expresso, la vieille maison et le blanc pur, l’espace où l’on boit seul et celui où l’on discute à plusieurs, et indique pour qui existent ce silence-ci et ce brouhaha-là, décomposant pour vous le mot « café » en plusieurs façons différentes de vivre. Un numéro sur les hôtels, un sur le blanc, un sur les « filtres » : chaque numéro choisit un sujet, déploie toute une catégorie de choses, pointe et dit « ceci mérite, parce que… », puis l’aligne page après page.
+
+Quand vous le feuilletez, vous croyez regarder de belles images, alors qu’en réalité on vous entraîne l’œil page après page. Avec le temps, vous découvrez qu’en faisant les boutiques vous vous mettez aussi à regarder ainsi : devant deux objets qui se ressemblent, vous vous arrêtez, vous voyez en quoi ils diffèrent, et vous savez dire pourquoi c’est justement l’un des deux qui vous a touché. Cette capacité de distinguer s’entraîne et se transmet ainsi, page après page. C’est ce que la revue vous vend vraiment sans vous le faire payer.
+
+Celle qui l’a dit le plus clairement, c’est Li Hui-chen, deuxième rédactrice en chef, qui a pris la suite de Huang Wei-jung. Elle a repris le poste en 2011 et l’a occupé jusqu’en 2017[^5]. Fait intéressant, elle aussi venait de la publicité : « Je remercie énormément la rédactrice en chef Hsu Li-wen de m’avoir laissée passer de déserteuse du monde publicitaire à une planificatrice avançant avec confiance », décrit-elle ainsi sa formation[^6]. Elle a traduit ce métier que Huang Wei-jung gardait caché dans la mise en pages en une phrase immédiatement audible : la revue doit rappeler au lecteur de vivre « avec conscience », de choisir et de consommer avec conscience. « Avec conscience », en langage courant, c’est distinguer : voir la différence et pouvoir aussi demander pourquoi. Elle a même rapporté une phrase de Chan Hung-chih : « Quand vous avez lu un certain livre, vous pouvez devenir une personne solitaire… »[^6] — plus on sait, moins on peut revenir à celui qui acceptait tout tel quel. En 2016, elle reçoit avec « Shopping Design » le prix du rédacteur en chef de la catégorie individuelle revues à la 40e édition des Golden Tripod Awards[^7] ; l’année suivante paraît le numéro 100, et le sujet qu’elle choisit est justement de revenir à ce blanc du premier numéro en y ajoutant les mots « acheter ».
+
+> **📝 Note de la curation**
+> Les deux rédactrices et rédacteurs en chef qui ont successivement dirigé cette revue se croisent en profondeur au même endroit : tous deux sont sortis de la publicité, et tous deux ont travaillé sous le même directeur éditorial de Locus Publishing, Liao Li-wen[^6]. Il ne faut pas y voir une filiation surinterprétée, mais cela révèle une chose : l’origine de la méthode par laquelle cette vague taïwanaise de « revues molles » a appris à regarder le design tient à un groupe de gens formés par la publicité, doués pour trouver un discours aux choses ordinaires, et qui ont transféré cette adresse de la vente à l’apprentissage de la distinction. Le métier de distinguer partage d’emblée les mêmes muscles que celui de vendre.
+
+Le regard qu’un rédacteur entraîne page après page tient, en principe, dans une seule revue. Ce que Shopping Design a fait pendant les vingt années suivantes, c’est élargir tour après tour cette action de « distinguer pour vous ».
+
+## Une revue ne suffit pas : palmarès, trimestriel, festival
+
+Un mensuel ne peut distinguer qu’un sujet à la fois. Elle a donc commencé à faire grandir cette même action sous d’autres formes.
+
+D’abord, le papier lui-même a changé de rythme. Fin 2019, Shopping Design est passée de mensuel à trimestriel, et le premier numéro trimestriel après la refonte fut le 134, paru en mars 2020[^8][^10]. Ce passage au trimestriel fut une division du travail délibérée : le site s’occupe du rapide, en suivant les actualités et expositions qui surviennent chaque jour dans le design ; le papier s’occupe du lent, en consacrant trois mois par trimestre à penser un sujet à fond. La rédaction l’explique ainsi : l’environnement change et les lecteurs aussi, et « s’il doit exister, nous voulons lui donner un peu plus de valeur », le rendre « utile, intéressant et signifiant »[^9].
+
+```tw-versus
+Revue trimestrielle papier | Site officiel
+Travail lent, un sujet complet par trimestre | Main rapide, à la poursuite de la fraîcheur des actualités du design
+Un numéro consacre trois mois à penser une seule chose à fond | Plusieurs mises à jour quotidiennes d’expositions et de marques
+Distinguer pour vous une question jusqu’au bout | Vous montrer d’abord ce qui est en train de se passer
+Source : rédaction de Shopping Design, entretien sur la refonte dans OKAPI (2019)
+```
+
+En ralentissant, le papier fait de chaque trimestre un sujet complet. En 2023 paraît « L’habitant idéal », qui demande quelle relation existe au fond entre une personne et l’espace où elle vit[^11] ; en 2024, « Nous collectionnons ce design », qui demande pourquoi quelqu’un veut garder un objet auprès de lui[^11]. Ce que fait chaque numéro, c’est distinguer jusqu’au bout et nommer clairement, au nom de tout un groupe de gens, une question de la vie que l’on ne sait pas formuler. C’est la version élargie du métier des débuts, sauf que le sujet est passé d’un objet à une manière de vivre.
+
+![Couverture de Shopping Design Vol.147, « L’habitant idéal » : un numéro trimestriel papier équivaut à un sujet de vie complet](/article-images/culture/shopping-design-vol147-the-stay-cover.webp)
+_Vol.147, « L’habitant idéal ». Après le passage au trimestriel, le papier ne pense à fond qu’une question par trimestre. (Fair use, editorial commentary)_
+
+Distinguer pour un groupe ne suffit pas non plus : elle se met ensuite à distinguer pour toute une année. Depuis 2012, Shopping Design organise chaque année le Taiwan Design BEST100, qui sélectionne cent personnes, faits et objets du design taïwanais de l’année pour en composer un palmarès annuel[^12]. La fonction de ce palmarès est de nommer et d’archiver une année entière de design taïwanais : ce qui mérite d’être retenu, ce qui a défini cette année-là. Celui de 2019 avait pour thème les « mots-clés de la force du design » et répartissait cent ensembles de personnes, faits et objets en neuf catégories, comme les personnalités de l’année, les faits de design de l’année ou les cent paysages humains[^13]. Il a fait pour toute une industrie ce que le premier numéro avait fait pour une couverture blanche : comparer, choisir, nommer. Après dix ans d’accumulation, cette pile de personnes, faits et objets sélectionnés est devenue l’index privé le plus proche d’une « histoire officielle » du design taïwanais : sans caution gouvernementale, mais pris en silence par tout un secteur comme coordonnée de l’année.
+
+```tw-note
+Précision
+Le Taiwan Design BEST100 est un prix médiatique créé et jugé par la rédaction de Shopping Design elle-même, et non un prix de design officiel organisé par le gouvernement. Le nombre de catégories fluctue même d’une année à l’autre : 9 en 2019, 11 en 2021 et 10 de 2024 à 2025 ; jusqu’au cadre de classification qui est repensé chaque année. Qu’un palmarès se disant « annuel » modifie chaque année jusqu’à sa propre ossature montre justement qu’il ne s’agit pas d’une évaluation mécanique appliquant une formule fixe, mais d’une rédaction qui se redemande chaque année « avec quel cadre faut-il regarder le design taïwanais cette année ? ».
+```
+
+![Couverture de Shopping Design Vol.150, « Nous collectionnons ce design » : le numéro spécial annuel transforme « qu’est-ce qui mérite d’être gardé » en un exercice public de distinction](/article-images/culture/shopping-design-vol150-collection-cover.webp)
+_Vol.150, « Nous collectionnons ce design ». Le palmarès et le numéro spécial sont un exercice de distinction au nom d’une année entière de design taïwanais. (Fair use, editorial commentary)_
+
+À la fin, elle a même sorti la distinction du papier. Depuis 2013, elle organise les « Design+ », qui transforment la comparaison et la nomination de la mise en pages en conférences et conversations sur place ; en 2016, elle crée l’École d’économie du style et commence à traduire l’esthétique en un langage commercial enseignable[^8]. En 2022, cette ligne a grandi jusqu’au premier DesignBIZ Fest, un festival centré sur « le nouveau commerce du design »[^14]. La définition qu’en donne l’organisation est une série de parallélismes : « le design est force créative, le design est force marketing, le design est force culturelle, le design est force de planification, le design est force d’intégration — le design est force vitale »[^14]. Sur scène, toute une rangée de dirigeants de marques, des espaces partagés aux scooters électriques en passant par la restauration en chaîne[^15]. Ses tentacules se sont aussi étendus au son, portant à l’oreille, par un podcast, les carrières des designers, les marques et la revitalisation locale[^16]. Cette même action de « regarder pour vous, choisir pour vous » était alors devenue, d’une page mise en pages, tout un langage commercial avec billetterie, écoute et partenariats.
+
+![Intervenants du premier DesignBIZ Fest de 2022 : le festival du design traduit le « distinguer pour vous » en tout un langage commercial](/article-images/culture/shopping-design-designbiz-2022-speaker.jpg)
+_Intervenants du DesignBIZ Fest 2022. La distinction passe du papier à la scène, et de l’esthétique au commerce. (Fair use, editorial commentary)_
+
+```tw-timeline
+La même action de « distinguer pour vous », élargie tour après tour pendant vingt ans
+2006 | Fondation de la revue | Naît en décembre, d’abord mensuelle, distinguant pour le lecteur une question de vie après l’autre
+2012 | Lancement du palmarès annuel des cent | Taiwan Design BEST100, qui nomme et archive une année entière de design taïwanais
+2013 | Les conférences se posent en rencontres | Lancement des Design+, qui portent la distinction du papier à la conversation sur place
+2016 | Ouverture de cours de commerce | Création de l’École d’économie du style, qui traduit l’esthétique en langage commercial enseignable
+2019 | Le papier passe au trimestriel | Refonte de fin d’année : le papier va vers les sujets lents et le site vers les actualités rapides, en double voie
+2022 | Élargissement en festival professionnel | Premier DesignBIZ Fest, avec toute une rangée de dirigeants de marques parlant du nouveau commerce du design
+2026 | Le papier paraît toujours | En avril, on atteint le numéro 156 : Internet ne l’a pas remplacé
+Sources : « Trajectoire » officielle de Shopping Design (archive Wayback du 29-12-2019), liste des numéros du site officiel, page officielle du DesignBIZ Fest
+```
+
+Une revue, un palmarès et un festival paraissent trois choses différentes, mais au fond c’est la même action à trois échelles : distinguer pour vous, distinguer pour une année entière, distinguer pour toute une industrie. Et dès que l’échelle atteint cette taille, une question cachée sous la mise en pages remonte à la surface : quand « distinguer pour vous » devient un commerce aussi grand, la main qui distingue pour vous et la main qui vend pour les marques peuvent-elles encore être séparées ?
+
+## La main qui choisit pour vous vend aussi pour les marques
+
+Regardons d’abord le document le moins romantique : l’immatriculation. La maison mère de Shopping Design s’appelle Business Next Media Corp. (巨思文化股份有限公司), avec le numéro fiscal 16780474 et Chen Su-lan comme présidente[^16b]. En ouvrant la rubrique « activités » de son immatriculation publique, on voit deux lignes côte à côte : l’une dit « édition de revues (périodiques) » et, non loin en dessous, une autre dit « services publicitaires généraux »[^15b]. Cette ligne figure noir sur blanc dans le document d’immatriculation et constitue le périmètre légal d’activité. La même société, la même licence, édite d’un côté des contenus qui distinguent le design pour vous et exploite de l’autre le commerce de la vente d’espaces publicitaires ; son site publie d’ailleurs ouvertement ses tarifs, de 100 000 à 280 000 yuans par emplacement, avec 10 % de remise pour une campagne annuelle[^17]. Aucune belle déclaration de marque ne pèse contre la dureté de ces deux lignes d’immatriculation : le contenu et la publicité habitent d’emblée les fondations de cette entreprise.
+
+```tw-stat
+Business Next Media | maison mère de Shopping Design, n° fiscal 16780474 | présidente Chen Su-lan
+Édition de revues ＋ services publicitaires généraux | deux lignes côte à côte dans les « activités » immatriculées | noir sur blanc
+100 000–280 000 yuans | tarif public d’un emplacement publicitaire sur le site officiel | 10 % de remise pour une campagne annuelle
+Sources : immatriculation au Département du commerce du ministère des Affaires économiques, opengovtw, page officielle des tarifs publicitaires de Shopping Design
+```
+
+De cela, les gens du métier parlent plus franchement que quiconque. En 2017, le rédacteur adjoint de Shopping Design, Pao Shu-ping, a tenu une conversation publique avec Eric, rédacteur en chef d’un autre média de style de vie, et ils ont parlé précisément du publireportage, ce contenu qui se lit comme un reportage et qui est en réalité de la publicité. « Le publireportage, c’est que ça vous plaise ou non, il faut l’écrire de manière accrocheuse », dit Pao Shu-ping[^18]. La phrase ne cache rien : le publireportage est la réalité du secteur, et l’adresse du média consiste à l’écrire de façon à ce que vous continuiez à lire. Il a ajouté une phrase qui peut servir de note à toute l’ère du papier : « ces deux dernières années les revues se vendent mal ; cette année beaucoup de médias ne sortent plus d’édition papier, et SD existe encore »[^18].
+
+```tw-quote
+Le publireportage, c’est que ça vous plaise ou non, il faut l’écrire de manière accrocheuse
+Pao Shu-ping | rédacteur adjoint de Shopping Design, 2017
+```
+
+Dans la même conversation, Eric a raconté comment ils l’affrontent : « dans le premier paragraphe du texte ou dans le titre, nous vous disons sans détour que c’est une publicité », en cherchant à ce que lecteur, client et rédacteur « créent une situation gagnant-gagnant-gagnant »[^18]. C’est une posture honnête : marquer clairement ce qui est publicité et rendre le choix au lecteur. Mais même honnête, la posture laisse la frontière en place. Un publireportage étiqueté « publicité » permet au moins au lecteur de le savoir ; en revanche, savoir si le goût global d’une revue, le « bon design » qu’elle a entouré pour vous, repose ou non sur une relation commerciale, cela ne s’accompagne le plus souvent d’aucune ligne d’indication. L’endroit où la frontière est la plus floue se cache souvent dans les contenus qui paraissent les plus purs et qui partagent en réalité la même licence que le service publicitaire.
+
+À la même époque, le site de Shopping Design a utilisé un publireportage de whisky pour louer rétrospectivement « Huang Wei-jung, rédacteur en chef de la période fondatrice » comme un « découvreur de talents qui sait vivre », emballant son image d’éditeur d’alors dans le récit de marque d’une bouteille[^19]. Il faut le préciser : ces phrases sur le fait d’« ouvrir les cinq sens et savoir déguster » ne sont pas de Huang Wei-jung, elles ont été écrites par la rédaction comme texte de présentation de ce publireportage. Qu’une revue qui vous apprend à distinguer utilise l’image de son fondateur, qu’elle a elle-même façonnée, pour servir de caution à une marque de consommation : voilà la fois où « distinguer pour vous » et « vendre pour les marques » se sont le plus rapprochés.
+
+> **📝 Note de la curation**
+> Il faut se garder d’en faire un problème propre à Shopping Design. Le même modèle « un média couvre un secteur et organise en plus des prix pour ce secteur » est aussi pratiqué par une autre revue molle, La Vie, qui organise depuis 2014 le « Taiwan Creative Power 100 »[^20]. Et en remontant d’un cran, c’est encore plus intéressant : le groupe mère de La Vie, Cité, a été créé en 1996 à l’initiative de Chan Hung-chih ; et la maison mère de Shopping Design, Business Next Media, a elle aussi été fondée en 1999 avec la participation de Chan Hung-chih[^21]. Les deux grandes familles taïwanaises de médias de style de vie se rejoignent à la source dans une même personne. Ce n’est pas un complot : c’est le portrait d’une industrie de l’édition taïwanaise très concentrée. « Organiser un palmarès pour le secteur » est une pratique commune à toute la profession, par laquelle chaque maison accumule de l’autorité de marque et élargit sa marge de collaboration commerciale, sans exception.
+
+Il faut dire clairement qu’on ne trouve aucun reportage public pointant et critiquant des problèmes dans les publireportages ou les sélections de Shopping Design ; ce qui précède ne constitue pas encore une « polémique déjà survenue » et ressemble davantage à une question que la structure elle-même pose depuis toujours en attendant que quelqu’un la formule. Mais cette question circule bel et bien dans l’imaginaire social : on colle souvent à la revue l’étiquette de « revue de hipsters », avec le sous-entendu d’une certaine mise en scène de la consommation et d’une supériorité de goût. Curieusement, Huang Wei-jung lui-même est venu réfuter cette étiquette : « je ne crois vraiment pas qu’il existe à Taïwan des revues de hipsters »[^4]. Son geste de réfutation prouve justement que le soupçon est là depuis toujours. Et puisque le soupçon est là depuis toujours, il faudra bien que quelqu’un distingue à la fin. Et ce quelqu’un ne peut être que le lecteur.
+
+## La dernière leçon : la distinguer, elle
+
+En décembre 2025, Shopping Design a publié le numéro 155, intitulé « Recherche design / Design Wanted »[^22]. Ce qu’elle emprunte, c’est le langage visuel le plus populaire qui soit : celui des petites annonces « recherche » collées sur les poteaux et les devantures. Direct, collé sans façon. Une revue qui a passé vingt ans à apprendre aux Taïwanais à choisir, à regarder et à distinguer finit par se coller elle-même comme une annonce d’emploi : design, recherché.
+
+![Couverture de Shopping Design Vol.155, « Recherche design / Design Wanted » : la revue se colle elle-même comme une annonce d’emploi](/article-images/culture/shopping-design-vol155-cover.webp)
+_Vol.155, « Recherche design ». La revue qui vous apprend à distinguer finit par se coller elle-même comme un examen. (crédit : Business Next Media, Fair use editorial commentary)_
+
+Cette fin rejoint en réalité la préparation de toute une société. Taïwan a publié dès 2002 le « Livre blanc de la politique d’éducation aux médias », et les lycées ont intégré l’éducation aux médias au programme à partir de l’année scolaire 2017[^23] : que « le lecteur ait la capacité de distinguer publireportage et contenu » est depuis longtemps un consensus au niveau des politiques éducatives. Autrement dit, qu’un média finisse par rendre au lecteur la responsabilité de distinguer est précisément ce que cette société avait décidé d’apprendre à tout le monde, et cela n’a rien de nouveau. La seule différence, c’est que cette fois l’objet à distinguer est celui qui vous a appris pendant vingt ans à distinguer.
+
+Et Shopping Design elle-même, où en est-elle ? Internet ne l’a pas remplacée : en avril 2026, le papier atteignait le numéro 156[^11]. Replacée dans la même vague de revues molles, c’est déjà un exploit : certaines ont changé de mains, d’autres ont leur dernier numéro fin 2025 sans qu’aucun nouveau n’ait été vu depuis ; Shopping Design est l’un des rares cas parvenus jusqu’à aujourd’hui en conservant la même marque et le même parcours. Sauf qu’elle se rétrécit aussi en silence. La page « Qui sommes-nous » de son site a été retirée ces dernières années ; la fonction de celui ou celle qui a tenu la barre de 2006 à 2017 était « rédacteur en chef », et le titre le plus élevé apparaissant dans les reportages publics de 2024 est déjà redescendu à « rédactrice Yi-hsin, rédactrice adjointe Ya-yun »[^24]. Une revue qui vous apprend à distinguer et aussi à demander « qui a choisi cela pour moi ? » voit, à l’inverse, les informations sur sa propre structure et son origine devenir plus difficiles à trouver qu’avant. Il faut d’abord apprendre cette distinction qu’elle enseigne pour pouvoir se retourner et distinguer qui elle est et pour qui elle travaille, et elle resserre chaque année un peu plus cette seconde moitié des indices. C’est en soi un exercice qu’elle n’énonce pas mais qu’elle laisse au lecteur.
+
+Et c’est justement la dernière leçon qu’elle rend au lecteur. De ce blanc du premier numéro à cette annonce d’emploi du numéro 155, il y a entre les deux tout un métier de « distinguer pour vous », élargi tour après tour en palmarès, en trimestriel et en festival, et rapproché pas à pas du commerce consistant à vendre pour les marques. Ce que cette revue a appris à Taïwan est bien plus profond que de savoir quelle chaise est belle ou quel hôtel mérite le détour. Ce qu’elle enseigne, c’est que « distinguer » peut s’entraîner comme une capacité, et que plus elle entraîne largement et élargit cette capacité, plus elle devient elle-même l’objet qu’il vous faut le plus sortir pour le distinguer.
+
+La couverture de « Recherche design » est donc aussi un examen. Ce qu’elle veut recruter, en réalité, c’est un lecteur capable de comprendre et de demander aussi « qui a choisi cela pour moi ? ». Il y a vingt ans, elle vous apprenait à acheter du blanc ; vingt ans plus tard, elle vous rend le pouvoir de distinguer, avec la nécessité de la distinguer elle. Savoir apprécier et savoir douter ont toujours pu tenir dans une même paire d’yeux, et cette paire d’yeux est justement celle qu’elle a entraînée pour vous, page après page, pendant vingt ans.
+
+---
+
+## Pour aller plus loin
+
+- [Revues](/culture/雜誌) — cent ans d’évolution de la revue taïwanaise ; Shopping Design est le cas représentatif de la branche des « revues molles »
+- [Revue Ren Jian](/culture/人間雜誌) — une autre âme de la revue taïwanaise, qui a distingué et nommé la société d’en bas par le photojournalisme ; c’est l’autre face de la médaille par rapport à la revue d’achat de design
+- [Histoire de la publicité à Taïwan](/culture/台灣廣告史) — la source de la formation de Huang Wei-jung et Li Hui-chen ; pour comprendre comment cette génération d’« Ideology » a porté son art du récit dans les revues
+- [Cérémonie du thé et esthétique du quotidien à Taïwan](/culture/台灣茶道與生活美學) — comment l’esthétique de la vie a poussé à Taïwan jusqu’à devenir un quotidien dont on parle et que l’on achète
+- [Aaron Nieh](/people/聶永真) — un autre nom du même contexte du design taïwanais, qui l’a poussé sous les yeux du grand public
+
+## Références
+
+[^1]: [La revue doit rappeler au lecteur de vivre avec conscience : Li Hui-chen, rédactrice en chef de « Shopping Design »](https://www.biosmonthly.com/article/8577) — Entretien de BIOS monthly de février 2017, qui consigne que Li Hui-chen « entrait dans sa sixième année » comme rédactrice en chef et que le numéro 100 répondait par « acheter du design blanc » au « design blanc » du numéro inaugural.
+
+[^2]: [L’éditeur transversal Huang Wei-jung : pour un créatif, le fade, l’ordinaire et le banal sont le plus grand péché](https://500times.udn.com/wtimes/story/120841/4313654) — Entretien de 500times en 2020, où Huang Wei-jung raconte lui-même son point de départ de rédacteur publicitaire, l’agence Ideology et Hsu Shun-ying, ainsi que son parcours en trois segments sur trente ans : « rédaction publicitaire et écriture d’édition → édition de revues et intégration image-texte → missions mixtes de services créatifs ».
+
+[^3]: [Une chose aussi romantique, cela n’arrive qu’une fois dans une vie : « Cent raisons de survivre à Taipei »](https://www.shoppingdesign.com.tw/post/view/1446) — Chronique de Huang Wei-jung lui-même en 2017, où il se souvient de ce livre écrit en 1998 avec Ma Shih-fang, Yao Jui-chung, Hsu Yun-pin et Chen Kuang-ta et publié par Locus Publishing.
+
+[^4]: [Les prétendues « revues de hipsters » résultent en fait de plusieurs malentendus…](https://www.cw.com.tw/article/5046241) — Texte publié par Huang Wei-jung en 2013 dans Independent Opinion@CommonWealth, qui contient l’origine de Shopping Design dans le « sujet mou » des supérettes en 2006, la définition de La Vie et PPAPER (2004) comme « avant-garde de la naissance des revues molles » et sa réfutation de l’étiquette de « revue de hipsters ».
+
+[^5]: [La force de planification qui retourne une vie ! Entretien avec la fondatrice du Projet Licorne, alias ancienne rédactrice en chef de Shopping Design](https://www.shoppingdesign.com.tw/podcast/view/104) — Podcast officiel de Shopping Design, qui confirme que Li Hui-chen fut rédactrice en chef et qu’après son départ en 2017 elle a fondé le « Projet Licorne ».
+
+[^6]: [La travailleuse indépendante Li Hui-chen : je ne crois pas au destin, tout dépend de ce que l’on fait](https://500times.udn.com/wtimes/story/120841/4313624) — Entretien de 500times, qui consigne l’origine de Li Hui-chen dans un village militaire de Yilan, son parcours dans l’édition, ses années 2011–2017 comme rédactrice en chef de Shopping Design, sa reprise de la phrase de Chan Hung-chih « quand vous avez lu un certain livre, vous pouvez devenir une personne solitaire » et la ligne cachée selon laquelle elle et Huang Wei-jung ont tous deux travaillé sous le directeur éditorial de Locus Publishing, Liao Li-wen.
+
+[^7]: [Liste des lauréats des éditions 1 à 49 des Golden Tripod Awards](https://data.gov.tw/dataset/25856) — Données ouvertes du ministère de la Culture. Le tableau officiel édition par édition l’établit : à la 40e édition (2016), le « prix du rédacteur en chef, catégorie individuelle revues » revient à Li Hui-chen / « Shopping Design 設計採買誌 » / Business Next Media Corp.
+
+[^8]: [Page officielle « Qui sommes-nous » de Shopping Design (archive Wayback Machine du 29-12-2019)](http://web.archive.org/web/20191229052902/https://www.shoppingdesign.com.tw/aboutus) — La chronologie officielle « Trajectoire » consigne mot à mot : fondation en 12/2006 (mensuel), BEST100 en 12/2012, lancement des Design+ en 12/2013, mise en ligne du site en 12/2015, création de l’École d’économie du style en 10/2016 et refonte en trimestriel en 12/2019.
+
+[^9]: [Entretien sur la refonte trimestrielle de Shopping Design](https://okapi.books.com.tw/article/13619) — OKAPI consigne l’explication par la rédaction de la logique de la refonte : le site poursuit la fraîcheur et la rapidité tandis que le papier construit des sujets à un rythme plus lent, ainsi que l’autodéfinition « utile, intéressant et signifiant ».
+
+[^10]: [« Shopping Design » se refond : passage au trimestriel dès cette année](http://mol.mcu.edu.tw/《shopping-design》改版-今年起改季刊發行/) — Dépêche de Mol News du 29 mars 2020, qui confirme que le premier numéro trimestriel après la refonte (le 134) est paru en mars 2020.
+
+[^11]: [Liste des numéros du site officiel de Shopping Design](https://www.shoppingdesign.com.tw/magazine/) — Catalogue officiel, qui permet de vérifier les thèmes et dates de numéros comme le Vol.147 « L’habitant idéal » (2023), le Vol.150 « Nous collectionnons ce design » (2024), le Vol.155 « Recherche design » (12-2025) ou le Vol.156 (04-2026).
+
+[^12]: [Sélectionnés du Taiwan Design Best100 2022](https://www.fundesign.tv/sd-2022-taiwan-design-best100/) — Article du média indépendant de design FunDesign, qui confirme depuis un tiers que le BEST100 est organisé par la rédaction de Shopping Design depuis 2012, qu’il sélectionne chaque année 100 personnes, faits et objets du design taïwanais et qu’il s’agit d’un prix médiatique et non d’un prix officiel du gouvernement.
+
+[^13]: [Sélectionné au Taiwan Design 100 de 2019 : le bimensuel Culture+ de l’agence CNA](https://www.cna.com.tw/news/firstnews/201912130216.aspx) — Article indépendant de l’agence CNA, qui consigne mot à mot que le BEST100 de 2019 « a sélectionné 100 ensembles de personnes, faits et objets du design sous le thème des "mots-clés de la force du design", les prix étant répartis en 9 catégories ».
+
+[^14]: [Page officielle du DesignBIZ Fest 2022](https://designbiz.shoppingdesign.com.tw/2022/) — La page officielle confirme que « depuis 2022, Shopping Design organise le premier DesignBIZ Fest » et reprend mot à mot la définition en parallélismes : « le design est force créative, le design est force marketing, le design est force culturelle, le design est force de planification, le design est force d’intégration — le design est force vitale ».
+
+[^15]: [Liste des intervenants du DesignBIZ Fest 2022](https://designbiz.shoppingdesign.com.tw/2022/) — Fonctions des intervenants selon la page officielle (en 2022) : Chen Yun-chu (cofondatrice de Plan b), Chen Ping-liang (directeur du centre de marque du groupe Gamania), Yeh Chuan-feng (vice-président marque et marketing de Gogoro), Chan Hsun-chih (vice-président de Chan Chi Hot Pot) et toute une rangée de dirigeants de marques et de start-up.
+
+[^16]: [Podcast de Shopping Design « Mots-clés du design »](https://www.shoppingdesign.com.tw/podcast) — Page officielle de l’émission, qui étend les contenus de Shopping Design au médium sonore avec des sujets d’actualité du design, des histoires de créateurs, des marques et la revitalisation locale.
+
+[^16b]: [Immatriculation de Business Next Media Corp.](https://www.companys.com.tw/16780474) — Consultation de l’immatriculation, qui confirme la dénomination chinoise « 巨思文化股份有限公司 », la dénomination anglaise « BUSINESS NEXT MEDIA CORP. », le numéro fiscal 16780474 et Chen Su-lan comme présidente.
+
+[^15b]: [Données publiques gouvernementales de Business Next Media Corp.](https://opengovtw.com/ban/16780474) — Données publiques d’immatriculation, dont la rubrique « activités » comporte à la fois « édition de revues (périodiques) » et « services publicitaires généraux » : la preuve dure que l’édition de contenus et les services publicitaires relèvent d’une même licence.
+
+[^17]: [Page des tarifs publicitaires de Shopping Design](https://edm.shoppingdesign.com.tw/price.htm) — Grille tarifaire officielle, avec des emplacements de 100 000 à 280 000 yuans et 10 % de remise pour une campagne annuelle.
+
+[^18]: [Conversation entre Eric et Pao Shu-ping : à quoi ressemble un média](http://www.everydayobject.us/eric-and-pao-talks-style-of-a-media/) — Conversation de décembre 2017 entre Eric, rédacteur en chef d’EVERYDAY OBJECT, et Pao Shu-ping, rédacteur adjoint de Shopping Design, avec des citations mot à mot sur l’éthique du publireportage (« le publireportage, c’est que ça vous plaise ou non, il faut l’écrire de manière accrocheuse », « nous vous disons sans détour que c’est une publicité », « créer une situation gagnant-gagnant-gagnant ») et sur les difficultés du papier (« ces deux dernières années les revues se vendent mal ; cette année beaucoup de médias ne sortent plus d’édition papier, et SD existe encore »).
+
+[^19]: [Pour bien vivre, il faut d’abord apprendre à goûter la différence : Huang Wei-jung, le découvreur de talents qui sait vivre](https://www.shoppingdesign.com.tw/post/view/5119) — Contenu de 2020 sur le site officiel de Shopping Design, confirmé par le code source comme publireportage d’une marque de whisky avec `is_ads:true` ; des formules comme « ouvrir les cinq sens et savoir déguster » sont une présentation à la troisième personne rédigée par la rédaction pour ce publireportage et non des citations directes de Huang Wei-jung.
+
+[^20]: [Le palmarès complet du Taiwan Creative Power 100 de 2025 dévoilé](https://www.wowlavie.com/article/250026501) — Page officielle de La Vie, qui consigne l’organisation bisannuelle du « Taiwan Creative Power 100 » depuis 2014, formant avec le BEST100 de Shopping Design un modèle parallèle de « palmarès annuels ou bisannuels organisés par les médias eux-mêmes ».
+
+[^21]: [Business Next Media Group](https://zh.wikipedia.org/zh-tw/巨思媒體集團) — Index de Wikipédia, qui consigne que le groupe Business Next Media a été fondé en 1999 par Chan Hung-chih, Ho Fei-peng et Chen Su-lan, avec « Business Next », « Manager Today » et « Shopping Design » parmi ses titres ; Chan Hung-chih avait par ailleurs initié en 1996 la création de Cité, groupe mère de La Vie.
+
+[^22]: [Shopping Design Vol.155 « Recherche design / Design Wanted »](https://www.shoppingdesign.com.tw/magazine/view/130050) — Page officielle du numéro, paru en décembre 2025, avec une couverture reprenant le langage visuel des petites annonces « recherche » et des contenus sur cent œuvres et équipes, la génération Z et la sensibilité taïwanaise.
+
+[^23]: [Éducation aux médias](https://zh.wikipedia.org/zh-tw/媒體素養) — Index de Wikipédia, qui consigne le contexte politique de la publication en 2002 du « Livre blanc de la politique d’éducation aux médias » de Taïwan et de l’intégration de l’éducation aux médias au programme du lycée à partir de l’année scolaire 2017.
+
+[^24]: [Retour sur la conférence « Nous collectionnons ce design » de 2024](https://www.shoppingdesign.com.tw/post/view/10553) — Article officiel de Shopping Design d’août 2024, où apparaît mot à mot « la rédactrice Yi-hsin et la rédactrice adjointe Ya-yun de Shopping Design », le titre le plus élevé vérifiable de la rédaction ces dernières années (déjà rétrogradé de « rédacteur en chef » à « rédactrice »).
+
+## Sources des images
+
+- **Hero｜visuel principal du DesignBIZ Fest 2022** : Shopping Design／DesignBIZ Fest, source <https://designbiz.shoppingdesign.com.tw/2022/>. Fair use (editorial commentary).
+- **Couverture du Vol.147 « L’habitant idéal »** : Shopping Design (Business Next Media), source : liste des numéros du site officiel <https://www.shoppingdesign.com.tw/magazine/>. Fair use (editorial commentary).
+- **Couverture du Vol.150 « Nous collectionnons ce design »** : Shopping Design (Business Next Media), source : liste des numéros du site officiel <https://www.shoppingdesign.com.tw/magazine/>. Fair use (editorial commentary).
+- **Intervenants du DesignBIZ Fest 2022** : Shopping Design／DesignBIZ Fest, source <https://designbiz.shoppingdesign.com.tw/2022/>. Fair use (editorial commentary).
+- **Couverture du Vol.155 « Recherche design »** : Business Next Media, source <https://www.shoppingdesign.com.tw/magazine/view/130050>. Fair use (editorial commentary).

--- a/knowledge/fr/Music/chthonic.md
+++ b/knowledge/fr/Music/chthonic.md
@@ -1,0 +1,202 @@
+---
+translatedFrom: 'Music/閃靈.md'
+sourceCommitSha: '087677fa'
+sourceContentHash: 'sha256:428539ef61aee065'
+sourceBodyHash: 'sha256:ca8382bb6533d023'
+translatedAt: '2026-07-24T03:00:00+08:00'
+lang: 'fr'
+title: 'CHTHONIC : le groupe qui a fait entrer l’histoire de Taïwan dans le black metal'
+description: 'CHTHONIC (閃靈) est un groupe taïwanais de heavy metal fondé à Taipei en 1995. Avec le black metal, l’erhu, le taïwanais, la mythologie de l’île, le récit des esprits et le traumatisme historique pour noyau, il a porté sur les scènes internationales du metal la légende de la Sœur Lintou, l’incident de Musha, l’incident du 28 février, les Unités de volontaires Takasago, la Terreur blanche et la question de la souveraineté taïwanaise. Ce n’est pas la toile de fond de Freddy Lim avant son entrée en politique, mais un corps créatif porté ensemble par Freddy, Doris, Jesse, Dani et CJ.'
+date: 2026-07-10
+category: 'Music'
+tags:
+  - '閃靈'
+  - 'CHTHONIC'
+  - 'heavy metal'
+  - 'black metal'
+  - 'taïwanais'
+  - 'histoire de Taïwan'
+  - 'Freddy Lim'
+subcategory: 'Heavy metal / histoire de Taïwan'
+author: 'Taiwan.md Translation Team'
+featured: false
+canonical-order: 999
+lastVerified: 2026-07-10
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/閃靈-outline.md'
+image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/b/bb/12-08_Wacken_Chthonic_02.jpg/1280px-12-08_Wacken_Chthonic_02.jpg'
+imageCredit: 'Achim Raschka / Wikimedia Commons'
+imageLicense: 'CC BY-SA 4.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:12-08_Wacken_Chthonic_02.jpg'
+rationale:
+  why_this_hook: 'Entrer par la manière dont le black metal peut porter l’histoire de Taïwan, pour ne pas réduire CHTHONIC au prologue politique de Freddy Lim.'
+  whats_excluded: 'Les changements complets de formation, l’analyse de tous les titres de chaque album, la liste intégrale des prix et la chronologie des polémiques politiques seront renforcés dans un texte ultérieur plus approfondi.'
+  where_it_hedges: 'Des thèmes des albums, on n’écrit que le contexte central soutenu par plusieurs sources ; les prix et les singles récents sont décrits avec prudence et l’index de Wikipédia n’est pas traité comme unique source de faits.'
+  whos_pushing_back: 'Ceux qui ne voient CHTHONIC que comme un groupe politique, ceux qui n’attendent que de la critique metal et les fans connaissant toute l’histoire du groupe et souhaitant une vérification plus complète des morceaux.'
+---
+
+# CHTHONIC : le groupe qui a fait entrer l’histoire de Taïwan dans le black metal
+
+> **En 30 secondes :** CHTHONIC (閃靈) est un groupe taïwanais de heavy metal fondé à Taipei en 1995. Parti du black metal, du death metal et du metal symphonique, il a fait entrer dans le metal extrême le taïwanais (hoklo), l’erhu, les instruments folkloriques, la légende de la Sœur Lintou, l’incident de Musha, l’[incident du 28 février](/history/二二八事件), les Unités de volontaires Takasago, la Terreur blanche et le sentiment de souveraineté taïwanaise. Le chanteur Freddy Lim (林昶佐) est ensuite entré sur la scène politique, mais la leader et bassiste Doris Yeh (葉湘怡), le guitariste Jesse Liu (劉笙彙), le batteur Dani Wang (汪子驤) et le claviériste CJ Kao (高嘉嶸) ont aussi maintenu CHTHONIC comme un corps créatif entier. Beaucoup de fans de metal à l’étranger ont entendu pour la première fois l’histoire de Taïwan grâce à CHTHONIC, et entendu comment les esprits, la langue et le sentiment de souveraineté d’un pays sont poussés sur une scène.
+
+En 1995, peu de gens à Taipei savaient encore ce qu’était le black metal. CHTHONIC s’est formé cette année-là, et le *Taipei Times* le décrira plus tard comme le premier groupe taïwanais de black metal. En 2003, il remporte le prix du meilleur groupe à la 14e édition des Golden Melody Awards avec « 9th Empyrean » (永劫輪迴). Le même article rapportait aussi que CHTHONIC avait joué lors d’un événement pour la rectification du nom de Taïwan devant le Palais présidentiel et porté sur scène la légende populaire taïwanaise de la « Sœur Lintou » (林投姊). À l’époque, CHTHONIC portait déjà un maquillage cadavérique, martelait des rythmes lourds et hurlait. Et posait en même temps une question très précoce : la mythologie, les blessures et les esprits propres à Taïwan peuvent-ils devenir le cœur du metal ?[^1]
+
+## L’histoire de Taïwan dans le black metal
+
+La musique de CHTHONIC a lié dès le départ la grammaire du genre et les matériaux taïwanais.
+
+Dans son entretien de 2003 avec le *Taipei Times*, Freddy Lim situe le point de départ du groupe dans la conscience de la culture matricielle du black metal : le black metal nordique adopte une posture de résistance envers les anciennes croyances remplacées par le christianisme, et CHTHONIC a ramené cette question vers Taïwan pour regarder la mémoire locale écrasée par l’historiographie sinocentrée, la colonisation et la politique autoritaire. Les premiers albums vont de la traversée des Han et du choc entre mythes han et mythes autochtones jusqu’aux légendes populaires comme celle de la Sœur Lintou, bâtissant peu à peu un univers taïwanais fait d’esprits, de divinités et de blessures historiques.[^1]
+
+Cette voie s’est ensuite prolongée vers l’histoire moderne. « Seediq Bale » (賽德克巴萊) traite de l’incident de Musha et de la résistance seediq contre le Japon. « Mirror of Retribution » (十殿) place l’incident du 28 février dans l’imaginaire du jugement infernal. « Takasago Army » (高砂軍) revient sur les Unités de volontaires Takasago enrôlées par l’Empire japonais pendant la Seconde Guerre mondiale. « Bú-Tik » (武德) se tourne vers la colonisation, la résistance et l’espace de pouvoir que symbolisent les salles Butokuden. « Battlefields of Asura » (政治) pousse au premier plan le Taïwan d’après-guerre, la démocratisation, la contestation et la sensibilité politique contemporaine. Ces thèmes se règlent facilement d’un « c’est très politique », mais dans l’œuvre de CHTHONIC ils sont plutôt la version souterraine de l’histoire de Taïwan : ceux que les manuels n’ont pas su déposer correctement reviennent sur scène pour élever la voix.
+
+C’est aussi ici que se précise la différence entre CHTHONIC et les chansons à slogan politique. CHTHONIC place les faits historiques dans des personnages, des esprits, des mythes, la réincarnation et le rituel scénique. Le public reçoit d’abord le coup de la double grosse caisse et des hurlements, et ne découvre que lentement que derrière ces sons il y a le 28 février, Musha, la Terreur blanche, les soldats coloniaux et les mémoires familiales réduites au silence.
+
+## L’erhu, le taïwanais et le mur de son du metal
+
+Ce qui se reconnaît le plus dans le son de CHTHONIC, ce sont les hurlements, les growls graves, la double grosse caisse, les guitares épaisses, l’ampleur symphonique du clavier, et un erhu qui semble s’approcher de loin en pleurant.
+
+Dès 2003, le *Taipei Times* observait que l’erhu donnait au son black metal de CHTHONIC une identité taïwanaise reconnaissable. Dans la pop sinophone, l’erhu sert souvent au lyrisme ou à la nostalgie ; chez CHTHONIC, il fonctionne plutôt comme la mèche des esprits : il peut tirer la tristesse du théâtre populaire, et tracer aussi, dans le mur de son metal, une ligne aiguë, inquiète, proche de l’invocation des morts.[^1]
+
+La langue est également au cœur du son de CHTHONIC. Pendant la tournée de l’Ozzfest 2007, Freddy Lim a dit à NPR qu’ils utilisaient le mandarin et le hoklo — c’est-à-dire le taïwanais — lors de leurs concerts américains. Le même article du *Taipei Times* indique que « UNlimited Taiwan » était chanté en anglais et portait directement sur la tournée américaine la revendication de la participation de Taïwan aux organisations internationales.[^2] L’anglais faisait comprendre la revendication au public étranger, tandis que le taïwanais et l’histoire de l’île transformaient l’œuvre en une grammaire metal irremplaçable.
+
+Après « Takasago Army », l’écriture de CHTHONIC franchit un pas de plus. Dans le résumé de l’entretien de Metalship cité par Wikipédia, Freddy Lim raconte qu’au début cela revenait plutôt à écrire d’abord du metal puis à y mettre une sensation taïwanaise. À l’époque de « Takasago Army », la création est devenue : écrire d’abord la charpente d’une chanson taïwanaise, d’une chanson en taïwanais ou d’un titre de variété taïwanaise, puis, avec Jesse, l’alourdir jusqu’au metal.[^3] Ce basculement est décisif : l’erhu, les mélodies en taïwanais, l’air d’enka, la structure du folklore et les arrangements heavy metal ont commencé à cette étape à se transformer mutuellement.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/c3t-0MIy-fc" title="CHTHONIC - TAKAO Official Video" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Clip officiel de CHTHONIC : « TAKAO » (皇軍). Ce titre de la période « Takasago Army » permet de voir comment le taïwanais, la mémoire de la guerre et les arrangements metal sont placés dans un même langage scénique._
+
+## La scène fait aussi partie du récit
+
+Le visuel scénique de CHTHONIC s’est toujours emboîté dans la musique. Le maquillage cadavérique des débuts empruntait la froideur du black metal nordique, mais les signes peints sur le visage, la monnaie funéraire en papier, les divinités, l’enfer et l’air d’invocation ramènent vite le visuel vers le folklore taïwanais et les esprits de son histoire. Le tissu de talismans enroulé autour de la tête du claviériste CJ Kao, les symboles sur le front du chanteur, le geste du public jetant de la monnaie funéraire dans la salle : tout cela faisait des concerts une sorte de cérémonie religieuse en version metal.[^13]
+
+À l’époque de « Takasago Army », CHTHONIC est passé à des costumes évoquant l’uniforme militaire asiatique, les arts martiaux et le champ de bataille, s’éloignant peu à peu de la simple image du maquillage cadavérique. Avec ce virage, la scène a cessé d’être une ambiance « le black metal, c’est sombre » pour servir directement le récit de l’album : les soldats japonais d’origine taïwanaise, les armées coloniales, les identités contraintes de changer de nom, les âmes d’après-guerre apparaissent devant le public par le costume et le visuel. C’est pourquoi les concerts de CHTHONIC se contentent rarement de rejouer le travail de studio. Ils ressemblent davantage à une convocation temporaire de l’univers d’esprits de l’album, au bord du port, dans une salle, dans un festival international ou sur l’avenue Ketagalan.
+
+Cela explique aussi que les clips de CHTHONIC aient souvent une allure cinématographique. « TAKAO » compose son image avec la guerre, la mémoire et la mélodie d’une chanson en taïwanais. « Broken Jade » (破夜斬), « Defenders of Bú-Tik Palace » (烏牛欄大護法) et « PATTONKAN » (護國山) poussent devant la caméra des personnages historiques, des luttes et des familles de victimes. Quand l’image, le costume, la langue et le son travaillent ensemble, la dimension politique de CHTHONIC ne dépend plus des seules explications des paroles : elle se ressent à travers tout le système scénique.
+
+## La trilogie du requiem : Musha, le 28 février et Takasago
+
+L’ensemble d’œuvres le plus adapté pour découvrir CHTHONIC, c’est le contexte de requiem que forment « Seediq Bale », « Mirror of Retribution » et « Takasago Army ».
+
+« Seediq Bale » a porté l’incident de Musha sur la scène du metal. L’album a fait du peuple seediq, de Mona Rudao, de la résistance antijaponaise et de la violence coloniale un ensemble de personnages tragiques et de paysages sonores. Il a aussi rendu CHTHONIC plus identifiable dans les médias metal étrangers : ce groupe taïwanais verse sa propre histoire dans la grammaire du genre et prend ses distances avec la voie qui se contente d’imiter le metal extrême nordique ou américain.[^4]
+
+« Mirror of Retribution » place l’incident du 28 février dans le monde souterrain et le jugement. L’enfer, les âmes injustement mortes et l’imaginaire de la réincarnation ont donné une forme audible à une violence politique longtemps refoulée. Le langage metal de CHTHONIC y fonctionne particulièrement bien : les hurlements sonnent comme si ceux à qui l’on n’a pas permis de parler correctement élevaient enfin la voix d’une manière impossible à ignorer.
+
+« Takasago Army » pousse le temps jusqu’à la Seconde Guerre mondiale. Le sujet de l’album désigne les jeunes des peuples autochtones taïwanais enrôlés par l’Empire japonais pendant la guerre du Pacifique, et rejoint la fracture historique entre « Seediq Bale » et « Mirror of Retribution ». Les sources compilées par l’article de Wikipédia montrent que « Takasago Army » s’inscrit dans le contexte historique des Takasago Volunteers. L’album accueille aussi Yu Tien, Chan Ya-wen et le musicien taroko Pitero Wukah, superposant chanson en taïwanais, voix autochtones et metal extrême.[^3]
+
+Ces trois œuvres rendent clair le noyau de CHTHONIC : le groupe accomplit un requiem pour une histoire qui n’a jamais été vraiment enterrée. Les esprits de sa musique portent le poids de l’histoire contemporaine de Taïwan et ne sont pas encore vraiment partis.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/Ynb9vFd0iNg" title="閃靈 - 鎮魂醒靈寺 Official Video" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Clip officiel de CHTHONIC : « Requiem at Xingling Temple » (鎮魂醒靈寺). Le temple Xingling, à Puli, tire le récit de requiem de « Takasago Army » et de « Mirror of Retribution » de l’univers de l’album vers un lieu concret._
+
+## Le nom de Taïwan sur les scènes internationales
+
+CHTHONIC a très tôt conçu les tournées comme une autre forme d’action publique.
+
+En 2007, le groupe donne vingt concerts à l’Ozzfest et parle à chaque fois au public, en anglais, de la difficulté pour Taïwan de participer normalement aux organisations internationales du fait du blocage chinois. Pour un groupe de metal, ce n’est pas de la diplomatie traditionnelle. Mais pour un Taïwan à qui l’on demande depuis longtemps de réduire sa présence dans les enceintes internationales, cette parole depuis la scène était déjà en soi une sorte de récit extérieur alternatif.[^2]
+
+Les médias étrangers ont ensuite souvent raconté l’entrée en politique de Freddy Lim dans le contraste « le chanteur de heavy metal arrive au Parlement ». En présentant en 2016 son élection comme député, GQ décrivait CHTHONIC comme un groupe prenant depuis longtemps pour matière les langues locales de Taïwan, les instruments traditionnels, l’oppression et les souffrances des peuples autochtones.[^5] En rendant compte de Freddy Lim en 2020, The Guardian le plaçait sur une ligne continue entre metal, mouvements sociaux, Parlement et identité taïwanaise.[^6] Ce contexte est important : Freddy Lim n’est pas entré d’un coup dans les affaires publiques après avoir quitté la musique. La musique de CHTHONIC a très tôt fait de la question « comment Taïwan peut-elle être entendue par le monde ? » une tâche créative.
+
+Le caractère international de CHTHONIC ne tient pas non plus à la seule carte de ses tournées. Le groupe a réalisé des versions de ses œuvres en taïwanais, en mandarin et en anglais, pour que des publics différents approchent le même univers historique par des portes différentes. Il a porté l’histoire de Taïwan sur des scènes internationales comme l’Ozzfest, Wacken ou le Fuji Rock, et a amené les médias étrangers à placer l’histoire taïwanaise, le metal et l’identité politique dans un même article. Ces reportages les simplifient parfois en « groupe de metal anti-Chine », mais si l’on revient à la musique, ce que CHTHONIC exporte vraiment, c’est tout un design sonore permettant à Taïwan d’être entendue.
+
+## Ce n’est pas l’affaire d’un seul chanteur
+
+L’image publique de CHTHONIC a souvent été amplifiée par Freddy Lim, surtout depuis qu’il est passé de musicien au Nouveau Pouvoir, au Yuan législatif puis à un poste diplomatique. Mais CHTHONIC n’est pas le projet personnel d’un chanteur.
+
+Doris Yeh est depuis longtemps leader, bassiste et cœur de la gestion du groupe. Jesse Liu est un compositeur important et la source du son de guitare. La batterie de Dani Wang et les claviers de CJ Kao ont poussé CHTHONIC vers une formation plus symphonique et plus théâtrale. Le site officiel et les réseaux sociaux font toujours fonctionner CHTHONIC comme une marque de groupe à part entière, ce qui rappelle au lecteur que l’histoire de CHTHONIC ne peut pas se comprendre à rebours depuis l’homme politique Freddy Lim.[^7]
+
+De « Takasago Army » à « Bú-Tik », les arrangements metal de Jesse, la batterie de Dani, les claviers de CJ, les graves et la gestion de Doris ont transformé l’ambition narrative de CHTHONIC en un son que l’on peut réellement tourner, enregistrer et faire comprendre aux médias étrangers. Freddy Lim a apporté la voix, le concept et le langage public, mais la vitalité de long terme du groupe vient de toute l’équipe. CHTHONIC est une communauté créative existant par elle-même dans l’histoire musicale taïwanaise, et non quelque chose que l’on pourrait ranger comme le prologue d’un homme politique.
+
+![CHTHONIC en concert en 2007 au Metropolis de Montréal (Canada). Sur scène, on voit le chanteur, la basse, la guitare, la batterie et un autre musicien, tandis que le public des premiers rangs répond bras levés.](https://upload.wikimedia.org/wikipedia/commons/0/0a/Chthonic.jpg)
+_En 2007, CHTHONIC jouait au Metropolis de Montréal, au Canada. Comme plusieurs positions de la scène apparaissent en même temps, l’image du groupe comme formation complète en concert se transmet plus clairement qu’avec un gros plan sur un seul membre. Photo : Kozikkris, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Chthonic.jpg) ([CC BY 3.0](https://creativecommons.org/licenses/by/3.0/))._
+
+## Du groupe au lieu : le Megaport Festival
+
+L’influence de CHTHONIC sur la musique taïwanaise ne reste pas non plus dans les albums et les tournées.
+
+En 2006, Freddy, Doris et l’équipe de TRA Music ont organisé la première édition du Megaport Festival (大港開唱) le long des quais 11 et 12 du port de Kaohsiung. Dans l’entretien du dossier de VERSE sur Megaport, Doris se souvient qu’ils voulaient alors créer un festival du sud différent du Formoz de Taipei, avec le paysage portuaire de Kaohsiung, un tempérament généreux et les groupes du sud de Taïwan comme tonalité de l’événement. Ce point de départ ressemble beaucoup à la manière dont CHTHONIC fait de la musique : porter le paysage, la langue, l’histoire et les voix peu visibles pour le grand public sur une scène suffisamment grande.[^14]
+
+![CHTHONIC en concert au Megaport Festival 2016 : le chanteur au centre de la scène, avec les lumières et une grande structure scénique entourant le groupe.](https://upload.wikimedia.org/wikipedia/commons/thumb/5/56/Chthonic_megaport_2016.jpg/1280px-Chthonic_megaport_2016.jpg)
+_En 2016, CHTHONIC jouait au Megaport Festival. Cette photographie transmet mieux qu’un gros plan sur un seul membre la rencontre entre le groupe, un festival au bord du port et une grande scène. Photo : Hisakon, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Chthonic_megaport_2016.jpg) ([CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))._
+
+Après l’élection de Freddy Lim comme député en 2016 et son départ de l’équipe de Megaport, Doris et le batteur Dani Wang ont repris la gestion et la coordination. Selon l’entretien de VERSE, Doris a d’abord dirigé les éditions 2016 et 2017 avant de devenir conseillère ; Dani participe à la coordination depuis 2016 et l’équipe le surnomme « le président ». Cette ligne rend plus évident le caractère collectif de CHTHONIC : sur scène, Doris et Dani portent les graves et le rythme ; hors scène, ils transforment la valeur culturelle du groupe en un festival capable de rassembler chaque année fans, groupes, associations et mémoire urbaine.[^14]
+
+La seconde partie de VERSE replace Megaport dans le contexte du Formoz, du Spring Scream et de la culture taïwanaise des concerts depuis les années 1990. Freddy et Doris ont repris le Formoz dans ses premières années, puis ont appris de l’expérience de scènes internationales comme le Fuji Rock, Wacken ou Download la gestion de plusieurs scènes, la circulation en coulisses, la répartition du bénévolat et l’accueil des artistes, et ont réinjecté cette expérience dans Megaport. Autrement dit, CHTHONIC n’a pas seulement porté Taïwan à l’étranger : le groupe a aussi ramené les méthodes d’organisation des scènes étrangères à Taïwan et transformé peu à peu la culture du live dans les festivals locaux.[^15]
+
+Le « village associatif » de Megaport laisse particulièrement voir le prolongement de CHTHONIC. Doris et Dani le relient dans l’entretien de VERSE aux concerts que Freddy avait organisés par le passé sur la justice, contre l’annexion et pour la liberté du Tibet, ainsi qu’aux valeurs de liberté et de justice que CHTHONIC poursuit depuis longtemps. Pour CHTHONIC, la scène n’est pas un lieu où fuir la réalité ; la scène peut aussi faire surgir ensemble les questions, les identités et les émotions que l’on a fait taire. C’est pourquoi Megaport, tout en méritant une entrée à part entière, reste une branche latérale importante pour comprendre CHTHONIC.
+
+## « Bú-Tik » et « Battlefields of Asura » : de la salle d’arts martiaux à la politique contemporaine
+
+« Bú-Tik » est l’œuvre avec laquelle CHTHONIC a poussé son univers discographique à un autre niveau. Selon les sources anglophones, « Bú-Tik » est sorti en 2013 chez des labels comme Spinefarm / Universal en Asie, au Royaume-Uni et en Amérique du Nord ; Blabbermouth consigne en outre qu’il a remporté le meilleur album, le meilleur groupe et le meilleur musicien, entre autres, aux Golden Indie Music Awards.[^8] Ce que montrent ces prix, c’est une chose : une œuvre taïwanaise de metal extrême pouvait désormais être traitée par les prix musicaux locaux comme un album à part entière, au lieu d’être rangée dans la case d’un genre exotique.
+
+Le concept de « Bú-Tik » a aussi rapproché CHTHONIC de la « scène historique » elle-même. Le Butokuden est un signe spatial des arts martiaux, de la discipline et de la modernité coloniale de l’époque japonaise ; CHTHONIC l’a converti en récit metal et a fait entrer dans le son la relation entre le corps, les armes, la domination coloniale, la résistance et l’État moderne. Les versions acoustiques et live ultérieures ont démonté ce mur de son initialement oppressant en une autre forme rituelle, confiant à la mélodie, à la langue et au sens de l’espace la force que portait auparavant le volume.
+
+« Battlefields of Asura », en 2018, a poussé au premier plan le Taïwan d’après-guerre et la politique contemporaine. En rendant compte de l’album à l’époque, Blabbermouth signale la participation de Randy Blythe et de Denise Ho ; les données de la 30e édition des Golden Melody Awards montrent en outre que « Battlefields of Asura » a remporté le prix du meilleur groupe et que le commentaire du jury le comprend dans le contexte d’une génération libre, du metal et de l’expression sociale.[^9][^10] Cet album est souvent vu comme la réponse de Freddy Lim après son entrée en politique, mais il prolonge en même temps une question que CHTHONIC posait depuis plus longtemps : comment les blessures de l’histoire entrent-elles dans le présent ? La politique y devient la réverbération qui demeure dans le corps, la famille et la mémoire de chacun.
+
+## Après la baisse d’activité, les esprits sont toujours là
+
+Quand Freddy Lim est entré au Parlement, l’activité de CHTHONIC a baissé un temps, mais le groupe n’a pas disparu.
+
+En 2019, CHTHONIC organise le concert « Taiwan Victory » sur l’avenue Ketagalan ; en 2020, il publie avec Matt Heafy, chanteur de Trivium, une nouvelle version de « Broken Jade » ; au Megaport 2021, il laisse une captation live ; et autour de l’anniversaire du 28 février 2023, il publie « PATTONKAN » (護國山), qui ramène dans la chanson la mémoire d’Uongu Yatauyungana, victime de la Terreur blanche, et de sa famille. Selon l’agence CNA, l’inspiration de « PATTONKAN » vient de proches de victimes politiques.[^11][^12] L’année suivante, le morceau a en outre été présenté dans l’émission « Global Spin » des Grammy, faisant de CHTHONIC le premier groupe taïwanais à y figurer.[^16]
+
+« PATTONKAN » montre que les œuvres tardives de CHTHONIC traitent toujours le même noyau : les victimes ont des lettres de famille, des enfants, des voix chantées et une mémoire communautaire. Quand le groupe écrit de Musha, du 28 février et de Takasago jusqu’à Uongu Yatauyungana et à sa fille Kao Chü-hua, l’histoire de Taïwan se détache de l’ordre des événements pour devenir un écho qui se transmet entre familles.
+
+« Millions of Reincarnations » (百萬遍), en 2025, a de nouveau relié cette ligne à la mémoire familiale et au sentiment de réincarnation. Ces œuvres récentes n’ont pas besoin de dépasser les vingt premières années de création de CHTHONIC, mais elles expliquent une chose : le noyau de CHTHONIC n’a pas disparu à cause de la politique, des élections ou des changements de rôle de ses membres. Il traite toujours ces voix qui reviennent sans cesse dans l’histoire de Taïwan.
+
+## Quelques portes par lesquelles commencer à écouter
+
+Pour comprendre CHTHONIC, il n’est pas obligatoire de commencer par l’histoire complète du groupe.
+
+On peut d’abord écouter « 9th Empyrean » et sentir comment ils ont relié la Sœur Lintou au black metal en taïwanais ; puis « Seediq Bale », « Mirror of Retribution », « Takasago Army » et « Bú-Tik », pour voir comment le groupe a poussé vers son univers discographique des sujets comme Musha, le 28 février, les Unités de volontaires Takasago ou la domination coloniale ; ensuite « Battlefields of Asura », pour comprendre comment, après l’entrée de Freddy Lim dans la politique institutionnelle, CHTHONIC continue de traiter l’histoire et le présent en format de groupe ; et enfin « PATTONKAN » et « Millions of Reincarnations », pour voir comment le CHTHONIC post-politique est revenu à la famille, à la Terreur blanche et à la réincarnation des esprits.
+
+Écouter ainsi rend aussi plus difficile de se méprendre sur CHTHONIC en y voyant un groupe qui aurait d’abord eu une position politique puis utilisé la musique comme emballage. Plus précisément : ils traitent depuis des années dans leur musique la langue, l’histoire, les esprits et l’identité, et c’est pour cela que les questions politiques paraissent naturelles dans leur œuvre.
+
+Cet itinéraire d’écoute ressemble davantage à une carte sonore d’une historiographie souterraine. CHTHONIC a donné à Taïwan un groupe de metal capable de monter sur les scènes des festivals internationaux, et il a en outre prouvé que l’histoire de Taïwan peut quitter les manuels, les monuments et les faits divers pour entrer dans les hurlements, l’erhu, le taïwanais, la mythologie, les rythmes lourds, les enceintes des festivals, les lieux culturels du port et les communautés de fans underground. Quand ces sons éclatent sur les scènes metal du monde entier, le public reçoit d’abord le choc du son et ne peut que lentement demander ensuite : d’où viennent ces esprits ?
+
+**Pour aller plus loin** : Freddy Lim, Megaport Festival, [musique indépendante taïwanaise](/music/台灣獨立音樂), [incident du 28 février](/history/二二八事件), incident de Musha, Terreur blanche
+
+## Sources des images
+
+- [12-08 Wacken Chthonic 02](https://commons.wikimedia.org/wiki/File:12-08_Wacken_Chthonic_02.jpg) — photographié par Achim Raschka au Wacken Open Air en Allemagne en 2012, versé sur Wikimedia Commons, licence CC BY-SA 4.0.
+- [Chthonic](https://commons.wikimedia.org/wiki/File:Chthonic.jpg) — photographié par Kozikkris au Metropolis de Montréal (Canada) en 2007, versé sur Wikimedia Commons, licence CC BY 3.0.
+- [Chthonic megaport 2016](https://commons.wikimedia.org/wiki/File:Chthonic_megaport_2016.jpg) — photographié par Hisakon au Megaport Festival 2016, versé sur Wikimedia Commons, licence CC BY-SA 3.0.
+- [CHTHONIC - TAKAO - Official Video](https://www.youtube.com/watch?v=c3t-0MIy-fc) — vidéo officielle de CHTHONIC sur YouTube, utilisée pour montrer le vocabulaire sonore et visuel de la période « Takasago Army ».
+- [閃靈 - 鎮魂醒靈寺 Official Video](https://www.youtube.com/watch?v=Ynb9vFd0iNg) — vidéo officielle de CHTHONIC sur YouTube, utilisée pour montrer le décor du temple Xingling et le récit de requiem.
+
+## Références
+
+[^1]: [Chthonic put spin on Taiwan's past](https://www.taipeitimes.com/News/taiwan/archives/2003/09/14/2003067797) — Entretien du Taipei Times en 2003, qui consigne le prix du meilleur groupe de la 14e édition des Golden Melody Awards pour « 9th Empyrean », les débuts du groupe, l’erhu, la Sœur Lintou et le contexte d’une création fondée sur l’histoire de Taïwan.
+
+[^2]: [ChthoniC promotes Taiwan's UN bid in interview with NPR](https://www.taipeitimes.com/News/taiwan/archives/2007/08/09/2003373320) — Reportage du Taipei Times en 2007 sur la manière dont CHTHONIC a parlé au public américain, pendant la tournée de l’Ozzfest, du blocage de la participation internationale de Taïwan, et sur l’usage du mandarin, du taïwanais et de l’anglais dans leurs concerts.
+
+[^3]: [Takasago Army](https://en.wikipedia.org/wiki/Takasago_Army) — Article de la Wikipédia anglophone utilisé comme index de sources, qui récapitule le sujet de « Takasago Army », les musiciens participants, le résumé de l’entretien de Metalship et les liens vers les clips officiels ; le texte le reformule avec prudence et évite d’utiliser seuls des classements sans source indiquée.
+
+[^4]: [Seediq Bale (album)](https://en.wikipedia.org/wiki/Seediq_Bale_%28album%29) — Article de l’album sur la Wikipédia anglophone utilisé comme index de sources, qui récapitule la sortie internationale de « Seediq Bale », le sujet de l’incident de Musha et les informations sur l’enregistrement et les participants.
+
+[^5]: [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic) — Reportage de GQ en 2016 sur l’élection de Freddy Lim comme député, qui comprend CHTHONIC dans le contexte créatif des langues locales de Taïwan, des instruments traditionnels, de l’oppression et des souffrances des peuples autochtones.
+
+[^6]: ['We want a fairer society': Freddy Lim, Taiwan's metalhead MP](https://www.theguardian.com/world/2020/aug/17/we-want-a-fairer-society-freddy-lim-taiwan-metalhead-mp) — Reportage de The Guardian en 2020 sur l’identité politique et musicale de Freddy Lim, qui complète la manière dont les médias internationaux comprennent la continuité entre CHTHONIC, les mouvements sociaux et l’identité taïwanaise.
+
+[^7]: [Site officiel de 閃靈 CHTHONIC](https://chthonic.tw/) — Site officiel de CHTHONIC, qui donne accès à la marque officielle du groupe, à ses réseaux sociaux et à ses plateformes musicales ; utilisé ici pour confirmer le site officiel et ses accès publics actuels.
+
+[^8]: [Bu-Tik](https://en.wikipedia.org/wiki/Bu-Tik) — Article de l’album sur la Wikipédia anglophone utilisé comme index de sources, qui récapitule la sortie et la production de « Bú-Tik », les Golden Indie Music Awards et les sources de critique internationale ; les détails des prix sont recoupés avec le reportage de Blabbermouth.
+
+[^9]: [CHTHONIC To Release 'Battlefields Of Asura' Album In October](https://blabbermouth.net/news/chthonic-to-release-battlefields-of-asura-album-in-october) — Reportage de Blabbermouth en 2018 sur les informations de sortie de « Battlefields of Asura » et la liste des collaborateurs comme Randy Blythe et Denise Ho, qui complète le contexte de l’album dans les médias metal internationaux.
+
+[^10]: [Prix du meilleur groupe (Golden Melody Awards)](https://zh.wikipedia.org/wiki/%E6%9C%80%E4%BD%B3%E6%A8%82%E5%9C%98%E7%8D%8E_%28%E9%87%91%E6%9B%B2%E7%8D%8E%29) — Article sur le prix du meilleur groupe des Golden Melody Awards utilisé comme index, qui récapitule l’obtention du prix par « Battlefields of Asura » à la 30e édition et le commentaire du jury ; il n’est pas utilisé comme pilier principal du récit.
+
+[^11]: [Le nouveau morceau de CHTHONIC « PATTONKAN » s’inspire de proches de victimes politiques](https://www.cna.com.tw/news/amov/202303010342.aspx) — Reportage de l’agence CNA en 2023 sur l’inspiration de « PATTONKAN » et le contexte des proches de victimes de la Terreur blanche, qui complète la manière dont les œuvres récentes prolongent le thème de la mémoire historique.
+
+[^12]: [Uongu Yatauyungana](https://zh.wikipedia.org/wiki/%E9%AB%98%E4%B8%80%E7%94%9F) — Article sur Uongu Yatauyungana utilisé comme index de sources, qui récapitule l’hommage rendu par « PATTONKAN » à lui et à Kao Chü-hua, l’écho avec le contenu des lettres de famille, ainsi que les sources associées de CNA et de la revue *New Messenger*.
+
+[^13]: [Chthonic (band)](https://en.wikipedia.org/wiki/Chthonic_%28band%29) — Article de la Wikipédia anglophone utilisé comme index de sources, qui récapitule les descriptions du costume scénique de CHTHONIC, de la monnaie funéraire, des symboles, de la visualité militarisée et du rituel en concert ; le texte les réécrit avec prudence.
+
+[^14]: [« Megaport » d’hier à aujourd’hui (I) — la vie généreuse de ceux qui tiennent la barre du festival](https://www.verse.com.tw/article/megaport-festival-01) — Dossier de VERSE de 2022 sur Megaport, avec les entretiens de Doris et Dani, qui récapitule les débuts de 2006, son positionnement de festival du sud, le passage de relais après le départ de Freddy et le contexte du village associatif et des valeurs de liberté et de justice.
+
+[^15]: [« Megaport » d’hier à aujourd’hui (II) — bien plus que 16 ans, la somme culturelle de l’histoire des festivals taïwanais](https://www.verse.com.tw/article/megaport-festival-02) — Seconde partie du dossier de VERSE de 2022 sur Megaport, qui revient sur le Formoz, la programmation des débuts de Freddy et Doris, l’expérience de Megaport et des festivals internationaux, et l’évolution de la culture taïwanaise des concerts et de l’expérience live.
+
+[^16]: [Le nouveau morceau de CHTHONIC « PATTONKAN » sélectionné par une émission des Grammy ; Freddy Lim : que le monde voie la belle Taïwan](https://www.cna.com.tw/news/amov/202305030257.aspx) — Reportage de l’agence CNA de mai 2023, qui rapporte la sélection de « PATTONKAN » dans l’émission « Global Spin » des Grammy et le fait que CHTHONIC est devenu le premier groupe taïwanais à y figurer.

--- a/knowledge/fr/Music/megaport-festival.md
+++ b/knowledge/fr/Music/megaport-festival.md
@@ -1,0 +1,133 @@
+---
+translatedFrom: 'Music/大港開唱.md'
+sourceCommitSha: '717a640b'
+sourceContentHash: 'sha256:2cde586b88469ed9'
+sourceBodyHash: 'sha256:db05dfd8f23d6ee9'
+translatedAt: '2026-07-24T01:10:00+08:00'
+lang: 'fr'
+title: 'Megaport Festival : le festival taïwanais né sur les quais de Kaohsiung'
+description: 'Le Megaport Festival (大港開唱) est un grand festival taïwanais en plein air fondé en 2006 sur le port de Kaohsiung. Parti de l’expérience curatoriale de l’équipe du Formoz Festival, des membres de CHTHONIC et de TRA Music, il a réuni dans un même espace les groupes du sud de Taïwan, les concerts en taïwanais, les affiches internationales, le village associatif et le paysage portuaire. Grâce à lui, les quais de Kaohsiung sont devenus un lieu majeur où se croisent la culture des concerts, l’identité urbaine et les questions publiques de Taïwan.'
+date: 2026-07-10
+category: 'Music'
+tags:
+  - '大港開唱'
+  - 'Megaport'
+  - 'festival de musique'
+  - 'Kaohsiung'
+  - 'musique indépendante'
+  - 'taïwanais'
+  - 'CHTHONIC'
+subcategory: 'Industrie musicale'
+author: 'Taiwan.md Translation Team'
+featured: false
+canonical-order: 999
+lastVerified: 2026-07-10
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/大港開唱-outline.md'
+image: 'https://upload.wikimedia.org/wikipedia/commons/8/8e/2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg'
+imageCredit: 'Xi.you 1010.2008 / Wikimedia Commons'
+imageLicense: 'CC BY 4.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg'
+rationale:
+  why_this_hook: 'Entrer par le lieu des quais de Kaohsiung et par la culture taïwanaise des concerts, pour éviter d’en faire un paragraphe annexe consacré à Freddy Lim ou à CHTHONIC.'
+  whats_excluded: 'La liste complète des affiches année par année, le détail des polémiques sur la billetterie et le contexte financier de toutes les années d’annulation et de reprise sont réservés à un texte ultérieur plus approfondi.'
+  where_it_hedges: 'Les records de billetterie et la polémique de l’annulation s’appuient sur des sources médiatiques et officielles vérifiables ; les détails non entièrement recoupés ne figurent pas dans l’axe principal du texte.'
+  whos_pushing_back: 'Ceux qui jugent Megaport trop politisé, ceux qui n’y voient qu’un grand divertissement et les lecteurs qui attendent une analyse complète de la gestion de l’industrie musicale.'
+---
+
+# Megaport Festival : le festival taïwanais né sur les quais de Kaohsiung
+
+![La scène Nanbatian du Megaport Festival 2025 : les lumières et le public tournés vers la grande scène installée sur les quais de Kaohsiung.](https://upload.wikimedia.org/wikipedia/commons/8/8e/2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg)
+_La scène Nanbatian du Megaport Festival 2025. Photo : Xi.you 1010.2008 / Wikimedia Commons, CC BY 4.0._
+
+> **En 30 secondes :** le Megaport Festival (大港開唱) est un grand festival en plein air fondé en 2006 sur les quais de Kaohsiung. Né du prolongement de l’expérience de l’équipe du Formoz Festival (野台開唱), il a d’abord été porté par Freddy Lim (林昶佐), Doris Yeh (葉湘怡) et l’équipe de TRA Music, avant que Doris et Dani Wang (汪子驤) ne prennent le relais avec leur équipe. Megaport réunit les groupes du sud de Taïwan, le paysage portuaire, les concerts en taïwanais, les affiches internationales, la mémoire de la pop taïwanaise et le village associatif, et transforme deux jours de concerts en une manière, pour une ville, de se réimaginer par le son.
+
+---
+
+En 2006, le Pier-2 de Kaohsiung venait tout juste de passer d’entrepôts portuaires à quartier artistique, et ni le métro ni le tramway n’avaient encore relié les quais au quotidien de la ville.
+
+Cet automne-là, le Megaport Festival ouvrait ses portes le long des quais 11 et 12 du port de Kaohsiung. La page officielle HISTORY, en revenant sur la première édition, écrit qu’il n’y avait alors que trois scènes : « Nanbatian » (南霸天), « Hailongwang » (海龍王) et « Fengyong » (風湧). L’affiche comptait Sugar Plum Ferry, Cheer Chen, Jeannie Hsieh, Fire EX., Bohemian Bo et Tizzy Bac, mais aussi les Japonais envy et YURA YURA TEIKOKU. Ce programme a placé dans un même week-end les groupes indépendants taïwanais, le son underground japonais, la mémoire de la pop en taïwanais et les quais de Kaohsiung.[^1]
+
+## Le Sud n’est pas un décor
+
+Le point de départ de Megaport est très clairement lié au Formoz Festival de Taipei.
+
+La page officielle ABOUT présente Megaport comme un festival fondé à Kaohsiung par l’équipe organisatrice du Formoz, l’un au sud et l’autre au nord, devenant ainsi l’un des pionniers du marché taïwanais des grands festivals. Dans l’entretien accordé à VERSE, Doris se souvient qu’en 2006 elle et Freddy ont monté la première édition avec l’équipe de TRA Music sous le slogan « 大港起風湧，海龍南霸天 », avec pour objectif de créer un festival du sud différent du Formoz de Taipei.[^2][^3]
+
+Ici, « le Sud » n’est ni un visuel de scène ni un slogan marketing. La moitié des artistes de la première édition venaient du sud de Taïwan, et jusqu’aux noms des scènes portaient l’accent de la ville portuaire : Nanbatian, Hailongwang, Fengyong. Des noms rugueux, éclatants, directs, liés à l’espace ouvert des quais de Kaohsiung, qui font que le festival parle avec la voix de Kaohsiung dès sa première édition.[^3]
+
+## Une équipe curatoriale née de CHTHONIC
+
+À l’extérieur, on retient souvent Megaport comme le festival fondé par Freddy Lim, mais ce qui l’a vraiment fait vivre comme une marque durable, c’est une équipe.
+
+L’entretien de VERSE indique qu’après l’élection de Freddy Lim comme député en 2016 et son départ de l’équipe de Megaport, Doris et Dani en ont pris la tête. Doris a dirigé les éditions 2016 et 2017 avant de se retirer comme conseillère ; Dani participe à la coordination depuis 2016 et l’équipe le surnomme « le président » (社長).[^3]
+
+Ce passage de relais est important. Megaport s’est peu à peu façonné en institution durable entre membres de groupes, curateurs, équipe de production et gestionnaires du site, sans rester suspendu au charisme d’une vedette. Dani dit dans VERSE que « ne pas progresser, c’est reculer », une phrase qui atterrit dans la réalité de la gestion d’un festival : scènes, circulation, coulisses, mesures sanitaires, billetterie, merchandising, espace de repos des artistes — tout est à refaire chaque année.[^4]
+
+Et précisément parce que ceux qui tiennent la barre sont eux-mêmes des interprètes, Megaport a très tôt adopté l’idée de gestion selon laquelle « les artistes sont aussi des clients de l’organisation ». Dani estime que de bonnes coulisses détendent les artistes et les rendent plus généreux sur scène ; Doris rappelle de son côté que Megaport est limité par la géographie des quais et doit se configurer selon les contraintes du site. L’internationalisation de Megaport n’apparaît donc pas seulement dans la liste des groupes étrangers, mais aussi dans la manière dont il démonte l’expérience des festivals étrangers pour la réinjecter, petit à petit, dans l’écosystème taïwanais du spectacle vivant, sur les quais de Kaohsiung.[^5]
+
+![Le groupe 1976 en concert au Megaport Festival 2016, les lumières de scène éclairant l’ensemble du groupe.](https://upload.wikimedia.org/wikipedia/commons/e/ea/1976bandatMegaport2016.jpg)
+_Le groupe 1976 au Megaport Festival 2016. Photo : Po Sing Tew / Wikimedia Commons, CC BY 2.0._
+
+## Le festival de la vie
+
+La programmation la plus reconnaissable de Megaport ne tient pas qu’aux groupes indépendants.
+
+Après la reprise de 2015, Doris et Dani ont invité He Yi-hang et LTK Commune à donner ensemble le « spectacle de cabaret Megaport ». Plus tard sont montés sur scène Shen Wen-cheng, Wang Tsai-hua, Tsai Kuei, Huang Hsi-tien, Jeannie Hsieh ou Tsai Chiu-feng, mémoires du taïwanais et de la variété de plusieurs générations. Ces choix ont fait sortir Megaport du « festival des amateurs de groupes » pour en faire une scène capable d’accueillir à la fois le rock underground, le cabaret en taïwanais, les idoles, le hip-hop, le heavy metal, le folk et les collaborations transversales.[^3][^6]
+
+La page officielle ABOUT appelle Megaport « le festival de la vie ». Ce n’est pas un slogan abstrait : cela correspond à une méthode curatoriale qui consiste à faire se rencontrer sur les quais des étapes de vie différentes, des mémoires générationnelles différentes, des langues différentes et des goûts musicaux différents. Les jeunes viennent peut-être pour Bloody Blender ou Sunset Rollercoaster, et voient le même week-end Huang Hsi-tien ou Shen Wen-cheng ; et les voix en taïwanais que connaissent les aînés se réentendent, cette fois dans le système son à plein volume d’un festival.[^2]
+
+![Enno Cheng en concert sur la scène du Megaport Festival 2018, une guitare et un micro à la main.](https://upload.wikimedia.org/wikipedia/commons/b/bc/Enno-2018%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1.jpg)
+_Enno Cheng au Megaport Festival 2018. Photo : Ken26729264 / Wikimedia Commons, CC BY-SA 4.0._
+
+## Le village associatif et l’espace public
+
+L’autre ligne de Megaport, ce sont les questions publiques.
+
+Doris explique dans VERSE qu’ils ont installé le village associatif parce que venir à un festival ne fait pas disparaître les choses dont il faut se souvenir. Dani et Doris relient aussi ce village à l’esprit des concerts que Freddy avait organisés par le passé : le « concert Justice invincible », le « concert contre l’annexion par la Chine » ou le « concert pour la liberté du Tibet ». Le caractère public de Megaport n’existe donc pas seulement dans quelques chansons ou dans la prise de parole d’un artiste : il est configuré comme une partie du lieu lui-même.[^7]
+
+Ce caractère public suscite aussi des polémiques. En 2019, lors d’une interpellation au conseil municipal de Kaohsiung, un conseiller du Kuomintang a diffusé un extrait où le conseiller de Taipei Froggy Chiu lâchait des grossièretés sur la scène de Megaport ; le maire de Kaohsiung de l’époque, Han Kuo-yu, a répondu en jugeant ces propos « vulgaires, indécents et insupportables ». L’agence CNA a rapporté cet échange, ainsi que les doutes de Huang Chieh sur le deux poids deux mesures.[^8]
+
+Pour Megaport, la polémique n’est pas une branche secondaire. Elle montre comment une ville regarde sa propre culture : un festival peut n’être qu’une activité touristique, ou devenir un lieu public où s’entrechoquent les jeunes, les groupes, les associations, les responsables politiques et les valeurs de la ville.
+
+## Après le guichet fermé
+
+En 2019, Megaport a annoncé son annulation, puis est revenu en 2021. Au moment de l’entretien avec VERSE en 2022, Doris y voyait déjà le résultat d’une accumulation de longue haleine, et non un emballement provoqué par un seul fait d’actualité. Elle dit que Megaport affiche complet chaque année depuis 2015, la seule différence étant qu’auparavant les billets partaient avant l’événement, alors qu’ils s’écoulent désormais dès l’ouverture de la vente.[^9]
+
+Le site officiel indique que le Megaport 2026 est fixé aux 21 et 22 mars, au Pier-2 Art Center de Kaohsiung ; l’affiche comprend Sunset Rollercoaster, Kessoku Band, AiNA THE END, Fire EX., Hiromi's Sonicwonder, Käärijä, Yang Fan ou Bloody Blender. Cette liste conserve le métissage propre à Megaport : un projet de groupe d’anime japonais, une figure médiatique finlandaise de l’Eurovision, du rock taïwanais et la mémoire de la pop en taïwanais peuvent apparaître côte à côte le même week-end portuaire.[^10]
+
+Si Megaport mérite une entrée à part entière, ce n’est pas seulement parce qu’il est grand, que les billets sont difficiles à obtenir ou que l’affiche est belle. Le plus important, c’est qu’il relie plusieurs fils essentiels de la [culture des festivals à Taïwan](/music/台灣音樂祭文化) : le regard local et international de CHTHONIC, l’identité urbaine du sud de Taïwan, l’écosystème du live de la [musique indépendante taïwanaise](/music/台灣獨立音樂), le retour du taïwanais comme langue contemporaine et la possibilité du festival comme espace public.
+
+Certains festivals ressemblent à un programme de salle ; Megaport ressemble plutôt à une ville provisoire. En deux jours, les entrepôts, les quais, les pelouses et les salles du port sont renommés par le son. Quand les lumières s’éteignent et que les scènes sont démontées, beaucoup reviennent l’année suivante, comme on rentre dans un pays natal qui n’existe qu’en mars.
+
+**Pour aller plus loin** : Freddy Lim, CHTHONIC, [culture des festivals à Taïwan](/music/台灣音樂祭文化), [musique indépendante taïwanaise](/music/台灣獨立音樂), [Fire EX.](/music/滅火器樂團)
+
+## Sources des images
+
+Ce texte utilise 3 images sous licence CC issues de Wikimedia Commons :
+
+- **Scène Nanbatian du Megaport 2025** (hero) — photographie de Xi.you 1010.2008 ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:2025%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1-%E5%8D%97%E9%9C%B8%E5%A4%A9_MEGAPORT_FEST.jpg)), 2025. Licence : [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/).
+- **Le groupe 1976 en concert au Megaport** (scene-mid 1) — photographie de Po Sing Tew ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:1976bandatMegaport2016.jpg)), 2016. Licence : [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/).
+- **Enno Cheng en concert au Megaport** (scene-mid 2) — photographie de Ken26729264 ([Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Enno-2018%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1.jpg)), 2018. Licence : [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/).
+
+## Références
+
+[^1]: [大港開唱 MEGAPORT FESTIVAL : HISTORY](https://megaportfest.com/info/history/) — Page officielle d’historique de Megaport, qui rassemble affiches, scènes, artistes et textes rétrospectifs officiels de toutes les éditions depuis 2006 ; c’est la principale porte d’entrée de première main pour vérifier années et programmations.
+
+[^2]: [大港開唱 MEGAPORT FESTIVAL : ABOUT](https://megaportfest.com/info/about/) — Page officielle de présentation de Megaport, qui explique sa fondation en 2006, son lien avec le Formoz Festival, le paysage portuaire et sa définition comme « festival de la vie ».
+
+[^3]: [VERSE : « Megaport » d’hier à aujourd’hui (I) — la vie généreuse de ceux qui tiennent la barre du festival](https://www.verse.com.tw/article/megaport-festival-01) — Entretien de VERSE en 2022 avec Doris et Dani, qui détaille les débuts de 2006, les quais 11 et 12 du port de Kaohsiung, la proportion de groupes du sud de Taïwan, le choix des noms de scènes et le changement d’équipe dirigeante après 2016.
+
+[^4]: [VERSE : « Megaport » d’hier à aujourd’hui (I) — la vie généreuse de ceux qui tiennent la barre du festival](https://www.verse.com.tw/article/megaport-festival-01) — Le même entretien rapporte l’idée de Dani selon laquelle, dans la gestion de Megaport, « ne pas progresser, c’est reculer », ainsi que les pressions curatoriales liées à la pandémie, aux mesures sanitaires, à la circulation et à l’expérience de l’événement.
+
+[^5]: [VERSE : « Megaport » d’hier à aujourd’hui (II) — bien plus que 16 ans, la somme culturelle de l’histoire des festivals taïwanais](https://www.verse.com.tw/article/megaport-festival-02) — La seconde partie de l’entretien de VERSE replace Megaport dans le contexte du Formoz et de la culture taïwanaise des concerts, et aborde la culture de la billetterie, les coulisses des artistes et l’expérience des interprètes.
+
+[^6]: [大港開唱 MEGAPORT FESTIVAL : HISTORY](https://megaportfest.com/info/history/) — La page officielle des affiches par année montre que différentes éditions ont intégré Jeannie Hsieh, Shen Wen-cheng, Huang Hsi-tien ou Tsai Chiu-feng, mémoires du taïwanais et de la variété de plusieurs générations, aux côtés des groupes indépendants et des affiches internationales.
+
+[^7]: [VERSE : « Megaport » d’hier à aujourd’hui (I) — la vie généreuse de ceux qui tiennent la barre du festival](https://www.verse.com.tw/article/megaport-festival-01) — L’entretien explique l’origine de l’esprit du village associatif de Megaport et la manière dont Doris et Dani conçoivent le rapport entre le festival et la liberté, la justice et les questions publiques.
+
+[^8]: [CNA : Han Kuo-yu juge Megaport indécent ; Huang Chieh dénonce un deux poids deux mesures](https://www.cna.com.tw/news/aloc/201909260286.aspx) — Reportage de l’agence CNA en 2019 sur les critiques et contre-critiques du langage employé sur la scène de Megaport lors d’une interpellation au conseil municipal de Kaohsiung, qui montre la polémique politico-culturelle suscitée par le caractère public du festival.
+
+[^9]: [VERSE : « Megaport » d’hier à aujourd’hui (II) — bien plus que 16 ans, la somme culturelle de l’histoire des festivals taïwanais](https://www.verse.com.tw/article/megaport-festival-02) — La seconde partie de l’entretien rapporte l’analyse de Doris sur le phénomène des guichets fermés, en soulignant qu’ils le sont chaque année depuis 2015 et que cela ne tient pas à une seule polémique politique.
+
+[^10]: [Site officiel de 大港開唱 MEGAPORT FESTIVAL](https://megaportfest.com/) — La page d’accueil officielle indique la date, le lieu, le slogan et une partie de l’affiche du Megaport 2026 ; elle sert à confirmer les informations publiques disponibles jusqu’en juillet 2026.

--- a/knowledge/fr/People/dwagie.md
+++ b/knowledge/fr/People/dwagie.md
@@ -1,0 +1,176 @@
+---
+translatedFrom: 'People/大支.md'
+sourceCommitSha: '498649fe'
+sourceContentHash: 'sha256:2e7abe81d37d5763'
+sourceBodyHash: 'sha256:42bdb5d4361f8a68'
+translatedAt: '2026-07-24T02:00:00+08:00'
+lang: 'fr'
+title: 'Dwagie : le « proviseur » du rap en taïwanais sorti d’une salle de répétition de Tainan'
+description: 'Dwagie (大支, de son vrai nom Tseng Kuan-jung) est un rappeur taïwanais originaire de Tainan et le fondateur du studio Kung Fu Entertainment (人人有功練). Du forum MU et de l’album « Lotus from the Tongue » chez Magic Stone Records jusqu’à « Taiwan Song », « Refugee », les droits des animaux, « The Rappers » et l’enseignement du hip-hop à Tainan, il a fait tenir dans un même micro le rap en taïwanais, les scènes locales, les questions publiques, la formation d’une nouvelle génération et la conscience de Taïwan comme sujet. Et il a fait de Tainan un lieu que l’histoire du rap taïwanais ne peut pas sauter.'
+date: 2026-07-10
+category: 'People'
+tags:
+  - 'personnalité'
+  - 'musique'
+  - 'hip-hop'
+  - 'rap'
+  - 'taïwanais'
+  - 'Tainan'
+  - 'Dwagie'
+  - 'Kung Fu Entertainment'
+subcategory: 'Musique et scène'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-10
+lastHumanReview: false
+researchReport: reports/research/2026-07/大支-outline.md
+readingTime: 14
+image: '/article-images/music/dwagie-portrait-2019.webp'
+imageCredit: 'Municipalité de Chiayi / Wikimedia Commons'
+imageLicense: 'Licence d’attribution (déclaration d’ouverture des données des sites gouvernementaux)'
+imageSource: 'https://commons.wikimedia.org/wiki/File:全國獨嘉三日跨年祭_力邀金鐘雙主持(大支)(cropped).jpg'
+rationale:
+  why_this_hook: 'Entrer par Tainan et le rap en taïwanais, pour éviter de réduire Dwagie à une figure de prise de position politique.'
+  whats_excluded: 'La liste complète des prix, la récente polémique sur les subventions et l’intégralité des titres de chaque album ne sont pas déployées et restent pour une recherche ultérieure plus complète.'
+  where_it_hedges: 'L’année de naissance, l’épisode de la salle NBA et la qualification de « Lotus from the Tongue » comme premier album entièrement rap sont atténués ou laissés dans les notes de recherche.'
+  whos_pushing_back: 'Les lecteurs en désaccord avec les positions politiques ou les prises de parole publiques de Dwagie peuvent attendre une chronologie plus détaillée des polémiques.'
+---
+
+# Dwagie : le « proviseur » du rap en taïwanais sorti d’une salle de répétition de Tainan
+
+> **En 30 secondes :** Dwagie (大支, de son vrai nom Tseng Kuan-jung / 曾冠榕) est un rappeur taïwanais originaire de Tainan et aussi le fondateur du studio musical Kung Fu Entertainment (人人有功練). À la fin des années 1990, il rencontre MC HotDog sur le forum Master U et passe des maquettes underground et des concerts en club au studio Big Circus de Magic Stone Records. Quand paraît « Lotus from the Tongue » (舌粲蓮花 ; parfois écrit 舌燦蓮花) en 2002, l’album est discuté dans le contexte des premiers albums entièrement rap du marché sinophone ; « Taiwan Song » transforme l’accent du taïwanais en une empreinte sonore de la conscience de Taïwan comme sujet. À partir de 2003, il rentre à Tainan et y fonde Kung Fu Entertainment, faisant d’un espace d’enregistrement et de répétition un bastion du hip-hop du Sud. En 2011, « Refugee » (人) accueille Deserts Chang, Freddy Lim, Wen Hsia et le XIVe dalaï-lama, et pousse les droits humains, la religion, les droits des animaux et l’engagement politique dans le vocabulaire du rap taïwanais. À l’époque de « The Rappers » (大嘻哈時代), en juré et en « proviseur », il transmet à la nouvelle génération l’expérience accumulée dans les scènes underground des débuts.[^1][^2][^3][^4]
+
+## Les années underground commencées sur le forum MU
+
+C’est sur les forums Internet, dans les disquaires et dans un coin de la sous-culture de Tainan que la scène hip-hop taïwanaise a commencé à reconnaître Dwagie.
+
+Dans un entretien avec l’agence CNA, il se souvient d’avoir découvert jeune, dans un disquaire, des disques de hip-hop de la côte ouest américaine comme « Doggystyle » de Snoop Dogg. À Tainan, des lieux comme POP Artist Shop ou Eastern Assassin lui ont montré comment une sous-culture peut se rassembler. Parti ensuite étudier à Taipei, il rencontre MC HotDog sur le forum Master U, et tous deux, à travers les rencontres hors ligne, le basket, les fêtes et l’échange de morceaux, deviennent l’un des duos centraux du rap underground taïwanais des débuts.[^1][^2]
+
+Le hip-hop taïwanais d’alors n’avait pas encore d’industrie mature. Selon l’extrait de « Hip Hop Kid : histoires du rap taïwanais » publié par Roomie, après 1998 Magic Stone Records repère MC HotDog lors d’un concert au club @live de Taipei, puis fonde le « studio musical Big Circus », avec parmi ses membres MC HotDog, Dwagie, Xiao Si, 168 et Charles. La maison de disques tâtonnait encore sur la production, le prix et la promotion du rap. Les maquettes underground, les réseaux des résidences universitaires, les concerts et l’industrie du disque grand public se sont brièvement connectés pendant ces quelques années.[^2]
+
+![MC HotDog en concert, un micro adidas à la main, de profil, casquette vissée sur la tête, l’air concentré.](/article-images/music/mc-hotdog-mic-2012.webp)
+_MC HotDog, concert de 2012. Dwagie et MC HotDog se sont croisés à l’époque de Master U et de Magic Stone. Leurs années underground composent ensemble un souvenir clé du rap taïwanais avant son entrée sur le marché grand public. Photo : Chiu Yu-feng, CC BY-SA 4.0 via Wikimedia Commons._
+
+En août 2002, Dwagie publie « Lotus from the Tongue ». L’extrait de Roomie le situe dans la dernière phase de Magic Stone : l’album porte le dernier numéro d’enregistrement du catalogue du label et fut, à l’époque, présenté par la promotion comme l’œuvre inaugurale de l’album entièrement rap sur le marché sinophone.[^2] Plutôt que de prendre ce slogan promotionnel pour un classement qui n’aurait pas besoin d’être vérifié, mieux vaut regarder la position historique qu’il désigne : à un moment où le rap taïwanais n’était pas encore pleinement compris par le marché grand public, Dwagie a placé dans un même album complet le taïwanais, le mandarin, les skits, l’expérimentation sur la rime, la conscience locale et les formes du hip-hop international.
+
+## Le son de « Taiwan Song »
+
+Le morceau le plus mémorable de « Lotus from the Tongue », c’est « Taiwan Song ».
+
+On le réduit souvent à une prise de position politique, mais l’essentiel est la méthode sonore : Dwagie utilise la prononciation du taïwanais, l’accent de Tainan et des cris en forme de question-réponse pour faire passer « Taïwan » du concept à un timbre que l’on peut entendre. Replacé dans le développement du hip-hop et du rap taïwanais, « Taiwan Song » est à la fois une chanson de conscience locale et une expérimentation linguistique. Le taïwanais y porte le rythme du rap, son agressivité et sa capacité à mobiliser une foule, et cesse d’être une simple couleur émotionnelle empruntée par une chanson pop en mandarin.[^2][^5]
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/mn_ptfQDOJA" title="大支 Dwagie - 台灣SONG Official MV" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Clip officiel de Dwagie : « Taiwan Song »._
+
+En 2017, il est invité à interpréter « Taiwan Song » lors de la « Taiwan Culture Night » organisée dans la salle des Brooklyn Nets, en NBA, et les médias taïwanais et les sources en ligne l’ont consigné comme l’épisode emblématique d’un rappeur taïwanais montant dans une salle de NBA.[^3] Cette scène illustre bien la position contradictoire de Dwagie : un morceau né de l’accent de Tainan, de paroles en taïwanais et de la conscience taïwanaise devient, dans une salle de basket professionnel américaine, l’étendard sonore d’un événement culturel taïwanais à l’étranger.
+
+## Rentrer à Tainan et ouvrir une salle de répétition
+
+Après « Lotus from the Tongue », Dwagie ne s’est pas dirigé uniquement vers le marché du spectacle de Taipei. Il est rentré à Tainan et y a monté Kung Fu Entertainment.
+
+Dans l’entretien avec CNA, il raconte que Kung Fu Entertainment n’était pas au départ un grand projet culturel, mais plutôt un endroit où ceux qui aimaient le hip-hop pouvaient enregistrer et répéter, et où des élèves pouvaient apprendre à rapper. À partir de 2003, cet espace de rencontre et d’enseignement est lentement devenu un bastion du hip-hop du Sud. Les cours de rap de l’été, le studio d’enregistrement, les événements et le réseau des membres ont fait de Tainan un autre centre de production du rap taïwanais.[^1]
+
+La particularité de Kung Fu Entertainment tient à ce qu’il assume à la fois l’enseignement, les concerts, la production, le rassemblement local et le relais des débutants. C’est plus hétéroclite qu’un simple label et plus public qu’un studio personnel. Que le hip-hop taïwanais ait fini par appeler Dwagie « le proviseur » tient à son ancienneté et à sa position générationnelle, mais aussi à sa manière de travailler, qui lie depuis des années l’enseignement du rap, le studio d’enregistrement et l’animation d’une scène.
+
+On imagine souvent le rap taïwanais comme une culture née des réseaux des résidences de Taipei, du Riverside Live House, des clubs et des associations étudiantes ; ce que Dwagie et Kung Fu Entertainment ont ajouté, c’est la voie de Tainan : un groupe de personnes s’exerçant dans des maisons de thé, des studios, des cours et des événements, et faisant entrer dans le hip-hop l’accent du Sud, le taïwanais et l’expérience locale.
+
+## Après « Refugee », le micro mène aux questions publiques
+
+Paru en 2011, « Refugee » (人) marque un tournant important dans la trajectoire créative de Dwagie. Selon la synthèse de CNA, l’album comprend des collaborations avec Deserts Chang, Freddy Lim, Wen Hsia et le XIVe dalaï-lama ; la chanson éponyme y fait entrer la religion, les droits humains, les animaux et le souci du vivant.[^1][^3]
+
+« Refugee » a ensuite été nommé pour le meilleur album en mandarin à la 23e édition des Golden Melody Awards, et a remporté le meilleur album et le meilleur album de hip-hop, entre autres, à la 3e édition des Golden Indie Music Awards.[^3] Les prix ne sont pas la part la plus nette de l’œuvre de Dwagie, mais ils ont fait entrer cette voie de rap rugueuse, très politique et chargée de taïwanais et de conscience taïwanaise dans une position identifiable par les institutions musicales grand public.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/_VpcRXNNZUg" title="大支 Dwagie - 人 feat. 第十四世達賴喇嘛 Official MV" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Clip officiel de Dwagie : « Refugee », avec l’apparition du XIVe dalaï-lama._
+
+Quand la télévision publique (PTS) a présenté Dwagie dans « Who's Coming to Dinner », elle l’a replacé dans le contexte de « dire les vérités de la société avec un micro », et a aussi consigné son végétarisme de longue date et son attention aux animaux et aux personnes vulnérables.[^6] Lors de la Journée mondiale des droits des animaux de 2019, le Centre d’information environnementale a rapporté qu’il avait mené sur place la lecture d’une déclaration des droits des animaux et interprété des morceaux sur l’abattage et les produits en cuir.[^7]
+
+Ces questions publiques rendent difficile de replacer la musique de Dwagie dans le seul marché du divertissement. Il conçoit le hip-hop comme un outil sonore capable d’intervenir dans le réel, et les droits humains, la subjectivité taïwanaise, les droits des animaux et l’attention aux plus fragiles sont ensuite devenus une part de son œuvre et de son image publique.
+
+Cette dimension politique a eu un prix. Fin 2016, les médias rapportent qu’une liste d’artistes taïwanais bannis circule en Chine ; l’authenticité de la liste n’était alors pas confirmée officiellement. Nommé dans cette liste, Dwagie a répondu qu’il parlait depuis des années de droits humains, de politique et de valeurs universelles, et qu’il était de toute façon en désaccord avec la position du Parti communiste chinois, ajoutant que « gagner un peu moins d’argent, ce n’est pas grave ».[^8] Cette réponse est souvent citée depuis, car elle dit sa position avec une grande franchise : le rap doit conserver la liberté de parler, même si cela rétrécit certains marchés.
+
+## Le corps, la famille et l’autre visage derrière la « dureté »
+
+L’image scénique de Dwagie s’enveloppe facilement dans quelques mots : grand gabarit, voix grave, paroles directes, position politique nette. Ces traits sont vrais, mais ne regarder que ce visage-là, c’est manquer la raison pour laquelle il a fait du hip-hop de l’enseignement et du plaidoyer public.
+
+En présentant son milieu familial, PTS mentionne que son père était policier et sa mère enseignante, et que ses frères se sont eux aussi orientés vers des métiers de service public comme la police et les pompiers.[^6] Replacé dans sa musique, ce contexte familial produit un contraste intéressant : il chante un hip-hop réputé rebelle, grossier, underground et anti-autoritaire, alors que les métiers les plus quotidiens de son entourage relèvent du soin et de l’ordre à l’intérieur des institutions : policier, enseignante, pompier.
+
+PTS consigne aussi qu’il a pratiqué le judo au lycée, qu’il s’est ensuite blessé et que cette expérience corporelle l’a fait passer du sport à la musique.[^6] Le nom de scène « Dwagie » porte de ce fait une certaine sensation physique : le rap s’appuie sur les mots et la tête, mais aussi sur le souffle, la capacité pulmonaire, le rythme, les accents et la pression de la scène pour projeter le corps. De « Taiwan Song » à « Refugee », sa part la plus reconnaissable tient souvent à ce rythme corporel rugueux, lourd et pourtant précis.
+
+C’est aussi pourquoi, lorsqu’il est devenu végétarien de longue date et s’est engagé pour les droits des animaux, cette force « dure » initiale a été réorientée. Pour Dwagie, le rap peut insulter, peut proclamer une position, et peut aussi porter la voix de vies qui ne peuvent pas parler. Ce retournement a rendu son image publique difficile à contenir dans une seule étiquette : il est à la fois un rappeur agressif, un proviseur qui apprend le rap à ses élèves, un militant présent aux événements pour les droits des animaux et un créateur qui met des questions religieuses et existentielles dans ses albums.
+
+## Les albums suivants : politique, langue et expérimentation de genre
+
+Après « Refugee », l’œuvre de Dwagie ne s’est pas figée dans une formule. Sa chronologie — « Refuse to Listen » (2013), « Hard » (2016), « Dark Net » (2018), « Burning Rap Soul » (2019), « Music and Politics » (2020), « Captain Taiwan » (2021), « Love » (2023) — le fait traverser successivement le rap politique, le taïwanais, le hardcore, les questions sociales et une sensation de vie personnelle.[^3]
+
+À l’époque de « Refuse to Listen », il collabore avec le rappeur américain Nas sur le morceau éponyme, établissant une liaison directe entre le rap taïwanais et une icône internationale du hip-hop.[^3] « Hard » a été nommé meilleur chanteur en mandarin à la 28e édition des Golden Melody Awards et a reçu le prix du jury à la 8e édition des Golden Indie Music Awards ; « Dark Net » a été nommé pour l’album de l’année, le meilleur album en taïwanais et le meilleur chanteur en taïwanais à la 30e édition des Golden Melody Awards.[^3] Il n’est pas nécessaire de lire ces prix comme un simple palmarès de réussite : le plus important est que le périmètre de la reconnaissance institutionnelle s’est progressivement élargi. L’œuvre de Dwagie circule entre albums en mandarin, albums en taïwanais, prix de genre hip-hop et prix d’artistes grand public, et pousse continuellement le rap taïwanais vers les frontières de catégories différentes.
+
+« Captain Taiwan », en 2021, a de nouveau ramené au premier plan le taïwanais et la mémoire de figures publiques. Selon les notes de recherche existantes, cet album repose principalement sur le taïwanais et a rendu hommage par des chansons à des personnalités comme Chi Chia-wei, Wang Chien-ming ou Lee Teng-hui. Cette manière d’écrire prolonge une habitude créative que Dwagie avait très tôt : au-delà de lui-même, il écrit dans ses chansons les personnes, les événements et les conflits de valeurs de la mémoire publique taïwanaise. Le taïwanais y devient une langue narrative capable de porter la biographie, la politique, l’hommage et la controverse.
+
+## « La même graine » et l’ère de The Rappers
+
+Après 2017, le hip-hop sinophone connaît un immense succès grâce aux télécrochets chinois, et le rap taïwanais reçoit davantage d’attention. En parlant de ce changement dans l’entretien avec CNA, Dwagie emploie une métaphore qui lui convient très bien à lui-même : « la même graine, dans des sols différents, pousse sous des formes différentes ».[^1]
+
+Cette phrase répond d’un côté aux différences entre les marchés des deux rives, et revient de l’autre au rap taïwanais lui-même : quand la graine du hip-hop américain entre à Taïwan, sa forme de croissance est refaçonnée par le taïwanais, le hakka, les langues autochtones, les différences entre scènes du Nord et du Sud, la politique identitaire post-démocratisation et l’histoire entrecroisée de la musique indépendante et des mouvements sociaux. La voie de Dwagie lui-même est justement la forme prise par cette graine dans le sol de Tainan.
+
+En 2021, « The Rappers » commence à être diffusée. L’émission est produite par Sanlih Television et MTV, diffusée sur TTV, MTV, MyVideo et d’autres plateformes, avec Leo Wang, Dwagie, Barzo Chiang et Kumachan comme mentors ou jurés.[^9] Pour beaucoup de jeunes auditeurs, Dwagie n’est plus seulement un OG des listes underground des débuts : il est devenu juré, professeur et proviseur à l’écran. Ce basculement a une valeur symbolique : le rap taïwanais, qui devait autrefois chercher ses semblables sur des forums, dans les réseaux des résidences et via des maquettes underground, a enfin grandi au point de pouvoir bâtir avec une émission de télévision la porte d’entrée d’une nouvelle génération.
+
+Son rôle dans l’émission ne se limite pas non plus à noter. Il représente une mémoire du hip-hop taïwanais des débuts : Tainan, le taïwanais, la dimension politique, Kung Fu Entertainment et le long chemin de l’underground au grand public. Quand les rappeurs de la nouvelle génération montrent devant la caméra leur flow, leurs battles, leur langue et leur posture, la présence de Dwagie rappelle au public qu’un télécrochet n’est qu’une porte d’entrée de plus, et que bien avant cela des gens forgeaient déjà le rap taïwanais dans de tout petits lieux.
+
+## Le passé fut ainsi, l’avenir on ne sait pas encore
+
+L’entretien de CNA de 2019 est titré « Le passé fut ainsi, l’avenir on ne sait pas encore ». La formule lui va très bien. Elle ne sonne pas comme un aîné bien installé annonçant son prochain projet, mais plutôt comme quelqu’un qui, après vingt ans, commence à sentir que l’énergie, le temps et les responsabilités sont en train de changer.[^1]
+
+Dans cet entretien, Dwagie parle des jeunes chanteurs, de l’enseignement, de l’exposition apportée par la vague du hip-hop chinois, et en même temps du temps qu’il pourra encore tenir. C’est le sens du réel d’un musicien d’âge mûr : la scène underground des débuts tenait par la passion, mais sont venus ensuite le studio, les élèves, les albums, les émissions et les questions publiques, et chacun de ces éléments ajoute du poids. Plus le titre de « proviseur » se stabilise, plus le créateur se voit poser cette question : comment continuer à écrire ses propres chansons tout en guidant, en enseignant et en répondant aux événements publics ?
+
+C’est aussi ce qui distingue Dwagie de la simple étiquette de « rappeur politique ». Les prises de parole politiques font l’actualité, mais l’enseignement et l’animation d’une scène sont un travail lent. Les faits d’actualité se retiennent facilement ; un studio d’enregistrement, un cours d’été, le processus par lequel un groupe de jeunes devient lentement rappeur s’écrivent difficilement dans un titre. Ce que Dwagie a vraiment laissé, c’est un ensemble de chansons à la position nette, et aussi une manière de faire durer une scène : quelqu’un a d’abord ouvert la porte à Tainan, et c’est pour cela que ceux qui viennent après ont un endroit où entrer s’entraîner.
+
+## Tainan, le taïwanais, le public
+
+Le plus important chez Dwagie ne tient ni à savoir s’il représente à jamais la plus haute technique du rap taïwanais, ni à savoir si toutes ses prises de position politiques recueillent l’accord de tous. Sa position historique la plus stable, c’est d’avoir noué ensemble trois choses : le rap en taïwanais, le lieu de Tainan et les questions publiques.
+
+Il a fait du rap en taïwanais une déclaration de sujet ; il a fait pousser à Tainan un bastion du Sud nommé Kung Fu Entertainment ; et il a permis à un rappeur de mettre les droits humains, les droits des animaux, l’identité taïwanaise et les questions sociales au cœur de sa création, au lieu de les laisser au registre du spectacle et du marché du divertissement.
+
+Dans l’histoire du hip-hop taïwanais, on place souvent MC HotDog au point où le rap sinophone entre sur le marché grand public, Song Yueh-ting du côté de l’écriture et du récit de vie, Soft Lipa et Kao!Inc. du côté de la veine poétique et jazz. La position de Dwagie est plus rugueuse et plus publique : il a porté le micro à Tainan, dans la rue, à côté des médias internationaux et des questions politiques, et a fait poser très tôt au rap taïwanais une question plus difficile : avec quelle langue, quel accent et quelle posture cette île va-t-elle parler d’elle-même ?
+
+Cette question donne aussi à l’œuvre de Dwagie une constante impression de friction. Ceux qui l’aiment voient souvent en lui l’une des rares personnes prêtes à chanter aussi franchement l’identité taïwanaise, les droits humains et les droits des animaux ; ceux qui ne l’aiment pas peuvent trouver sa dimension politique trop forte, son ton trop dur, sa position trop affirmée d’avance. Cette division est elle-même la position de Dwagie dans la culture populaire taïwanaise : difficile de le ranger comme pure figure de divertissement, difficile de le résumer à un unique rôle militant. Ses chansons ont une scène et un rythme, mais aussi des slogans, des attaques, des hommages et des convictions ; son studio fait de la production musicale, mais aussi de l’enseignement et de la fabrique de scène.
+
+C’est pourquoi, en regardant Dwagie rétrospectivement, la meilleure porte d’entrée reste la musique. Les événements politiques passent les uns après les autres, les polémiques publiques changent sans cesse, mais cet accent de Tainan de « Taiwan Song », la tentative d’album entièrement rap qu’a été « Lotus from the Tongue » et la scène du Sud lentement nourrie par une salle de répétition nommée Kung Fu Entertainment sont ce qu’il a laissé de plus solide dans l’histoire du hip-hop taïwanais. C’est le processus par lequel un rappeur taïwanais chante une forme venue d’ailleurs jusqu’à en faire un son local, et aussi celui par lequel le rap taïwanais passe de l’underground à la langue publique.
+
+**Pour aller plus loin** :
+
+- [Développement du hip-hop et du rap à Taïwan](/music/台灣嘻哈與饒舌發展) — le fil du rap taïwanais, de Song Yueh-ting, MC HotDog et Dwagie jusqu’à Leo Wang, Kumachan et la nouvelle génération.
+- [Musique indépendante taïwanaise](/music/台灣獨立音樂) — comment les labels indépendants, les scènes locales et la musique non mainstream ont soutenu une autre voie pour la musique de Taïwan.
+- [Golden Melody Awards](/music/金曲獎) — les mutations des genres musicaux et de la politique des langues à Taïwan vues depuis les prix de musique populaire.
+- [Incident du 28 février](/history/二二八事件) — l’une des mémoires historiques et politiques taïwanaises que l’œuvre de Dwagie touche fréquemment.
+
+## Sources des images
+
+- Photographie de Dwagie de l’image principale : municipalité de Chiayi, Wikimedia Commons, licence d’attribution (déclaration d’ouverture des données des sites gouvernementaux). Fichier original : [全國獨嘉三日跨年祭 力邀金鐘雙主持（大支）](https://commons.wikimedia.org/wiki/File:全國獨嘉三日跨年祭_力邀金鐘雙主持(大支)(cropped).jpg).
+- Photographie du concert de MC HotDog en 2012 : Chiu Yu-feng, Wikimedia Commons, CC BY-SA 4.0. Fichier original : [2012 Super Slipper](https://commons.wikimedia.org/wiki/File:MC_HotDog_at_2012_Super_Slipper.jpg).
+
+## Références
+
+[^1]: [〖Entretien〗Dwagie / Le passé fut ainsi, l’avenir on ne sait pas encore](https://www.cna.com.tw/culture/article/20191207w003) — Entretien culturel de l’agence CNA en 2019, qui récapitule la découverte du hip-hop par Dwagie, sa rencontre avec MC HotDog, Magic Stone Records, Kung Fu Entertainment, « Refugee » et son regard sur le développement du hip-hop taïwanais.
+
+[^2]: [Archéologie du hip-hop taïwanais : quand ils ont signé MC HotDog et Dwagie, personne chez Magic Stone ne savait faire du rap](https://www.roomie.tw/posts/64860) — Extrait publié par Roomie du livre « Hip Hop Kid : histoires du rap taïwanais » de Kao!Inc., qui explique Master U, le studio Big Circus de Magic Stone Records, les années underground de MC HotDog et Dwagie, et la place de « Lotus from the Tongue » dans l’histoire du rap taïwanais.
+
+[^3]: [Dwagie — Wikipédia](https://zh.wikipedia.org/zh-tw/%E5%A4%A7%E6%94%AF) — Article de Dwagie sur la Wikipédia en chinois, utilisé comme index de sa chronologie d’albums, de ses émissions, de ses collaborations, de ses prix et de ses concerts ; les passages narratifs clés sont recoupés avec CNA, Roomie et la télévision publique.
+
+[^4]: [Studio musical Kung Fu Entertainment — Wikipédia](https://zh.wikipedia.org/wiki/%E4%BA%BA%E4%BA%BA%E6%9C%89%E5%8A%9F%E7%B7%B4%E9%9F%B3%E6%A8%82%E5%B7%A5%E4%BD%9C%E5%AE%A4) — Article de Kung Fu Entertainment sur la Wikipédia en chinois, index auxiliaire qui récapitule la création du studio, la scène de Tainan, l’enseignement et les membres.
+
+[^5]: [Développement du hip-hop et du rap à Taïwan](https://taiwan-md.vercel.app/music/%E5%8F%B0%E7%81%A3%E5%98%BB%E5%93%88%E8%88%87%E9%A5%92%E8%88%8C%E7%99%BC%E5%B1%95) — Article existant de Taiwan.md, qui synthétise le rap en taïwanais, « Taiwan Song », Kung Fu Entertainment et le contexte du hip-hop taïwanais.
+
+[^6]: [Ne pas jouer selon les règles pour avoir un autre regard : Dwagie](https://www.pts.org.tw/dinner11/recom09.html) — Présentation de l’émission « Who's Coming to Dinner 11 » de la télévision publique, qui consigne le milieu familial de Dwagie, son végétarisme de longue date, son attention aux animaux et son image publique d’intervention dans les questions sociales par le micro.
+
+[^7]: [Taipei et Kaohsiung marquent la Journée mondiale des droits des animaux : une grande tête de cochon apparaît sur la pelouse de Huashan](https://e-info.org.tw/node/218325) — Reportage du Centre d’information environnementale en 2019, qui documente l’événement de la Journée mondiale des droits des animaux, la lecture de la déclaration des droits des animaux menée par Dwagie et sa participation musicale au plaidoyer pour les droits des animaux.
+
+[^8]: [On dit que le PCC bannit 55 artistes : Vivian Hsu et Wu Nien-jen figurent sur la liste](https://www.epochtimes.com/b5/16/12/30/n8647750.htm) — Reportage d’Epoch Times en 2016, qui consigne la liste d’artistes taïwanais bannis circulant sur Internet et la réponse de Dwagie ; l’authenticité de la liste est traitée comme « rapportée » et « non confirmée ».
+
+[^9]: [The Rappers — Wikipédia](https://zh.wikipedia.org/wiki/%E5%A4%A7%E5%98%BB%E5%93%88%E6%99%82%E4%BB%A3) — Article de l’émission sur la Wikipédia en chinois, qui récapitule les plateformes de diffusion de « The Rappers », la présentation et les informations sur les mentors Leo Wang, Dwagie, Barzo Chiang et Kumachan ; il sert de source pour les données de base de l’émission.

--- a/knowledge/fr/People/freddy-lim.md
+++ b/knowledge/fr/People/freddy-lim.md
@@ -1,0 +1,238 @@
+---
+translatedFrom: 'People/林昶佐.md'
+sourceCommitSha: 'f28a9528'
+sourceContentHash: 'sha256:42745728f5eb5c1a'
+sourceBodyHash: 'sha256:b26e0a7ce99faf37'
+translatedAt: '2026-07-24T03:20:00+08:00'
+lang: 'fr'
+title: 'Freddy Lim : du chanteur de CHTHONIC à l’hémicycle, celui qui a fait de l’histoire de Taïwan une voix publique'
+description: 'En tant que Freddy, chanteur de CHTHONIC, Freddy Lim a inscrit dans la mémoire publique le 28 février, la Terreur blanche, l’incident de Musha, la mythologie taïwanaise et le metal en taïwanais, et a fait du Megaport Festival, avec ses camarades, un lieu culturel du Sud. La musique, la conscience taïwanaise, la pratique culturelle, la politique institutionnelle, l’expérience familiale et son rôle public après son départ du Parlement s’enchevêtrent chez lui et dessinent un chemin qui va de la scène à la société, au Parlement et aux enceintes internationales.'
+date: 2026-07-10
+category: 'People'
+tags:
+  - 'personnalité'
+  - 'musique'
+  - 'heavy metal'
+  - 'politique'
+  - 'mouvements sociaux'
+  - 'CHTHONIC'
+subcategory: 'Musique et figures publiques'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-10
+lastHumanReview: false
+image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Freddy_Lim%2C_founder_of_ChthoniC.jpg/1280px-Freddy_Lim%2C_founder_of_ChthoniC.jpg'
+imageCredit: 'Hyw83516 / Wikimedia Commons'
+imageLicense: 'CC BY-SA 3.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg'
+difficulty: 'intermediate'
+readingTime: 14
+rationale:
+  why_this_hook: 'Ouvrir sur le conflit de plusieurs identités serrées en une seule personne, puis revenir au noyau identitaire le plus profond : le chanteur de CHTHONIC.'
+  whats_excluded: 'L’histoire complète de CHTHONIC, l’analyse approfondie album par album, l’histoire intégrale de la gestion de Megaport et l’histoire du Nouveau Pouvoir sont réservées à des sujets indépendants ; on ne prend ici que la ligne principale nécessaire à la compréhension de Freddy Lim.'
+  where_it_hedges: 'La campagne de Ko Wen-je de 2014 n’est pas retenue comme déclencheur personnel de son entrée en politique ; pour la Finlande on emploie le titre de « représentant en Finlande » ; les détails de la révocation ne servent que d’indication de contexte et aucun résultat de mandat non vérifié n’est écrit.'
+  whos_pushing_back: 'Ceux qui critiquent son service de circonscription et sa ligne partisane, ceux qui jugent CHTHONIC trop politique et ceux qui estiment qu’il ne faut pas romantiser le passage d’un artiste à la politique.'
+---
+
+> **En 30 secondes :** Freddy Lim est Freddy, le chanteur de CHTHONIC, l’un des initiateurs des débuts du Megaport Festival, ancien président de la section taïwanaise d’Amnesty International, et l’une des figures représentatives de la troisième force entrée au Parlement après le Mouvement des Tournesols. CHTHONIC a inscrit dans le black metal l’[incident du 28 février](/history/二二八事件), la [Terreur blanche à Taïwan](/history/台灣白色恐怖), l’incident de Musha, la mythologie taïwanaise et le récit des esprits, et a fait que l’histoire de Taïwan ne se lit pas seulement mais s’entend et se crie. Il a ensuite participé à la fondation du Nouveau Pouvoir, a été élu député, puis a connu le départ du parti et une procédure de révocation. Après avoir quitté son siège, il a renoué avec le travail international comme représentant de Taïwan en Finlande. La politique fut pour lui une aventure ; CHTHONIC reste son corps.
+
+Mettre Freddy Lim dans une seule identité le déforme presque toujours. En 2017, le *New York Times* est entré dans son bureau de député et y a vu une batterie électronique, une affiche de David Bowie et une photo de CHTHONIC jouant sur la place de la Liberté. En 2022, l’allemand *Der Tagesspiegel* a trouvé dans un mélange similaire une image « Free Tibet » signée par le dalaï-lama, un drapeau arc-en-ciel, un portrait de David Bowie et des photos de concerts de CHTHONIC. Ces objets sont comme une coupe transversale d’identités : chanteur de metal, initiateur d’un festival, défenseur des droits humains, politique de la troisième force, député, protagoniste d’une révocation, aidant familial, et plus tard représentant en Finlande.[^5][^6][^11][^12][^13][^14][^15][^16]
+
+Que toutes ces identités se serrent en même temps dans une seule personne fait que l’histoire de Freddy Lim n’est pas seulement le contraste « un musicien entre en politique ». Freddy Lim n’a pas laissé CHTHONIC derrière lui pour aller à la politique. Son identité publique a poussé depuis la méthode qui consiste à traiter par la musique l’histoire, la langue et le sentiment de souveraineté de Taïwan. Avant de s’asseoir en commission et de battre un politicien chevronné, celui qui hurlait sur scène les esprits de Taïwan cherchait déjà la voix de son époque.
+
+## D’abord le chanteur de CHTHONIC
+
+Freddy Lim est né en 1976 et son prénom anglais est Freddy. Pour beaucoup de médias internationaux, la présentation la plus commode est « death-metal star turned politician » : un chanteur de death metal ou de black metal devenu député taïwanais. Mais cette formule, bien que facile à comprendre, raconte son histoire à l’envers.
+
+Avant la politique, Freddy Lim traitait déjà la politique dans la musique.
+
+Il a grandi à la fin de la loi martiale. Dans l’entretien avec *Der Tagesspiegel*, il se souvient qu’à l’école primaire, parler taïwanais valait dix yuans d’amende et son nom inscrit au tableau. Les manuels ne parlaient presque pas de Taïwan et l’on éduquait les enfants comme des Chinois. Ce n’est qu’au lycée qu’il s’est mis à lire les livres sur Taïwan que son père rapportait, et à comprendre peu à peu que le lieu où il vivait ne pouvait pas s’épuiser dans le récit sinocentré des manuels.[^6]
+
+CHTHONIC s’est formé à Taipei en 1995 et a refusé dès le départ d’être un simple imitateur du black metal nordique. Lors de l’entretien de 2003 avec le *Taipei Times*, Freddy Lim situe le point de départ du groupe dans l’interrogation du black metal sur la « culture matricielle » : le black metal nordique se retourne vers les anciennes croyances écrasées par le christianisme, et CHTHONIC ramène cette question vers Taïwan pour chercher la mémoire locale abaissée par l’historiographie sinocentrée, la colonisation et la politique autoritaire. Le groupe emprunte l’intensité du black metal, du death metal et du metal symphonique, mais ramène le contenu à Taïwan : les esprits ancestraux, l’enfer, les médiums, l’incident de Musha, le 28 février, la Terreur blanche, les Unités de volontaires Takasago, l’histoire taïwanaise réprimée. Freddy Lim y est chanteur et participe aussi à la construction du concept, des paroles et du récit public. Si les reportages internationaux décriront plus tard CHTHONIC par « le taïwanais, les instruments traditionnels et l’histoire de Taïwan », c’est parce que ces éléments font qu’au sein de la scène metal mondiale on entend d’emblée qu’il ne s’agit pas d’une copie d’un groupe occidental.[^1][^17]
+
+Cela distingue légèrement CHTHONIC des groupes ordinaires « à position politique nette ». Ce n’est pas qu’il ait d’abord eu un programme politique puis mis des slogans dans ses chansons. C’est plutôt ceci : l’histoire de Taïwan est d’emblée pleine de morts, de silences, de tabous et de deuils inachevés. L’obscurité, les hurlements, la vitesse et la ritualité du black metal se sont trouvés être un registre vocal capable d’accueillir cette histoire.
+
+> **💡 Le saviez-vous ?**
+> Le nom anglais du groupe, Chthonic, vient du concept grec lié au souterrain et aux enfers. Pour un groupe de metal taïwanais qui écrit depuis des années sur les esprits, les ancêtres et les âmes injustement mortes de l’histoire, ce nom ressemble presque à un destin.
+
+Le personnage scénique de Freddy Lim n’est pas non plus un ornement. Ses hurlements, l’erhu, le maquillage, la monnaie funéraire et les versions taïwanaise et anglaise des albums composent tout un système sonore qui rend Taïwan identifiable dans le monde. Pour les fans internationaux de metal, CHTHONIC est peut-être l’endroit où ils ont entendu pour la première fois, par la musique, le 28 février, l’incident de Musha ou la situation de la souveraineté taïwanaise. Pour le public taïwanais, CHTHONIC a transformé en quelque chose que l’on peut crier ensemble en concert une histoire découpée par les manuels, la famille et les tabous politiques.
+
+Quand il a parlé plus tard du taïwanais, il a dit que cette langue lui permettait d’imaginer comment vivaient ses grands-parents dans leur jeunesse. Cet indice est important : le metal en taïwanais de CHTHONIC remet dans le corps et la voix une expérience taïwanaise écrasée par le silence de l’école, de l’État et de la famille.[^6]
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/kta4ZAwI6rY" title="閃靈、元千歲 - 暮沉武德殿（民謠版）" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Vidéo officielle de CHTHONIC : version folk de « Sunset in My Hometown » (暮沉武德殿). Même quand le mur de son metal est démonté en version acoustique, la voix de Freddy Lim, la mélodie en taïwanais et le sentiment de l’histoire restent au premier plan._
+
+## Histoire et esprits dans le black metal
+
+La méthode créative la plus importante de CHTHONIC consiste à écrire l’histoire de Taïwan comme un univers d’esprits qui reviennent sans cesse.
+
+« Seediq Bale » traite de l’incident de Musha. « Mirror of Retribution » place le 28 février dans l’imaginaire de l’enfer et du jugement. « Takasago Army » se retourne vers les jeunes autochtones taïwanais enrôlés par l’Empire japonais pendant la guerre du Pacifique. « Bú-Tik » entremêle la modernité, la salle d’arts martiaux et la mémoire coloniale. « Battlefields of Asura » pousse directement à la surface la violence et la résistance du Taïwan d’après-guerre.
+
+Ces albums dépassent la fonction de « présenter l’histoire ». Ils demandent plutôt : si les victimes ne sont pas vraiment mémorisées, ne reviendront-elles pas toujours ?
+
+« Battlefields of Asura » ne naît pas non plus des seuls grands sujets nationaux. Dans l’entretien avec la Fondation des soins palliatifs, Freddy Lim raconte la mort subite de son père d’un infarctus en 2017 et le fait qu’il n’est pas arrivé à temps pour le voir une dernière fois. Sa fille est née la même année, et la vie et la mort se sont abattues sur lui en même temps sur une très courte période. Il dit que la mort de son père lui a fait comprendre qu’il faut chérir ceux qu’on aime et ne pas laisser les émotions causer des blessures irréparables. Ce sentiment de la mort, de la filiation et de la réconciliation est aussi entré dans « Battlefields of Asura », en 2018.[^7]
+
+Dans un long entretien après son départ du Parlement, Freddy Lim raconte qu’après avoir découvert l’histoire de la famille de son grand-père maternel, il a compris autrement la manière dont CHTHONIC écrivait depuis des années sur la Terreur blanche, les victimes du 28 février et la réincarnation. Il dit qu’il ne savait pas au départ comment terminer cette histoire appelée CHTHONIC. Quand les personnages de fiction se sont raccordés à l’histoire réelle de sa famille, cet univers musical a semblé enfin rejoindre le monde réel.
+
+Le cœur de ce que CHTHONIC fait depuis des années ne tient pas à l’apparence « du metal plus des sujets taïwanais », mais au fait d’utiliser le metal pour traiter une sensation très familière aux Taïwanais et pourtant souvent indicible : l’histoire n’est pas vraiment passée, et la famille cache peut-être une histoire qu’on n’a jamais fini de raconter.
+
+L’engagement social a poussé dans ce travail musical. Quand les victimes, les esprits ancestraux et ceux que l’on a fait taire ont obtenu une voix sur scène, la question suivante a surgi : ces voix peuvent-elles être entendues dans la société ?
+
+![Freddy Lim sur scène, micro à la main, brandissant un drapeau tibétain devant une grande structure scénique.](https://upload.wikimedia.org/wikipedia/commons/thumb/7/77/Freddy_Lim%2C_founder_of_ChthoniC.jpg/1280px-Freddy_Lim%2C_founder_of_ChthoniC.jpg)
+_En 2012, Freddy Lim brandissait un drapeau tibétain sur scène. Cette image place au même endroit son identité de chanteur, son engagement pour les droits humains et la situation internationale de Taïwan. Photo : Hyw83516, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg) ([CC BY-SA 3.0](https://creativecommons.org/licenses/by-sa/3.0/))._
+
+## Megaport Festival : transformer le son en lieu
+
+Si CHTHONIC fut pour Freddy Lim l’endroit où chanter l’histoire, le Megaport Festival fut celui où il a transformé la musique en espace public.
+
+Avant Megaport, Freddy Lim et Doris Yeh apprenaient depuis longtemps, dans les festivals, à organiser le terrain. À la fin des années 1990, ils reprennent le Formoz Festival. En 2000, CHTHONIC joue au Fuji Rock Festival au Japon et voit de près, pour la première fois, la scène, les coulisses, la circulation et la répartition des tâches d’un grand festival international. Cette expérience les pousse à faire évoluer le Formoz vers plusieurs scènes, des groupes internationaux, un système de billetterie et une expérience live plus complète. Ensuite, l’expérience des coulisses, du bénévolat et de l’accueil des artistes accumulée par CHTHONIC sur des scènes internationales comme Wacken ou Download a reflué vers la conception du Megaport, lui donnant l’intention de « montrer un contenu local taïwanais avec des standards internationaux ».[^10]
+
+En 2006, Freddy Lim, Doris et l’équipe de TRA Music organisent la première édition du Megaport le long des quais 11 et 12 du port de Kaohsiung. Le festival reprend le contexte des festivals taïwanais existants et développe vite son propre caractère : le Sud, les quais, le taïwanais, les groupes indépendants, un son lourd, l’identité urbaine et un sens du public très proche des questions sociales. À ses débuts, l’équipe l’a délibérément conçu comme un festival du sud différent du Formoz de Taipei. Les noms des scènes, le paysage portuaire et la proportion de groupes du Sud ont fait de « Kaohsiung » le contenu du festival.[^2][^9]
+
+L’importance de Megaport dépasse de loin la ligne de CV « Freddy Lim a aussi organisé un festival ». C’est un médiateur : les groupes y deviennent une communauté culturelle, le public y devient une collectivité, et Kaohsiung passe de lieu de concert à coordonnée culturelle. Les musiciens y programment, organisent, coordonnent et assument la billetterie et la pression publique. Le public y vérifie avec son corps que le son de Taïwan n’a pas besoin de se concentrer à Taipei et que les scènes grand public ne sont pas les seules à compter comme culture.
+
+Megaport conserve aussi un sens du public à la manière de CHTHONIC. Après sa reprise en 2015, l’équipe l’a appelé un festival sur la vie et a maintenu le village associatif, pour que le public puisse toucher entre deux scènes aux droits humains, à la liberté, à Hong Kong, au Tibet et à toutes sortes de questions sociales. Le reportage de VERSE relie cette ligne aux concerts que Freddy Lim avait organisés par le passé : Justice invincible, contre l’annexion par la Chine ou pour la liberté du Tibet. Pour ces musiciens, un festival peut être un lieu où l’on s’éloigne un moment du quotidien et, en même temps, un lieu par où la réalité entre autrement.[^9]
+
+Megaport n’a jamais non plus été l’épopée d’un héros solitaire. Freddy Lim raconte en entretien que beaucoup de choses, de la musique au Formoz, de Megaport à la politique, il les a menées avec Doris. Il souligne aussi que dans des milieux très masculins comme le rock ou les festivals, le travail des femmes est souvent davantage invisibilisé. Après son élection comme député en 2016 et son départ de l’équipe, Megaport a surtout été repris par Doris et par le batteur de CHTHONIC, Dani. Tous deux ont prolongé l’esprit de CHTHONIC — creuser le local en regardant l’international — et considèrent les coulisses, la billetterie, l’expérience des artistes et les routines d’équipe comme faisant partie du festival. Megaport est porté par toute une équipe de musique et de programmation qui soutient une scène du Sud, et non par la réussite personnelle d’un chanteur.[^9][^10]
+
+Megaport a produit un deuxième basculement dans le rôle de Freddy Lim. De celui qui se tenait au centre de la scène, il est aussi devenu celui qui monte la scène. Cette différence mène ensuite à la politique : la politique aussi, dans une certaine mesure, consiste à monter une scène, sauf que cette scène devient circonscription, commissions, hémicycle, projets de loi et terrain médiatique. De CHTHONIC à Megaport, l’identité de musicien de Freddy Lim a cessé de concerner seulement les concerts pour assumer des lieux, des communautés et des questions publiques.
+
+## Après les Tournesols, à l’intérieur des institutions
+
+Après le [Mouvement des Tournesols](/society/太陽花學運) de 2014, une nouvelle vague d’imagination politique est apparue à Taïwan. Beaucoup de jeunes, de militants et de professionnels de la culture se sont mis à croire qu’au-delà de la protestation de rue, il fallait aussi des gens à l’intérieur des institutions.
+
+Freddy Lim fut l’un des visages les plus visibles de cette vague. Il a participé à la fondation du Nouveau Pouvoir et a été élu député en 2016 dans la cinquième circonscription de la ville de Taipei. Dans l’entretien de 2015 avec le *Taipei Times*, on voyait déjà dans son équipe de campagne les liens avec la génération des Tournesols : Wu Cheng, Lai Pin-yu et d’autres avaient rejoint l’équipe, et musiciens, militants et jeunes professionnels de la politique se retrouvaient sur un même terrain électoral.[^11] Cette circonscription comprend Wanhua et une partie de Zhongzheng ; pour un chanteur de heavy metal, cette élection l’a fait entrer dans le terrain de long terme du service de circonscription et du travail parlementaire. Il fallait affronter chaque jour les doléances, les budgets, les liens locaux, les joutes parlementaires et les attentes concrètes des électeurs envers un élu — bien au-delà d’une candidature symbolique.
+
+Les médias internationaux de l’époque adoraient ce contraste : un chanteur de metal au visage peint, qui chante l’histoire de Taïwan, entre au Parlement. GQ l’a présenté comme « la star du death metal devenue élue » et a replacé le Nouveau Pouvoir dans le contexte politique d’après les Tournesols. Le *New York Times* a observé qu’au-delà des réformes intérieures, il inscrivait aussi à son agenda politique la reconnaissance internationale de Taïwan.[^3][^5] Mais pour sa propre histoire, c’était plutôt le prolongement d’un même chemin. Ce que CHTHONIC traitait, c’était la mémoire historique et la visibilité internationale. Ce que traitait Megaport, c’était le lieu culturel. Ce qu’il a rencontré en entrant au Yuan législatif, c’étaient la défense, la diplomatie, les droits humains, la culture et la justice transitionnelle à l’intérieur des institutions.
+
+Sauf que le sens du temps de la politique est tout autre que celui de la musique.
+
+Revenant plus tard sur son expérience parlementaire, il a dit que la politique n’est pas comme écrire des chansons. Dans un groupe, quelques personnes se mettent d’accord et l’œuvre avance. Le Yuan législatif, lui, est un lieu de plus de cent personnes où les choses ne peuvent bouger que petit à petit. Cette différence fait que l’« idéal » ne consiste plus à savoir si la voix peut porter plus fort, mais si l’on peut faire bouger lentement quelque chose à l’intérieur des institutions.
+
+C’est là ce qu’il y a de plus dense dans l’histoire de Freddy Lim. La musique fait croire qu’une chanson peut exploser en un instant. La politique oblige à reconnaître que beaucoup de choses ne peuvent que se polir lentement.
+
+## Les thèmes au Parlement
+
+Les huit années de Freddy Lim au Yuan législatif ne se résument pas à « un artiste entre en politique ».
+
+Son travail politique prolonge globalement plusieurs lignes déjà présentes dans sa période musicale : la participation internationale de Taïwan, les droits humains, la justice transitionnelle, la politique culturelle, la défense et la diplomatie. De 2010 à 2014, il a présidé la section taïwanaise d’Amnesty International. Dans l’entretien de 2015, il plaçait aussi les droits humains, l’environnement, la politique culturelle, l’indépendance de Taïwan et la justice transitionnelle dans un même langage politique de « justice et équité ».[^6][^11] Une fois au Parlement, il est resté attentif au Tibet, à Hong Kong, aux droits humains et à l’espace international de Taïwan. La continuité de ces thèmes avec sa période musicale explique ses choix politiques mieux qu’une énumération de ses interpellations.
+
+Cette continuité existait avant même son entrée en politique. Pendant la tournée de l’Ozzfest 2007, CHTHONIC a donné vingt concerts aux États-Unis et a expliqué en anglais au public la situation de Taïwan, empêchée par la Chine de participer normalement aux organisations internationales. « UNlimited Taiwan » a aussi porté directement la revendication de participation internationale sur une tournée metal. L’espace international dont Freddy Lim a parlé plus tard au Parlement avait déjà été répété sur scène.[^18]
+
+![Pendant la campagne législative de 2015, Freddy Lim, en gilet de campagne jaune, distribue des tracts aux électeurs dans la rue.](https://upload.wikimedia.org/wikipedia/commons/a/a1/%E6%99%82%E4%BB%A3%E5%8A%9B%E9%87%8F%E7%AB%8B%E5%A7%94%E5%80%99%E9%81%B8%E4%BA%BA%E6%9E%97%E6%98%B6%E4%BD%90_03.JPG)
+_En 2015, Freddy Lim faisait campagne comme candidat du Nouveau Pouvoir dans la circonscription de Zhongzheng-Wanhua. Après être passé de la scène à la politique institutionnelle, il a dû entrer aussi dans ce terrain public fait de rue, de circonscription et de mobilisation locale. Photo : 國會無雙, [Wikimedia Commons](https://commons.wikimedia.org/w/index.php?curid=48398521) ([CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/))._
+
+Ces thèmes paraissent très politiques, mais ils communiquent en réalité avec le noyau musical de CHTHONIC : qui a le droit d’être entendu par le monde ? L’histoire de qui est-elle réduite au silence ? Comment un pays non officiellement reconnu peut-il parler de lui-même sur les scènes internationales ?
+
+Le rôle public de Freddy Lim se range difficilement dans la seule case « musicien » ou « homme politique ». Ce fut une série de poussées : chez CHTHONIC, il a fait de l’histoire de Taïwan du son. À Megaport, il a fait du son un lieu. Au Parlement, il a tenté de faire du lieu une pratique institutionnelle.
+
+Ce chemin n’est pas romantique. La politique institutionnelle exige négociation, compromis, votes, organisation et service aux électeurs, et elle est aussi usée par les révocations, les scissions de parti, les joutes médiatiques et les pressions locales. Cela ne fonctionne pas comme sur scène, où il suffit que les lumières s’éteignent et qu’un coup de batterie retentisse pour que l’émotion converge.
+
+Son travail politique se concentre sur quelques directions récurrentes. La première est l’international : la place de Taïwan dans les organisations internationales, le nom olympique, les alliances démocratiques et la visibilité sur les questions de droits humains. La deuxième est la défense et la diplomatie, en particulier la manière dont Taïwan préserve sa sécurité et ses relations extérieures sous la pression chinoise. La troisième est les droits humains, prolongeant son attention de longue date à Amnesty International, au Tibet libre et à Hong Kong. La quatrième est la culture, car il a toujours placé la musique populaire, la langue, la mémoire historique et le récit national sur une même carte.
+
+Ces quatre directions ne sont pas séparées. Pour Freddy Lim, savoir si la musique de Taïwan peut être entendue dans le monde, si le nom de Taïwan peut être prononcé normalement lors des compétitions internationales, si l’histoire des Taïwanais peut être reconnue dans l’éducation et la culture — tout cela renvoie à la même question : comment une communauté longtemps nommée, représentée et réécrite par d’autres peut-elle retrouver la position de parler ?
+
+## L’usure de la politique
+
+Freddy Lim a quitté le Nouveau Pouvoir en 2019, a soutenu la réélection de Tsai Ing-wen et s’est présenté comme indépendant aux législatives de 2020.[^12] Après sa réélection, il a aussi connu la scission du Nouveau Pouvoir, une procédure de révocation et la recomposition de la troisième force. Le vote de révocation de 2022 n’a pas abouti : les voix favorables ont dépassé les voix défavorables, sans atteindre le seuil légal. La plupart des analyses de l’époque ont replacé ce vote dans le contexte du système taïwanais de révocation, de la mobilisation partisane et de la lassitude de l’électorat, et non seulement dans une victoire ou une défaite personnelle.[^8][^13] En 2023, il annonce qu’il ne briguera pas de nouveau mandat de député ; la raison rendue publique est la prise en charge d’un proche atteint d’une maladie rare. En novembre de la même année, il demande son adhésion au Parti démocrate progressiste et soutient les élections de 2024.[^14][^15] En 2025, la Présidence annonce sa nomination comme représentant de Taïwan en Finlande, reliant de nouveau, sous une autre forme, « musique, plaidoyer international et diplomatie ».[^16]
+
+Ce parcours est plus complexe qu’une simple victoire ou défaite.
+
+En entretien, Freddy Lim revient sur sa ligne politique de 2016 à 2020 et raconte qu’il avait cru qu’en y versant son esprit, son âme et toutes ses forces et en fonçant sans cesse, il pourrait pousser Taïwan plus loin. Mais les scissions de parti, les défaites de ses camarades, la vague de révocations et la réalité politique ont contraint ce sentiment juvénile du « si je fonce, j’arriverai » à s’arrêter.
+
+Cela contraste vivement avec la musique. En musique, quelques personnes peuvent foncer ensemble, ceux qui aiment aiment et ceux qui n’aiment pas n’aiment pas. La politique, elle, exige de rassembler beaucoup de gens et d’assumer aussi les moments où le résultat n’est pas celui imaginé. Freddy Lim a porté son idéal dans les institutions, et les institutions l’ont aussi changé.
+
+> **⚠️ Point de vue en débat**
+> L’évaluation politique de Freddy Lim est divisée depuis longtemps. Ses soutiens voient des avancées sur les droits humains, l’international et la conscience locale ; ses critiques interrogent son service de circonscription, sa ligne partisane et ses choix politiques. Ces polémiques sont restées avec ses années au Parlement et donnent à son expérience de passage l’usure et le coût du terrain politique.
+
+## La voix hors des institutions
+
+En repassant, après son départ, ses huit années de travail politique, Freddy Lim évoque une différence : un politique peut convaincre par un discours, une interpellation ou une prestation médiatique, et toucher les gens sur le plan rationnel. Mais la musique et le cinéma peuvent rester bien plus longtemps, et faire qu’on s’aperçoive des années plus tard qu’une œuvre nous avait changé.
+
+Il n’a dit ni que la politique était inférieure ni que la musique était supérieure. Il s’agit plutôt de reconnaître à nouveau, après avoir traversé les institutions, que ces deux formes de travail atteignent les gens différemment. La politique exige négociation, procédure, voix et organisation. La musique traite la mémoire, l’émotion, la langue et le corps. La particularité de Freddy Lim, c’est d’avoir porté dans l’espace public le sentiment de l’histoire, des esprits et de la souveraineté présent dans la musique, et d’avoir vu dans la réalité politique que certaines choses peuvent être poussées par les institutions et que d’autres n’atteignent quand même que par une chanson.
+
+Si la politique fut pour lui une aventure consistant à porter sa voix dans les institutions, CHTHONIC est la racine vers laquelle cette voix revient sans cesse.
+
+Le Parlement lui a donné une autre échelle pour comprendre le réel. La musique le ramène à un caractère public que la politique ne peut pas entièrement remplacer.
+
+## Réordonner les rôles
+
+Le Freddy Lim d’après le Parlement ne s’est ni « retiré de la politique » ni « remis à chanter » tout simplement. Ses rôles se sont réordonnés : la politique institutionnelle recule, et la musique, le plaidoyer international, la diplomatie et la parole publique gardent chacun leur place. L’œuvre de CHTHONIC peut toujours faire entrer les gens dans l’ombre de l’histoire de Taïwan. En 2023, « PATTONKAN » (護國山) a ramené dans la chanson la mémoire d’Uongu Yatauyungana, victime de la Terreur blanche, et de sa famille, et a sorti le CHTHONIC de ces années du seul cycle créatif de « Millions of Reincarnations ». Megaport et la culture des festivals prouvent toujours que le son peut se rassembler en un lieu. Et l’expérience parlementaire lui rappelle qu’un idéal qui entre dans les institutions sera éprouvé par elles.[^19]
+
+C’est pourquoi l’histoire de Freddy Lim ne s’arrête pas à la curiosité politique du « chanteur de metal au Parlement ». Il a d’abord découvert Taïwan dans la musique, puis poussé cette découverte vers la scène, la ville, les mouvements sociaux et le Parlement, et il est enfin revenu au plus profond de la musique en portant la fatigue et la compréhension de la politique.
+
+Ces rôles ne s’annulent pas. CHTHONIC a laissé un univers discographique, le metal en taïwanais, une présence dans la scène metal internationale et un récit de l’histoire de Taïwan. Le Megaport Festival a laissé une ville du Sud, la gestion d’un festival et une équipe de programmation. Le Nouveau Pouvoir a fait entrer dans sa biographie la structure politique de la troisième force d’après les Tournesols. Et toutes les lignes qui traversent Freddy Lim finissent par revenir à la voix née de ce chanteur.
+
+## Pour aller plus loin
+
+CHTHONIC : l’univers du groupe, le contexte de ses albums, son influence internationale et l’esthétique du black metal taïwanais.
+
+Megaport Festival : le festival du Sud, l’identité urbaine, la culture contemporaine en taïwanais et l’évolution de long terme de l’équipe de programmation.
+
+[Musique indépendante taïwanaise](/music/台灣獨立音樂) : pour comprendre comment Freddy Lim a participé au passage de langage de l’« underground » à l’« indépendant ».
+
+[Culture des festivals à Taïwan](/music/台灣音樂祭文化) : pour comprendre la place du Megaport dans l’écosystème des festivals taïwanais.
+
+[Mouvement des Tournesols](/society/太陽花學運), le Nouveau Pouvoir et la [transition démocratique de Taïwan](/history/台灣民主轉型) : pour comprendre le contexte d’époque de son entrée dans la politique institutionnelle.
+
+## Sources des images
+
+- [Portrait de Freddy Lim de 2012](https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg) — Photo : Hyw83516, Wikimedia Commons, CC BY-SA 3.0.
+- [Candidat du Nouveau Pouvoir Freddy Lim 03](https://commons.wikimedia.org/wiki/File:%E6%99%82%E4%BB%A3%E5%8A%9B%E9%87%8F%E7%AB%8B%E5%A7%94%E5%80%99%E9%81%B8%E4%BA%BA%E6%9E%97%E6%98%B6%E4%BD%90_03.JPG) — Photo : 國會無雙, Wikimedia Commons, CC BY-SA 4.0.
+- [閃靈、元千歲 - 暮沉武德殿（民謠版）](https://www.youtube.com/watch?v=kta4ZAwI6rY) — vidéo officielle de CHTHONIC sur YouTube, utilisée pour montrer la voix de Freddy Lim en tant que chanteur et son interprétation en version acoustique.
+
+## Notes
+
+[^1]: [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic) — Portrait de GQ en 2016, qui décrit comment Freddy Lim, chanteur de CHTHONIC, est entré avec le taïwanais et les instruments traditionnels dans le champ de vision du metal international et de la politique.
+[^2]: [Site officiel du Megaport Festival](https://megaportfest.com/) — Site officiel de l’événement, utilisé pour confirmer la position contemporaine de Megaport comme festival de Kaohsiung ; son historique est recoupé avec Wikipédia.
+[^3]: [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic) — Le même article de GQ, qui fournit le contexte de la manière dont les médias internationaux ont compris en 2016 « le chanteur de metal arrive au Parlement ».
+[^4]: ['We want a fairer society': Freddy Lim, Taiwan's metalhead MP](https://www.theguardian.com/world/2020/aug/17/we-want-a-fairer-society-freddy-lim-taiwan-metalhead-mp) — Reportage de The Guardian en 2020, qui complète l’observation des médias internationaux sur son rôle public autour de sa réélection.
+[^5]: [De la rock star au député : les convictions du Taïwanais Freddy Lim](https://cn.nytimes.com/china/20170531/from-heavy-metal-frontman-to-taiwans-parliament/zh-hant/) — Reportage de 2017 de l’édition chinoise du New York Times, qui documente sa première phase politique, de la scène musicale underground au Parlement, en poussant la visibilité internationale de Taïwan et les questions sociales.
+[^6]: [Metal-Sänger und Politiker Freddy Lim: „Wir waren nie ,das freie China' – wir sind Taiwan"](https://www.tagesspiegel.de/gesellschaft/metal-sanger-und-politiker-freddy-lim-wir-waren-nie-das-freie-china--wir-sind-taiwan-8904460.html) — Entretien de Der Tagesspiegel en 2022, qui fournit le regard rétrospectif de Freddy Lim sur l’éducation sous la loi martiale, le taïwanais, l’identité de Taïwan et le récit international.
+[^7]: [De fils à mari et à père. Freddy Lim : que l’amour se prolonge autrement](https://www.hospice.org.tw/content/3435) — Entretien de la Fondation des soins palliatifs, qui complète l’expérience de vie de Freddy Lim entre la mort subite de son père, la naissance de sa fille, les soins palliatifs et l’album « Battlefields of Asura ».
+[^8]: [Cheveux longs, maquillage cadavérique… il y a 7 ans, Freddy Lim, chanteur de groupe, battait un vétéran militaire du KMT et écrivait une légende de participation politique citoyenne](https://www.businesstoday.com.tw/article/category/80392/post/202201090014/) — Reportage de Business Today en 2022, qui récapitule le contexte politique autour de la révocation, des sujets progressistes comme le mariage pour tous et l’analyse du seuil de révocation.
+[^9]: [« Megaport » d’hier à aujourd’hui (I) — la vie généreuse de ceux qui tiennent la barre du festival](https://www.verse.com.tw/article/megaport-festival-01) — Reportage de VERSE en 2022, qui récapitule le contexte allant des débuts de 2006 sur les quais de Kaohsiung au passage de relais à Doris et Dani après 2016 et au village associatif.
+[^10]: [« Megaport » d’hier à aujourd’hui (II) — bien plus que 16 ans, la somme culturelle de l’histoire des festivals taïwanais](https://www.verse.com.tw/article/megaport-festival-02) — Reportage de VERSE en 2022, qui complète la longue ligne du Formoz, de l’internationalisation multi-scènes, du paiement par l’usager, des coulisses des artistes et de la montée en gamme de la culture taïwanaise des concerts.
+[^11]: [INTERVIEW: Freddy Lim unfolds New Power Party platform](https://www.taipeitimes.com/News/taiwan/archives/2015/06/26/2003621612) — Entretien du Taipei Times en 2015, qui fournit le contexte de son entrée en campagne comme chanteur de CHTHONIC, défenseur des droits humains et fondateur du Nouveau Pouvoir.
+[^12]: [Lim to leave NPP, back Tsai re-election bid](https://www.taipeitimes.com/News/front/archives/2019/08/02/2003719765) — Reportage du Taipei Times en 2019, qui confirme son départ du Nouveau Pouvoir, sa candidature comme indépendant et son soutien à la réélection de Tsai Ing-wen.
+[^13]: [Independent Legislator Freddy Lim survives recall vote](https://focustaiwan.tw/politics/202201090008) — Reportage de Focus Taiwan/CNA en 2022, qui confirme que la révocation n’a pas abouti faute d’atteindre le seuil de voix favorables.
+[^14]: [Freddy Lim to retire from politics, look after family](https://www.taipeitimes.com/News/taiwan/archives/2023/03/18/2003796315) — Reportage du Taipei Times en 2023, qui consigne son annonce de ne pas briguer de nouveau mandat pour s’occuper d’un proche atteint d’une maladie rare.
+[^15]: [Independent lawmaker Freddy Lim applies to join DPP](https://focustaiwan.tw/politics/202311270019) — Reportage de Focus Taiwan/CNA en 2023, qui confirme sa demande d’adhésion au Parti démocrate progressiste et sa disposition à soutenir les élections de 2024.
+[^16]: [Rock star-turned-politician named Taiwan's representative to Finland](https://focustaiwan.tw/politics/202505190024) — Reportage de Focus Taiwan/CNA en 2025, qui confirme l’annonce par la Présidence de sa nomination comme représentant de Taïwan en Finlande.
+[^17]: [Chthonic put spin on Taiwan's past](https://www.taipeitimes.com/News/taiwan/archives/2003/09/14/2003067797) — Entretien du Taipei Times en 2003, qui documente les débuts de CHTHONIC, l’erhu, la Sœur Lintou, le prix du meilleur groupe des Golden Melody Awards, et la manière dont Freddy Lim a ramené la conscience de la culture matricielle du black metal vers l’histoire et les légendes populaires taïwanaises.
+[^18]: [ChthoniC promotes Taiwan's UN bid in interview with NPR](https://www.taipeitimes.com/News/taiwan/archives/2007/08/09/2003373320) — Reportage du Taipei Times en 2007, qui récapitule la manière dont CHTHONIC a expliqué en anglais au public américain, pendant la tournée de l’Ozzfest, le blocage de la participation internationale de Taïwan, ainsi que le contexte de l’interprétation d’« UNlimited Taiwan ».
+[^19]: [Le nouveau morceau de CHTHONIC « PATTONKAN » s’inspire de proches de victimes politiques](https://www.cna.com.tw/news/amov/202303010226.aspx) — Reportage de l’agence CNA en 2023 sur l’inspiration de « PATTONKAN », les proches de victimes de la Terreur blanche et la mémoire de la famille d’Uongu Yatauyungana, qui complète la manière dont les œuvres récentes de CHTHONIC prolongent le thème de la mémoire historique.
+
+## Références
+
+- [EP109 Nous sommes tous l’un parmi un million de réincarnations｜Freddy Lim de CHTHONIC](https://www.youtube.com/watch?v=5TBDAhWwtr8), Only Drinking Library, 2026. Ce texte s’appuie sur le résumé des sous-titres en chinois traditionnel et consulte surtout les passages autour de 00:26, 01:04, 01:17, 02:53 et 02:58.
+- [Meet Freddy Lim, the Death-Metal Star Who Just Became an Elected Official in Taiwan](https://www.gq.com/story/freddy-lim-taiwan-parliament-cthonic), GQ, 2016.
+- ['We want a fairer society': Freddy Lim, Taiwan's metalhead MP](https://www.theguardian.com/world/2020/aug/17/we-want-a-fairer-society-freddy-lim-taiwan-metalhead-mp), The Guardian, 2020.
+- [De la rock star au député : les convictions du Taïwanais Freddy Lim](https://cn.nytimes.com/china/20170531/from-heavy-metal-frontman-to-taiwans-parliament/zh-hant/), édition chinoise du New York Times, 2017.
+- [Metal-Sänger und Politiker Freddy Lim: „Wir waren nie ,das freie China' – wir sind Taiwan"](https://www.tagesspiegel.de/gesellschaft/metal-sanger-und-politiker-freddy-lim-wir-waren-nie-das-freie-china--wir-sind-taiwan-8904460.html), Der Tagesspiegel, 2022.
+- [De fils à mari et à père. Freddy Lim : que l’amour se prolonge autrement](https://www.hospice.org.tw/content/3435), Fondation des soins palliatifs.
+- [Cheveux longs, maquillage cadavérique… il y a 7 ans, Freddy Lim, chanteur de groupe, battait un vétéran militaire du KMT et écrivait une légende de participation politique citoyenne](https://www.businesstoday.com.tw/article/category/80392/post/202201090014/), Business Today, 2022.
+- [INTERVIEW: Freddy Lim unfolds New Power Party platform](https://www.taipeitimes.com/News/taiwan/archives/2015/06/26/2003621612), Taipei Times, 2015.
+- [Lim to leave NPP, back Tsai re-election bid](https://www.taipeitimes.com/News/front/archives/2019/08/02/2003719765), Taipei Times, 2019.
+- [Independent Legislator Freddy Lim survives recall vote](https://focustaiwan.tw/politics/202201090008), Focus Taiwan/CNA, 2022.
+- [Freddy Lim to retire from politics, look after family](https://www.taipeitimes.com/News/taiwan/archives/2023/03/18/2003796315), Taipei Times, 2023.
+- [Independent lawmaker Freddy Lim applies to join DPP](https://focustaiwan.tw/politics/202311270019), Focus Taiwan/CNA, 2023.
+- [Rock star-turned-politician named Taiwan's representative to Finland](https://focustaiwan.tw/politics/202505190024), Focus Taiwan/CNA, 2025.
+- [Chthonic put spin on Taiwan's past](https://www.taipeitimes.com/News/taiwan/archives/2003/09/14/2003067797), Taipei Times, 2003.
+- [ChthoniC promotes Taiwan's UN bid in interview with NPR](https://www.taipeitimes.com/News/taiwan/archives/2007/08/09/2003373320), Taipei Times, 2007.
+- [Le nouveau morceau de CHTHONIC « PATTONKAN » s’inspire de proches de victimes politiques](https://www.cna.com.tw/news/amov/202303010226.aspx), agence CNA, 2023.
+- [« Megaport » d’hier à aujourd’hui (I) — la vie généreuse de ceux qui tiennent la barre du festival](https://www.verse.com.tw/article/megaport-festival-01), VERSE, 2022.
+- [« Megaport » d’hier à aujourd’hui (II) — bien plus que 16 ans, la somme culturelle de l’histoire des festivals taïwanais](https://www.verse.com.tw/article/megaport-festival-02), VERSE, 2022.
+- [Many Young Taiwanese Want to Go to the Olympics With a New Flag and Anthem](https://time.com/4567456/taiwan-flag-anthem-independence-tokyo-2020-olympics/), TIME, 2016.
+- [Site officiel du Megaport Festival](https://megaportfest.com/)
+- [Site officiel de CHTHONIC 閃靈](https://www.chthonic.tw/)
+- [Freddy Lim, founder of ChthoniC](https://commons.wikimedia.org/wiki/File:Freddy_Lim,_founder_of_ChthoniC.jpg), Photo : Hyw83516, Wikimedia Commons, CC BY-SA 3.0.
+- [Candidat du Nouveau Pouvoir Freddy Lim 03](https://commons.wikimedia.org/wiki/File:%E6%99%82%E4%BB%A3%E5%8A%9B%E9%87%8F%E7%AB%8B%E5%A7%94%E5%80%99%E9%81%B8%E4%BA%BA%E6%9E%97%E6%98%B6%E4%BD%90_03.JPG), Photo : 國會無雙, Wikimedia Commons, CC BY-SA 4.0.
+- [閃靈、元千歲 - 暮沉武德殿（民謠版）](https://www.youtube.com/watch?v=kta4ZAwI6rY), YouTube officiel de CHTHONIC.
+- [Megaport Festival - Wikipédia](https://zh.wikipedia.org/wiki/%E5%A4%A7%E6%B8%AF%E9%96%8B%E5%94%B1)
+- [Chthonic (band) - Wikipédia](https://en.wikipedia.org/wiki/Chthonic_%28band%29)
+- [Freddy Lim - Wikipédia](https://en.wikipedia.org/wiki/Freddy_Lim)
+- [Cinquième circonscription de la ville de Taipei (députés) - Wikipédia](https://zh.wikipedia.org/wiki/%E8%87%BA%E5%8C%97%E5%B8%82%E7%AC%AC%E4%BA%94%E9%81%B8%E8%88%89%E5%8D%80_%28%E7%AB%8B%E6%B3%95%E5%A7%94%E5%93%A1%29)

--- a/knowledge/fr/Society/taipei-smoking-room.md
+++ b/knowledge/fr/Society/taipei-smoking-room.md
@@ -1,0 +1,318 @@
+---
+translatedFrom: 'Society/台北吸菸室.md'
+sourceCommitSha: '1929e495'
+sourceContentHash: 'sha256:38028701b07f0fef'
+sourceBodyHash: 'sha256:9688d39de8d42815'
+translatedAt: '2026-07-24T03:45:00+08:00'
+lang: 'fr'
+title: 'Le fumoir de Taipei : la boîte de verre qui respire dans une ville sans fumée'
+description: 'Le 7 mai 2026, une boîte transparente s’est dressée à côté de la sortie 6 du métro Ximen : le premier fumoir extérieur à pression négative de Taïwan. On ouvre la porte, l’air entre et ne ressort pas. Taipei veut être une ville sans fumée et a pourtant commencé par bâtir en pleine rue une maison de verre pour fumer. De 1984, quand Yen Tao a perdu un lobe pulmonaire, à aujourd’hui, avec un tabagisme passif intérieur tombé à 3,2 % et encore près de la moitié dehors, cette boîte contient une cigarette légale et un contrat sur l’espace public que la ville n’a pas fini de négocier.'
+date: 2026-07-13
+category: 'Society'
+tags:
+  - 'fumoir'
+  - 'ville sans fumée'
+  - 'lutte antitabac'
+  - 'tabagisme passif'
+  - 'fumoir à pression négative'
+  - 'santé publique'
+  - 'Ximending'
+  - 'cigarette électronique'
+subcategory: 'Society'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-13
+lastHumanReview: false
+readingTime: 17
+researchReport: 'reports/research/2026-07/台北吸菸室.md'
+image: '/article-images/society/taipei-ximending-smoking-booth-2026.webp'
+imageCredit: '花花日報 / journaliste Chang Hsiang-ying'
+imageLicense: 'Fair use editorial commentary'
+imageSource: 'https://n.yam.com/Article/20260518246667'
+sporeLinks:
+  - id: 155
+    platform: 'threads'
+    date: '2026-07-14'
+    url: 'https://www.threads.com/@taiwandotmd/post/DaxYe4Sk52Q'
+  - id: 156
+    platform: 'x'
+    date: '2026-07-14'
+    url: 'https://x.com/taiwandotmd/status/2076992601543327976'
+relatedDiary:
+  - 2026-07-14-193334-manual
+---
+
+_À la sortie 6 du métro Ximen, le premier fumoir extérieur à pression négative de Taïwan : une boîte de verre transparente à cadre noir, dressée sur le trottoir. Photo : 花花日報 / journaliste Chang Hsiang-ying (fair use editorial commentary)._
+
+> **En 30 secondes :** Taipei a inscrit dans la rue le « interdit par principe, ouvert par exception » : à Ximending et dans le quartier de Xinzhongshan, il est interdit de fumer partout à l’extérieur, et l’on y bâtit en même temps les premiers fumoirs extérieurs à pression négative de Taïwan, qui créent par extraction une différence de pression pour que l’odeur de tabac entre sans ressortir. Ceux qui approuvent disent qu’ils peuvent enfin respirer ; mais les associations antitabac s’y opposent, car plus on les construit confortables, plus on s’éloigne du but qui est d’amener les gens à arrêter. Une boîte de verre visible contient une longue marche antitabac de quarante ans, désormais poussée jusqu’à l’extérieur.
+
+## Une boîte transparente posée près de l’arcade
+
+Le 7 mai 2026, à la sortie 6 du métro Ximen, entre les enseignes de Chengdu Yangtao Bing et du magasin d’origine de Taiwan Yan Su Chi, une boîte transparente est apparue sur le trottoir. Environ 16 mètres carrés ; quelqu’un l’a mesurée sur Dcard : « pratiquement la taille d’une place de stationnement ». À l’intérieur, quatre filtres (graisse, filtration primaire de l’air, charbon actif, PM2,5) : la fumée entre, se fait laver couche après couche, puis ressort par une bouche d’extraction en biais. Ouverture de 8 heures du matin à minuit, avec un panneau à l’entrée : interdit aux moins de 20 ans et aux femmes enceintes. C’est le premier fumoir extérieur à pression négative de Taïwan[^1].
+
+Les mots « pression négative » sonnent comme du jargon de laboratoire, mais dépliés ils décrivent un phénomène physique contre-intuitif. Dès 2008, quand l’hôtel Sheraton installa un fumoir intérieur conforme, la responsable de la communication Pai Ching-hui l’expliquait ainsi à un journaliste de télévision : « la sensation de pression négative, c’est qu’en ouvrant la porte, l’air de l’intérieur ne sort pas, c’est l’air de l’extérieur qui entre »[^2]. L’extracteur maintient la pression de la boîte plus basse qu’au-dehors : en ouvrant la porte, l’air entre et l’odeur de tabac reste coincée à l’intérieur. Le principe est exactement celui des chambres à pression négative où les hôpitaux isolent les patients contagieux.
+
+Le premier geste visible d’une ville qui veut devenir une « ville sans fumée » aura pourtant été de bâtir, au carrefour le plus animé, une maison de verre pour fumer. Contradictoire ? Cette boîte transparente qui respire est en réalité la forme la plus concrète qu’ait prise jusqu’ici la tentative de Taipei de replacer dans le contrat de l’espace public une cigarette légale mais qui blesse indéniablement les autres. En suivant l’odeur du tabac depuis le cendrier de bureau jusqu’à cette maison de verre, on voit une négociation que la ville n’a pas conclue en quarante ans.
+
+Sauf que cette boîte n’a pas été très sage dès le départ. Trois jours après sa mise en service, la porte manuelle de l’une d’elles ne fermait plus et s’ouvrait toute seule ; la Direction des travaux publics a indiqué avoir ajusté le rail[^3]. Une boîte censée maintenir la pression négative par l’étanchéité, et dont la porte ne ferme pas. Cette petite fente annonçait justement toutes les polémiques à venir : entre l’étanchéité affichée et les fuites réelles, il y a toujours une bataille sans fin.
+
+## L’air a été gratuit, autrefois
+
+Pour comprendre comment un fumoir de rue peut devenir une affaire, il faut revenir à l’époque où l’odeur de tabac faisait partie de l’air. Avant 2009, la fumée flottait dans les bureaux, les trains, les karaokés et les restaurants de Taïwan. La « Longévité » du Monopole fut longtemps numéro un du marché dès sa sortie en 1958, et représentait encore 76 % des ventes de tabac taïwanaises en 1987 : sur quatre fumeurs, trois fumaient des Longévité[^4]. L’usine de tabac de Songshan, commencée en 1937 par le Bureau du monopole du Gouvernement général, a compté jusqu’à deux mille employés et plus de 21 milliards de yuans de production annuelle, et a fonctionné jusqu’en 1998[^5]. Le tabac fut jadis une affaire d’État, et fumer était le bruit de fond quotidien de l’île.
+
+![Façade nord de l’atelier de production de l’usine de tabac de Songshan, usine de cigarettes moderne construite en 1937 par le Bureau du monopole du Gouvernement général de Taïwan et devenue après-guerre une base de production du Monopole du tabac et de l’alcool.](/article-images/society/songshan-tobacco-factory-north.webp)
+
+_Atelier de production de l’usine de tabac de Songshan : construit en 1937 par le Bureau du monopole du Gouvernement général, repris après-guerre par le Monopole du tabac et de l’alcool et en activité jusqu’à l’arrêt de la production en 1998 ; c’est aujourd’hui le Songshan Cultural and Creative Park. Le tabac fut jadis une affaire d’État. Photo : 寺人孟子 / Wikimedia Commons, CC BY-SA 4.0._
+
+Le retournement de ce bruit de fond commence quand un homme perd un lobe pulmonaire. Yen Tao a appris à fumer à 12 ans ; à 52 ans, on lui retire le lobe supérieur du poumon droit à cause du tabac. À sa sortie d’hôpital, il décide en secret de se consacrer à la lutte antitabac[^6]. Le 19 mai de cette même année 1984, quand son ami Tung Chih-ying lui offre 2,5 millions de dollars américains (environ 100 millions de nouveaux dollars taïwanais au taux de l’époque) pour le remercier d’avoir réglé un litige, Yen Tao propose plutôt d’employer cet argent à créer une fondation orientée vers la lutte antitabac[^7]. Ainsi naît la Fondation John Tung.
+
+En avril de la même année, l’acteur Sun Yueh tourne « Le second printemps du vieux Mo » dans le sud de Taïwan. Un plan terminé, il sort comme d’habitude une cigarette pour l’allumer, voit venir deux lycéens en uniforme, et une phrase lui traverse l’esprit : « Sun Yueh ! Ton tabac fait du mal aux autres. Vas-tu encore fumer ? ». Il met fin à 38 ans de tabagisme, se propose comme bénévole à la Fondation John Tung et pousse un slogan que beaucoup retiendront : « chacun a le droit de refuser le tabagisme passif »[^8]. Cette phrase déplace le problème de « veux-tu arrêter pour ta santé ? » à « ta cigarette blesse-t-elle celui qui est à côté ? ». Ce déplacement est le point de départ de toute la logique de l’interdiction en extérieur, quarante ans plus tard.
+
+De ce slogan à la loi, il a fallu treize ans. La loi de lutte antitabac est promulguée en mars 1997 et entre en vigueur en septembre. Révisée en 2007, elle rend totalement non-fumeurs, à partir du 11 janvier 2009, les lieux publics et de travail intérieurs accueillant trois personnes ou plus. Le 22 mars 2023, elle s’élargit encore, intégrant les crèches, les universités, les bars et les boîtes de nuit, interdisant totalement la cigarette électronique et portant à 20 ans l’âge légal pour fumer[^9]. À chaque élargissement, l’espace où l’on peut fumer se resserre d’un tour.
+
+```tw-timeline
+Quarante ans de lutte antitabac : l’espace où l’on peut fumer se resserre tour après tour
+1984 | Création de la Fondation John Tung | Yen Tao la fonde après son opération du poumon ; Sun Yueh promeut « chacun a le droit de refuser le tabagisme passif »
+1997 | Entrée en vigueur de la loi antitabac | Promulguée le 19 mars, en vigueur le 19 septembre ; premier encadrement du tabac dans les lieux publics
+2009 | Interdiction totale à l’intérieur | À partir du 11 janvier, tous les lieux de travail intérieurs de trois personnes ou plus sont non-fumeurs
+2023 | Élargissement et interdiction totale de la cigarette électronique | En vigueur le 22 mars ; l’âge pour fumer passe à 20 ans
+2026 | Ville sans fumée et fumoir extérieur à pression négative | Le 7 mai, mise en service du premier fumoir extérieur à pression négative de Taïwan
+Sources : Base nationale de la réglementation, ministère de la Santé et du Bien-être, agence CNA
+```
+
+L’affaire du tabac s’est elle aussi retirée. En 2002, Taïwan entre à l’OMC et le Bureau du monopole devient Taiwan Tobacco & Liquor Corporation, mettant fin à quarante ans de monopole[^10]. En 2016, un accord est trouvé entre les planteurs et l’entreprise ; au printemps 2017, la dernière récolte est séchée et la culture du tabac taïwanais entre dans l’histoire[^11]. Ce qui a dominé l’air et nourri les caisses de l’État a été prié, pas à pas, de quitter l’espace public.
+
+![Ancien bâtiment du Bureau du monopole du tabac et de l’alcool de la province de Taïwan, rue Nanchang à Taipei : architecture baroque en brique rouge, aujourd’hui siège de Taiwan Tobacco & Liquor Corporation.](/article-images/society/taiwan-tobacco-monopoly-bureau-building.webp)
+
+_Ancien bâtiment du Bureau du monopole du tabac et de l’alcool de la province de Taïwan, aujourd’hui Taiwan Tobacco & Liquor Corporation. Le tabac fut une affaire d’État monopolistique jusqu’au relâchement lié à l’entrée à l’OMC en 2002. Photo : lienyuan lee / Wikimedia Commons, CC BY 3.0._
+
+## À l’intérieur, c’est gagné ; dehors, pas encore
+
+Cette longue marche arrive dans les années 2020 sur une grande victoire comptable. La prévalence du tabagisme chez les adultes de 18 ans et plus est passée de 21,9 % en 2008 à 12,8 % en 2024, soit une baisse de plus de 40 %, la plus basse depuis 1990[^12]. L’exposition au tabagisme passif sur les lieux de travail intérieurs est également passée de 32,1 % en 2008 à 22,1 % en 2020[^13]. Avec plusieurs centaines de milliers de fumeurs en moins, les cendriers de bureau ont presque disparu.
+
+Mais si l’on décompose les chiffres du tabagisme passif, deux courbes vont en sens contraire. L’exposition dans les lieux publics intérieurs s’est effondrée de 27,8 % en 2008 à 3,2 % en 2024 : la bataille de l’intérieur est presque écrasante. En revanche, dans les lieux publics extérieurs non soumis à l’interdiction, elle est passée sur la même période de 36,2 % à un pic de 58,5 % en 2013, avant de redescendre ces dernières années à 48,9 % en 2024 : encore près de la moitié[^12]. L’odeur du tabac n’a pas disparu : elle a été poussée dehors.
+
+```tw-line
+Les deux courbes du tabagisme passif : l’intérieur presque vidé, encore près de la moitié dehors (taux d’exposition %)
+Année | Lieux publics intérieurs | Lieux extérieurs sans interdiction
+2008 | 27,8 | 36,2
+2024 | 3,2 | 48,9
+Source : Administration de promotion de la santé, enquête sur le comportement tabagique des adultes
+```
+
+Si l’on demande où cette fumée rencontre le plus souvent les gens, la réponse est très concrète. Dans l’enquête de 2024, le lieu où l’on est le plus exposé au tabagisme passif est « la chaussée, la rue, les arcades et autres espaces extérieurs de circulation », avec 27,9 %, loin devant les parcs (7,7 %) et les arcades des supérettes (7,7 %)[^14]. Autrement dit, l’interdiction intérieure a chassé les fumeurs dehors, et les arcades sont devenues le nouveau couloir de fumée. Se sentir devenu « champion de l’apnée » en traversant Ximending n’a rien d’exagéré au regard des données.
+
+> 📝 **Note de la curation** : il vaut la peine de s’arrêter un instant sur le geste de fond de cette politique. Jusqu’ici, la méthode à l’extérieur consistait à « dessiner des zones non-fumeurs » : on suppose d’abord qu’on peut fumer partout, puis on entoure quelques zones où c’est interdit. La ville sans fumée de l’actuelle municipalité retourne entièrement ce réglage par défaut : à l’extérieur, on ne peut en principe fumer nulle part, et seulement dans les endroits désignés « inscrits sur la liste ». Sur un même trottoir, le réglage par défaut est passé de « on peut fumer » à « on ne peut pas ». Ajouter quelques panneaux n’est que la surface ; ce qui est vraiment réécrit, c’est à qui appartient l’air de toute la ville.
+
+## Interdit par principe, ouvert par exception
+
+Une fois le retournement opéré, reste la question de savoir où va la minorité qui fume encore. La réponse de l’actuelle municipalité est la « gestion par séparation » : interdiction totale à l’extérieur, mais orientation des fumeurs vers des zones ou des fumoirs désignés[^15]. Ximending et le quartier de Xinzhongshan sont totalement non-fumeurs depuis le 1er juin, avec une amende maximale de 10 000 nouveaux dollars taïwanais. Dans le même temps, les zones fumeurs désignées de la ville sont passées à 183, puis à 201 fin mai, et parmi elles se glissent ces premiers fumoirs extérieurs à pression négative de Taïwan[^16].
+
+Le principe de la pression négative a été expliqué très clairement le jour de l’inauguration par Lin Hui-chung, secrétaire principal de la Direction des nouveaux travaux : « cette installation utilise une "technologie de contrôle de flux par pression négative" : par extraction et ajustement de pression, la pression intérieure est maintenue sous la pression atmosphérique extérieure, formant une barrière physique par laquelle l’air ne peut qu’entrer et ne peut pas s’échapper, ce qui réduit efficacement le débordement de la fumée »[^15]. Ces boîtes sont de tailles diverses ; la plus grande, avenue Zhonghua, peut accueillir 16 personnes[^1] ; une plus petite, comme celle de la sortie 4 de la station Ximen, mesure 2 mètres sur 8, et le président de la Commission de recherche et d’évaluation, Yin Wei, indique qu’« une dizaine de personnes peuvent s’y tenir debout en même temps »[^17].
+
+Que cette conception soit devenue « à pression négative » et non un fumoir clos sur ses quatre côtés comme à Osaka tient à un détour technique. Taipei voulait au départ transposer directement le modèle clos d’Osaka, mais le gouvernement central l’a bloqué au motif que « fermer les fenêtres sur les quatre côtés revient à un intérieur, et la loi antitabac interdit de fumer à l’intérieur »[^18]. La conception « à pression négative », fondée sur le contrôle du flux d’air plutôt que sur un confinement physique total, est donc en un sens une solution née pour contourner le seuil réglementaire du « est-ce un intérieur ? ». La technologie elle-même n’est pas nouvelle. La loi japonaise de promotion de la santé, en vigueur depuis 2020, fixe déjà pour les fumoirs clos une vitesse d’air à l’entrée d’au moins 0,2 mètre par seconde, et la métropole de Tokyo ajoute des règles complémentaires plus strictes[^19]. La vraie nouveauté de Taipei n’est pas la technologie de pression négative et de filtration, mais le fait d’en avoir fait un mobilier urbain gratuit planté dans la rue.
+
+Sur le coût, la municipalité n’a pas publié le décompte unité par unité. Lors des réponses au conseil municipal, elle a pris environ 1,5 million de yuans par unité comme base d’estimation et évalué la dépense totale à environ 100 millions d’ici fin juin[^20]. De son côté, Tao Lien-sheng, président de la Fédération nationale des associations de parents, conteste du point de vue du rapport coût-bénéfice : les fumoirs extérieurs doivent légalement disposer d’une cloison indépendante, d’une climatisation indépendante, d’une conception à pression négative et d’une porte automatique, et « quand on ne parvient pas à l’effet de "ne pas sentir le tabac" et qu’on dépense tout de même de plusieurs centaines de milliers à un million de yuans pour les installer, c’est manifestement non rentable »[^21]. L’un est une base de planification municipale, l’autre une estimation critique d’une association de parents ; les deux chiffres sont de nature différente, mais tous deux pointent la même question : cette boîte en vaut-elle la peine ?
+
+## Même le camp antitabac s’est mis à se disputer
+
+Si les opposants n’étaient que des parents trouvant cela cher, l’affaire serait simple. Ce qui a compliqué les choses, c’est que le camp antitabac s’est lui-même mis à se disputer, non pas sur l’opportunité de lutter contre le tabac, mais sur la manière de le faire.
+
+La position de l’Alliance taïwanaise antitabac et de la Fondation John Tung est claire : opposition à la construction de fumoirs clos à pression négative en extérieur. Lin Ching-li, directrice du Centre de lutte antitabac de la Fondation John Tung, soutient qu’il faut aller « de l’intérieur vers l’extérieur : d’abord appliquer réellement le 100 % sans fumée à l’intérieur, puis ouvrir des points fixes de consommation à l’extérieur », et dit sans détour qu’« une ville sans fumée doit rendre les choses inconfortables pour les fumeurs, et non semer des cabines de fumeurs partout »[^22]. Dans leur logique, plus le fumoir est confortable, plus il pave la voie au fait de fumer et s’éloigne du but de faire arrêter les gens. Ce n’est pas non plus une position nouvelle : dès 2011, la Fondation John Tung critiquait le projet de l’aéroport de Taoyuan de rétablir ses fumoirs intérieurs.
+
+```tw-versus
+Réduction des risques : enfermer le tabac dans une boîte | Réduction du volume : rendre le tabac de plus en plus difficile
+Reconnaître qu’il reste des fumeurs et leur donner un coin qui ne dérange pas | L’objectif est de continuer à faire baisser la prévalence
+Gérer de façon groupée l’odeur et les mégots, nettoyer le paysage urbain | Plus c’est inconfortable, plus on fume moins ou l’on arrête
+La logique de séparation de l’actuelle municipalité | La position des associations antitabac et d’une partie du corps médical
+```
+
+Kuo Fei-jan, médecin au département de médecine familiale de l’hôpital universitaire national de Taïwan et secrétaire général de l’Alliance médicale taïwanaise pour la lutte antitabac, va un cran plus loin. Dans une tribune, il cite la Convention-cadre de l’OMS pour la lutte antitabac et souligne qu’aucune ventilation, aucun équipement de filtration de l’air et aucun fumoir désigné ne peut empêcher l’exposition au tabagisme passif, et qu’« il n’existe aucun niveau sûr d’exposition à la fumée secondaire »[^23]. Et sa phrase la plus acérée vise l’effet secondaire de l’existence même de cette boîte.
+
+```tw-quote
+Je soutiens beaucoup la ville sans fumée, mais n’installez pas de fumoirs clos en extérieur ; ne dites pas que parce que le fumoir a une pression négative et des équipements de filtration, il n’y a plus de tabagisme passif ; ne propagez pas des idées fausses au nom d’un but bienveillant.
+Kuo Fei-jan | médecin au département de médecine familiale de l’hôpital universitaire national de Taïwan, secrétaire général de l’Alliance médicale taïwanaise pour la lutte antitabac, 2026
+```
+
+> 📝 **Note de la curation** : dans cette phrase de Kuo Fei-jan se cache un mécanisme facile à négliger. Une boîte de verre au reflet futuriste, affichant « quatre filtres », suggère que « s’il y a de l’équipement, c’est sûr » : en voyant la fumée aspirée dans une boîte high-tech, on sent inconsciemment que le problème du tabagisme passif est réglé. Scientifiquement, pourtant, cette tranquillité ne tient pas. Le rapport du Surgeon General américain de 2006 conclut que même des fumoirs à pression négative, chacun clos et doté d’une extraction indépendante, n’empêchent pas la fumée secondaire de s’infiltrer dans les zones voisines[^24]. L’OMS et l’ASHRAE partagent cette position. La maison de verre est à la fois un compromis attentionné et, peut-être, une digue qui fait baisser la garde — ces deux choses peuvent être vraies en même temps.
+
+## Cette étude de Kyoto mesurait en fait autre chose
+
+Arrivés là, les deux camps sortent chacun leurs preuves. Et l’une des études les plus citées est justement un bon exemple de « comment un même matériau se raconte de deux manières ».
+
+L’Alliance antitabac a cité en conférence de presse une étude de 2023 de l’Université des femmes de Kyoto, selon laquelle la concentration de PM2,5 d’un « fumoir clos » doté d’une climatisation haut de gamme dépassait le seuil d’alerte de qualité de l’air, les mesures à 5 mètres de l’entrée dépassant elles aussi la limite[^25]. Cela sonne comme le coup le plus direct porté aux fumoirs à pression négative. Mais en remontant à l’article, le titre est en réalité « Situation du tabagisme passif aux abords de l’espace fumeurs *extérieur* de la gare de Kyoto », et l’objet d’étude était un coin fumeurs ouvert devant la gare, muni de cloisons partielles mais sans porte ni plafond, les mesures portant sur les PM2,5 à 3 et 10 mètres vers l’est[^26]. Ce n’était pas un local clos, mais un coin extérieur sous un auvent et ventilé de tous côtés.
+
+L’écart n’est pas mince. Un local clos à pression négative et un espace fumeurs ouvert sont deux structures physiques différentes. Le professeur Hiroshi Yamato, de l’Université des sciences de la santé au travail et de l’environnement, a qualifié cet espace de Kyoto, en entretien, de « coin fumeurs de type ouvert », et a critiqué le fait d’installer un tel coin sous une grande toiture, estimant qu’il faudrait l’éloigner d’au moins 25 mètres des cheminements des non-fumeurs[^27]. Autrement dit, le camp antitabac voulait démontrer avec cette étude que « même un local clos ne retient pas la fumée », alors que l’étude démontre que « même un coin ouvert couvert laisse s’échapper l’odeur du tabac ».
+
+Les deux camps ont cité la même étude, mais ce qui était mesuré n’était pas la même chose. Le plus intéressant, c’est que ce décalage informationnel ramène à un avertissement plus honnête : le problème ne tient pas seulement au caractère clos ou non, mais au fait que si la conception du flux d’air n’est pas à la hauteur, l’odeur du tabac ne se retient ni en milieu clos ni en milieu ouvert. Pour vérifier scientifiquement un local clos à pression négative, il faut revenir aux conclusions convergentes des CDC, de l’OMS et de l’ingénierie, et non à une étude extérieure déformée à force d’être rapportée. Qu’un camp ait raison sur le fond mais se trompe de preuve est, dans le débat public, plus fréquent qu’on ne le croit.
+
+## À qui est l’arcade ?
+
+En ramenant la caméra des données et des articles vers la rue, on voit un ensemble de gens plus complexe. Les fumeurs invités dans la boîte de verre, ou chassés de l’arcade, ne forment pas non plus un bloc.
+
+![Carrefour de la zone piétonne de Ximending : les premiers fumoirs extérieurs à pression négative de Taïwan sont installés sur ce trottoir très fréquenté.](/article-images/society/ximending-street-crossing.webp)
+
+_Zone piétonne de Ximending : les premiers fumoirs extérieurs à pression négative de Taïwan ont été installés dans le quartier où la densité de passants est la plus forte. Qui a le droit d’allumer ici une cigarette est le cœur de toute cette polémique. Photo : Bigmorr / Wikimedia Commons, CC BY-SA 4.0._
+
+Certains s’en réjouissent. Dans le micro-trottoir du *China Times* à Ximending, un habitant ayant fumé estime que « pour ceux qui ne fument pas, c’est bien, on ne leur impose pas de fumée secondaire » ; une fumeuse dit qu’auparavant, en fumant dans la rue, elle croisait souvent des enfants ou des parents avec des poussettes, et que maintenant, avec des zones fumeurs fixes, les gênes réciproques ont plutôt diminué[^28]. Mais d’autres se sentent repoussés trop loin. Un fumeur s’est plaint sur Dcard que le fumoir soit bien plus petit qu’imaginé, à peine une place de stationnement, et a demandé s’il fallait désormais faire la queue pour fumer et se plier en plus à des horaires[^29]. La municipalité a répondu que les fumoirs à pression négative japonais ne sont ouverts que jusqu’à 22 ou 23 heures, et que les différents fumoirs sont à trois à cinq minutes de marche les uns des autres[^30].
+
+Ce qui est intéressant, c’est une réponse en dessous. À ce message se plaignant que « c’est petit comme une place de parking », un utilisateur a répondu : « Vous comprenez maintenant ce que ressentent d’ordinaire ceux qui ne fument pas ? »[^29]. Une seule phrase met côte à côte deux injustices : le fumeur se sent poussé dans une boîte petite et lointaine, et le non-fumeur estime avoir été repoussé pendant des décennies par l’odeur du tabac, sans avoir jamais eu beaucoup de place. Dans la même maison de verre, l’un voit l’étroitesse de l’espace et l’autre une équité qui arrive tard.
+
+Et en reculant d’un pas, on voit que fumer se distribue le long d’une ligne de classe. Chez les hommes adultes, la prévalence du tabagisme atteint 35,8 % parmi ceux qui ont un niveau collège ou inférieur, soit le triple de ceux ayant fait des études supérieures (11,9 %) ; dans la tranche des 30-49 ans, elle monte à 50 % chez les premiers, soit près du double des seconds (27 %)[^31]. Plus le niveau d’études est bas, plus il est probable qu’on soit celui qui fume.
+
+```tw-bars
+Plus le niveau d’études est bas, plus la prévalence est élevée : les hommes de niveau collège ou moins triplent ceux du supérieur (%)
+*Collège ou moins | 35,8 | le triple du supérieur
+Études supérieures | 11,9
+Source : ministère de la Santé et du Bien-être (prévalence chez les hommes adultes, statistiques du 6e anniversaire de la loi antitabac)
+```
+
+> 📝 **Note de la curation** : sous cette ligne d’écart du simple au triple se cache un cercle peu confortable. Une grande part de la taxe santé prélevée sur chaque millier de cigarettes revient en subvention aux plus fragiles : cette taxe paie la cotisation d’assurance maladie de 446 000 personnes en difficulté économique et soutient aussi le fonctionnement de 13 établissements publics d’accueil du pays[^32]. Autrement dit, ceux dont la position socio-économique est la plus basse fument le plus, et la taxe supplémentaire qu’ils paient à chaque paquet subventionne le réseau de soins des plus fragiles, eux compris. Ce n’est pas un dispositif dont on peut juger en une phrase, et il mérite que chaque lecteur le rumine : quand nous invitons les fumeurs dans une boîte de verre, ceux qui y entrent sont souvent des personnes déjà en marge de cette ville.
+
+Ce qui préoccupe les commerçants et les chefs de quartier, c’est un problème de gestion plus concret. Liu Chia-hsin, président de l’Association pour le développement du quartier piéton de Ximen, a soutenu le premier le commerce sans fumée, mais dit aussi que « de jour, les problèmes de gestion sont moins probables ; ce qui m’inquiète, c’est plutôt la nuit » ; et Yeh Min-hui, cheffe du quartier de Ximen, souligne qu’il y a beaucoup de personnes sans domicile à Ximending et craint que « la gestion soit à l’avenir le plus gros problème »[^33]. Ce sont des anticipations au moment de l’entretien, non des faits établis, mais elles reflètent fidèlement le quotidien auquel devra faire face une politique qui concentre les gens dans un espace fixe.
+
+## Tokyo aussi en a construit, et après ?
+
+Taipei n’est pas la première ville à se soucier de cela. Séparer les fumeurs dans des espaces spécifiques est depuis longtemps un langage commun à beaucoup de villes asiatiques, avec des visages différents.
+
+Le Japon a été le plus précoce et le plus fragmenté. L’arrondissement de Chiyoda, à Tokyo, sanctionnait dès octobre 2002 le fait de fumer sur la voie publique d’une amende de 2 000 yens, l’une des premières sanctions de ce type au Japon ; l’arrondissement de Shibuya a suivi en 2019, interdisant de fumer dans les lieux publics de tout l’arrondissement[^34]. La fragmentation tient à ce que la métropole de Tokyo n’a pas de règle unifiée et que les 23 arrondissements font chacun à leur manière : une même cigarette est légale dans cette rue et peut valoir 2 000 yens d’amende dans l’arrondissement voisin. En comparaison, Taipei applique pour l’instant un critère unique à toute la ville, et évite cette confusion entre arrondissements.
+
+![Zone fumeurs désignée en extérieur au parc Ōhori de Fukuoka (Japon), de conception semi-ouverte en claustra de bois, avec un panneau SMOKING AREA.](/article-images/society/ohori-park-smoking-area-fukuoka.webp)
+
+_Zone fumeurs extérieure du parc Ōhori de Fukuoka (Japon). Un coin semi-ouvert est délimité par un claustra de bois, très différent de la boîte de verre taipeienne, close sur quatre côtés et maintenue en pression négative par extraction. Photo : Hirho / Wikimedia Commons, CC BY 4.0._
+
+D’autres villes ont chacune leurs calculs, mais avec des monnaies et des mécanismes différents il ne convient pas d’en comparer directement les ordres de grandeur.
+
+```tw-stat
+NT$2 000–10 000 | Infraction pour tabac à Ximending / quartier commerçant de Xinzhongshan, Taipei | à partir du 01-06-2026
+¥2 000 | Tabac sur la voie publique à Chiyoda et Shibuya, Tokyo | amende administrative, réglée sur place
+HK$3 000 | Zones d’interdiction légale de Hong Kong | à partir du 01-01-2026, relevée depuis 1 500
+€135 | Lieux extérieurs fréquentés par les enfants en France | à partir du 01-07-2025
+Sources : annonces des municipalités / autorités sanitaires respectives
+```
+
+Singapour peint au sol, devant les centres de restauration et les cafés, des « cadres jaunes » dans lesquels le fumeur doit se tenir tout entier ; la très animée Orchard Road est zone sans fumée depuis le 1er janvier 2019, où l’on ne peut fumer que sur quelques points désignés[^35]. Hong Kong a relevé le 1er janvier 2026 l’amende forfaitaire dans les zones d’interdiction légale de 1 500 à 3 000 dollars hongkongais et a ajouté la règle de ne pas fumer en faisant la queue[^36]. La France est allée plus loin : depuis juillet 2025, il est interdit de fumer dans les parcs, sur les plages, devant les écoles et dans les autres lieux extérieurs fréquentés par les enfants[^37]. La frontière de la séparation avance partout vers des scènes du quotidien de plus en plus fines.
+
+La municipalité de Taipei emploie elle-même l’expression « première du pays », c’est-à-dire le premier fumoir extérieur à pression négative à l’intérieur de Taïwan. Ni les médias en chinois ni les médias anglophones n’ont dit « première au monde »[^38]. Cette formulation relativement mesurée tient : dans les limites de ce qui a été vérifié, on ne trouve pas d’autre gouvernement ayant installé dans la rue ce type de cabine extérieure mécanique à pression négative. Quant à la phrase souvent citée en guise d’alerte, « à Tokyo, 80 % ne respectent pas la règle », en remontant à la source il s’agit d’une étude de l’équipe de l’université de Kobe publiée dans *BMC Public Health*, qui mesurait la proportion de restaurants et bars *intérieurs* de Tokyo, d’Osaka et d’Aomori ne respectant pas l’interdiction (78,4 %), et non un taux d’infraction dans les espaces fumeurs extérieurs[^39]. Les deux ne sont pas directement comparables, mais tous deux pointent le même avertissement : aussi finement que la règle soit écrite, la vraie épreuve reste toujours celle de l’application.
+
+## Cartouches zombies et une facture sans fin
+
+Le champ de bataille du tabac continue de se déplacer. Pendant que Taipei se dispute autour d’une maison de verre pour la cigarette de papier, la bataille suivante a déjà changé d’adversaire.
+
+Tandis que la cigarette traditionnelle se retire, la cigarette électronique a grandi en silence chez les adolescents. Son usage chez les collégiens est passé de 1,9 % en 2018 à 3,9 % en 2021, et chez les lycéens et élèves de l’enseignement professionnel de 3,4 % à 8,8 %, alors que l’usage de la cigarette de papier chez ces mêmes jeunes reculait[^40]. Taïwan a totalement interdit la cigarette électronique en 2023, tandis que le tabac chauffé a suivi une autre voie et, après une évaluation des risques sanitaires, est vendu légalement en supérette depuis octobre 2025[^41]. Et la dernière bataille, celle de 2026, tient à ce que la drogue étomidate, surnommée « cartouche zombie », utilise souvent la cigarette électronique comme vecteur : le Yuan exécutif a adopté le 25 juin un nouveau projet de révision de la loi antitabac portant l’amende pour possession et usage de cigarettes électroniques de 2 000–10 000 yuans à 30 000–100 000, et faisant de la fabrication et de la vente un délit pénal passible de 7 ans de prison ; ce texte est toujours en examen au Yuan législatif et n’a pas passé la troisième lecture[^42].
+
+![Une cigarette électronique jetable moderne (de type pod). Taïwan interdit depuis 2023 la fabrication, l’importation, la vente et l’usage des cigarettes électroniques.](/article-images/society/electronic-cigarette-pod.webp)
+
+_La cigarette électronique est le nouvel adversaire du champ de bataille du tabac : Taïwan l’a totalement interdite en 2023, mais son usage chez les jeunes continue de monter et, parce qu’elle transporte désormais la drogue de la « cartouche zombie », la loi est de nouveau révisée. Le tabac a changé d’enveloppe et la bataille n’est pas finie. Photo : Jacek Halicki / Wikimedia Commons, CC BY-SA 4.0._
+
+La société civile continue elle aussi de pousser. En septembre 2025, quelqu’un a proposé sur la plateforme de participation publique en ligne d’« interdire aux piétons de fumer », soutenant qu’il faudrait aussi interdire de fumer en marchant, et a rapidement atteint le seuil de signatures[^43]. La place du tabac s’est resserrée de l’intérieur vers l’arcade, puis de l’arcade vers cette maison de verre ; aujourd’hui, certains soutiennent qu’il faudrait même interdire d’allumer une cigarette en marchant. L’espace où l’on peut fumer continue de se réduire.
+
+Revenons à cette boîte transparente de la sortie 6 du métro Ximen. Celui qui est dedans la trouve petite et étroite, et doit éteindre et sortir quand l’heure arrive ; celui qui est dehors peut enfin traverser l’arcade sans retenir son souffle. L’actuelle municipalité dit que c’est une attention liée à la séparation, ceux qui veulent des espaces sans fumée disent que c’est un compromis qui trahit l’objectif, et le médecin de famille dit que le plus dangereux est de faire croire que « s’il y a un filtre, il n’y a plus de tabagisme passif ». Quatre types de personnes regardent la même boîte et voient quatre vérités — et c’est peut-être précisément pour cela qu’elle a été faite transparente : qui regarde qui, et qui est regardé par qui, tout cela est étalé sur le verre.
+
+Le tabac n’a jamais vraiment disparu. Il s’est retiré du cendrier de bureau vers l’arcade, de l’arcade vers cette maison de verre qui respire, et il file maintenant, sous l’enveloppe de la cigarette électronique, vers la prochaine bataille inachevée. Il y a quarante ans, l’année où Yen Tao perdit un lobe pulmonaire, l’air de Taïwan était encore gratuit ; quarante ans plus tard, une cigarette légale mais nuisible est de nouveau replacée dans le contrat sur l’espace public que cette ville n’a pas fini de négocier. Cette boîte transparente de la rue de Ximen ne sera pas un point final : elle n’est, jusqu’ici, que la forme la plus visible de cette négociation.
+
+**Pour aller plus loin** :
+
+- [Ximending](/geography/西門町) — le premier fumoir extérieur à pression négative de Taïwan se dresse dans la rue, à la sortie du métro Ximen ; comment un quartier commerçant né du quartier de loisirs de l’époque japonaise est devenu le terrain d’essai d’une nouvelle politique
+- [Système de santé publique et de prévention épidémique de Taïwan](/society/台灣公共衛生與防疫體系) — la lutte antitabac fait partie de la longue marche de la santé publique taïwanaise et partage avec le système de prévention la même logique de « priorité à la santé collective »
+- [Justice environnementale et conflits NIMBY à Taïwan](/society/台灣環境正義與鄰避爭議) — où bâtir le fumoir et savoir si des personnes sans domicile s’y rassembleront relève, au fond, d’un dilemme NIMBY à l’échelle de la rue
+- [Période de loi martiale](/history/戒嚴時期) — l’époque où la cigarette Longévité détenait 70 % du marché et où le Bureau du monopole contrôlait tabac et alcool est justement le contexte historique d’un État gérant le quotidien
+
+## Sources des images
+
+Ce texte utilise 6 images, toutes mises en cache dans `public/article-images/society/` pour éviter le lien direct vers les serveurs d’origine :
+
+- [花花日報 / journaliste Chang Hsiang-ying](https://n.yam.com/Article/20260518246667) — scène de rue du fumoir extérieur à pression négative de Ximending (hero), Fair use editorial commentary
+- [寺人孟子 / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E6%9D%BE%E5%B1%B1%E8%8F%B8%E5%BB%A0%E8%A3%BD%E8%8F%B8%E5%B7%A5%E5%BB%A0%E5%8C%97%E9%9D%A2.jpg) — façade nord de l’atelier de production de l’usine de tabac de Songshan, CC BY-SA 4.0
+- [lienyuan lee / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E5%8E%9F%E5%8F%B0%E7%81%A3%E8%8F%B8%E9%85%92%E5%85%AC%E8%B3%A3%E5%B1%80_Former_Taiwan_Tobacco_and_Wine_Monopoly_Bureau_-_panoramio.jpg) — ancien bâtiment du Bureau du monopole du tabac et de l’alcool de la province de Taïwan, CC BY 3.0
+- [Bigmorr / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Ximending_rainbow_crossing_20260326.jpg) — carrefour de la zone piétonne de Ximending, CC BY-SA 4.0
+- [Hirho / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%C5%8Chori_Park_The_smoking_area_%C5%8Chorik%C5%8Den_Ch%C5%AB%C5%8D-ku_Fukuoka_20260113_150049.jpg) — zone fumeurs extérieure du parc Ōhori de Fukuoka (Japon), CC BY 4.0
+- [Jacek Halicki / Wikimedia Commons](https://commons.wikimedia.org/wiki/File:2023_Lost_Vape_Ursa_Nano_Pod.jpg) — pod de cigarette électronique jetable, CC BY-SA 4.0
+
+## Références
+
+[^1]: [Peoplenews : mise en service du premier fumoir extérieur à pression négative de Taïwan](https://www.peoplenews.tw/articles/lifestyle/30593) — Reportage du journaliste Lin Wei-cheng du 07-05-2026, comprenant les quatre filtres, la capacité de 16 personnes de la plus grande unité avenue Zhonghua, l’ouverture de 8 heures à minuit, l’emplacement des 5 installations et les sanctions.
+
+[^2]: [TVBS : fumoirs à pression négative, seulement 2 conformes dans tout Taïwan](https://news.tvbs.com.tw/life/189736) — Reportage du 12-12-2008, avec la description mot à mot du flux en pression négative par Pai Ching-hui, responsable de la communication du Sheraton, et le rappel qu’à l’époque Taïwan comptait environ 4,2 millions de fumeurs pour seulement 2 fumoirs conformes.
+
+[^3]: [Liberty Times : le fumoir à pression négative de Ximen tombe en panne au bout de 3 jours](https://news.ltn.com.tw/news/life/breakingnews/5434547) — Reportage du 12-05-2026 sur une interpellation au conseil municipal ; le directeur de la Santé, Huang Chien-hua, répond que la gestion des équipements continuera d’être améliorée et la Direction des travaux publics dit avoir ajusté le rail de la porte.
+
+[^4]: [UDN : longtemps première marque du marché taïwanais du tabac, le Monopole lance la « Longévité »](https://udn.com/news/story/120910/8940040) — Chronique nostalgique, qui consigne les chiffres historiques de part de marché de la Longévité : 72 % en 1974 (source unique) et 76 % en 1987.
+
+[^5]: [Bureau du patrimoine culturel du ministère de la Culture : usine de tabac de Songshan](https://nchdb.boch.gov.tw/assets/overview/monument/20020416000001) — Fiche d’inscription patrimoniale, qui indique le début des travaux en 1937 par le Bureau du monopole du Gouvernement général, environ 2 000 employés à l’apogée, l’arrêt de la production en 1998 et l’ouverture du Songshan Cultural and Creative Park en 2011.
+
+[^6]: [Wikipédia : Yen Tao (entrepreneur)](<https://zh.wikipedia.org/zh-tw/%E5%9A%B4%E9%81%93_(%E4%BC%81%E6%A5%AD%E5%AE%B6)>) — Consigne la vie de Yen Tao : début du tabac à 12 ans, ablation du lobe supérieur du poumon droit à 52 ans à cause du tabac et création de la Fondation John Tung en 1984.
+
+[^7]: [StoryStudio : qui est vraiment le « Tung » de la Fondation John Tung ?](https://storystudio.tw/article/gushi/cold104) — Article de fond expliquant l’origine de la fondation : Tung Chih-ying a offert la somme pour remercier Yen Tao d’avoir réglé un litige, et Yen Tao a proposé de la convertir en œuvre publique de lutte antitabac.
+
+[^8]: [Réseau chinois du sevrage tabagique : notre très cher oncle Sun](https://www.e-quit.org/CustomPage/HtmlEditorPage.aspx?MId=1178&ML=3) — Site du réseau de la Fondation John Tung, qui consigne le monologue intérieur de Sun Yueh décidant d’arrêter de fumer lors d’un tournage en avril 1984 et le slogan « chacun a le droit de refuser le tabagisme passif » (attention : et non « refuser le tabagisme passif est le droit de chacun »).
+
+[^9]: [Ministère de la Santé et du Bien-être : la nouvelle loi antitabac entre en vigueur le 22 mars 2023](https://www.mohw.gov.tw/cp-6566-74078-1.html) — Communication officielle, recoupée avec l’historique de la Base nationale de la réglementation, qui confirme les trois dates d’entrée en vigueur (1997, 11-01-2009 et 22-03-2023), l’élargissement de l’interdiction, l’interdiction totale de la cigarette électronique et le passage de l’âge à 20 ans.
+
+[^10]: [The News Lens : pourquoi le Bureau du monopole du tabac et de l’alcool de la province de Taïwan a mis fin à 40 ans de monopole](https://www.thenewslens.com/article/188943) — Consigne les deux dates : l’entrée à l’OMC le 01-01-2002 et la transformation du Bureau du monopole en Taiwan Tobacco & Liquor Corporation le 01-07-2002.
+
+[^11]: [CNews : l’entreprise cesse ses achats en mars, la culture du tabac taïwanais entre dans l’histoire](https://cnews.com.tw/%E8%8F%B8%E9%85%92%E5%85%AC%E5%8F%B83%E6%9C%88%E5%81%9C%E6%AD%A2%E6%94%B6%E8%B3%BC-%E5%8F%B0%E7%81%A3%E8%8F%B8%E8%91%89%E7%A8%AE%E6%A4%8D%E8%B5%B0%E5%85%A5%E6%AD%B7%E5%8F%B2/) — Récit composite de l’accord de 2016 avec les planteurs et de la dernière récolte et du dernier séchage de janvier à mars 2017.
+
+[^12]: [Administration de promotion de la santé : résultats de l’enquête sur le comportement tabagique de la population](https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=1718&pid=9913) — Statistique de première main : prévalence adulte de 21,9 % (2008) à 12,8 % (2024), soit −41,6 % ; exposition au tabagisme passif dans les lieux publics intérieurs de 27,8 % à 3,2 % et dans les lieux extérieurs sans interdiction de 36,2 % à 58,5 % puis 48,9 %.
+
+[^13]: [Ministère de la Santé et du Bien-être : ne laissons pas le tabac devenir un risque professionnel](https://www.mohw.gov.tw/fp-16-63866-1.html) — Consigne la baisse de l’exposition au tabagisme passif sur les lieux de travail intérieurs de 32,1 % (2008) à 22,1 % (2020).
+
+[^14]: [CNA : l’exposition extérieure au tabagisme passif frôle les 50 % ; la proposition d’interdire aux piétons de fumer atteint le seuil](https://www.cna.com.tw/news/ahel/202511200366.aspx) — Reportage du 20-11-2025 citant l’enquête 2024 de l’Administration de promotion de la santé, avec la chaussée/rue/arcades comme principal lieu d’exposition (27,9 %), et consignant que la proposition en ligne d’« interdire aux piétons de fumer » a atteint le seuil de signatures.
+
+[^15]: [Municipalité de Taipei : le maire Chiang Wan-an inspecte le premier fumoir extérieur à pression négative de Taïwan](https://www.gov.taipei/News_Content.aspx?n=2044902FC839D045&s=AC7A74FD2EA0F1BD) — Communiqué municipal avec l’explication mot à mot de la technologie de contrôle de flux par pression négative par le secrétaire principal Lin Hui-chung, le cœur de la politique de « gestion par séparation » et les chiffres de sondage de 96,2 % et près de 80 %.
+
+[^16]: [CNA : mise en service du fumoir extérieur à pression négative de Taipei, dans un ensemble de 183 zones fumeurs](https://www.cna.com.tw/news/aloc/202605070075.aspx) — Reportage de la journaliste Chen Yu-ting avec le détail des 183 zones désignées et des 5 fumoirs à pression négative ; l’interdiction totale à Ximending à partir du 1er juin et l’amende maximale de 10 000 yuans figurent dans [Focus Taiwan](https://focustaiwan.tw/society/202605300006) ; le chiffre de 201 correspond à la mise à jour de l’application Taipei Pass du 30 mai.
+
+[^17]: [UDN : les fumeurs désespérés ; la municipalité répond sur les spécifications du fumoir](https://udn.com/news/story/7323/9477562) — Réponse du président de la Commission de recherche et d’évaluation, Yin Wei : « le fumoir de la sortie 4 de la station Ximen mesure 2 sur 8 mètres et une dizaine de personnes peuvent s’y tenir debout en même temps » ; la capacité de 16 personnes de la plus grande unité avenue Zhonghua figure dans le reportage de Peoplenews ([^1]) et correspond à un autre local.
+
+[^18]: [UDN : le fumoir extérieur de Taipei bloqué ; le gouvernement central répond que « fermer les fenêtres sur quatre côtés, c’est un intérieur »](https://udn.com/news/story/7323/9303502) — Reportage du 02-02-2026 consignant le contenu de la réponse de l’administration centrale et la référence de la Commission de recherche et d’évaluation au modèle d’Osaka, et expliquant l’origine de la conception à pression négative pour contourner la qualification d’« intérieur ».
+
+[^19]: [Ministère japonais de la Santé, du Travail et des Affaires sociales : mesures contre le tabagisme passif (critères techniques des fumoirs)](https://jyudokitsuen.mhlw.go.jp/point/) — La loi japonaise de promotion de la santé est pleinement en vigueur depuis avril 2020 et impose aux fumoirs clos une vitesse d’air à l’entrée d’au moins 0,2 m/s ; la métropole de Tokyo ajoute des critères plus stricts pour les « cabines fumeurs avec fonction d’élimination de la fumée », avec un taux d’élimination des composés organiques volatils supérieur à 95 % ([repris par un fournisseur d’équipements de séparation](https://www.tornex.co.jp/3096)).
+
+[^20]: [ETtoday : réponse au conseil municipal sur le coût des fumoirs à pression négative de Taipei](https://www.ettoday.net/news/20260515/3166314.htm) — Reportage du 15-05-2026 : la municipalité retient 1,5 million de yuans par unité comme base de planification (environ 75 millions, et près de 100 millions au total d’ici fin juin) ; le reportage de CNA du même jour recoupe les chiffres ([CNA](https://www.cna.com.tw/news/aloc/202605150083.aspx)).
+
+[^21]: [CNA : l’Alliance antitabac s’oppose aux fumoirs clos en extérieur](https://www.cna.com.tw/news/ahel/202605070248.aspx) — Compte rendu mot à mot de la conférence de presse, avec la critique du président de la Fédération nationale des associations de parents, Tao Lien-sheng, selon laquelle les installer « en dépensant de plusieurs centaines de milliers à un million de yuans est manifestement non rentable » (estimation de l’association de parents, source unique).
+
+[^22]: [Awakening News Networks : Lin Ching-li plaide pour appliquer l’interdiction de l’intérieur vers l’extérieur](https://www.anntw.com/articles/20260317-ec68) — Citations mot à mot de Lin Ching-li, directrice du Centre de lutte antitabac de la Fondation John Tung : « de l’intérieur vers l’extérieur » et « une ville sans fumée doit rendre les choses inconfortables pour les fumeurs, et non semer des cabines de fumeurs partout » ; recoupé avec [UDN](https://udn.com/news/story/7314/9383252).
+
+[^23]: [Liberty Times Talk : tribune de Kuo Fei-jan, n’installez pas de fumoirs clos en extérieur](https://talk.ltn.com.tw/article/breakingnews/5424206) — Tribune signée par Kuo Fei-jan lui-même, qui cite l’article 8 de la Convention-cadre de l’OMS pour la lutte antitabac et souligne qu’aucune ventilation, aucun équipement de filtration et aucun fumoir désigné ne peut empêcher l’exposition au tabagisme passif.
+
+[^24]: [CDC des États-Unis : Ventilation and secondhand smoke](https://archive.cdc.gov/www_cdc_gov/tobacco/secondhand-smoke/protection/ventilation.htm) — Synthétise le rapport du Surgeon General de 2006 et les positions de l’OMS (2007) et de l’ASHRAE (2010), et souligne que même des fumoirs à pression négative clos et à extraction indépendante n’empêchent pas la fumée secondaire de fuir vers les zones voisines.
+
+[^25]: [Peoplenews : Kuo Fei-jan critique les fumoirs clos en extérieur](https://www.peoplenews.tw/articles/hot-news/35538) — Reportage du 01-06-2026 avec la citation mot à mot de Kuo Fei-jan « ne propagez pas des idées fausses au nom d’un but bienveillant » ; le même article contient le contexte de la référence de l’Alliance antitabac à l’étude de Kyoto.
+
+[^26]: [Dépôt académique de l’Université des femmes de Kyoto : situation du tabagisme passif aux abords de l’espace fumeurs extérieur de la gare de Kyoto](http://repo.kyoto-wu.ac.jp/dspace/handle/11173/3852) — Le titre de l’article confirme que l’objet d’étude était l’espace fumeurs « extérieur » de la gare de Kyoto (mesure des PM2,5 à 3 et 10 mètres vers l’est) et non le « fumoir clos » évoqué par l’Alliance antitabac.
+
+[^27]: [Kyoto Shimbun (repris sur notobacco.jp) : plaintes concernant l’espace fumeurs de la place de la gare de Kyoto](https://notobacco.jp/pslaw/kyoto240314.html) — Reportage du 14-03-2024 décrivant cet espace comme une structure entourée de cloisons d’environ 2 mètres de haut, sans porte ni plafond, et dans lequel le professeur Hiroshi Yamato, de l’Université des sciences de la santé au travail et de l’environnement, le qualifie de « coin fumeurs de type ouvert ».
+
+[^28]: [China Times : micro-trottoir du premier jour sans fumée à Ximending, le 1er juin](https://www.chinatimes.com/realtimenews/20260601003176-260405) — Reportage du journaliste Yu Ting-kang, avec la citation directe d’un habitant fumeur (« pour ceux qui ne fument pas, c’est bien, on ne leur impose pas de fumée secondaire ») et le témoignage, rapporté par le journaliste, d’une fumeuse estimant que les zones fixes réduisent les gênes réciproques.
+
+[^29]: [UDN Oops : elle se plaint que le fumoir de Ximending soit trop petit et limité dans le temps](https://udn.com/news/story/120912/9478980) — Reprise d’un message anonyme de Dcard (réseau social, et non micro-trottoir) se plaignant que le fumoir soit plus petit qu’imaginé, de la taille d’une place de stationnement (rapporté par le journaliste) ; la réponse d’un utilisateur, « Vous comprenez maintenant ce que ressentent d’ordinaire ceux qui ne fument pas ? », est une citation mot à mot.
+
+[^30]: [UDN : les fumeurs désespérés ; la municipalité répond sur les distances et les horaires](https://udn.com/news/story/7323/9477562) — Réponse du président de la Commission de recherche et d’évaluation, Yin Wei : « les fumoirs à pression négative japonais n’ouvrent eux aussi que jusqu’à 22 ou 23 heures » et « la distance est dans un rayon de 3 à 5 minutes de marche ».
+
+[^31]: [Ministère de la Santé et du Bien-être : 6e anniversaire des nouvelles règles antitabac, réduire les inégalités de santé](https://www.mohw.gov.tw/cp-2636-21202-1.html) — Consigne la stratification de la prévalence masculine selon le niveau d’études : 35,8 % pour le collège ou moins contre 11,9 % pour le supérieur (le triple) ; chez les hommes de 30 à 49 ans, 50,0 % contre 27,0 % (1,9 fois).
+
+[^32]: [Administration nationale de l’assurance maladie : répartition et taux d’exécution de la taxe santé sur le tabac](https://www.nhi.gov.tw/ch/cp-2145-4f27d-3126-1.html) — Données officielles : la taxe sur le tabac subventionne la cotisation d’assurance maladie de 446 000 personnes fragiles et soutient le fonctionnement de 13 établissements publics d’accueil du pays.
+
+[^33]: [UDN : fumoir à pression négative de Ximen ; commerçants et cheffe de quartier évoquent leurs craintes de gestion](https://udn.com/news/story/7323/9488277) — Liu Chia-hsin, président de l’Association pour le développement du quartier piéton de Ximen : « de jour, les problèmes de gestion sont moins probables ; ce qui m’inquiète, c’est plutôt la nuit » ; Yeh Min-hui, cheffe du quartier de Ximen : « la gestion sera sans doute à l’avenir le plus gros problème » (anticipations au moment de l’entretien, non des faits établis).
+
+[^34]: [Mairie de l’arrondissement de Chiyoda : sanction administrative pour tabac sur la voie publique](https://www.city.chiyoda.lg.jp/koho/machizukuri/sekatsu/jore/karyoshobun.html) — Chiyoda a instauré en octobre 2002 la première ordonnance de sanction du pays contre le tabac sur la voie publique, avec une amende de 2 000 yens ; les règles de Shibuya figurent sur le [site officiel de l’arrondissement](https://www.city.shibuya.tokyo.jp/kankyo/machi-seiso/kitsuen/kituenrule.html).
+
+[^35]: [NEA de Singapour : Orchard Road No Smoking Zone](https://www.nea.gov.sg/ORNSZ) — Orchard Road est zone sans fumée depuis le 01-01-2019, avec seulement quelques points fumeurs désignés ; les « cadres jaunes » (Yellow Box) peints au sol des centres de restauration et l’interdiction à moins de 5 mètres des entrées d’immeubles sont des pratiques courantes à Singapour, voir la [page de la NEA sur l’interdiction de fumer](https://www.nea.gov.sg/our-services/smoking-prohibition).
+
+[^36]: [Service d’information du gouvernement de Hong Kong : l’ordonnance modifiée sur le contrôle du tabac entre en vigueur le 01-01-2026](https://www.info.gov.hk/gia/general/202512/29/P2025122900227.htm) — L’amende forfaitaire dans les zones d’interdiction légale passe de 1 500 à 3 000 dollars hongkongais, et des règles comme l’interdiction de fumer en faisant la queue sont ajoutées.
+
+[^37]: [Euronews: France to implement smoking ban in public spaces with children](https://www.euronews.com/my-europe/2025/05/30/france-to-implement-smoking-ban-in-public-spaces-with-children-from-1-july) — La France interdit totalement de fumer depuis le 01-07-2025 dans les parcs, sur les plages, devant les écoles et dans les autres lieux extérieurs fréquentés par les enfants, sous peine d’une amende de 135 euros.
+
+[^38]: [Direction de la Santé de la municipalité de Taipei : communiqué sur la première zone fumeurs à pression négative du pays](https://health.gov.taipei/News_Content.aspx?n=BB5A41BA1E6CA260&sms=72544237BBE4C5F6&s=CEA10961E1B594E8) — La formulation officielle du titre est « première du pays » (limitée à Taïwan), et les médias anglophones parlent seulement de « Taipei's first » ; aucune formulation « première au monde » n’a été trouvée.
+
+[^39]: [Kataoka et al., BMC Public Health (2024)](https://pmc.ncbi.nlm.nih.gov/articles/PMC11606096/) — Étude de l’équipe de l’université de Kobe : les 78,4 % correspondent à la proportion de restaurants et bars *intérieurs* de Tokyo, d’Osaka et d’Aomori n’ayant pas modifié leur situation conformément à l’interdiction de 2020, et non à un taux d’infraction dans les espaces fumeurs extérieurs.
+
+[^40]: [Administration de promotion de la santé : en 2021, l’usage de la cigarette électronique chez les jeunes bondit à 6,6 %](https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=4576&pid=16031) — L’usage de la cigarette électronique passe chez les collégiens de 1,9 % (2018) à 3,9 % (2021) et chez les lycéens et élèves de l’enseignement professionnel de 3,4 % à 8,8 %, tandis que l’usage de la cigarette de papier recule sur la même période.
+
+[^41]: [ETtoday Santé : le tabac chauffé en vente au plus tôt le 11 octobre](https://health.ettoday.net/news/3032516) — L’Administration de promotion de la santé a approuvé sous conditions, le 29-07-2025, 14 produits de 2 entreprises ; 8 références de bâtonnets de tabac et 3 dispositifs sont entrés en vigueur le 11-10-2025 et sont arrivés progressivement en supérette.
+
+[^42]: [Administration de promotion de la santé : le Conseil des ministres adopte le projet de révision partielle de la loi antitabac](https://www.hpa.gov.tw/Pages/Detail.aspx?nodeid=5020&pid=20160) — Projet adopté le 25-06-2026 en réponse à l’étomidate des « cartouches zombies », portant l’amende pour possession et usage à 30 000–100 000 yuans et punissant la fabrication et la vente de jusqu’à 7 ans de prison ; au moment de la vérification, il était toujours en examen au Yuan législatif sans avoir passé la troisième lecture (recoupé avec [CNA](https://www.cna.com.tw/news/aipl/202606250150.aspx)).
+
+[^43]: [CNA : l’exposition extérieure au tabagisme passif frôle les 50 % ; la proposition d’interdire aux piétons de fumer atteint le seuil](https://www.cna.com.tw/news/ahel/202511200366.aspx) — Le proposant a soumis le 26 septembre 2025, sur la plateforme de participation publique en ligne, l’idée d’« interdire aux piétons de fumer », et a atteint le seuil de signatures.

--- a/knowledge/fr/Technology/ai-hardware-supply-chain.md
+++ b/knowledge/fr/Technology/ai-hardware-supply-chain.md
@@ -1,0 +1,206 @@
+---
+translatedFrom: 'Technology/AI硬體供應鏈.md'
+sourceCommitSha: '8f5e81ee'
+sourceContentHash: 'sha256:96b285db19941653'
+sourceBodyHash: 'sha256:96ecb5a6142f55f7'
+translatedAt: '2026-07-24T02:20:00+08:00'
+lang: 'fr'
+title: 'La chaîne d’approvisionnement du matériel d’IA : là où Taïwan transforme le nuage en machines'
+description: 'L’IA générative ressemble à un service dans le nuage, mais elle exige en réalité toute une route physique : quelqu’un conçoit les puces, quelqu’un fabrique les plaquettes, quelqu’un les encapsule, quelqu’un s’occupe de la mémoire, de l’électricité, de la dissipation, des cartes mères et des racks. L’importance de Taïwan ne tient pas seulement à TSMC, mais au fait que beaucoup de verrous de cette route s’y concentrent. Cet intérêt commun existe réellement, et il s’accompagne d’eau et d’électricité, d’émissions de carbone, de répartition des revenus, d’usines à l’étranger et de risque géopolitique, transformant des slogans abstraits en preuves vérifiables sur la chaîne d’approvisionnement.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'matériel d’IA'
+  - 'semi-conducteurs'
+  - 'chaîne d’approvisionnement'
+  - 'serveurs d’IA'
+  - 'procédés de pointe'
+  - 'encapsulation avancée'
+  - 'industrie technologique taïwanaise'
+subcategory: 'Semi-conducteurs et matériel'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Entrer par le plan de table du « banquet du billion » pour que le lecteur voie d’abord que la chaîne du matériel d’IA n’est pas une seule entreprise, mais tout un ensemble de nœuds d’ingénierie taïwanais.'
+  whats_excluded: 'Ne pas faire une encyclopédie industrielle complète, ni énumérer une à une toutes les entreprises taïwanaises de semi-conducteurs, de serveurs et de composants.'
+  where_it_hedges: 'Traiter la valeur de Taïwan dans la chaîne d’approvisionnement en même temps que l’eau et l’électricité, les émissions, la répartition des revenus, les usines à l’étranger et le risque géopolitique.'
+  whos_pushing_back: 'Les clients et alliés mondiaux ont besoin de Taïwan tout en réduisant, par des usines à l’étranger, leur dépendance à un point unique autour du détroit de Taïwan.'
+image: '/article-images/technology/ai-hardware-supply-chain-flow.svg'
+imageCredit: 'Taiwan.md Contributors'
+imageLicense: 'CC BY-SA 4.0'
+---
+
+# La chaîne d’approvisionnement du matériel d’IA : là où Taïwan transforme le nuage en machines
+
+> **En 30 secondes :** l’IA semble répondre à des questions sur un écran, mais derrière se déroule un long relais physique. Quelqu’un formule un besoin, quelqu’un conçoit une puce, quelqu’un la fabrique, quelqu’un assemble puces, mémoire, dissipation, alimentation et carte mère en machines, et le tout part enfin vers un centre de données. L’importance de Taïwan ne s’épuise pas dans un « TSMC est très fort » : plusieurs relais clés de cette course se trouvent à Taïwan. Cet intérêt commun est réel, mais ce n’est pas une garantie : il apporte en même temps des pressions sur l’eau et l’électricité, les émissions, la répartition des revenus, les usines à l’étranger et la géopolitique.
+
+Le 28 mai 2026, Jensen Huang a organisé un dîner à Taipei. Les médias l’ont appelé « le banquet du billion », parce que la somme des capitalisations boursières des entreprises représentées à table était stupéfiante. Mais ce qui mérite le plus d’être regardé dans ce dîner, ce n’est ni qui occupait la place d’honneur ni ce que valent ensemble ces entreprises.
+
+Ce qui mérite vraiment d’être regardé, c’est le plan de table.
+
+Pour la fonderie, C.C. Wei de TSMC. Pour l’assemblage des serveurs et des racks d’IA, Young Liu de Foxconn, Barry Lam de Quanta, Simon Lin de Wistron et Emily Hong de Wiwynn. Pour la conception de circuits intégrés, Rick Tsai de MediaTek. Pour l’alimentation et la dissipation, Ping Cheng de Delta, Sen-bin Chiu de Lite-On et Ching-hsing Shen d’AVC. Pour les cartes mères et les marques finales, Jonney Shih d’ASUS, Pei-cheng Yeh de GIGABYTE et Jason Chen d’Acer. Les catégories de la chaîne d’approvisionnement énumérées par l’agence CNA dans son article — fonderie, encapsulation et tests, modules de dissipation, gestion de l’alimentation, cartes mères, fabrication sous contrat et marques — dessinent presque la coupe transversale d’un serveur d’IA démonté.[^1]
+
+![Jensen Huang tenant un GPU RTX Blackwell lors de la conférence d’ouverture du CES 2025 ; sur le fond noir de la scène apparaît le nom NVIDIA et, dans sa main, le module de la nouvelle puce d’IA.](/article-images/technology/jensen-huang-ces-2025-blackwell.webp)
+
+_Jensen Huang présente le GPU RTX Blackwell lors de la conférence d’ouverture du CES 2025. Cette image ramène l’« IA » de l’interface logicielle au matériel que l’on tient dans la main. Photo : Steve Jurvetson. CC BY 2.0 via Wikimedia Commons._
+
+Ce n’était pas un dîner d’entreprise ordinaire. C’était plutôt poser une question sur la table : quand le monde entier dit que l’IA a besoin de Taïwan, de quoi a-t-il besoin au juste ?
+
+La réponse ne sera ni une seule entreprise ni une seule puce. Elle ressemble plutôt à une route : elle part d’une phrase, « il nous faut plus de puissance de calcul pour l’IA », traverse les puces, les usines, l’encapsulation, l’électricité, la dissipation, les cartes mères et les racks, et arrive enfin dans un centre de données. Taïwan se tient à plusieurs verrous de cette route.
+
+## Penser d’abord l’IA comme un service qui a besoin d’un corps
+
+Les gens rencontrent d’ordinaire l’IA sur un téléphone, un ordinateur ou une page web. On tape un texte, la réponse apparaît. Cela ressemble à de la magie, et aussi à un service dans le nuage sans poids.
+
+![Le hall de Computex au Centre d’exposition de Nangang, à Taipei : de larges allées bordées de stands de fabricants informatiques et une foule rassemblée, une scène où la chaîne du matériel taïwanaise devient visible.](/article-images/technology/computex-nangang-floor-2015.webp)
+
+_Le hall de Computex au Centre d’exposition de Nangang, à Taipei. La chaîne du matériel d’IA n’existe pas seulement dans les rapports financiers : elle se voit concrètement dans les salons, les machines de démonstration, les racks et les rendez-vous d’affaires. Photo : Solomon203. CC BY-SA 4.0 via Wikimedia Commons._
+
+Mais pour que l’IA réponde, il faut que des machines calculent derrière. Ces machines sont dans des centres de données, consomment de l’électricité, dégagent de la chaleur, exigent de la maintenance, et il faut aussi que quelqu’un les fabrique, les assemble et les livre au client.
+
+On peut imaginer l’IA comme un très grand restaurant. Ce que l’on voit, c’est le serveur qui apporte le plat à table, mais on ne voit pas la conception de la carte, les achats, la cuisine, le gaz, l’eau et l’électricité, la chambre froide, le circuit d’envoi et le nettoyage. C’est pareil pour l’IA. Ce que l’on voit, c’est la réponse à l’écran ; derrière, il y a toute une cuisine matérielle.
+
+La position de Taïwan se trouve précisément à beaucoup des plans de travail importants de cette cuisine.
+
+## Comment une commande devient un rack
+
+Une chaîne du matériel d’IA commence souvent par un besoin très ordinaire : une entreprise du nuage, une entreprise de modèles ou un grand groupe a besoin de plus de puissance de calcul. Cette phrase sonne comme l’achat d’un service dans le nuage, mais elle se transforme aussitôt en une série de problèmes physiques : quelle puce concevoir ? Où peut-on la fabriquer ? Comment rapprocher la mémoire de la puce ? Comment évacuer la chaleur ? Comment acheminer l’électricité ? Et enfin, qui assemble ces pièces très coûteuses en une machine livrable, maintenable et installable dans un centre de données ?
+
+![Schéma de flux de la chaîne du matériel d’IA : la demande d’IA passe par la conception des puces, les procédés de pointe, l’encapsulation avancée, la HBM et les substrats, la dissipation et l’alimentation, les cartes mères, l’ODM/EMS et les racks d’IA, avant d’entrer dans le centre de données ; le schéma signale les verrous d’ingénierie fortement concentrés à Taïwan, comme les procédés, l’encapsulation, l’électricité et la chaleur, les cartes, l’assemblage et les racks.](/article-images/technology/ai-hardware-supply-chain-flow.svg)
+
+_Schéma conceptuel réalisé par Taiwan.md. Ce n’est ni un graphique de parts de marché ni une carte complète des entreprises ; il sert à expliquer un chemin central : comment la demande d’IA atterrit en machines alimentables, refroidissables et expédiables._
+
+La conception des puces, tout en amont, est majoritairement entre les mains d’entreprises comme NVIDIA, AMD, Broadcom, Google, Amazon ou Microsoft. L’une des positions importantes de Taïwan apparaît quand ces plans deviennent des puces. La feuille de route technologique officielle de TSMC énumère les procédés logiques 7, 5, 3 et 2 nanomètres, A16 et A14, N2 étant indiqué en production de masse au quatrième trimestre 2025.[^2] Pour beaucoup de puces d’IA, c’est là que la conception touche pour la première fois le sol taïwanais.
+
+Mais qu’une puce soit fabriquée ne signifie pas encore que l’IA puisse fonctionner. Une puce d’IA doit être proche de la mémoire et relier différents dies en un système capable de coopérer à grande vitesse. TSMC décrit 3DFabric comme la combinaison de technologies d’empilement 3D du silicium et d’encapsulation avancée, incluant SoIC, CoWoS et InFO. AP, en rendant compte de la nouvelle usine de SPIL à Taichung, l’a également replacée dans le contexte du renforcement de la production de puces d’IA.[^3][^4] Le rôle de Taïwan commence ici à s’étendre de « fabriquer la puce » à « relier les puces en un module capable de travailler ».
+
+Si l’on continue vers l’extérieur, la chaîne ressemble de moins en moins à une ligne droite. La mémoire à large bande passante (HBM) est surtout dominée par des entreprises coréennes. Les équipements, les matériaux et les logiciels de conception impliquent des fournisseurs américains, néerlandais, japonais et européens. Les plateformes du nuage et les services de modèles sont majoritairement américains. Taïwan ne monopolise pas chaque segment et n’en tire pas partout le plus grand profit. Sa particularité tient à ce que des nœuds clés — fonderie, encapsulation, tests, substrats, alimentation, dissipation, cartes mères et assemblage final — sont très proches les uns des autres et ont l’habitude, depuis des années, de résoudre ensemble les problèmes d’ingénierie.
+
+![Schéma en couches d’un serveur d’IA : puces et accélérateurs, cartes et carte mère, alimentation et dissipation, serveur et rack, centre de données s’empilent dans l’ordre et expliquent comment un GPU devient une infrastructure d’IA opérationnelle.](/article-images/technology/ai-server-rack-stack.svg)
+
+_Schéma conceptuel réalisé par Taiwan.md. Le GPU n’est que l’un des cœurs d’un serveur d’IA ; il faut encore le relier aux cartes, à l’alimentation, à la dissipation, à la machine complète, au rack et au centre de données._
+
+À l’étape de la machine complète, le problème devient très concret. Plus la puce est puissante, plus le courant est fort et plus la chaleur est difficile à évacuer. Carte mère, alimentation, dissipation, châssis, système de gestion et planning d’expédition bougent ensemble. Ce que récupèrent des entreprises comme Foxconn, Quanta, Wistron, Wiwynn, Inventec, Compal ou Pegatron, c’est justement le travail d’assembler puces, cartes, alimentation, dissipation et conception mécanique en serveurs et racks d’IA. Quand CNA a rendu compte de l’expédition de la nouvelle plateforme de Foxconn, elle l’a également replacée dans le contexte de la présentation de systèmes de serveurs d’IA.[^10]
+
+Ce schéma de flux ne cherche donc pas à faire mémoriser des termes. Ce qu’il veut montrer, c’est que la valeur de Taïwan ne réside ni dans une seule entreprise ni dans une seule puce, mais dans la capacité à pousser un produit complexe de la plaquette et de l’encapsulation jusqu’au rack et au centre de données sur une très courte distance et dans un temps très court. Cette densité est ce qui sépare Taïwan d’une base de fabrication à bas coût ordinaire.
+
+Pour le lecteur non spécialiste, ce parcours offre aussi une manière de lire l’actualité. La prochaine fois qu’une entreprise annoncera une nouvelle plateforme d’IA, il n’est pas obligatoire de demander seulement qui a conçu la puce ; on peut aussi poursuivre : où se fait l’encapsulation ? Qui fabrique la machine complète ? Qui gère l’électricité et la chaleur ? Qui assume les délais et la maintenance ? Dès que ces questions sont posées, le contour de Taïwan dans la chaîne devient plus net, plus concret et plus facile à juger.
+
+## Les semi-conducteurs sont la porte, pas la destination
+
+Écrire l’industrie technologique taïwanaise comme « une entreprise appelée TSMC » est commode, mais fait manquer beaucoup de choses.
+
+Ce à quoi répond une usine de plaquettes, c’est « la puce peut-elle être fabriquée ? ». La chaîne du matériel d’IA doit répondre à d’autres questions encore : la puce peut-elle être reliée à la mémoire ? Peut-elle être alimentée, refroidie, testée, maintenue ? Peut-elle être assemblée, dans le délai exigé par le client, en un rack entier, une rangée entière, un centre de données entier ?
+
+Ce qu’il faut vraiment poursuivre ici, c’est la contrainte que résout chaque segment. Le procédé logique le plus avancé résout « peut-on mettre plus de transistors dans une puce plus petite et moins gourmande ? ». L’encapsulation avancée résout « quand une seule puce ne suffit pas, peut-on relier la puce de calcul, la mémoire et différents dies de façon à la fois proche et rapide ? ». Ce que demande un serveur d’IA est encore autre chose : ces pièces coûteuses peuvent-elles devenir une machine stable, maintenable, industrialisable et livrable ?
+
+La dissipation et l’alimentation ne sont donc pas des rôles secondaires. Plus la puce est puissante, plus le courant est fort et plus la chaleur est difficile à gérer. Si l’alimentation est instable ou si la chaleur ne sort pas, même la puce la plus avancée doit ralentir, voire ne peut pas fonctionner. Les procédés matures n’ont pas disparu pour autant, car une machine d’IA a encore besoin de nombreuses puces de contrôle, de connexion, de gestion d’alimentation et de périphériques. Si le procédé le plus avancé est le moteur, les procédés matures et les composants sont les freins, le circuit de carburant, le tableau de bord et le système de refroidissement. Sans l’un de ces segments, la voiture ne peut pas rouler de façon fiable.
+
+Dans ce grand tableau, il suffit de retenir une chose : les semi-conducteurs sont la porte, pas la destination. Pour que l’IA fonctionne vraiment, il faut encore traverser tout un segment qui transforme les puces en machines.
+
+C’est aussi pourquoi « Taïwan a de la valeur » ne devrait pas rester une consolation abstraite. Cela devrait pouvoir se décomposer en un schéma : qui fait les plaquettes, qui fait l’encapsulation, qui fait la dissipation, qui fait l’alimentation, qui fait les cartes mères, qui fait la machine complète, qui assume les délais, qui assume l’eau et l’électricité, et à qui coupe-t-on les commandes en premier quand le cycle se retourne.
+
+Ce schéma aide aussi à décrypter le langage de l’actualité. Quand un chef d’entreprise dit « Taïwan est un partenaire », on peut lui demander si ce dont il dépend est le procédé, l’encapsulation, l’ODM, l’alimentation ou la vitesse de réaction de tout le système. Quand un responsable politique dit « intérêt commun », on peut demander dans quelles entreprises, quelles villes et quels travailleurs cet intérêt se concentre. Quand un investisseur dit « l’avenir de l’IA est prometteur », on peut poursuivre en demandant si cet avenir atterrit dans la conception de puces, la capacité d’encapsulation, l’assemblage de serveurs ou les composants de dissipation et d’alimentation. Une fois qu’un slogan abstrait est décomposé en couches, le lecteur se laisse moins facilement porter par la seule émotion.
+
+## L’intérêt commun est réel, mais ce n’est pas de la magie
+
+La position de Taïwan dans la chaîne du matériel d’IA a bien créé un intérêt commun.
+
+Pour NVIDIA, les grands acteurs du nuage et les entreprises mondiales d’IA, Taïwan est l’endroit où l’on transforme une conception en produit. Pour des pays comme les États-Unis, le Japon ou ceux d’Europe, Taïwan est un nœud d’approvisionnement incontournable pour les puces de pointe et l’infrastructure d’IA. Pour Taïwan, cette relation d’être nécessaire apporte exportations, investissements, emplois, visibilité boursière et atouts dans la politique internationale.
+
+Quand AP a rendu compte en 2026 de l’économie de l’IA à Taïwan, elle a placé dans un même article la forte croissance, la hausse des exportations et l’extension de la présence de NVIDIA sur l’île à côté de la bulle de l’IA, du risque géopolitique et des inégalités de revenus.[^5] Cette juxtaposition est importante, car elle rappelle au lecteur que l’intérêt commun n’est ni une protection à sens unique ni une amulette qui ne s’use jamais.
+
+D’autres pays s’efforcent de faire sortir une partie de la chaîne. Que TSMC construise des usines aux États-Unis, au Japon et en Allemagne prouve d’un côté que le monde a besoin de TSMC, et signifie de l’autre que les clients et les gouvernements ne veulent pas miser tout le risque sur Taïwan. Les usines à l’étranger ne reproduiront peut-être pas à court terme la densité complète de Taïwan, mais elles modifieront à long terme la structure de la négociation.
+
+De plus, l’intérêt des entreprises n’équivaut pas à l’intérêt de l’État. Ce que veut NVIDIA, c’est un approvisionnement stable et de fortes marges. Ce que veut TSMC, c’est l’avance technologique et des clients mondiaux. Ce que veulent les ODM, ce sont des commandes et un taux d’utilisation. Ce que veut la société taïwanaise, ce sont des salaires, du logement, la sécurité énergétique, une capacité de charge environnementale et des garanties de sécurité. Ces intérêts se recoupent, mais entrent aussi en conflit.
+
+Tout le monde autour de la table compte, mais le pouvoir n’est pas réparti également. NVIDIA tient l’architecture des GPU, l’écosystème CUDA et le rythme de la plateforme. TSMC tient les procédés de pointe et une capacité d’encapsulation cruciale. Les grands acteurs du nuage tiennent les achats des centres de données. Les ODM tiennent la conception des machines complètes, l’assemblage des racks et les expéditions de masse, mais leurs marges restent généralement bien inférieures à celles des concepteurs de puces. Parmi les fabricants de composants d’alimentation, de dissipation, de substrats ou d’interfaces de test, certains obtiennent de bonnes marges grâce à de fortes barrières techniques, d’autres montent et descendent au rythme des commandes de leurs grands clients. C’est aussi pourquoi il faut décomposer l’« intérêt commun » : dans une même chaîne, chaque segment est nécessaire, mais tous ne reçoivent pas la même part de pouvoir.
+
+Une formulation plus juste devrait être plus prudente : le fait que le monde ait besoin de Taïwan lui donne un ensemble d’atouts importants. Mais ces atouts doivent être entretenus ensemble par la défense, la diplomatie, l’énergie, la gouvernance industrielle et la répartition sociale.
+
+## Construire à l’étranger n’est pas un simple déménagement
+
+Que TSMC construise des usines aux États-Unis, au Japon et en Allemagne se retrouve souvent dans la même inquiétude : si la fabrication de pointe s’en va, le bouclier de silicium de Taïwan va-t-il s’amincir ?
+
+On ne peut pas répondre à cette question par un « oui » ou un « non ».
+
+Construire à l’étranger est d’un côté un prolongement de la capacité taïwanaise. Que les clients et les alliés acceptent de fournir subventions, terrains et capital politique tient précisément à l’importance de TSMC et de la chaîne taïwanaise. Ces usines rapprochent TSMC de ses clients et rendent la chaîne mondiale politiquement plus acceptable.
+
+De l’autre côté, construire à l’étranger est aussi un geste de dispersion du risque. Ni les États-Unis, ni l’Europe, ni le Japon ne souhaitent que les puces les plus critiques restent à jamais concentrées près du détroit de Taïwan. Taïwan est nécessaire, donc on y investit. Taïwan est trop importante, donc on la disperse. Ces deux phrases tiennent en même temps.
+
+Mais une usine n’équivaut pas à tout un écosystème. Les procédés de pointe exigent équipements, matériaux, produits chimiques, ingénieurs, maintenance, expérience du rendement, capacité d’encapsulation, coordination avec le client et vitesse de réaction des fournisseurs. Déplacer un segment de capacité à l’étranger et déplacer toute une société d’ingénierie sont deux difficultés distinctes.
+
+Construire à l’étranger ressemble donc moins à arracher Taïwan de la chaîne qu’à en étirer quelques nœuds vers l’extérieur. Cela modifiera lentement la structure de la négociation et testera la manière dont Taïwan conserve sa R&D centrale, sa production de masse la plus avancée et la densité de sa chaîne.
+
+## Les procédés matures sont sur la même carte
+
+La fièvre de l’IA pousse à concentrer toute l’attention sur le 3 nanomètres, le 2 nanomètres et CoWoS. Mais une machine d’IA ne fonctionne pas uniquement avec les puces les plus avancées.
+
+Les circuits intégrés de gestion d’alimentation, les contrôleurs, les capteurs, les puces de communication, les périphériques, les puces automobiles et industrielles utilisent encore majoritairement des procédés matures. Ces puces ne font pas la une comme les GPU, mais elles soutiennent la conversion d’énergie, le contrôle des signaux, la surveillance des équipements et quantité de fonctions discrètes dans les centres de données.
+
+La pénurie mondiale de puces pendant la pandémie a fait comprendre aux chaînes de production automobiles, électroménagères et industrielles une chose : le monde ne manque pas seulement des puces les plus avancées, mais aussi de ces nœuds matures qui paraissent ordinaires et sans lesquels on ne peut rien expédier. La carte taïwanaise des semi-conducteurs ne peut donc pas se regarder par le seul sommet. TSMC, UMC, Vanguard, PSMC et un ensemble d’entreprises de procédés spéciaux, d’encapsulation et tests et de matériaux composent ensemble un socle plus épais.
+
+Ce point est important pour le lecteur. La valeur de Taïwan ne devrait pas se comprendre comme une course aux nanomètres. Plus le matériel d’IA est complexe, plus il faut que l’avancé et le mature travaillent ensemble. Plus il faut que la machine complète et les composants soient livrés ensemble.
+
+Les procédés matures doivent donc être replacés sur la même carte. Ils sont le châssis qui détermine si le matériel d’IA peut fonctionner de manière stable. Le GPU le plus avancé doit s’appuyer sur une multitude de puces ordinaires pour devenir une machine réellement utilisable, maintenable et industrialisable.
+
+## La facture du massif des montagnes sacrées
+
+Raccorder à Taïwan la demande mondiale de matériel d’IA y laisse aussi la facture.
+
+La première facture visible, c’est l’électricité. Les usines de plaquettes de pointe, la lithographie EUV, les lignes d’encapsulation, les tests de serveurs d’IA et les centres de données exigent tous une électricité stable. Les médias spécialisés ont rapporté que l’industrie taïwanaise des semi-conducteurs a tiré la sonnette d’alarme sur l’énergie verte et l’approvisionnement électrique. TSMC publie aussi régulièrement ses plans d’économies d’énergie sur l’EUV et de gestion de l’eau.[^6][^7] Les gains d’efficacité comptent, mais tant que la demande d’IA s’étend, la pression sur le total demeure.
+
+La deuxième facture, c’est l’eau et la vulnérabilité climatique. La fabrication des plaquettes exige d’énormes quantités d’eau ultrapure. Le reportage de WIRED sur l’eau dans la fabrication de puces indique qu’une seule usine peut utiliser plusieurs millions de gallons par jour, et lors des sécheresses taïwanaises la tension entre eau agricole et production de puces a fait surface. La capacité de procédé ne peut pas se séparer des barrages, des pluies, de l’eau régénérée et de la répartition régionale.[^8]
+
+La troisième facture, ce sont les émissions et le verrouillage de la trajectoire industrielle. L’étude de Roussilhe et al., portant sur des fabricants taïwanais de composants électroniques, examine comment l’énergie, l’eau et les émissions de gaz à effet de serre augmentent avec la croissance de la production, ainsi que le risque de carbon lock-in.[^9] Le massif des montagnes sacrées apporte des atouts internationaux et arrime en même temps profondément l’énergie et l’usage des sols du pays à une fabrication très intensive en énergie.
+
+La quatrième facture, c’est la répartition. L’IA a fait monter la Bourse, les exportations et les salaires du secteur technologique taïwanais, mais tout le monde n’est pas sur cette chaîne de croissance principale. Les industries traditionnelles, les services, les locataires et les jeunes hors du secteur technologique ne touchent pas nécessairement le dividende en même temps. Quand les prix du logement, les tarifs de l’électricité, le foncier et l’investissement public sont tous entraînés par la haute technologie, « l’avenir de Taïwan est prometteur » n’équivaut pas à « la vie de chaque Taïwanais s’améliore ».
+
+Il ne s’agit pas de nier l’importance des semi-conducteurs et de la chaîne de l’IA. Au contraire : c’est précisément parce qu’elle est importante qu’il faut écrire clairement la facture.
+
+## Où Taïwan se place-t-elle elle-même ?
+
+Ce que la chaîne du matériel d’IA a donné à Taïwan, outre des devises et des commandes, c’est aussi une manière de se comprendre.
+
+Taïwan n’est ni simplement une petite île protégée par le monde, ni un empire technologique capable de contrôler unilatéralement l’IA mondiale. Elle ressemble plutôt à un nœud d’ingénierie hautement spécialisé : elle est nécessaire, donc elle a des atouts. On dépend d’elle, donc elle a des responsabilités. Elle est concentrée, donc elle porte aussi le risque.
+
+La prochaine fois que le lecteur entendra « Taïwan est irremplaçable », il n’est pas obligé de s’arrêter au slogan. Il peut faire apparaître mentalement un chemin physique : la demande d’une entreprise de modèles entre dans la conception de puces, la conception entre dans les procédés de TSMC, la plaquette entre dans l’encapsulation avancée, le module encapsulé entre dans la dissipation, l’alimentation, la carte mère et le rack, et l’ODM/EMS taïwanais livre enfin le tout à un centre de données.
+
+Ce chemin est la preuve concrète. Il transforme l’« intérêt commun » d’une émotion en un fait que l’on peut discuter, contester et aussi défendre.
+
+Taïwan transforme le nuage en machines. Le vrai sens de cette phrase est celui-ci : même l’IA la plus abstraite doit, à la fin, passer par l’île la plus concrète.
+
+Et c’est aussi l’une des positions les plus claires — et les plus nécessaires à voir clairement — de Taïwan en ce moment.
+
+## Pour aller plus loin
+
+- [Commerce extérieur de Taïwan et chaînes d’approvisionnement mondiales](/economy/台灣外貿與全球供應鏈) — le contexte macro, de l’orientation exportatrice et du commerce triangulaire à la recomposition des chaînes entre les États-Unis et la Chine.
+- [NVIDIA à Taïwan](/technology/NVIDIA在台灣) — comment NVIDIA confie à Taïwan la fabrication des puces, l’encapsulation et l’assemblage des serveurs.
+- [Industrie des semi-conducteurs](/technology/半導體產業) — le long contexte, du transfert technologique de RCA à la fonderie de TSMC jusqu’au champ de bataille des matériaux et de l’encapsulation.
+- [Computex](/technology/Computex) — pourquoi le salon informatique de Taipei est devenu, à l’ère de l’IA, le lieu de pèlerinage de l’offre matérielle mondiale.
+- [Électricité et semi-conducteurs à Taïwan](/technology/台灣的電力與半導體) — la facture électrique, la pression de l’énergie verte et la sécurité énergétique derrière la chaîne de l’IA.
+- [L’eau des semi-conducteurs et les ressources hydriques de Taïwan](/technology/半導體用水與台灣水資源) — comment les usines de plaquettes se relient aux barrages, aux sécheresses, à l’eau régénérée et à la gouvernance locale.
+- [Usines de la chaîne d’IA à l’étranger](/technology/AI供應鏈海外設廠) — comment le monde fait sortir la chaîne taïwanaise, de TSMC, Foxconn et Wistron jusqu’à Delta.
+
+## Sources des images
+
+- **Schéma de flux de la chaîne du matériel d’IA** : schéma conceptuel SVG réalisé par Taiwan.md Contributors, CC BY-SA 4.0, stocké dans `public/article-images/technology/ai-hardware-supply-chain-flow.svg`. Les nœuds du schéma ont été organisés d’après le texte et les références et servent à expliquer comment la demande d’IA entre dans le centre de données en passant par la conception des puces, les procédés de pointe, l’encapsulation avancée, la HBM et les substrats, la dissipation et l’alimentation, les cartes mères, l’ODM/EMS et les racks d’IA ; ce n’est ni un graphique de parts de marché ni une carte complète des entreprises.
+- **Schéma en couches du serveur d’IA** : schéma conceptuel SVG réalisé par Taiwan.md Contributors, CC BY-SA 4.0, stocké dans `public/article-images/technology/ai-server-rack-stack.svg`. Il sert à expliquer les niveaux système d’un serveur d’IA, de la puce au centre de données, et ne représente ni une carte complète des entreprises ni des parts de marché.
+- **Jensen Huang présentant le GPU RTX Blackwell** : [Jensen Huang holding RTX Blackwell at CES 2025](<https://commons.wikimedia.org/wiki/File:Jensen_Huang_-_RTX_Blackwell_-_Nvidia_Keynote_-_CES_2025_Las_Vegas_(3).jpg>) — Photo : Pronoia, Wikimedia Commons, CC0. Ce texte utilise la version mise en cache dans `public/article-images/technology/jensen-huang-ces-2025-blackwell.webp`.
+- **Hall de Computex à Nangang** : [Computex Taipei at Taipei Nangang Exhibition Center](https://commons.wikimedia.org/wiki/File:Computex_Taipei_at_Taipei_Nangang_Exhibition_Center_20150602.jpg) — Photo : NVIDIA Taiwan, Wikimedia Commons, CC BY 2.0. Ce texte utilise la version mise en cache dans `public/article-images/technology/computex-nangang-floor-2015.webp`.
+
+## Références
+
+[^1]: [CNA : le « banquet du billion » de Jensen Huang ; C.C. Wei, Young Liu, Barry Lam et d’autres grandes figures y assistent](https://www.cna.com.tw/news/afe/202605280300.aspx) — Reportage de l’agence CNA du 28 mai 2026 sur le dîner auquel Jensen Huang a convié à Taipei les dirigeants des entreprises taïwanaises de la chaîne d’IA, avec l’énumération de catégories comme la fonderie, l’encapsulation et les tests, les modules de dissipation, la gestion de l’alimentation, les cartes mères, la fabrication sous contrat et les marques.
+[^2]: [TSMC Logic Technology](https://www.tsmc.com/english/dedicatedFoundry/technology/logic) — Page officielle des technologies de procédés logiques de TSMC, avec les procédés avancés 7, 5, 3 et 2 nanomètres, A16 et A14 et l’explication de leur feuille de route.
+[^3]: [TSMC Advanced Packaging Services](https://www.tsmc.com/english/dedicatedFoundry/services/advanced-packaging) — Page officielle des services d’encapsulation avancée de TSMC, qui explique que 3DFabric inclut des technologies d’intégration amont et aval comme SoIC, CoWoS et InFO.
+[^4]: [AP: Taiwan takes a further step in production of AI chips with advanced new plant](https://apnews.com/article/1e087e92592b0b9ab7fb20442a5b8dc7) — Reportage d’AP sur la nouvelle usine de SPIL à Taichung et la présence de Jensen Huang, qui apporte un regard international sur le rôle de l’encapsulation avancée taïwanaise dans la chaîne des puces d’IA.
+[^5]: [AP: Taiwan's AI-powered economy soars in the shadow of bubble fears and China threats](https://apnews.com/article/7527bd4bf3089cbd2dab1c530ee61c3e) — Reportage d’AP en 2026 sur la manière dont la demande d’IA tire la croissance et les exportations taïwanaises, tout en récapitulant les limites que sont la bulle de l’IA, le risque géopolitique et les inégalités de revenus ; utile comme matériau d’équilibre.
+[^6]: [Tom's Hardware: TSMC-led semiconductor association warns of power supply pressure](https://www.tomshardware.com/tech-industry/tmsc-led-semiconductor-association-begs-taiwan-government-for-clean-green-energy-as-demand-skyrockets-fabs-are-struggling-to-keep-up-with-power-needs) — Reportage d’un média spécialisé sur l’alerte de l’industrie taïwanaise des semi-conducteurs concernant l’énergie verte et la stabilité de l’approvisionnement ; utilisable comme source secondaire sur les contraintes énergétiques et la pression RE100, mais une citation formelle devrait remonter à la TSIA ou au texte officiel.
+[^7]: [Tom's Hardware: TSMC reduces peak power consumption of EUV tools by 44%](https://www.tomshardware.com/tech-industry/semiconductors/tsmc-reduces-peak-power-consumption-of-euv-tools-by-44-percent-company-to-save-190-million-kilowatt-hours-of-electricity-by-2030) — Reportage sur le plan d’économies d’énergie de TSMC sur l’EUV et l’ordre de grandeur de sa consommation totale ; utile pour expliquer la tension entre gains d’efficacité et croissance du total, mais une citation formelle devrait être recoupée avec la documentation développement durable de TSMC.
+[^8]: [WIRED: Want to Win a Chip War? You’re Gonna Need a Lot of Water](https://www.wired.com/story/want-to-win-a-chip-war-youre-gonna-need-a-lot-of-water/) — Reportage de WIRED en 2023 sur les besoins de la fabrication de semi-conducteurs en eau ultrapure et en installations de traitement, avec mention de la tension entre TSMC et l’eau agricole pendant les sécheresses taïwanaises ; il soutient la section sur les ressources hydriques de ce texte.
+[^9]: [Roussilhe et al.: From Silicon Shield to Carbon Lock-in?](https://arxiv.org/abs/2209.12523) — Étudie l’empreinte environnementale de 16 fabricants taïwanais de composants électroniques entre 2015 et 2020 et pose que l’énergie, l’eau et les émissions augmentent avec la croissance de la production, ainsi que le risque de carbon lock-in.
+[^10]: [CNA : Young Liu confiant dans les expéditions de Vera Rubin de NVIDIA au second semestre](https://www.cna.com.tw/news/afe/202605290100.aspx) — Reportage de l’agence CNA du 29 mai 2026, dans lequel le président de Foxconn, Young Liu, évoque les expéditions de la plateforme Vera Rubin, le CPO et la photonique sur silicium et la présentation de systèmes de serveurs d’IA.

--- a/knowledge/fr/Technology/ai-supply-chain-overseas-manufacturing.md
+++ b/knowledge/fr/Technology/ai-supply-chain-overseas-manufacturing.md
@@ -1,0 +1,223 @@
+---
+translatedFrom: 'Technology/AI供應鏈海外設廠.md'
+sourceCommitSha: 'fd01d452'
+sourceContentHash: 'sha256:7fa246cf8f0f5c00'
+sourceBodyHash: 'sha256:453d3851b08255ad'
+translatedAt: '2026-07-24T02:40:00+08:00'
+lang: 'fr'
+title: 'Usines de la chaîne d’IA à l’étranger : quand le monde fait sortir la capacité taïwanaise'
+description: 'Construire des usines de la chaîne du matériel d’IA hors de Taïwan, ce n’est pas seulement TSMC qui va aux États-Unis, au Japon et en Allemagne : Foxconn, Wistron, Delta ainsi que les fournisseurs d’encapsulation, de tests et de serveurs sont eux aussi attirés vers les États-Unis, le Japon, l’Europe, l’Inde, l’Asie du Sud-Est et le Mexique par les clients, les droits de douane, les subventions et la géopolitique. Ce texte l’explique par la mondialisation, la réduction des risques et le rapport de force des chaînes d’approvisionnement : la sortie des entreprises taïwanaises est un prolongement de leur capacité et en même temps un geste du monde pour réduire sa dépendance à un point unique ; ce n’est pas un simple déménagement.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'matériel d’IA'
+  - 'usines à l’étranger'
+  - 'semi-conducteurs'
+  - 'chaîne d’approvisionnement'
+  - 'TSMC'
+  - 'Foxconn'
+  - 'Wistron'
+  - 'Delta Electronics'
+subcategory: 'Semi-conducteurs et matériel'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Entrer par les multiples parties prenantes de la construction d’usines à l’étranger, pour éviter de réduire la sortie à « TSMC s’en va » ou à l’actualité d’une seule entreprise.'
+  whats_excluded: 'Ne pas recenser cas par cas tous les montants d’investissement à l’étranger, les conditions des subventions et les calendriers des sites.'
+  where_it_hedges: 'Traiter en même temps la croissance des entreprises, la sécurité des gouvernements, le coût pour la population, la redondance offerte aux partenaires étrangers et la question de savoir si la capacité centrale de Taïwan se déplace.'
+  whos_pushing_back: 'Les gouvernements et clients étrangers ont besoin de la capacité taïwanaise, mais souhaitent aussi explicitement réduire leur dépendance à la capacité concentrée sur l’île.'
+image: '/article-images/economy/tsmc-fab21-arizona-2023.webp'
+imageCredit: 'Hunter Trick / Wikimedia Commons'
+imageLicense: 'CC BY-SA 4.0'
+---
+
+# Usines de la chaîne d’IA à l’étranger : quand le monde fait sortir la capacité taïwanaise
+
+> **En 30 secondes :** construire des usines de la chaîne d’IA à l’étranger n’est ni un simple « déménagement » ni « vendre Taïwan ». C’est ce qui arrive après que la capacité manufacturière taïwanaise a été jugée nécessaire par le monde : les entreprises veulent se rapprocher de leurs clients et de leurs marchés, les gouvernements veulent réduire le risque d’être pris à la gorge, la population se soucie de l’emploi, des salaires, de l’eau et de l’électricité et de la vie locale, et les partenaires étrangers veulent placer la capacité critique là où ils la maîtrisent mieux. TSMC est le chef de file le plus visible, mais il n’y a pas que les usines de plaquettes qui sortent : les serveurs d’IA, les racks, l’alimentation, les équipements réseau, l’encapsulation et les tests, les services d’usine et les composants sortent aussi. On a besoin de Taïwan, donc on la fait sortir ; Taïwan est trop concentrée, donc on la disperse aussi.
+
+En 2025, NVIDIA a déployé une chaîne d’approvisionnement taïwanaise sur la carte des États-Unis.
+
+L’entreprise a annoncé que les puces Blackwell étaient déjà produites dans l’usine TSMC de Phoenix, que la fabrication des superordinateurs d’IA serait assurée par Foxconn avec une usine à Houston et par Wistron avec une autre à Dallas, et que l’encapsulation et les tests impliquaient en outre SPIL et Amkor en Arizona.[^1] Ce n’était pas la première sortie des entreprises taïwanaises, mais cela illustrait très clairement le changement des années 2020 : les clients étrangers ne veulent plus seulement que Taïwan sache faire, ils veulent que le matériel critique puisse être fait là où ils ont davantage de contrôle.
+
+Longtemps, l’idéal de la mondialisation fut très simple : on fabrique là où c’est le mieux, le moins cher et le plus rapide. Les entreprises taïwanaises ont grandi dans ce monde-là. Taïwan prenait les commandes, la côte chinoise assurait la production de masse, l’Asie du Sud-Est apportait main-d’œuvre et foncier, les États-Unis et l’Europe tenaient les marques, les clients et le marché, et le Japon, les Pays-Bas et la Corée gardaient les matériaux, les équipements et la mémoire. Cette division a rendu les produits moins chers et a habitué le monde à placer l’efficacité avant la sécurité.
+
+Puis plusieurs choses se sont produites en même temps : la COVID-19 a transformé la pénurie de puces en arrêts de production, la guerre technologique sino-américaine a fait des puces une question de sécurité nationale, la guerre en Ukraine a rappelé aux États que l’énergie comme les chaînes d’approvisionnement peuvent être transformées en armes, et l’IA a fait de la puissance de calcul un nouveau symbole de puissance nationale. Autrefois, on demandait : « où est-ce le plus efficace ? ». Aujourd’hui, on demande aussi : « si quelque chose arrive là-bas, vais-je être pris à la gorge ? ».
+
+C’est le contexte des usines taïwanaises de la chaîne d’IA à l’étranger. Derrière l’expansion internationale d’une seule entreprise, il y a le monde entier qui ramène les chaînes d’approvisionnement du « coût minimal » vers le « contrôlable, fiable et négociable ».
+
+![Vue aérienne de l’ensemble des usines de TSMC dans le Parc scientifique de Hsinchu : de nombreux grands bâtiments concentrés dans le parc, un paysage qui traduit la densité de la chaîne des semi-conducteurs sur l’île de Taïwan.](/article-images/economy/tsmc-fabs-hsinchu-2020.webp)
+
+_Ensemble des usines de TSMC dans le Parc scientifique de Hsinchu. Le contexte des usines à l’étranger, c’est précisément que cette densité manufacturière très concentrée sur l’île est jugée nécessaire par le monde, et que le monde veut en même temps la disperser. Photo : Tseng Cheng-Hsun. CC BY 2.0 via Wikimedia Commons._
+
+## De la mondialisation à la réduction des risques
+
+Construire des usines à l’étranger n’a rien de nouveau. L’électronique taïwanaise a très tôt pris l’habitude de suivre les clients, les salaires, le foncier et les droits de douane.
+
+Après les années 1990, beaucoup de sous-traitants électroniques taïwanais ont installé une grande partie de leur capacité en Chine. La logique d’alors était celle de la mondialisation : les clients voulaient de la grande échelle, du bas coût et des livraisons à l’heure. La Chine offrait du foncier, de la main-d’œuvre, des ports, la coordination des collectivités locales et un écosystème complet de fournisseurs. Le rôle des entreprises taïwanaises y était la gestion, l’ingénierie, l’amélioration des procédés et l’intermédiation avec les clients mondiaux.
+
+Mais après 2020, les raisons de sortir ont changé. Les entreprises ne sortent plus seulement pour le prix, mais aussi pour disperser le risque. Les clients américains veulent que leurs produits soient fabriqués aux États-Unis ou dans des pays amis. L’Inde, le Vietnam, la Thaïlande et le Mexique offrent des bases d’assemblage hors de Chine. Le Japon et l’Europe veulent relier de nouveau les semi-conducteurs aux chaînes automobile et industrielle.
+
+On appelle souvent ce changement la réduction des risques, ou *de-risking*. Cela n’équivaut pas nécessairement à un découplage total ni à un retour à un monde où chaque pays fabriquerait tout. Cela ressemble davantage à découper en plusieurs nœuds de secours une chaîne trop concentrée et trop dépendante d’un seul lieu.
+
+Pour Taïwan, c’est un moment très délicat. Les entreprises taïwanaises ont grandi grâce à la mondialisation, et la réduction des risques les pousse aujourd’hui à se redistribuer.
+
+## L’IA pousse la chaîne du matériel vers les frontières
+
+L’IA a rendu la construction d’usines à l’étranger plus urgente.
+
+Un grand système d’IA n’est pas seulement du logiciel dans le nuage. Il faut des GPU, des CPU, de la mémoire HBM, de l’encapsulation avancée, des substrats, de la dissipation, de l’alimentation, des commutateurs réseau, des racks, des centres de données et beaucoup d’électricité. Ce matériel est volumineux, énergivore, coûteux, et souvent lié à la sécurité nationale, à la souveraineté des données et à la sécurité énergétique.
+
+Les clients ne demandent donc plus seulement : « Taïwan sait-elle le faire ? ».
+
+Les clients demandent aussi : « peut-on le faire là où je suis plus tranquille ? ».
+
+Dans cette annonce sur la fabrication aux États-Unis, NVIDIA a indiqué avoir commandé plus d’un million de pieds carrés d’espace de production en Arizona et au Texas ; que les puces Blackwell étaient déjà produites dans l’usine TSMC de Phoenix ; que la fabrication des superordinateurs d’IA serait assurée par Foxconn à Houston et Wistron à Dallas ; et que l’encapsulation et les tests seraient réalisés avec la taïwanaise SPIL et avec Amkor en Arizona.[^1]
+
+Cette liste est très intéressante. Plaquettes, encapsulation et tests, machine complète du serveur, racks et tests se retrouvent tous dans le récit de l’« infrastructure d’IA américaine », et TSMC n’y est que le nom le plus visible.
+
+![Vue aérienne du chantier de la Fab 21 de TSMC à Phoenix, en Arizona : un immense chantier et la structure de l’usine se déployant en bordure d’une ville du désert, une scène de la fabrication de puces de pointe attirée sur le territoire américain.](/article-images/economy/tsmc-fab21-arizona-2023.webp)
+
+_Chantier de la Fab 21 de TSMC à Phoenix, en Arizona. Construire à l’étranger atterrit dans un lieu où l’usine, l’eau et l’électricité, les travailleurs, la société locale et la chaîne d’approvisionnement doivent fonctionner ensemble. Photo : Hunter Trick. CC BY-SA 4.0 via Wikimedia Commons._
+
+OpenAI et Foxconn ont annoncé ensuite un partenariat pour concevoir et fabriquer aux États-Unis des racks de centres de données d’IA, avec des produits comprenant câblage, équipements réseau et systèmes d’alimentation ; selon AP, Foxconn utilisera des sites américains au Wisconsin, dans l’Ohio et au Texas.[^2] « Construire à l’étranger » cesse ainsi d’être une simple question de production de puces et entraîne dans la localisation tout l’ensemble du matériel des centres de données d’IA.
+
+![Carte des routes de l’expansion internationale de la chaîne d’IA : la capacité centrale de l’île de Taïwan s’étend vers les États-Unis, le Japon, l’Europe, le Mexique, l’Asie du Sud-Est, l’Inde et le marché des centres de données, montrant quatre forces d’attraction : entreprises, gouvernements, collectivités locales et clients.](/article-images/technology/ai-supply-chain-overseas-footprint.svg)
+
+_La sortie de la chaîne d’IA taïwanaise ne suit pas une route unique. Chaque segment est attiré par des marchés différents : les puces et l’encapsulation et les tests se rapprochent de la sécurité nationale et des clients du nuage, tandis que les serveurs, les racks, l’alimentation et la dissipation suivent les centres de données, les droits de douane et les exigences de livraison. Schéma conceptuel réalisé par Taiwan.md Contributors._
+
+## Pourquoi les entreprises taïwanaises regardent si souvent vers l’international
+
+Le marché taïwanais est trop petit, et il est de toute façon difficile d’y faire grandir de grandes entreprises de matériel avec la seule demande intérieure.
+
+Les entreprises taïwanaises ont souvent grandi en captant d’abord les besoins de clients internationaux, puis en se forgeant en fournisseurs de niveau mondial. TSMC sert les concepteurs de puces du monde entier ; Foxconn, Quanta, Wistron, Compal et Pegatron captent les marques mondiales et les clients du nuage ; Delta s’occupe d’alimentation, de dissipation et de gestion de l’énergie ; ASE et SPIL captent l’encapsulation et les tests ; et tout un ensemble d’entreprises de services d’usine, de matériaux, d’électromécanique, d’équipements et de composants suit les grands clients.
+
+Cela donne à la chaîne taïwanaise une caractéristique : elle fonctionne pour le monde, et le marché intérieur taïwanais n’en est qu’une toute petite part.
+
+Quand le monde croyait encore à la mondialisation, c’était un avantage. Les entreprises taïwanaises savaient gérer à l’échelle transnationale, monter vite des usines, répondre aux clients et mobiliser les fournisseurs. Maintenant que le monde réduit les risques, c’est toujours un avantage, mais l’énoncé est devenu plus difficile. Les clients veulent non seulement que les entreprises taïwanaises sachent faire, mais aussi qu’elles atteignent la même qualité et la même vitesse aux États-Unis, au Mexique, en Inde, au Vietnam, en Thaïlande, au Japon, en Allemagne ou ailleurs.
+
+« Sortir » ne signifie donc pas seulement déplacer des usines. C’est aussi une nouvelle démonstration de la capacité des entreprises : la gestion d’ingénierie, la collaboration avec les fournisseurs et le rythme de fabrication forgés à Taïwan peuvent-ils être replantés dans un autre système institutionnel, une autre langue, d’autres syndicats, d’autres tarifs électriques, d’autres ressources en eau et une autre culture du travail ?
+
+## Une même usine à l’étranger, des problèmes différents selon le regard
+
+La construction d’usines à l’étranger s’écrit très facilement comme une actualité d’entreprise : combien telle société investit, où elle bâtit, dans combien d’années la production de masse démarrera, si le chiffre d’affaires augmentera.
+
+C’est bien sûr le premier problème que regarde un dirigeant. Pour l’entreprise, sortir est une affaire : se rapprocher du client, contourner les droits de douane, obtenir des subventions, disperser le risque chinois, établir une deuxième base de production à la demande d’un grand client. Si l’usine à l’étranger permet de décrocher des commandes, de retenir des clients et d’accéder à la commande publique, le dirigeant y verra naturellement une stratégie de croissance.
+
+Mais un gouvernement voit autre chose dans cette même usine.
+
+Pour les gouvernements des États-Unis, du Japon et d’Europe, les usines taïwanaises à l’étranger se comprennent dans le cadre de la sécurité économique. Que le CHIPS and Science Act américain ait subventionné TSMC en Arizona visait à faire produire les puces de pointe sur le sol américain et à réduire la dépendance à l’approvisionnement asiatique. Quand AP a rapporté que le gouvernement américain offrait à TSMC jusqu’à 6,6 milliards de dollars d’aides, il a aussi replacé l’affaire dans le contexte de la reconstruction de la capacité américaine de fabrication de puces avancées et de la sécurité de la chaîne.[^8]
+
+Pour le gouvernement taïwanais, le problème est plus délicat. Dans son entretien avec TIME, le président Lai Ching-te a dit d’une part que les semi-conducteurs sont une industrie de division mondiale du travail, avec matières premières, équipements et technologies répartis entre les États-Unis, le Japon, les Pays-Bas et d’autres ; et d’autre part que si les entreprises de semi-conducteurs se déploient aux États-Unis, au Japon, en Europe ou ailleurs pour leur propre intérêt et leur développement, le gouvernement le respecte en principe.[^9] Cela signifie que le gouvernement ne peut pas regarder la sortie uniquement comme « rester à Taïwan » ou « sortir, c’est perdre », mais doit chercher un équilibre entre croissance des entreprises, alliances internationales et capacité centrale locale.
+
+## La population et les partenaires étrangers regardent aussi cette usine
+
+Ce que voit la population, c’est encore un autre ensemble de problèmes.
+
+À Taïwan, on demandera : si les usines et les commandes les plus importantes partent peu à peu, y aura-t-il moins d’emplois à Taïwan ? Les salaires vont-ils stagner ? L’effet protecteur de la montagne sacrée va-t-il s’affaiblir ? Mais la population peut aussi en bénéficier d’un autre côté : si la sortie apporte davantage de commandes, de R&D, de postes d’encadrement et de coopération internationale, le siège taïwanais peut conserver des emplois plus qualifiés au lieu de garder sur l’île toute la pression sur l’eau, l’électricité, le foncier, les transports et le logement.
+
+Là où les usines s’implantent, la population demande : ces investissements technologiques apportent-ils vraiment de bons emplois ? La collectivité peut-elle assumer l’eau, l’électricité, les transports, le logement et les risques environnementaux ? Quand The Verge a rendu compte du cluster de semi-conducteurs de l’Arizona, il a placé les attentes d’emploi liées aux investissements en puces à côté des inquiétudes sur l’eau, les produits chimiques, la sécurité des travailleurs et le bénéfice réel pour les riverains.[^10] Cela rappelle qu’après leur sortie, les entreprises taïwanaises ne rencontrent pas seulement des clients étrangers, mais aussi des sociétés locales étrangères.
+
+Le point de vue des fournisseurs et partenaires étrangers diffère également. Des entreprises comme NVIDIA, OpenAI, Sony, Denso, Toyota, Bosch, Infineon ou NXP collaborent avec des entreprises taïwanaises parce que Taïwan complète un segment de capacité qui manque à leurs propres chaînes. Cette collaboration les rapproche des marchés du calcul, de l’automobile, de l’industrie ou des centres de données, et réduit aussi leur dépendance à un point unique. Pour elles, les entreprises taïwanaises sont des partenaires et en même temps une part de leur gestion du risque.
+
+Construire à l’étranger ne devrait donc pas se résumer à « l’entreprise a-t-elle gagné de l’argent ? ». Cela demande en même temps : quelle sécurité le gouvernement obtient-il, quel coût la population assume-t-elle, quelle redondance les partenaires étrangers gagnent-ils, et quelle capacité centrale reste-t-il sur l’île de Taïwan ?
+
+## Sortir n’est pas copier un autre Taïwan
+
+On imagine facilement la sortie comme « déplacer la même usine dans un autre pays ». Mais dans l’industrie manufacturière, acheter le terrain, bâtir l’usine et installer les machines n’est qu’un début. Le vraiment difficile est d’emporter tout un ensemble d’habitudes de travail vers un lieu nouveau.
+
+À Taïwan, un coup de fil suffit pour trouver le fournisseur de matériaux habituel, l’entreprise d’électromécanique, la maintenance des équipements, la logistique et le soutien technique. Les fournisseurs connaissent la vitesse des uns et des autres et savent comment se relayer quand un problème survient. Cette densité appartient à tout un cluster industriel : c’est une entente que de nombreuses entreprises ont polie pendant des années.
+
+À l’étranger, l’entreprise doit affronter de nouveau un autre marché du travail, un autre système syndical, d’autres procédures d’évaluation environnementale, une autre politique locale, d’autres tarifs de l’électricité et de l’eau, d’autres talents d’ingénierie et une autre maturité des fournisseurs. Certains problèmes se règlent avec de l’argent, d’autres demandent du temps, et certains modifient même la méthode de gestion d’origine.
+
+C’est pourquoi la difficulté de sortir varie beaucoup selon le segment. Les serveurs d’IA, les racks, l’alimentation, le câblage et l’assemblage suivent plus facilement les clients et les centres de données ; la fabrication des plaquettes et l’encapsulation avancée dépendent bien davantage de la densité de la chaîne, de la formation des ingénieurs et du rendement de long terme. Le monde peut faire sortir les entreprises taïwanaises à coups de subventions, mais il ne peut pas nécessairement reproduire immédiatement la vitesse de l’île.
+
+Pour évaluer les usines à l’étranger, il ne suffit donc pas de regarder « où est la capacité ». Ce qui compte davantage : où sont les décisions, où est la R&D, où est la capacité à résoudre les problèmes, si les fournisseurs peuvent suivre, et où sera fabriquée en premier la prochaine génération technologique. Ces questions déterminent si la sortie prolonge la capacité taïwanaise ou déplace peu à peu la capacité centrale ailleurs.
+
+## Tous les segments ne sortent pas de la même manière
+
+Dans la chaîne de l’IA, chaque segment sort pour des raisons différentes.
+
+La fabrication des plaquettes a la barrière capitalistique la plus élevée et engage l’eau, l’électricité, le foncier, les talents, les équipements, les produits chimiques et le rendement. Elle est la plus difficile à déplacer et la plus visible politiquement. L’encapsulation avancée et les tests se situent entre les deux : ils doivent être proches des plaquettes, des clients et de l’intégration système. Les serveurs d’IA, les racks et les systèmes d’alimentation sont plus proches du centre de données final et plus sensibles aux droits de douane, aux délais, à la localisation du client et aux achats liés à la sécurité nationale.
+
+On voit donc les différents fabricants se déplacer dans des directions différentes.
+
+Foxconn et Wistron ont été entraînés dans la fabrication de superordinateurs d’IA aux États-Unis. Delta étend ses bases à l’étranger dans l’alimentation, les centres de données et les équipements électriques industriels ; selon la presse, son campus de Plano (Texas) prévoit d’approcher 1,5 million de pieds carrés après extension et d’offrir une option de fabrication locale aux États-Unis ; son usine indienne de Krishnagiri poursuit aussi son agrandissement pour servir des clients de véhicules électriques, de télécommunications, de centres de données et de l’industrie.[^3][^4]
+
+Les nœuds de plaquettes et d’encapsulation et tests comme TSMC, ASE ou SPIL entrent plus directement dans les politiques de semi-conducteurs des États-Unis, du Japon et de l’Europe. S’ils sortent, c’est pour que clients et gouvernements croient que, même si l’île de Taïwan reste le cœur, une part de la capacité peut aussi s’enraciner en territoire allié.
+
+## La montagne sacrée porte la question à son intensité maximale
+
+TSMC est le personnage le plus visible de cette histoire, mais la sortie de la chaîne ne s’arrête pas à TSMC.
+
+Que TSMC soit le symbole de la « montagne sacrée qui protège le pays » porte la question des usines à l’étranger à son intensité maximale. Ce qui est ici en jeu, c’est la fabrication des plaquettes, la plus complexe, la plus coûteuse et la plus dépendante de la densité de la chaîne, et on lui demande en plus de s’enraciner en territoire allié. Si cela se produit, il est encore moins probable que les autres segments restent entièrement sur l’île.
+
+La page officielle de TSMC sur l’Arizona explique que l’investissement sur le campus de Phoenix a été porté à 165 milliards de dollars et que le plan comprend six usines de plaquettes, deux installations d’encapsulation avancée et un centre de R&D ; l’une des usines est entrée en production de masse en procédé N4 au quatrième trimestre 2024, avec N3, N2 et A16 prévus ensuite.[^5] C’est le cas emblématique des États-Unis attirant sur leur territoire une part de la capacité de fabrication des puces d’IA de pointe.
+
+Kumamoto, au Japon, représente un autre besoin. Selon AP, TSMC prévoit de produire des puces 3 nanomètres dans sa deuxième usine de Kumamoto pour l’IA, les smartphones, la robotique et la conduite autonome ; ce qui importe au Japon, c’est la sécurité économique et le fait de relier de nouveau les semi-conducteurs aux industries de l’automobile, de la robotique, des matériaux et des équipements.[^6]
+
+ESMC, à Dresde (Allemagne), relève d’une troisième logique. Le site officiel d’ESMC explique qu’il s’agit d’une coentreprise entre TSMC, Bosch, Infineon et NXP, dont l’objectif est de bâtir une usine de plaquettes en Allemagne pour servir les marchés européens de l’industrie, de l’IoT, des télécommunications et de l’automobile.[^7] Ce qui préoccupe l’Europe, c’est la résilience de l’approvisionnement en puces automobiles, de contrôle industriel et de télécommunications, et non de rattraper Taïwan sur tous les nœuds.
+
+Même quand il s’agit de bâtir à l’étranger, ce que cherchent les États-Unis, le Japon et l’Allemagne n’est pas la même chose. Les États-Unis cherchent l’IA et la sécurité nationale, le Japon la reconstruction industrielle, l’Europe la résilience industrielle. Et TSMC, entre ces besoins, est devenu l’interface internationale la plus visible de la chaîne taïwanaise.
+
+## Après la sortie, que reste-t-il à Taïwan ?
+
+Ce qui mérite vraiment d’être demandé, c’est ceci : « après le départ, que reste-t-il à Taïwan ? ».
+
+Certaines choses se déplacent assez vite : les bâtiments, une partie des lignes de production, la capacité d’assemblage, le service client, la maintenance locale, une partie des tests et de la logistique. D’autres sont difficiles à déplacer : la densité des fournisseurs, la formation des ingénieurs, la vitesse d’amélioration des procédés, la culture du rendement, la collaboration entre entreprises, la confiance accumulée pendant des années, et un groupe de gens qui savent qui appeler quand quelque chose ne va pas.
+
+La valeur centrale de Taïwan ne disparaîtra pas d’un coup parce que quelques usines apparaissent à l’étranger. Mais elle ne continuera pas non plus d’exister automatiquement pour toujours.
+
+Construire à l’étranger produit deux effets opposés. Premièrement, cela enfonce davantage les entreprises taïwanaises dans les marchés alliés et renforce l’intérêt commun. Deuxièmement, cela permet aussi aux alliés de bâtir peu à peu une capacité de secours et de réduire leur dépendance à un point unique sur l’île. Le dirigeant voit la croissance, le gouvernement la sécurité, le partenaire étranger la redondance, et la population voit à la fois l’opportunité et l’inquiétude.
+
+Ces deux choses tiennent en même temps.
+
+Taïwan ne peut donc pas voir les usines à l’étranger seulement comme une perte, ni seulement comme un honneur. C’est un test de résistance : si les entreprises taïwanaises emportent leur capacité au-dehors, l’île pourra-t-elle continuer à conserver la R&D la plus avancée, les procédés, l’encapsulation, la densité d’ingénierie, les talents et le réseau de fournisseurs ?
+
+Si la réponse est oui, la sortie devient un prolongement. Si la réponse est non, la sortie peut devenir une dilution.
+
+## Nécessaire, et aussi dispersée
+
+Les usines taïwanaises de la chaîne d’IA à l’étranger ont rendu plus complexe la phrase « Taïwan est irremplaçable ».
+
+Le monde a bel et bien besoin de Taïwan. Mais le monde s’efforce aussi, à coups de subventions, de politiques, de foncier, d’eau et d’électricité, de droits de douane et de marchés, de ne plus dépendre autant de Taïwan.
+
+C’est la réaction inévitable qui suit le succès de Taïwan. Quand une île devient un nœud clé de la chaîne mondiale de l’IA, il est naturel que d’autres pays veuillent attirer une part de cette capacité chez eux.
+
+Ce que Taïwan doit faire ensuite, c’est que le monde, après la sortie, continue d’avoir besoin de Taïwan. Les usines étrangères peuvent pousser aux États-Unis, au Japon, en Allemagne, en Inde, au Vietnam, en Thaïlande ou au Mexique, mais la capacité centrale doit continuer de se renouveler à Taïwan.
+
+Ce « renouvellement » est très concret : Taïwan doit retenir ceux qui savent stabiliser un procédé nouveau, ceux qui savent débloquer un goulot d’étranglement d’encapsulation, ceux qui savent tenir les délais de livraison des serveurs, ceux qui savent faire réagir vite les fournisseurs. Si ces capacités continuent de s’accumuler, Taïwan restera le lieu où naît la prochaine série de solutions. Tant que le prochain problème difficile revient d’abord se résoudre à Taïwan, construire à l’étranger ressemblera davantage à étendre la capacité taïwanaise vers l’extérieur qu’à vider Taïwan.
+
+C’est la question la plus importante des usines de la chaîne d’IA à l’étranger : une fois que le monde a fait sortir la capacité taïwanaise, Taïwan elle-même peut-elle encore faire pousser la couche suivante de capacité ?
+
+## Pour aller plus loin
+
+- [Chaîne d’approvisionnement du matériel d’IA](/technology/AI硬體供應鏈) — pourquoi le monde a besoin que Taïwan transforme la demande du nuage en machines.
+- [Chaîne d’approvisionnement du matériel d’IA](/technology/AI硬體供應鏈) — du GPU au rack : comment les ODM/EMS taïwanais captent le matériel des centres de données d’IA.
+- [Électricité et semi-conducteurs à Taïwan](/technology/台灣的電力與半導體) — comment la fabrication de pointe revient à l’électricité et à la sécurité énergétique.
+- [L’eau des semi-conducteurs et les ressources hydriques de Taïwan](/technology/半導體用水與台灣水資源) — comment les usines de plaquettes entrent dans les barrages, les sécheresses et la gestion de l’eau régénérée.
+- [Entreprises taïwanaises : TSMC](/economy/台灣企業：台積電) — comment le modèle de fonderie de TSMC a réécrit la division mondiale du travail dans les semi-conducteurs.
+- [Entreprises taïwanaises : Foxconn](/economy/台灣企業：鴻海精密) — de la sous-traitance électronique aux serveurs d’IA et au matériel des centres de données.
+- [Entreprises taïwanaises : Delta Electronics](/economy/台灣企業：台達電子) — comment l’alimentation, la dissipation et la gestion de l’énergie sont devenues une part de l’infrastructure d’IA.
+- [Développement des parcs scientifiques](/technology/科技園區發展) — comment le cluster taïwanais des semi-conducteurs a poussé depuis les terres et les villes.
+
+## Sources des images
+
+- **Vue aérienne du chantier de la Fab 21 de TSMC en Arizona (hero / intérieur)** : [231105-1 TSMC Fab 21 construction](https://commons.wikimedia.org/wiki/File:231105-1_TSMC_Fab_21_construction.jpg) — Photo : Hunter Trick, 2023-11-05, Wikimedia Commons, CC BY-SA 4.0. Ce texte utilise la version mise en cache dans `public/article-images/economy/tsmc-fab21-arizona-2023.webp`.
+- **Ensemble des usines de TSMC dans le Parc scientifique de Hsinchu** : [TSMC fabs in Hsinchu 01](https://commons.wikimedia.org/wiki/File:TSMC_fabs_in_Hsinchu_01.jpg) — Photo : Tseng Cheng-Hsun, 2020-01-02, Wikimedia Commons, CC BY 2.0. Ce texte utilise la version mise en cache dans `public/article-images/economy/tsmc-fabs-hsinchu-2020.webp`.
+- **Carte des routes de l’expansion internationale de la chaîne d’IA** : schéma conceptuel SVG réalisé par Taiwan.md Contributors, CC BY-SA 4.0, stocké dans `public/article-images/technology/ai-supply-chain-overseas-footprint.svg`. Il sert à expliquer les multiples routes et les forces des différentes parties prenantes dans la sortie de la chaîne taïwanaise du matériel d’IA, et ne représente ni la répartition complète des entreprises ni des proportions de capacité.
+
+## Références
+
+[^1]: [AP: Nvidia plans to manufacture AI chips in the US for the first time](https://apnews.com/article/nvidia-ai-artificial-intelligence-tariffs-dcf48112ce98a7b61bfd32157359ce2f) — Reportage d’AP sur la production par NVIDIA des puces Blackwell et de superordinateurs d’IA aux États-Unis, qui nomme TSMC Phoenix, Foxconn Houston, Wistron Dallas et la collaboration de SPIL / Amkor pour l’encapsulation et les tests en Arizona.
+[^2]: [AP: OpenAI and Taiwan’s Foxconn to partner in AI hardware design and manufacturing in the US](https://apnews.com/article/openai-foxconn-ai-hon-taiwan-china-b022977e34c23f5f3ddf7522817accfe) — Reportage d’AP sur le partenariat entre OpenAI et Foxconn pour concevoir et fabriquer des racks de centres de données d’IA, avec des produits comprenant câblage, équipements réseau et systèmes d’alimentation, et une mention de la répartition des sites américains de Foxconn.
+[^3]: [MySA: Plans move forward on $115M electronics factory in Plano](https://www.mysanantonio.com/business/article/delta-electronics-plano-20254702.php) — Reportage sur l’extension par Delta Electronics de ses installations de production et de bureaux à Plano (Texas), qui récapitule ses centres de R&D et de production existants, la taille ultérieure du campus et son positionnement de fabrication locale aux États-Unis.
+[^4]: [Times of India: Delta Electronics pushes for capacity expansion](https://timesofindia.indiatimes.com/city/chennai/delta-electronics-pushes-for-capacity-expansion/articleshow/123853472.cms) — Reportage sur l’extension de l’usine indienne de Delta Electronics à Krishnagiri, qui explique la demande des clients des télécommunications, des centres de données, des véhicules électriques et de l’industrie, ainsi que son déploiement d’une chaîne localisée en Inde.
+[^5]: [TSMC Arizona](https://www.tsmc.com/static/abouttsmcaz/index.htm) — Page officielle de TSMC sur l’Arizona, qui expose l’ampleur de l’investissement à Phoenix, les six usines de plaquettes, les deux installations d’encapsulation avancée, le calendrier N4/N3/N2/A16 et les plans de recyclage de l’eau.
+[^6]: [AP: TSMC to make advanced AI computer chips in Japan](https://apnews.com/article/semiconductors-tsmc-japan-taiwan-ai-11256f2bfde73ca23d08331ad138d6d5) — Reportage d’AP sur le projet de TSMC de produire des puces 3 nanomètres dans sa deuxième usine de Kumamoto (Japon), qui récapitule la sécurité économique japonaise et la demande liée à l’IA, à la robotique et à la conduite autonome.
+[^7]: [ESMC: European Semiconductor Manufacturing Company](https://www.esmc.eu/) — Site officiel d’ESMC, qui explique qu’il s’agit d’une coentreprise entre TSMC, Bosch, Infineon et NXP destinée à bâtir une usine de plaquettes à Dresde (Allemagne) pour servir les marchés européens de l’industrie, de l’IoT, des télécommunications et de l’automobile.
+[^8]: [AP: Biden administration announces $6.6 billion to ensure leading-edge microchips are built in the US](https://apnews.com/article/microchips-biden-commerce-arizona-taiwan-semiconductor-manufacturing-7e627aad5b9ce5a715aa4d660ad86149) — Reportage d’AP sur les aides du CHIPS and Science Act américain à l’extension de TSMC en Arizona, qui explique comment le gouvernement américain considère la fabrication de puces de pointe comme une question de sécurité de la chaîne et de sécurité nationale.
+[^9]: [TIME : lisez l’entretien intégral du président taïwanais Lai Ching-te](https://time.com/6986139/taiwan-president-lai-ching-te-interview-mandarin/) — Dans la transcription intégrale en chinois publiée par TIME, Lai Ching-te évoque les semi-conducteurs comme industrie de division mondiale du travail et la manière dont le gouvernement considère le déploiement de TSMC et d’autres entreprises de semi-conducteurs aux États-Unis, au Japon et en Europe.
+[^10]: [The Verge: The new silicon valley (literally)](https://www.theverge.com/features/825207/semiconductor-chip-manufacturing-new-silicon-valley) — Reportage sur l’emploi, le développement local, les ressources hydriques, l’environnement et les controverses sur la sécurité au travail liés à l’expansion du cluster de semi-conducteurs de l’Arizona ; utile pour équilibrer le regard des sociétés locales sur les usines à l’étranger.

--- a/knowledge/fr/Technology/semiconductor-water-use-and-taiwan-water-resources.md
+++ b/knowledge/fr/Technology/semiconductor-water-use-and-taiwan-water-resources.md
@@ -1,0 +1,189 @@
+---
+translatedFrom: 'Technology/半導體用水與台灣水資源.md'
+sourceCommitSha: '2d46f088'
+sourceContentHash: 'sha256:e3dbfa5f81690467'
+sourceBodyHash: 'sha256:45c1175dae9b247b'
+translatedAt: '2026-07-24T01:45:00+08:00'
+lang: 'fr'
+title: 'L’eau des semi-conducteurs et les ressources hydriques de Taïwan : le barrage à côté de l’usine de plaquettes'
+description: 'La fabrication des puces exige de l’eau ultrapure, mais l’eau de Taïwan n’existe pas seulement dans les canalisations de l’usine : elle existe aussi entre les barrages, les pluies, les sécheresses, l’irrigation agricole, l’eau régénérée et la répartition locale. Ce texte n’écrit pas l’eau des semi-conducteurs comme un conflit linéaire du type « TSMC accapare l’eau » : il explique comment les procédés de pointe relient l’hydrologie insulaire de Taïwan, la gouvernance publique, les installations d’eau régénérée et les chaînes d’approvisionnement mondiales, et ramènent la haute technologie aux barrages, aux champs et à la confiance locale.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'semi-conducteurs'
+  - 'ressources hydriques'
+  - 'TSMC'
+  - 'eau ultrapure'
+  - 'eau régénérée'
+  - 'chaîne d’approvisionnement'
+subcategory: 'Semi-conducteurs et matériel'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Mettre ensemble le barrage, les champs, l’usine d’eau régénérée et la gouvernance locale qui entourent une usine de plaquettes, pour faire de l’eau des semi-conducteurs une question publique compréhensible.'
+  whats_excluded: 'Ne pas réduire l’eau des semi-conducteurs à « TSMC accapare l’eau », ni en faire un article technique complet de génie hydraulique.'
+  where_it_hedges: 'Reconnaître que l’eau des semi-conducteurs exige beaucoup d’infrastructures publiques, tout en expliquant la fonction de gouvernance de l’eau recyclée, de l’eau régénérée et de la répartition locale.'
+  whos_pushing_back: 'L’agriculture, les usages domestiques, les sociétés locales et les lieux d’implantation à l’étranger demandent tous si l’usage de l’eau par les usines de plaquettes est équitable, durable et contrôlable.'
+image: '/article-images/technology/tainan-science-park-tsmc-fab18-fields-2025.webp'
+imageCredit: '4300streetcar / Wikimedia Commons'
+imageLicense: 'CC BY 4.0'
+---
+
+# L’eau des semi-conducteurs et les ressources hydriques de Taïwan : le barrage à côté de l’usine de plaquettes
+
+> **En 30 secondes :** l’eau des semi-conducteurs ne se résume pas à « TSMC consomme beaucoup d’eau ». La fabrication des plaquettes exige de l’eau ultrapure pour les nettoyer, mais aussi de l’eau recyclée, de l’eau régénérée, une séparation des effluents et un système d’adduction local. L’avantage taïwanais dans les semi-conducteurs ne se trouve donc pas seulement dans les salles blanches, mais aussi dans les barrages, les pluies, les sécheresses, l’irrigation agricole, les usines d’eau régénérée et la gouvernance locale.
+
+Au printemps 2021, Taïwan a connu la plus grave sécheresse depuis un demi-siècle.
+
+L’irrigation a été suspendue, des camions-citernes sont entrés dans les parcs scientifiques et les médias internationaux ont commencé à placer le niveau des barrages taïwanais et l’approvisionnement mondial en puces dans une même image.[^1] À cet instant, la distance entre l’usine de plaquettes et le barrage s’est brusquement raccourcie.
+
+Une usine de plaquettes paraît très éloignée d’un barrage. Elle se trouve dans un parc scientifique, avec ses salles blanches, ses zones jaunes, ses machines de lithographie, ses canalisations de produits chimiques et ses ingénieurs en combinaison intégrale. Le barrage, lui, est dans la montagne, relié aux typhons, aux pluies de mousson, aux rivières, aux champs et à l’eau domestique. Mais dans l’industrie des semi-conducteurs, ces deux lieux sont en réalité tenus par la même canalisation.
+
+Plus la puce est avancée, plus le procédé est fin, et moins la surface de la plaquette peut tolérer d’impuretés. L’eau y est à la fois un matériau de nettoyage, un environnement de procédé et une partie du contrôle de la contamination. Les semi-conducteurs exigent d’énormes quantités d’eau ultrapure pour éliminer les contaminants microscopiques, les résidus chimiques et les particules présents sur la plaquette. Selon WIRED, une seule usine de plaquettes peut utiliser plusieurs millions de gallons d’eau par jour, et l’eau joue un rôle central dans le nettoyage des plaquettes et le maintien de la propreté du procédé.[^1]
+
+L’eau des semi-conducteurs n’est donc pas un sujet marginal des pages environnement. Elle fait partie de la position de Taïwan dans la chaîne d’approvisionnement.
+
+![L’usine de plaquettes n° 18 de TSMC dans le parc de Tainan du Parc scientifique du Sud, avec des champs cultivés juste à côté des bâtiments : une scène où l’usine, la terre et les conditions hydriques locales se touchent.](/article-images/technology/tainan-science-park-tsmc-fab18-fields-2025.webp)
+
+_L’usine de plaquettes n° 18 de TSMC dans le parc de Tainan du Parc scientifique du Sud. Les usines de plaquettes poussent à côté de la terre, des barrages, des champs et des infrastructures locales, et c’est là que le risque de chaîne d’approvisionnement devient concret. Photo : 4300streetcar. CC BY 4.0 via Wikimedia Commons._
+
+## L’eau entre dans l’environnement du procédé
+
+Si l’on imagine une puce comme une ville miniature, l’eau est le système de nettoyage qui y circule sans cesse.
+
+Au cours de la fabrication, la plaquette passe par le dépôt, la lithographie, la gravure, le nettoyage, la métrologie. Chaque étape peut laisser des résidus. Une particule invisible à l’œil nu peut être un défaut pour un circuit nanométrique. L’eau ultrapure est donc une eau industrielle plusieurs fois traitée, débarrassée autant que possible des ions, des matières organiques, des micro-organismes et des particules.
+
+Cette eau ne s’utilise pas telle quelle en ouvrant un robinet. Une fois entrée dans l’usine, elle subit filtration, osmose inverse, échange d’ions, traitement ultraviolet et élimination des matières organiques avant de devenir l’eau ultrapure exigée par le procédé. Après usage, elle ne fait pas qu’un seul passage : les usines les plus avancées séparent les eaux selon leur degré de contamination, les traitent puis les récupèrent pour les réutiliser, ou les envoient vers le système de traitement des effluents.
+
+WIRED indique que les effluents des semi-conducteurs peuvent contenir des eaux acides, de l’acide fluorhydrique, des particules de silicium et des résidus de carbone organique issus de la lithographie, de la gravure ou de l’amincissement des plaquettes, et que l’industrie sépare les effluents pour augmenter les possibilités de réutilisation.[^1] Cela montre que « consommer de l’eau » dans une usine de plaquettes relève d’une ingénierie du traitement de l’eau extrêmement complexe, bien plus fine que de rincer à grande eau.
+
+L’eau des semi-conducteurs pose donc au moins trois questions. D’abord, où l’usine obtient-elle son eau brute ? Ensuite, comment la transforme-t-elle en eau ultrapure une fois entrée ? Enfin, comment l’eau usée est-elle récupérée, réutilisée, traitée ou rejetée ?
+
+Si l’on ne regarde que la première question, la discussion se réduit à « qui a pris l’eau de qui ». Mais pour Taïwan, le plus difficile est de traiter les trois ensemble.
+
+## La sécheresse fait voir le barrage à la chaîne d’approvisionnement
+
+Il pleut beaucoup à Taïwan d’ordinaire, mais les ressources en eau ne sont pas pour autant stables.
+
+Les pluies se concentrent sur la mousson et la saison des typhons, les rivières sont courtes, les pentes montagneuses sont raides, et l’eau file vite vers la mer. Quand les typhons se font rares, que la mousson est faible et que le niveau des barrages du Sud ou du Centre baisse, les parcs scientifiques, l’agriculture et les usages domestiques se retrouvent dans une même répartition.
+
+La sécheresse taïwanaise de 2021 l’a rendu très concret. L’irrigation agricole peut être suspendue, des camions-citernes peuvent entrer dans les parcs scientifiques, et la consommation d’eau des usines de plaquettes est vue par les médias internationaux. WIRED mentionne que la sécheresse à Taïwan a fait remonter à la surface la tension entre l’irrigation des agriculteurs et la fabrication des puces.[^1]
+
+![Après les pluies diluviennes du typhon Morakot en 2009, dans un village de Minxiong (comté de Chiayi), la route et les rez-de-chaussée sont noyés sous une eau boueuse, tandis qu’au loin des habitants marchent dans l’eau.](/article-images/nature/morakot-minxiong-flood-2009.webp)
+
+_Inondation à Minxiong (Chiayi) après les pluies de Morakot en 2009. Le problème hydrique taïwanais n’est pas seulement le manque d’eau : il inclut aussi la concentration des pluies, les événements extrêmes et la résilience de la répartition. Photo : zilupe. CC BY 2.0 via Wikimedia Commons._
+
+Il n’est pas nécessaire d’écrire cette histoire comme « les agriculteurs contre TSMC ». Ce serait trop simplificateur.
+
+Ce qui mérite davantage d’attention, c’est la manière dont Taïwan maintient en même temps, sur une même île, l’agriculture, les usages domestiques, l’industrie et son crédit dans la chaîne d’approvisionnement mondiale. La sécheresse ne teste pas seulement la capacité des barrages : elle teste aussi si les institutions savent se préparer à l’avance, répartir de façon transparente et réduire les conflits.
+
+Pour les clients étrangers, une sécheresse taïwanaise se lit comme un risque de chaîne d’approvisionnement. Pour la société taïwanaise, l’eau des semi-conducteurs touche à la politique industrielle, à la politique agricole, à la croissance urbaine et au changement climatique, et ne s’arrête pas au rapport de développement durable d’une entreprise.
+
+C’est pourquoi l’eau compte autant que l’électricité : toutes deux ramènent la « montagne sacrée » du mythe d’entreprise à l’infrastructure publique.
+
+## L’eau régénérée fait des ressources hydriques un ouvrage public
+
+Le mot clé suivant de l’eau des semi-conducteurs, c’est l’eau régénérée.
+
+L’eau régénérée, ce sont les eaux usées urbaines ou industrielles traitées pour devenir une ressource utilisable par l’industrie. Pour les semi-conducteurs, elle réduit la pression sur les barrages et les rivières et offre aux usines une source plus stable en période de sécheresse.
+
+Mais l’eau régénérée n’est pas une magie gratuite. Elle exige un système de collecte des eaux usées, des usines de régénération, des canalisations, une qualité d’eau stable, des contrats de long terme et une acceptation locale. Elle ramène les semi-conducteurs de « l’eau d’une entreprise » à un ouvrage public.
+
+Une usine d’eau régénérée n’est pas un équipement annexe posé à côté d’une usine. Elle implique en général le réseau d’assainissement urbain, les collectivités locales, les subventions de l’État, les besoins des zones industrielles, la confiance des habitants dans le traitement des eaux usées et les coûts d’exploitation de long terme. Pour que l’industrie des semi-conducteurs utilise massivement de l’eau régénérée, il faut d’abord que la ville elle-même sache collecter, traiter, transporter et surveiller ces eaux.
+
+C’est aussi pourquoi « l’eau régénérée » est un bon poste d’observation des semi-conducteurs taïwanais. Elle est moins éclatante que les procédés de pointe, mais elle révèle si une société sait faire entrer une industrie de haute technologie dans son propre système de vie.
+
+Si l’eau régénérée fonctionne bien, la consommation des usines de plaquettes pèse moins directement sur les usages domestiques ou agricoles. Si elle fonctionne mal, l’expansion des semi-conducteurs sera plus facilement perçue comme une charge locale, et la défiance sociale s’en trouvera renforcée.
+
+## La valeur de l’eau régénérée ne tient pas qu’à une source de plus
+
+L’avantage le plus intuitif de l’eau régénérée, c’est une source de plus. En période de sécheresse, si une partie de l’eau industrielle peut provenir des eaux usées urbaines traitées, on réduit la pression immédiate sur les barrages et les rivières.
+
+Mais sa valeur ne s’arrête pas là.
+
+Premièrement, l’eau régénérée relie la ville et l’industrie. La ville produit chaque jour des eaux usées, l’industrie a chaque jour besoin d’une source stable. Autrefois, l’objectif du traitement des eaux usées était d’atteindre les normes de rejet ; si l’on peut désormais aller plus loin et en faire de l’eau industrielle, cela revient à raccorder une partie du métabolisme urbain au système productif.
+
+Deuxièmement, l’eau régénérée donne de la marge à la répartition en cas de sécheresse. Quand le niveau des barrages baisse, le gouvernement n’est plus obligé de trancher brutalement entre agriculture, usages domestiques et industrie. L’eau régénérée ne remplace pas toutes les sources, mais elle permet à une partie de l’eau industrielle très exigeante en stabilité de ne plus dépendre directement de la saison des pluies.
+
+Troisièmement, l’eau régénérée impose plus de transparence sur les données. Pour que la société locale fasse confiance à l’eau régénérée, il faut dire clairement d’où vient l’eau, jusqu’à quel niveau elle est traitée, où elle est envoyée, qui paie, comment les effluents sont surveillés et qui est responsable en cas de problème. Plus ces informations sont publiées clairement, moins l’expansion des semi-conducteurs peut reposer sur les seules promesses des entreprises ou la seule caution de l’État.
+
+L’eau régénérée n’est donc pas « un rustine pour le manque d’eau des semi-conducteurs ». Elle ressemble davantage à un test institutionnel : Taïwan sait-elle assembler les eaux usées urbaines, les besoins industriels, la confiance locale et le risque climatique en un système hydrique capable de fonctionner durablement ?
+
+![Schéma du cycle de l’eau entre eau régénérée et fabrication de semi-conducteurs : barrages et rivières, eaux usées urbaines, usine d’eau régénérée, usine de plaquettes et gouvernance locale forment une boucle hydrique.](/article-images/technology/reclaimed-water-semiconductor-loop.svg)
+
+_Schéma conceptuel réalisé par Taiwan.md. L’eau régénérée relie en système les eaux usées urbaines, les besoins industriels, la confiance locale et la réponse à la sécheresse, et fait de l’eau des semi-conducteurs une question d’ouvrage public._
+
+## Construire à l’étranger n’échappe pas non plus à l’eau
+
+Les ressources en eau ne concernent pas que Taïwan.
+
+L’Arizona est aride, et pourtant il est devenu une base importante de la fabrication de pointe de TSMC aux États-Unis. La page officielle de TSMC Arizona explique que le campus de Phoenix prévoit des installations de régénération de l’eau industrielle, avec un objectif de plus de 90 % de récupération et de réutilisation ; les versions antérieures de la page indiquaient aussi qu’au démarrage une partie de l’eau provenait du système de récupération interne.[^2] Ces informations pèsent sur l’acceptation des usines à l’étranger par les sociétés locales : ce ne sont pas de petites lignes de développement durable dans une image de marque.
+
+Quand The Verge a rendu compte du cluster de semi-conducteurs de l’Arizona, il a lui aussi placé les attentes d’emploi liées aux investissements en puces à côté des inquiétudes sur l’eau, les produits chimiques, la sécurité des travailleurs et le bénéfice réel pour les riverains.[^3] Cela rappelle une chose : déplacer une usine de plaquettes à l’étranger ne fait pas disparaître la question de l’eau, cela la renégocie simplement ailleurs.
+
+Ce à quoi Taïwan fait face sur son île, ce sont la mousson, les typhons, les barrages, l’agriculture et les parcs scientifiques. Ce à quoi l’Arizona fait face, ce sont la sécheresse, les eaux souterraines, l’expansion urbaine et la concurrence pour l’eau en zone désertique. Les conditions géographiques diffèrent, mais la question se ressemble beaucoup : un territoire est-il prêt — et capable — d’assumer la pression hydrique pour la chaîne mondiale des puces ?
+
+Construire à l’étranger n’est donc pas seulement une affaire de géopolitique ou de subventions. Cela demande aussi : les États-Unis, le Japon, l’Allemagne, l’Inde ou d’autres régions sont-ils prêts à faire entrer ensemble l’eau, l’électricité, le foncier, le travail et la société locale dans la chaîne des semi-conducteurs ?
+
+## Une meilleure efficacité hydrique ne fait pas disparaître la pression sur le total
+
+Les entreprises de semi-conducteurs continueront d’améliorer leur taux de recyclage et de réduire la consommation d’eau par produit. C’est très important.
+
+Mais si la production augmente plus vite, la consommation totale peut malgré tout augmenter. L’étude de Roussilhe et al., portant sur des fabricants taïwanais de composants électroniques, indique qu’entre 2015 et 2020 la consommation d’eau des entreprises de l’échantillon a augmenté en moyenne de 6,1 % par an, et replace consommation d’eau, énergie et émissions dans le même contexte de croissance de la production.[^4]
+
+Cela rappelle une chose : les gains d’efficacité sont une condition nécessaire, mais pas une réponse complète.
+
+Qu’une île puisse soutenir les puces de pointe du monde entier ne dépend pas seulement de la baisse de la consommation d’eau par plaquette, mais aussi de savoir si l’extension des parcs scientifiques, la montée en gamme des procédés, la capacité d’encapsulation, les centres de données et la consommation urbaine croissent en même temps. Ce que Taïwan doit traiter, c’est un ensemble de problèmes qui s’entraînent mutuellement : l’efficacité technique, le changement climatique et la répartition publique doivent être pensés ensemble.
+
+Il faut aussi éviter un autre malentendu : le problème de l’eau ne signifie pas que les semi-conducteurs ne devraient pas se développer. Il signifie que ce développement ne peut pas être décidé par les seuls investissements des entreprises, et qu’il faut aussi voir si la gouvernance de l’eau suit.
+
+Si l’industrie traite les économies d’eau, l’eau recyclée, l’eau régénérée, le traitement des effluents et la concertation locale comme de purs coûts, elle rencontrera une résistance sociale. Si elle les traite comme une partie de la résilience de sa chaîne d’approvisionnement, elle a davantage de chances de rester durablement à Taïwan.
+
+## Qui se trouve dans la même goutte d’eau
+
+Le plus difficile, avec l’eau des semi-conducteurs, c’est qu’une même goutte n’est pas la même chose selon les yeux qui la regardent.
+
+Pour l’usine de plaquettes, c’est la stabilité du procédé. Pour l’agriculteur, c’est peut-être l’irrigation. Pour l’habitant, c’est de savoir si l’eau coule quand il ouvre le robinet. Pour le gouvernement, c’est la répartition des barrages, l’investissement dans l’eau régénérée et la réponse à la sécheresse. Pour le client étranger, c’est de savoir si les puces seront livrées à temps. Pour les associations environnementales, c’est le débit des rivières, le traitement des effluents et la capacité de charge locale.
+
+Quand l’eau est abondante, ces différences se voient mal. Quand la sécheresse arrive, chaque usage devient net.
+
+Une bonne gouvernance de l’eau des semi-conducteurs ne devrait donc reposer ni sur les camions-citernes en temps de crise, ni sur les seuls taux de recyclage affichés dans les rapports de développement durable. Elle exige une planification plus précoce : quels parcs scientifiques se prêtent à une extension, quels territoires ont besoin d’usines d’eau régénérée, quelles industries doivent utiliser de l’eau régénérée, quelles données doivent être publiées, et comment les principes de répartition en période de sécheresse peuvent gagner la confiance de la société.
+
+Ces questions paraissent moins brillantes que le 2 nanomètres, le CoWoS ou les serveurs d’IA, mais ce sont elles qui déterminent si la haute technologie peut se poser sur une île.
+
+## L’eau ramène la chaîne d’approvisionnement à une île
+
+Les semi-conducteurs sont souvent décrits comme une industrie mondialisée : conception américaine, équipements néerlandais, matériaux japonais, fabrication taïwanaise, mémoire coréenne, centres de données partout dans le monde.
+
+Mais l’eau ramène cette chaîne mondiale à une île.
+
+D’où vient l’eau ? Les typhons sont-ils venus ? Les barrages suffisent-ils ? Faut-il ajuster l’irrigation ? L’usine d’eau régénérée sera-t-elle achevée à temps ? Les habitants font-ils confiance au traitement des effluents de l’usine ? Ces questions ne sonnent pas très « haute technologie », mais elles déterminent si la haute technologie peut fonctionner de façon stable.
+
+Ce que « l’eau des semi-conducteurs » fait donc vraiment voir, c’est où se tient la montagne sacrée.
+
+Elle se tient à côté des barrages, dans les bassins versants, dans les canalisations d’eau régénérée et dans la gouvernance locale. Taïwan transforme une part de la puissance de calcul mondiale en puces, et ramène en même temps la pression de la chaîne mondiale dans ses propres conditions hydrologiques.
+
+C’est là ce qui mérite le plus d’être compris dans l’eau des semi-conducteurs : elle retransforme la compétition technologique mondiale la plus abstraite en une question très concrète — comment une île répartit son eau.
+
+## Pour aller plus loin
+
+- [Chaîne d’approvisionnement du matériel d’IA](/technology/AI硬體供應鏈) — comment Taïwan transforme la demande du nuage en machines prêtes à être expédiées.
+- [Électricité et semi-conducteurs à Taïwan](/technology/台灣的電力與半導體) — la facture électrique derrière la chaîne de l’IA.
+- [Usines de la chaîne d’IA à l’étranger](/technology/AI供應鏈海外設廠) — pourquoi d’autres pays veulent eux aussi assumer une part de la pression de fabrication et d’infrastructure.
+- [Développement des parcs scientifiques](/technology/科技園區發展) — comment le cluster des semi-conducteurs a poussé dans les terres et les villes de Taïwan.
+
+## Sources des images
+
+- **Usine n° 18 de TSMC et champs, Parc scientifique du Sud (hero / intérieur)** : [TSMC Fab 18 and fields May 2025](https://commons.wikimedia.org/wiki/File:TSMC_Fab_18_and_fields_May_2025.jpg) — Photo : 4300streetcar, Wikimedia Commons, CC BY 4.0. Ce texte utilise la version mise en cache dans `public/article-images/technology/tainan-science-park-tsmc-fab18-fields-2025.webp`.
+- **Inondation à Minxiong (Chiayi) après les pluies de Morakot** : [2009-08-09 at a village under the Typhoon Morakot, in Minxiong, Chiayi](https://commons.wikimedia.org/wiki/File:2009-08-09_at_a_village_under_the_Typhoon_Morakot,_in_Minxiong,_Chiayi.jpg) — Photo : zilupe, Wikimedia Commons, CC BY 2.0. Ce texte utilise la version mise en cache dans `public/article-images/nature/morakot-minxiong-flood-2009.webp`.
+- **Schéma du cycle de l’eau entre eau régénérée et fabrication de semi-conducteurs** : schéma conceptuel SVG réalisé par Taiwan.md Contributors, CC BY-SA 4.0, stocké dans `public/article-images/technology/reclaimed-water-semiconductor-loop.svg`. Il sert à expliquer les relations entre barrages, eaux usées urbaines, usine d’eau régénérée, usine de plaquettes et gouvernance locale, et n’est pas le plan d’un site industriel particulier.
+
+## Références
+
+[^1]: [WIRED: Want to Win a Chip War? You’re Gonna Need a Lot of Water](https://www.wired.com/story/want-to-win-a-chip-war-youre-gonna-need-a-lot-of-water/) — Reportage de WIRED en 2023 sur les besoins de la fabrication de semi-conducteurs en eau ultrapure, en traitement de l’eau et en ressources locales, avec mention de la tension entre fabrication de puces et irrigation agricole pendant les sécheresses taïwanaises.
+[^2]: [TSMC Arizona](https://www.tsmc.com/static/abouttsmcaz/index.htm) — Page officielle de TSMC Arizona, qui expose l’investissement sur le site, le plan des procédés de pointe, le système de récupération de l’eau et les objectifs des installations de régénération de l’eau industrielle ; utilisable comme cas de gouvernance hydrique des usines à l’étranger.
+[^3]: [The Verge: The new silicon valley (literally)](https://www.theverge.com/features/825207/semiconductor-chip-manufacturing-new-silicon-valley) — Reportage sur l’emploi, le développement local, les ressources hydriques, l’environnement et les controverses sur la sécurité au travail liés à l’expansion du cluster de semi-conducteurs de l’Arizona ; utile pour équilibrer le point de vue des sociétés locales sur les usines à l’étranger.
+[^4]: [Roussilhe et al.: From Silicon Shield to Carbon Lock-in?](https://arxiv.org/abs/2209.12523) — Étudie l’empreinte environnementale de 16 fabricants taïwanais de composants électroniques entre 2015 et 2020 et pose le risque d’une hausse de la consommation d’eau, de l’énergie et des émissions avec la croissance de la production.

--- a/knowledge/fr/Technology/taiwan-electricity-and-semiconductors.md
+++ b/knowledge/fr/Technology/taiwan-electricity-and-semiconductors.md
@@ -1,0 +1,195 @@
+---
+translatedFrom: 'Technology/台灣的電力與半導體.md'
+sourceCommitSha: '250410ea'
+sourceContentHash: 'sha256:739eb8c857d7b377'
+sourceBodyHash: 'sha256:814f9eb8b97792cf'
+translatedAt: '2026-07-24T01:30:00+08:00'
+lang: 'fr'
+title: 'Électricité et semi-conducteurs à Taïwan : la facture électrique de la montagne sacrée qui protège le pays'
+description: 'L’atout international des semi-conducteurs taïwanais repose sur un système électrique très concret. Les usines de plaquettes de pointe, la lithographie EUV, l’encapsulation avancée, les tests de serveurs d’IA et les centres de données exigent tous une alimentation stable, peu interrompue et extensible. Ce texte ne fait pas de la consommation électrique des semi-conducteurs une simple dénonciation écologiste : il la replace dans le rapport de force des chaînes d’approvisionnement — le monde a besoin que Taïwan fabrique les puces d’IA, et Taïwan doit aussi répondre à la question de savoir qui assume le coût électrique, la pression carbone et le risque pour la sécurité énergétique.'
+date: 2026-07-11
+category: 'Technology'
+tags:
+  - 'semi-conducteurs'
+  - 'électricité'
+  - 'énergie'
+  - 'TSMC'
+  - 'matériel d’IA'
+  - 'chaîne d’approvisionnement'
+subcategory: 'Semi-conducteurs et matériel'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-07-11
+lastHumanReview: false
+researchReport: 'reports/research/2026-07/半導體供應鏈草稿地圖.md'
+rationale:
+  why_this_hook: 'Relier vers le bas la « montagne sacrée qui protège le pays » au réseau électrique, pour que le lecteur voie la facture d’infrastructure qui se cache derrière l’atout des semi-conducteurs.'
+  whats_excluded: 'Ne pas transformer l’article en plaidoyer à sens unique sur le nucléaire, l’énergie verte ou la politique tarifaire.'
+  where_it_hedges: 'Traiter simultanément la stabilité de l’alimentation, l’électricité bas carbone, la compétitivité industrielle, le coût public et la sécurité énergétique.'
+  whos_pushing_back: 'Les industries des semi-conducteurs et de l’IA ont besoin d’une électricité stable et bas carbone, mais la société interroge aussi les coûts, les risques, la charge environnementale et l’équité de la répartition.'
+image: '/article-images/nature/maanshan-nuclear-plant-nan-wan-2014.webp'
+imageCredit: 'M. Weitzel / Wikimedia Commons'
+imageLicense: 'CC BY-SA 3.0'
+---
+
+# Électricité et semi-conducteurs à Taïwan : la facture électrique de la montagne sacrée qui protège le pays
+
+> **En 30 secondes :** les semi-conducteurs ne se font pas seulement avec des ingénieurs, des usines de plaquettes et des équipements de pointe, mais aussi avec un réseau électrique stable. Plus les puces d’IA sont puissantes, plus la fabrication des plaquettes, l’encapsulation avancée, les tests de serveurs et les centres de données ont besoin d’électricité. C’est ainsi que Taïwan a obtenu un atout dans la chaîne d’approvisionnement mondiale, et c’est ainsi qu’elle a fait entrer dans une même facture les tarifs de l’électricité, l’importation de combustibles, les énergies renouvelables, les émissions de carbone et le risque de coupure.
+
+25,55 milliards de kilowattheures.
+
+C’est la consommation électrique de TSMC en 2024 selon le média spécialisé Tom's Hardware. Cet article traitait à l’origine de la manière dont TSMC réduit la consommation de pointe des machines de lithographie EUV, et mentionnait que ces économies pourraient représenter 190 millions de kilowattheures en moins d’ici 2030. Mais le même texte plaçait à côté l’ordre de grandeur de la consommation annuelle de TSMC : 25,55 milliards de kilowattheures.[^1]
+
+Ces deux chiffres côte à côte changent l’image. Quand on parle de la « montagne sacrée qui protège le pays », on pense en général à TSMC, aux procédés de pointe, au cours de l’action, aux exportations et à l’atout diplomatique. Les 25,55 milliards de kilowattheures ramènent cette même montagne au sol, au réseau, au combustible, aux centrales, aux contrats d’énergie renouvelable et à chacune des factures.
+
+Une usine de plaquettes de pointe ne peut pas tomber en panne de courant. Les machines EUV, la climatisation des salles blanches, l’approvisionnement en produits chimiques, le traitement des gaz d’échappement, les systèmes d’eau ultrapure, les équipements de mesure, les centres de données et les systèmes de secours doivent tous fonctionner de façon stable. Que les puces puissent être produites en série dépend au bout du compte de la stabilité de l’alimentation.
+
+C’est aussi pourquoi la consommation électrique des semi-conducteurs ne devrait pas s’écrire seulement comme « TSMC consomme énormément ».
+
+La question la plus juste est celle-ci : quand Taïwan accueille la demande mondiale de puces d’IA et de fabrication de pointe, qui fournit cette électricité stable ? Qui assume l’importation de combustibles et la pression carbone ? Qui paie le coût quand les tarifs sont ajustés ? Qui assume le risque en cas de coupure ou d’instabilité du réseau ?
+
+![Vue extérieure de la troisième centrale nucléaire près de Nanwan, à Hengchun (comté de Pingtung) : les bâtiments, la cheminée et le trait de côte dans un même cadre, une scène où se croisent les choix électriques de Taïwan et l’environnement local.](/article-images/nature/maanshan-nuclear-plant-nan-wan-2014.webp)
+
+_La troisième centrale nucléaire (centrale de Maanshan) à Hengchun, comté de Pingtung. La demande électrique de l’IA et des semi-conducteurs a ramené dans l’espace public le débat sur le nucléaire, le gaz, les renouvelables et la résilience du réseau. Photo : M. Weitzel. CC BY-SA 3.0 via Wikimedia Commons._
+
+## La demande d’IA finit par revenir au compteur
+
+L’IA générative ressemble à un service dans le nuage, mais ce sont en réalité des machines qui calculent.
+
+Une puce d’IA, de la conception à la mise en service, traverse la fabrication des plaquettes, l’encapsulation avancée, les tests, la carte mère, l’alimentation, la dissipation, le rack et le centre de données. Chaque étape consomme de l’électricité. La fabrication amont en consomme parce que les équipements de procédé et l’environnement propre ne peuvent pas être interrompus. L’encapsulation aval en consomme parce que l’intégration des puces et de la mémoire devient de plus en plus complexe. Les serveurs d’IA en consomment parce que les GPU et les accélérateurs transforment de grandes quantités d’électricité en calcul, et aussi en chaleur.
+
+La chaîne d’approvisionnement de l’IA n’est donc pas seulement ce mot abstrait, « puissance de calcul ». Le calcul a des factures d’électricité, un réseau, des groupes au gaz, des achats d’énergie renouvelable, et aussi des émissions de carbone.
+
+Le sens de ces 25,55 milliards de kilowattheures du début n’est pas d’impressionner, mais de rappeler au lecteur que l’avantage des procédés de pointe repose sur un apport énergétique énorme et continu. Les machines EUV peuvent économiser de l’énergie, les salles blanches peuvent être optimisées, les systèmes d’usine peuvent être réglés. Mais tant que la demande d’IA continue de pousser les capacités vers le haut, la pression sur le total ne disparaîtra pas d’elle-même parce qu’un équipement consomme moins.
+
+C’est aussi ce qui distingue l’ère de l’IA de l’électronique d’autrefois. Autrefois, parler de la fabrication taïwanaise revenait à parler d’efficacité industrielle, de densité de fournisseurs, de culture des ingénieurs et de délais. Il faut désormais ajouter une question : Taïwan peut-elle raccorder de façon stable la demande mondiale de calcul à son propre réseau électrique ?
+
+Si la réponse est oui, l’électricité fait partie du crédit de Taïwan dans la chaîne d’approvisionnement. Si la réponse commence à vaciller, les clients étrangers feront entrer dans le même tableur la localisation de la fabrication, l’accès aux renouvelables, le risque de coupure et la géopolitique.
+
+## La stabilité compte plus que le prix bas
+
+Quand on parle d’électricité, on pense d’abord au prix. Mais pour une usine de plaquettes, la stabilité peut compter davantage que le seul tarif.
+
+De nombreuses étapes de la fabrication doivent se dérouler en continu dans un environnement hautement contrôlé. Fluctuations de tension, microcoupures ou qualité d’alimentation instable peuvent provoquer des arrêts d’équipement, des produits mis au rebut ou des ruptures de planning. Pour un foyer, quelques minutes sans courant sont une gêne ; pour une usine de pointe, quelques minutes peuvent représenter un lot de plaquettes, un pan de rendement, voire la confiance d’un client.
+
+C’est aussi l’un des points les plus négligés du rapport de force des chaînes d’approvisionnement. Les clients étrangers ont besoin de Taïwan parce que Taïwan sait livrer des puces de manière durable, stable et ponctuelle. Une alimentation électrique stable devient donc une partie du crédit taïwanais.
+
+Inversement, quand les clients internationaux et les gouvernements évaluent l’idée de déplacer une partie de la fabrication vers les États-Unis, le Japon ou l’Europe, l’électricité entre aussi en ligne de compte. Ce n’est pas seulement le risque géopolitique qui pousse à construire des usines à l’étranger : l’approvisionnement énergétique, la structure tarifaire, l’accès aux renouvelables et la résilience du réseau entrent également dans le calcul.
+
+Il y a là une subtilité. Une partie de la compétitivité passée de Taïwan venait d’une électricité stable et relativement abordable. Mais lorsque la transition énergétique, les prix des combustibles, les finances de Taipower, les tarifs industriels et la pression de décarbonation montent en même temps, cette base ne peut plus aller de soi.
+
+Ce que veut l’industrie des semi-conducteurs, c’est une électricité « bon marché, stable, bas carbone et extensible ». Le problème, c’est qu’il est très difficile de satisfaire ces quatre conditions à la fois. Une électricité bon marché peut réduire les coûts des entreprises mais faire porter davantage à Taipower ou à la population ; une électricité stable peut exiger des capacités de réserve, des groupes au gaz ou du stockage ; une électricité bas carbone exige des renouvelables, du nucléaire ou d’autres solutions ; et l’extensibilité touche au foncier, au réseau, aux ports, aux terminaux méthaniers et à l’acceptation locale.
+
+Le problème électrique des semi-conducteurs est donc à la fois technique, financier et politique.
+
+## L’énergie verte devient peu à peu une condition des commandes
+
+La consommation électrique des semi-conducteurs subit encore une autre pression : les engagements de décarbonation des clients.
+
+Apple, NVIDIA, les grands acteurs du nuage et les marques mondiales affrontent la pression carbone de leur chaîne d’approvisionnement. Ils ne regardent pas seulement si TSMC sait fabriquer la puce, mais aussi d’où vient l’électricité du processus de production. Quand un client s’engage sur le net zéro ou sur RE100, la consommation du fournisseur cesse d’être un coût interne pour devenir une partie de l’empreinte carbone du produit du client.
+
+Les semi-conducteurs taïwanais font donc face à une double exigence : augmenter la production d’un côté, obtenir davantage d’électricité bas carbone de l’autre. Augmenter la production accroît la consommation, et décarboner exige de transformer la structure électrique. Lorsque les deux surviennent en même temps, la difficulté ne se résout plus par les seules économies d’énergie d’une entreprise.
+
+Tom's Hardware, reprenant un article de DigiTimes, indique que l’Association taïwanaise de l’industrie des semi-conducteurs a alerté le gouvernement sur l’urgence de la stabilité électrique et de l’approvisionnement en renouvelables ; l’article mentionne aussi qu’en 2024 la part des renouvelables dans la consommation des usines de plaquettes taïwanaises restait inférieure à ce qu’exige la trajectoire RE100.[^2] De tels articles ne devraient pas se lire comme une simple plainte contre le gouvernement, mais être replacés dans le contexte de la chaîne d’approvisionnement : si les clients veulent des puces bas carbone, Taïwan doit disposer d’assez d’électricité bas carbone.
+
+C’est pourquoi l’« énergie verte » n’est pas un joli slogan dans les semi-conducteurs. Elle devient peu à peu une condition des commandes, une condition financière et une condition diplomatique.
+
+![Parc éolien en mer au large de Miaoli, avec les éoliennes blanches alignées sur la mer, une scène représentative de l’expansion des renouvelables à Taïwan.](/article-images/nature/hai-neng-offshore-wind-farm-2024.webp)
+
+_Parc éolien en mer au large de Miaoli. Quand les clients des semi-conducteurs exigent une chaîne bas carbone, la consommation des usines de plaquettes se raccorde jusqu’aux parcs éoliens, au raccordement réseau, au stockage et à la concertation locale. Image : ministère des Affaires économiques de la République de Chine, CC BY-SA 4.0 via Wikimedia Commons._
+
+Si Taïwan parvient à offrir un environnement de fabrication bas carbone et stable, son caractère irremplaçable n’en sera que renforcé. Si Taïwan ne peut offrir qu’une fabrication à haute densité sans suivre les exigences carbone de ses clients, une partie des commandes pourrait être poussée vers d’autres régions, ou l’on demandera aux entreprises taïwanaises de construire à l’étranger pour y obtenir de l’électricité bas carbone.
+
+## Les gains d’efficacité ne compensent pas automatiquement la croissance du total
+
+Les entreprises économisent bien sûr de l’énergie. Les machines EUV, la climatisation des salles blanches, les systèmes d’usine, les équipements de procédé et les centres de données ont tous une marge d’amélioration.
+
+Mais les gains d’efficacité et la pression sur le total sont deux choses différentes.
+
+Si chaque équipement consomme moins, mais que le nombre d’équipements, la capacité de production de plaquettes, la capacité d’encapsulation avancée, les tests de serveurs d’IA et la demande des centres de données augmentent plus vite, la consommation totale continuera de monter. C’est le dilemme de la chaîne de l’IA : le progrès technique améliore souvent l’efficacité tout en créant une demande plus grande.
+
+L’étude de Roussilhe et al., portant sur 16 fabricants taïwanais de composants électroniques, indique qu’entre 2015 et 2020 les émissions de gaz à effet de serre, l’énergie finale, la consommation électrique et l’usage de l’eau des entreprises de l’échantillon ont augmenté avec la croissance de la production, et pose le risque du carbon lock-in.[^3] Cet avertissement est important : la montée en gamme industrielle n’entraîne pas automatiquement une baisse de la charge environnementale.
+
+Autrement dit, Taïwan ne peut pas se demander seulement « chaque plaquette consomme-t-elle moins ? ». Il faut aussi demander : « une fois l’ensemble de l’industrie agrandi, comment gère-t-on la consommation totale, les émissions totales, les importations totales de combustibles et la charge sur le réseau ? ».
+
+Cette question ne disparaîtra pas parce que Taïwan est importante. C’est justement parce que Taïwan est importante qu’il faut l’affronter de face.
+
+## De qui est cette facture électrique ?
+
+Les semi-conducteurs apportent exportations, salaires, recettes fiscales, Bourse et visibilité internationale. Ces bénéfices sont réels.
+
+Mais la facture électrique l’est aussi.
+
+Une partie est payée par les entreprises et se reflète dans les tarifs, l’investissement en équipements, l’achat de renouvelables et la gestion de l’énergie. Une autre partie est assumée par la société dans son ensemble et se reflète dans la construction du réseau, la politique tarifaire, l’importation de combustibles, la pollution de l’air et les émissions, l’implantation des centrales, les lignes de transport et l’acceptation locale des installations énergétiques.
+
+Il n’y a pas de réponse simple. Si les tarifs sont trop bas, on peut reporter le coût industriel sur la population ou sur les finances de Taipower ; s’ils montent trop vite, cela peut affecter la compétitivité industrielle et le budget des ménages. Si les renouvelables s’étendent trop lentement, la pression carbone sur les entreprises augmente ; si elles s’étendent trop vite, on peut se heurter au foncier, à la pêche, au paysage et à la politique locale.
+
+« La facture électrique de la montagne sacrée » est donc un problème public : avec quel mélange énergétique Taïwan veut-elle soutenir sa position dans la chaîne d’approvisionnement mondiale ?
+
+Ce que voit le gouvernement, c’est la sécurité énergétique et la compétitivité industrielle. Ce que voient les entreprises, ce sont les coûts, les délais, les exigences des clients et les options d’usines à l’étranger. Ce que voit la population, ce sont les tarifs, la pollution, les coupures, les aménagements locaux et la qualité de vie. Et ce que voient les clients étrangers, c’est ceci : Taïwan pourra-t-elle continuer à livrer de façon stable durant la prochaine décennie, tout en respectant les exigences d’une chaîne bas carbone ?
+
+Un même kilowattheure est une chose différente selon celui qui le regarde. Pour l’usine, c’est de la capacité ; pour le foyer, une facture ; pour le gouvernement, une politique énergétique ; pour le client étranger, un risque de chaîne d’approvisionnement.
+
+## Les entreprises achètent du vert, la société doit encore bâtir le système
+
+Les grandes entreprises de semi-conducteurs peuvent signer des contrats d’achat d’électricité, acheter des certificats d’énergie renouvelable, investir dans des équipements sobres et exiger de leurs fournisseurs qu’ils réduisent aussi leurs émissions. Toutes ces démarches sont nécessaires, car les clients internationaux remontent la chaîne pour traquer les émissions.
+
+Mais que les entreprises achètent du vert n’équivaut pas à résoudre automatiquement le problème social.
+
+Premièrement, l’énergie verte doit pouvoir être réellement produite. L’éolien en mer, le photovoltaïque, la géothermie, la biomasse ou d’autres sources bas carbone exigent du foncier, des espaces maritimes, un raccordement, du stockage, de la maintenance et une coordination locale. Les entreprises peuvent signer des contrats d’achat, mais les installations de production et le réseau doivent toujours être portés par la société entière.
+
+![Grands panneaux solaires installés sur le toit de l’aire de service de Xihu, sur l’autoroute nationale, avec les voies et les bâtiments de l’aire en contrebas, montrant comment le photovoltaïque entre dans l’infrastructure du quotidien.](/article-images/nature/xihu-service-area-solar-2014.webp)
+
+_Panneaux solaires sur le toit de l’aire de service de Xihu. Avant que les entreprises n’achètent du vert, la société doit d’abord avoir bâti les systèmes de production, de foncier, de raccordement et de maintenance. Photo : lienyuan lee. CC BY 3.0 via Wikimedia Commons._
+
+Deuxièmement, l’énergie verte pose un problème de temps. Le jour, le solaire est abondant, mais l’usine de plaquettes tourne aussi la nuit ; quand il y a du vent, l’éolien est abondant, mais quand il n’y en a pas il faut compenser par d’autres sources ou par du stockage. Ce dont les semi-conducteurs ont besoin, c’est d’une électricité stable à chaque instant, et pas seulement d’avoir acheté assez d’énergie verte sur le total annuel.
+
+Troisièmement, l’énergie verte pose aussi un problème de répartition. Si les entreprises les plus riches et les mieux placées pour négocier accèdent en priorité à l’électricité bas carbone, que deviennent les autres industries, les PME et les foyers ? Si les exportations technologiques peuvent répercuter le coût sur les clients mondiaux tandis que les habitants assument le réseau, les postes électriques, les parcs éoliens, les centrales solaires et les ajustements tarifaires, la confiance sociale devient fragile.
+
+Le problème de l’énergie verte dans les semi-conducteurs taïwanais ne peut donc pas être résolu par le seul département développement durable d’une entreprise. Il exige que la politique énergétique, le marché de l’électricité, la gouvernance locale et la transformation industrielle suivent ensemble. La capacité d’achat des entreprises peut pousser le marché, mais derrière le marché il faut toujours une infrastructure publique.
+
+## La polémique nucléaire est elle aussi ramenée par l’IA
+
+Le débat électrique taïwanais peut difficilement éviter le nucléaire.
+
+En 2025, après l’arrêt du dernier réacteur nucléaire en service à Taïwan, la question de la prolongation est revenue dans le débat public par référendum. AP rapporte que, lors du référendum de 2025 sur la prolongation de la troisième centrale, les voix favorables l’ont nettement emporté sur les voix défavorables, sans atteindre toutefois le seuil requis ; les partisans du nucléaire soutiennent qu’il aide à faire baisser les tarifs et à absorber la croissance de la consommation liée aux applications d’IA.[^4]
+
+La polémique nucléaire n’a pas besoin d’être réduite ici à une prise de position. Ce qui mérite vraiment l’attention, c’est ceci : l’IA et les semi-conducteurs ont de nouveau fait de l’énergie une question de capacité nationale.
+
+Les partisans du nucléaire diront que Taïwan a besoin d’une électricité stable et bas carbone et ne peut pas dépendre seulement du gaz importé et de renouvelables en croissance. Ses opposants diront que les déchets nucléaires, le risque sismique, le coût du démantèlement et la sécurité locale ne peuvent pas être écrasés par la fièvre de l’IA. Derrière la dispute, les deux camps répondent en réalité à la même question : avec quel type de risque Taïwan veut-elle payer sa position dans la chaîne d’approvisionnement mondiale ?
+
+Cette question ne peut pas être confiée aux seuls TSMC ou Taipower. C’est un choix de toute la société.
+
+## Les atouts d’une chaîne d’approvisionnement exigent des infrastructures
+
+La valeur de Taïwan dans la chaîne des semi-conducteurs ne vient pas seulement de TSMC, mais de toute une société d’ingénierie : parcs scientifiques, fournisseurs, ingénieurs, encapsulation et tests, produits chimiques, logistique, eau et électricité, et coordination gouvernementale.
+
+L’électricité est l’infrastructure la plus fondamentale de cette société d’ingénierie.
+
+Quand le monde dit « Taïwan est irremplaçable », il dépend aussi du réseau électrique taïwanais. Quand des gouvernements étrangers poussent TSMC à construire aux États-Unis, au Japon ou en Allemagne, ils tentent aussi de déplacer une partie de la facture électrique sur leur propre territoire. Cela montre plutôt que la valeur de Taïwan est si élevée qu’aucun pays ne veut miser tout le risque sur une même île.
+
+Ce que Taïwan doit vraiment affronter ensuite, c’est un problème institutionnel plus difficile : si les semi-conducteurs sont l’atout international de Taïwan, avec quel système énergétique Taïwan est-elle prête à le maintenir ?
+
+Une bonne réponse ne se limitera pas à « construire plus de centrales » ou « acheter plus de vert ». Elle inclut aussi la résilience du réseau, le stockage, l’effacement de la demande, les tarifs industriels, la sécurité des importations énergétiques, la concertation locale, le raccordement des renouvelables, et la manière dont les industries très consommatrices expliquent à la société leurs coûts et leurs apports.
+
+Les semi-conducteurs ont rendu Taïwan nécessaire au monde. L’électricité lui rappelle qu’être nécessaire n’est pas gratuit.
+
+## Pour aller plus loin
+
+- [Chaîne d’approvisionnement du matériel d’IA](/technology/AI硬體供應鏈) — comment Taïwan transforme la demande du nuage en machines prêtes à être expédiées.
+- [L’eau des semi-conducteurs et les ressources hydriques de Taïwan](/technology/半導體用水與台灣水資源) — comment la fabrication des plaquettes entre dans les barrages, les sécheresses et la gestion de l’eau régénérée.
+- [Usines de la chaîne d’IA à l’étranger](/technology/AI供應鏈海外設廠) — comment la construction d’usines à l’étranger lie chaîne d’approvisionnement, électricité et infrastructures locales.
+- [Entreprises taïwanaises : TSMC](/economy/台灣企業：台積電) — comment le modèle de fonderie pure est devenu le goulot d’étranglement mondial des puces de pointe.
+
+## Sources des images
+
+- **Vue extérieure de la troisième centrale nucléaire (Maanshan, Hengchun, Pingtung ; hero / intérieur)** : [Maanshan Nuclear Power Plant, Nan Wan](https://commons.wikimedia.org/wiki/File:Maanshan_Nuclear_Power_Plant,_Nan_Wan.jpg) — Photo : M. Weitzel, Wikimedia Commons, CC BY-SA 3.0. Ce texte utilise la version mise en cache dans `public/article-images/nature/maanshan-nuclear-plant-nan-wan-2014.webp`.
+- **Parc éolien en mer au large de Miaoli** : [Hai Long offshore wind farm](https://commons.wikimedia.org/wiki/File:Hai_Long_offshore_wind_farm.jpg) — Wikimedia Commons, CC BY-SA 4.0. Ce texte utilise la version mise en cache dans `public/article-images/nature/hai-neng-offshore-wind-farm-2024.webp`.
+- **Panneaux solaires sur le toit de l’aire de service de Xihu** : [Xihu Service Area solar panels](https://commons.wikimedia.org/wiki/File:Xihu_Service_Area_solar_panels.jpg) — Photo : lienyuan lee, Wikimedia Commons, CC BY 3.0. Ce texte utilise la version mise en cache dans `public/article-images/nature/xihu-service-area-solar-2014.webp`.
+
+## Références
+
+[^1]: [Tom's Hardware: TSMC reduces peak power consumption of EUV tools by 44%](https://www.tomshardware.com/tech-industry/semiconductors/tsmc-reduces-peak-power-consumption-of-euv-tools-by-44-percent-company-to-save-190-million-kilowatt-hours-of-electricity-by-2030) — Rend compte du plan d’économies d’énergie de TSMC sur l’EUV, de l’ordre de grandeur de sa consommation totale et de la proportion d’économies des outils ; utile pour expliquer la coexistence des gains d’efficacité et de la pression sur le total.
+[^2]: [Tom's Hardware: TSMC-led semiconductor association warns of power supply pressure](https://www.tomshardware.com/tech-industry/tmsc-led-semiconductor-association-begs-taiwan-government-for-clean-green-energy-as-demand-skyrockets-fabs-are-struggling-to-keep-up-with-power-needs) — Rend compte de l’alerte de l’Association taïwanaise de l’industrie des semi-conducteurs sur la stabilité électrique et l’approvisionnement en renouvelables, et récapitule RE100, la demande d’énergie verte des usines de plaquettes et le risque de transfert à l’étranger.
+[^3]: [Roussilhe et al.: From Silicon Shield to Carbon Lock-in?](https://arxiv.org/abs/2209.12523) — Étudie l’empreinte environnementale de 16 fabricants taïwanais de composants électroniques entre 2015 et 2020 et pose que l’énergie, l’eau et les émissions augmentent avec la croissance de la production, ainsi que le risque de carbon lock-in.
+[^4]: [AP: Taiwan lawmakers survive recall vote; nuclear power referendum fails](https://apnews.com/article/taiwan-recall-vote-nuclear-referendum-2efa596845858a7e4bd89e0c23af39b8) — Reportage d’AP sur le résultat du référendum de 2025 concernant la prolongation de la troisième centrale nucléaire de Taïwan, qui explique aussi comment les partisans du nucléaire intègrent les tarifs et la demande électrique de l’IA à leur argumentaire.


### PR DESCRIPTION
補上 fr 相對 `knowledge/`（zh-TW SSOT）尚缺的最後 10 篇。合併後 fr 覆蓋率 853/853 → 100%。

這是 ja (#1237) / ko (#1239) / es (#1240) 之後的第四批，做法完全一致。

## 檔案與結構對齊

每一篇都與 zh 原文逐項比對：H2 數、`[^N]` 引用數、`[^N]` 定義數、外部連結數、非空行數 **全部相同**。

| 檔案 | 來源 | 比值 | H2 | `[^N]` 引用 | `[^N]` 定義 | 連結 | 非空行 |
|---|---|---|---|---|---|---|---|
| `Music/megaport-festival.md` | `Music/大港開唱.md` | 2.71 | 7 | 14 | 10 | 19 | 51 |
| `Technology/taiwan-electricity-and-semiconductors.md` | `Technology/台灣的電力與半導體.md` | 3.44 | 11 | 4 | 4 | 7 | 85 |
| `Technology/semiconductor-water-use-and-taiwan-water-resources.md` | `Technology/半導體用水與台灣水資源.md` | 3.51 | 11 | 7 | 4 | 6 | 82 |
| `People/dwagie.md` | `People/大支.md` | 3.13 | 11 | 26 | 9 | 13 | 74 |
| `Technology/ai-hardware-supply-chain.md` | `Technology/AI硬體供應鏈.md` | 3.14 | 11 | 10 | 10 | 12 | 95 |
| `Technology/ai-supply-chain-overseas-manufacturing.md` | `Technology/AI供應鏈海外設廠.md` | 3.22 | 13 | 11 | 10 | 12 | 103 |
| `Music/chthonic.md` | `Music/閃靈.md` | 2.92 | 12 | 21 | 16 | 29 | 88 |
| `People/freddy-lim.md` | `People/林昶佐.md` | 2.57 | 12 | 32 | 19 | 57 | 128 |
| `Society/taipei-smoking-room.md` | `Society/台北吸菸室.md` | 3.02 | 11 | 48 | 43 | 56 | 158 |
| `Culture/shopping-design.md` | `Culture/Shopping Design.md` | 2.89 | 8 | 38 | 26 | 32 | 117 |

合計：zh 106,493 字元 → fr 320,123 字元（整體比值 3.01）

## fr 慣例（依現有 fr 語料統計，非我自己選的）

| 項目 | 採用 | 語料實測 |
|---|---|---|
| 國名／形容詞 | `Taïwan` / `taïwanais` | 6613 / 5270 次 |
| 首都 | `Taipei`（不加音符） | 2604 次 |
| 其他城市 | `Kaohsiung` / `Tainan` | 沿用既有 |
| 摘要 callout | `> **En 30 secondes :**` | 305 次（冒號前有空格，法文排版） |
| 參考資料 | `## Références` | 715 次 |
| 延伸閱讀 | `## Pour aller plus loin` | 201 次 |
| 圖片來源 | `## Sources des images` | 129 次 |

## 保留項

- `tw-timeline` / `tw-line` / `tw-versus` / `tw-quote` / `tw-bars` / `tw-stat` / `tw-note` 七種區塊全數保留，**標籤翻譯、數字一字不動**。
- YouTube iframe 的 `title` 保留原始中文曲名（例：`閃靈 - 鎮魂醒靈寺 Official Video`），因為那是影片本身的標題。
- 圖片 CC 授權的 `Photo:` 姓名保留授權者原始寫法，不在地化。
- 〈平安戲〉客語段落維持不譯（與既有 fr 譯文一致），華語版本全譯。
- zh 原文中未被引用的腳註定義（如 `[^4]`）照樣保留，因為原文就有。

## 驗證

```
python scripts/tools/check-slug-consistency.py
✅ slug 一致性：3384 檔全部與 en 對齊

python scripts/tools/article-health.py --profile=pre-commit <10 files>
hard=0（10 篇全部 passed=True）

python scripts/tools/lang-sync/flatten-translation-wikilinks.py --files <10 files>
0 wikilink / 0 檔 待扁平
```

翻譯內不留 `[[wikilink]]`，延伸閱讀採標準 markdown 連結指向 zh 路徑。

## 兩個順帶回報（不在本 PR 修）

1. `article-health.py` 的 `image-health` 檢查把 `## 圖片來源` 這個中文標題寫死了，所以**所有非中文譯文**只要 frontmatter 有 `imageCredit` 就會噴 warn。既有已合併的 `fr/Art/graffiti-and-street-art-in-taiwan.md`、`fr/Geography/chiayi-county.md` 等 16 篇用 `## Sources des images` 的檔案同樣中招。是 warn 不是 hard，不擋 CI，但建議把該檢查改成吃各語言的標題對照表。
2. `knowledge/fr/Food/portuguese-egg-tart-in-taiwan.md`（既有檔案，非本 PR 觸碰）目前 `article-health --profile=pre-commit` 是 **hard=1**：斜體 caption 內含 percent-encoded CJK Commons URL。

`_translations.json` 一樣沒有重建 —— 理由同 #1238：沒有任何 workflow 引用 `sync-translations-json.py`，而 312KB 的 JSON 放在 contributor PR 裡極易衝突。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGZT4FDb3XyzKSYFCSYs48
