### PR TITLE
fix(data): re-render enterprise bubble labels on metric/sector switch (#1223)

### DIFF
--- a/src/templates/companies.template.astro
+++ b/src/templates/companies.template.astro
@@ -365,10 +365,24 @@ const sectors = [...new Set(companies.map((c) => c.sector))];
         .attr('dominant-baseline', 'central')
         .attr('fill', '#fff')
         .attr('font-weight', '600')
-        .attr('pointer-events', 'none')
-        .each(function (d) {
-          const r = getRadius(d);
+        .attr('pointer-events', 'none');
+
+      function metricUnit() {
+        if (currentMode === 'employees') return lang === 'zh-TW' ? ' 人' : '';
+        return lang === 'zh-TW' ? ' 億' : 'B';
+      }
+
+      // Redraw each label from the CURRENT mode/sector. Labels used to be
+      // drawn once at init, so switching the size metric (市值/營收/員工數)
+      // or a sector left the old market-cap number frozen on a resized
+      // bubble, so the value stopped matching the bubble it sat on (#1223).
+      function renderLabels() {
+        labels.each(function (d) {
           const el = d3.select(this);
+          el.selectAll('tspan').remove();
+          el.text(null);
+          if (currentSector !== 'all' && d.sector !== currentSector) return;
+          const r = getRadius(d);
           const shortName = d.name.split(' ')[0];
           if (r > 40) {
             el.append('tspan')
@@ -381,13 +395,16 @@ const sectors = [...new Set(companies.map((c) => c.sector))];
               .attr('dy', '1.2em')
               .attr('font-size', `${Math.min(10, r / 5)}px`)
               .attr('fill-opacity', 0.8)
-              .text(d.marketCap.toLocaleString());
+              .text(getValue(d).toLocaleString() + metricUnit());
           } else if (r > 20) {
             el.attr('font-size', `${Math.min(10, r / 3)}px`).text(shortName);
           } else {
             el.attr('font-size', '8px').text(shortName.slice(0, 2));
           }
         });
+      }
+
+      renderLabels();
 
       const tooltipData = {
         marketCap: lang === 'zh-TW' ? '市值' : 'Market Cap',
@@ -481,13 +498,9 @@ const sectors = [...new Set(companies.map((c) => c.sector))];
             return 0.82;
           });
 
-        labels
-          .transition()
-          .duration(600)
-          .attr('fill-opacity', (d) => {
-            if (currentSector !== 'all' && d.sector !== currentSector) return 0;
-            return 1;
-          });
+        // Re-render labels so the number inside each bubble matches the
+        // active size metric and the current sector filter (#1223).
+        renderLabels();
 
         simulation
           .force(

--- a/src/templates/data.template.astro
+++ b/src/templates/data.template.astro
@@ -739,12 +739,25 @@ const dataCategories = getCategories(t);
         .attr('dominant-baseline', 'central')
         .attr('fill', '#fff')
         .attr('font-weight', '600')
-        .attr('pointer-events', 'none')
-        .each(function (d) {
-          const r = getRadius(d);
+        .attr('pointer-events', 'none');
+
+      function metricUnit() {
+        if (currentMode === 'employees') return lang === 'zh-TW' ? ' 人' : '';
+        return lang === 'zh-TW' ? ' 億' : 'B';
+      }
+
+      // Redraw each label from the CURRENT mode/sector. Labels used to be
+      // drawn once at init, so switching the size metric (市值/營收/員工數)
+      // or a sector left the old market-cap number frozen on a resized
+      // bubble, so the value stopped matching the bubble it sat on (#1223).
+      function renderLabels() {
+        labels.each(function (d) {
           const el = d3.select(this);
+          el.selectAll('tspan').remove();
+          el.text(null);
+          if (currentSector !== 'all' && d.sector !== currentSector) return;
+          const r = getRadius(d);
           const shortName = d.name.split(' ')[0];
-          const suffix = lang === 'zh-TW' ? ' 億' : 'B';
           if (r > 40) {
             el.append('tspan')
               .attr('x', 0)
@@ -756,13 +769,16 @@ const dataCategories = getCategories(t);
               .attr('dy', '1.2em')
               .attr('font-size', `${Math.min(10, r / 5)}px`)
               .attr('fill-opacity', 0.8)
-              .text(d.marketCap.toLocaleString() + suffix);
+              .text(getValue(d).toLocaleString() + metricUnit());
           } else if (r > 20) {
             el.attr('font-size', `${Math.min(10, r / 3)}px`).text(shortName);
           } else {
             el.attr('font-size', '8px').text(shortName.slice(0, 2));
           }
         });
+      }
+
+      renderLabels();
 
       // Get tooltip labels from translations
       const tooltipData = {
@@ -855,13 +871,9 @@ const dataCategories = getCategories(t);
             return 0.8;
           });
 
-        labels
-          .transition()
-          .duration(600)
-          .attr('fill-opacity', (d) => {
-            if (currentSector !== 'all' && d.sector !== currentSector) return 0;
-            return 1;
-          });
+        // Re-render labels so the number inside each bubble matches the
+        // active size metric and the current sector filter (#1223).
+        renderLabels();
 
         simulation
           .force(


### PR DESCRIPTION
## 這個 PR 做了什麼？

修復 `/data`（企業版圖）與 `/companies` 泡泡圖：切換泡泡大小指標（市值 / 營收 / 員工數）或業種篩選時，泡泡內顯示的數字會錯置。

## 變更類型

- [x] 技術改善（程式碼）
- [x] 修復錯誤

## 問題根因

泡泡圖的標籤只在初始化時（marketCap 模式）畫一次。之後切換指標或業種，`updateBubbles()` 只用 transition 改圓的半徑與 opacity，從不重畫標籤：

- 數字永遠印 `d.marketCap`，切到營收 / 員工數時仍顯示市值。
- 「只有名字」與「名字 + 數字」的分層是用初始半徑決定的，之後不再更新。
- 半徑改變後，原本大泡泡的數字被留在縮小後的泡泡上（連單位都可能錯），看起來就是數字錯置。

例如切到員工數：台積電（員工較少）縮小卻仍顯示市值「590,000 億」；鴻海（員工最多）變成最大泡泡卻沒有任何數字。

## 修法

把畫標籤的邏輯抽成 `renderLabels()`，在初始化與每次切換指標 / 業種時都呼叫：

- 數字改用當前指標 `getValue(d)`，並依模式配上正確單位（億 / 人）。
- 分層（名字 / 名字 + 數字、字級）依當前半徑重新計算。
- 被篩掉的泡泡清空文字，不再留下殘影數字。

同一段泡泡圖邏輯在 `data.template.astro` 與 `companies.template.astro` 各有一份，兩份都修。

## Evidence

環境：Windows 11、Node v24.15.0。

重現（線上 https://taiwan.md/data/ ，目前線上仍是舊碼）：捲到「企業版圖」，點「員工數」。

- 台積電泡泡縮小卻仍顯示 `台積電590,000 億`（市值，非員工數）。
- 鴻海變成最大泡泡卻只顯示 `鴻海`，沒有數字。
- DOM 讀值：`labelsWithNumber = [{ text: '台積電590,000 億', r: 32.85 }]`；最大泡泡 `鴻海 r: 75` 無數字。

修後（本機 `astro dev` 載入本分支）：同樣點「員工數」。

- 鴻海（最大泡泡 r: 75）顯示 `鴻海826,608 人`。
- 台積電（r: 32.85）顯示 `台積電`，舊的市值數字已清除。
- `labelsWithNumber` 只剩鴻海一筆，數值與大小指標一致。

業種篩選（本機，market cap 模式點「半導體」）：

- 可見且有標籤的泡泡 7 個，全為 semiconductor。
- `hiddenButStillLabeled = 0`（被篩掉的泡泡不再殘留數字）。

其他檢查：

- `npx prettier --check src/templates/data.template.astro src/templates/companies.template.astro` 回報 `All matched files use Prettier code style!`
- `astro dev` 能正常編譯並提供 `/data/`，泡泡圖互動正常。

本次改動僅為 client 端 D3 標籤邏輯，已在實際頁面 click-through 驗證（before 用線上舊碼、after 用本機本分支）。截圖可提供。

未測試：完整 `npm run build`（該指令的 prebuild 需要 bash / python 管線，本機未跑）。沒有變更 frontmatter、內容、顏色 token 或樣式，內容檢查清單不適用。

## 相關 Issue

Closes #1223

## AI 揭露

本 PR 由 AI 協助完成（Cursor），並由人類 Stan Shih（@stantheman0128）審閱與驗證。
