### PR TITLE
fix(lang-sync): correct translation status on Windows (path keys + CJK git cache)

### DIFF
--- a/scripts/tools/lang-sync/backfill-source-sha.py
+++ b/scripts/tools/lang-sync/backfill-source-sha.py
@@ -32,9 +32,15 @@ def _build_git_history_cache():
     global _GIT_HISTORY_CACHE
     if _GIT_HISTORY_CACHE is not None:
         return _GIT_HISTORY_CACHE
+    # core.quotepath=false + explicit utf-8 decode: knowledge paths are CJK, and
+    # git octal-escapes non-ASCII paths by default while text=True decodes with
+    # the locale codec (cp950 on Windows), so every CJK-named article misses the
+    # cache and silently falls back to the current HEAD sha (mirror of status.py).
     out = subprocess.run(
-        ["git", "log", "--name-only", "--format=__COMMIT__|%H|%aI", "HEAD"],
-        cwd=REPO, capture_output=True, text=True, check=False,
+        ["git", "-c", "core.quotepath=false", "log", "--name-only",
+         "--format=__COMMIT__|%H|%aI", "HEAD"],
+        cwd=REPO, capture_output=True, encoding="utf-8", errors="replace",
+        check=False,
     ).stdout
     history = {}
     cur_sha = cur_date = None

--- a/scripts/tools/lang-sync/status.py
+++ b/scripts/tools/lang-sync/status.py
@@ -89,9 +89,15 @@ def _build_git_history_cache():
     global _GIT_HISTORY_CACHE
     if _GIT_HISTORY_CACHE is not None:
         return _GIT_HISTORY_CACHE
+    # core.quotepath=false + explicit utf-8 decode: knowledge paths are CJK, and
+    # git octal-escapes non-ASCII paths by default while text=True decodes with
+    # the locale codec (cp950 on Windows), either of which corrupts the cache key
+    # so every CJK-named article lookup misses.
     out = subprocess.run(
-        ["git", "log", "--name-only", "--format=__COMMIT__|%H|%aI", "HEAD"],
-        cwd=REPO, capture_output=True, text=True, check=False,
+        ["git", "-c", "core.quotepath=false", "log", "--name-only",
+         "--format=__COMMIT__|%H|%aI", "HEAD"],
+        cwd=REPO, capture_output=True, encoding="utf-8", errors="replace",
+        check=False,
     ).stdout
     history = {}  # rel_path → list of (sha8, sha40, iso_date)
     cur_sha = None
@@ -110,7 +116,10 @@ def _build_git_history_cache():
 
 def git_last_commit(file_path: Path) -> tuple[str, str]:
     """Returns (sha8, iso8601 date) of the last commit that touched file."""
-    rel = str(file_path.relative_to(REPO))
+    # as_posix(): git log --name-only always emits forward slashes, so the
+    # cache key must too. str() yields `knowledge\...` on Windows and never
+    # matches, leaving every article with an empty sha/date.
+    rel = file_path.relative_to(REPO).as_posix()
     cache = _build_git_history_cache()
     hist = cache.get(rel)
     if hist:
@@ -121,7 +130,7 @@ def git_last_commit(file_path: Path) -> tuple[str, str]:
 
 def git_commits_between(sha: str, file_path: Path) -> int:
     """Count commits touching file since sha (exclusive). Returns -1 if sha not found."""
-    rel = str(file_path.relative_to(REPO))
+    rel = file_path.relative_to(REPO).as_posix()
     cache = _build_git_history_cache()
     hist = cache.get(rel)
     if not hist:
@@ -138,7 +147,7 @@ def git_commits_between(sha: str, file_path: Path) -> int:
 
 def git_diff_summary(sha: str, file_path: Path) -> str:
     """Returns +N -M summary since sha."""
-    rel = str(file_path.relative_to(REPO))
+    rel = file_path.relative_to(REPO).as_posix()
     out = git("diff", "--shortstat", f"{sha}..HEAD", "--", rel)
     # e.g. " 1 file changed, 12 insertions(+), 3 deletions(-)"
     ins = re.search(r"(\d+) insertion", out)
@@ -228,7 +237,9 @@ def scan_zh() -> dict:
         # Skip _Home.md / _* files
         if md.name.startswith("_"):
             continue
-        rel = str(md.relative_to(KNOWLEDGE))
+        # as_posix(): keys must match the forward-slash translatedFrom paths
+        # from frontmatter (and stay stable across OSes in the derived cache).
+        rel = md.relative_to(KNOWLEDGE).as_posix()
         content = md.read_text(encoding="utf-8")
         sha, date = git_last_commit(md)
         result[rel] = {
@@ -264,7 +275,7 @@ def scan_translations(lang: str) -> dict:
         sha, date = git_last_commit(md)
         result[tf] = {
             "lang": lang,
-            "path": str(md.relative_to(KNOWLEDGE)),
+            "path": md.relative_to(KNOWLEDGE).as_posix(),
             "translatedFrom": tf,
             "sourceCommitSha": fm.get("sourceCommitSha", ""),
             "sourceContentHash": fm.get("sourceContentHash", ""),


### PR DESCRIPTION
## What

Two sibling scripts in `scripts/tools/lang-sync/` mishandle paths on Windows, the same Windows path class as the merged fix in #1238 but in generators that PR did not touch. They share one git-history cache builder (`backfill-source-sha.py` is an explicit "mirror of status.py"), so both carry the same defect.

`status.py` has two Windows-specific defects:

1. The git-history cache keys are built with `str(Path)`, which yields backslash-separated paths on Windows (`knowledge\...`). `git log --name-only` always emits forward slashes, so every cache lookup misses.
2. The git log output is decoded with the locale codec (cp950 on a zh-TW Windows box) and `core.quotepath` is left on, so CJK article paths are octal-escaped or mis-decoded and never match either.

Combined effect on Windows: the whole translation dashboard is wrong. Every source key comes out backslash-separated with an empty `lastCommit`, and every translation is misreported as `missing`.

`backfill-source-sha.py` shares the same cache builder and the same CJK-decode defect: CJK article paths come back octal-escaped, so every CJK-named article misses the cache and silently falls back to the current HEAD sha instead of the honest at-or-before source sha it is supposed to backfill.

## Fix

- `status.py`: use `Path.relative_to(REPO).as_posix()` for all git-cache keys and scan paths so they match the forward-slash paths git emits and the `translatedFrom` frontmatter values.
- Both files: read `git log` as UTF-8 with `core.quotepath=false` so CJK filenames resolve.

## Evidence

Run on Windows 11 (zh-TW), Python 3.

`status.py --no-write --json`, before (current `main`) vs this branch:

```
before: articles: 848  backslash keys: 848  EMPTY lastCommit: 848  status dist: {'missing': 7632}
after:  articles: 848  backslash keys: 0    EMPTY lastCommit: 0/848 status dist: {'stale': 893, 'missing': 3232, 'fresh': 3507}
```

`backfill-source-sha.py` git-history cache, before vs after:

```
before: octal-escaped keys: 6271   raw-CJK keys: 0     lookup 'knowledge/Culture/中元節.md': None
after:  octal-escaped keys: 0      raw-CJK keys: 6271  lookup 'knowledge/Culture/中元節.md': True
```

Every source key now uses forward slashes, every article resolves its last commit, translations are classified correctly instead of all reported as missing, and CJK articles resolve their real source sha during backfill.

## What was not tested

- Not re-verified on macOS/Linux. The `as_posix()` change is a no-op there (`as_posix()` equals `str()` on POSIX). The `core.quotepath=false` + UTF-8 change also affects POSIX, where `git` octal-escapes CJK paths by default too, so it is a correctness improvement for CJK articles everywhere, not only Windows.
- No unit-test harness exists for these scripts in the repo, so Evidence is the before/after summaries above.

## AI assistance

This change was prepared with AI assistance and reviewed by me. Reproduced and verified on a real Windows 11 zh-TW machine.
