### PR TITLE
fix(article-health): 語言清單接回 registry SSOT，修好 loader 讀不到 registry 的路徑錯誤

### DIFF
--- a/scripts/tools/article-health.py
+++ b/scripts/tools/article-health.py
@@ -37,6 +37,7 @@ from lib.article_health import (  # noqa: E402
     load_config,
     load_target,
     list_checks,
+    TRANSLATION_LANGS,
     run_checks,
 )
 from lib.article_health.config import Config, ProfileConfig  # noqa: E402
@@ -72,7 +73,9 @@ def _get_all_zh() -> list[Path]:
         return []
     files = []
     for cat in root.iterdir():
-        if not cat.is_dir() or cat.name in ("en", "ja", "ko", "es", "fr"):
+        # 語言清單吃 langs.py SSOT，不寫死（2026-07-24：原本停在出生戰役前的五語，
+        # `--all` 會把 knowledge/{vi,id,pt,hi}/ 當成 zh-TW 分類目錄掃進來）。
+        if not cat.is_dir() or cat.name in TRANSLATION_LANGS:
             continue
         for md in cat.glob("*.md"):
             if not md.name.startswith("_"):

--- a/scripts/tools/lib/article_health/__init__.py
+++ b/scripts/tools/lib/article_health/__init__.py
@@ -6,6 +6,7 @@ Public API:
 設計提案：reports/article-health-ssot-design-2026-05-04.md
 """
 
+from .langs import ALL_LANGS, TRANSLATION_LANGS
 from .types import (
     FileTarget,
     Severity,
@@ -34,6 +35,8 @@ __all__ = [
     "list_checks",
     "load_config",
     "run_checks",
+    "ALL_LANGS",
+    "TRANSLATION_LANGS",
 ]
 
 __version__ = "0.1.0-phase1"

--- a/scripts/tools/lib/article_health/checks/correction_meta.py
+++ b/scripts/tools/lib/article_health/checks/correction_meta.py
@@ -33,6 +33,7 @@ import os
 import re
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -78,7 +79,8 @@ _PATTERNS: list[tuple[re.Pattern[str], str]] = [
 
 def _is_excluded_path(path: str) -> bool:
     p = str(path)
-    if any(f"/knowledge/{lg}/" in p for lg in ("en", "ja", "ko", "es", "fr")):
+    # 語言清單吃 langs.py SSOT，不寫死（2026-07-24：原本停在出生戰役前的五語）。
+    if any(f"/knowledge/{lg}/" in p for lg in TRANSLATION_LANGS):
         return True
     if os.path.basename(p).startswith("_") and p.endswith(".md"):
         return True

--- a/scripts/tools/lib/article_health/checks/cross_reference.py
+++ b/scripts/tools/lib/article_health/checks/cross_reference.py
@@ -16,6 +16,7 @@ import re
 from pathlib import Path
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -28,7 +29,8 @@ APPLIES_TO = ["zh-TW"]
 _RE_WIKILINK = re.compile(r"\[\[([^\]|\n]+?)(?:\|[^\]\n]+)?\]\]")
 _RE_MD_LINK_INTERNAL = re.compile(r"\]\(/([a-z]+)/([^)\n]+?)\)")
 
-_LANG_DIRS_SKIP = {"en", "ja", "ko", "es", "fr"}
+# 語言清單吃 langs.py SSOT，不寫死（2026-07-24：原本停在出生戰役前的五語）。
+_LANG_DIRS_SKIP = set(TRANSLATION_LANGS)
 _KNOWLEDGE_ROOT = Path("knowledge")
 
 

--- a/scripts/tools/lib/article_health/checks/image_health.py
+++ b/scripts/tools/lib/article_health/checks/image_health.py
@@ -9,7 +9,8 @@ Dimensions:
   3. external hot-link detection — http/https URLs not under
      `/article-images/` or `https://upload.wikimedia.org/...`
      (canonical CC sources allowed)
-  4. ## 圖片來源 section presence (when CC images used)
+  4. ## 圖片來源 section presence (when CC images used) — 各語言說法皆可，
+     見 `_RE_IMAGE_SOURCES_H2`
   5. **image count gate (added 2026-05-11 kind-mirzakhani per 哲宇 callout)** —
      depth article 理想 hero + 1-2 scene-mid = 2-3 張，min_images=3 預設
      soft-launch WARN（legacy heal），rewrite-stage-4 profile severity_override
@@ -27,6 +28,7 @@ import re
 from pathlib import Path
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -60,7 +62,47 @@ _RE_IFRAME = re.compile(r"<iframe[\s>]", re.IGNORECASE)
 # 「圖+影片+視覺模組 ≈ 1 媒體 / 500–800 字（含 hero 與 tw-* 模組）」；paragraph_rhythm 的
 # density 已這樣數，本 gate 漏了 → 大罷免 dogfood F7 儀器漂移 (REFLEXES #56)。
 _RE_VIZ_MODULE = re.compile(r"^```tw-[a-z]+", re.MULTILINE)
-_RE_IMAGE_SOURCES_H2 = re.compile(r"^##\s*圖片來源", re.MULTILINE)
+# §3 的圖片出處小標 —— 各語言各自的說法，不是只有中文。
+#
+# 2026-07-24：原本寫死 `^##\s*圖片來源`，於是每一篇 frontmatter 有 imageCredit 的
+# 非中文譯文都必噴 warn —— 全 corpus 1,022 筆裡有 759 筆是這樣來的假陽性
+# （en/ja/ko/es/fr 各約 150 筆），真正缺出處區塊的只有 263 篇。假陽性佔 74%，
+# 等於這條 warn 對譯文完全失去訊號。
+#
+# 樣式（不是逐字清單）比對，因為既有語料本身就有變體：en 有 Image Sources ×119 /
+# Image Credits ×23、es 有 Fuentes de imágenes ×73 / Fuentes de las imágenes ×39 /
+# Créditos de imágenes ×18、fr 有 Sources des images ×130 / Crédits photographiques ×10。
+# 逐字表會漏長尾（Fuentes imágenes、Crédits images、画像と動画の出典…）。
+#
+# 聯集比對、不看檔案本身的 lang：中文標題殘留在譯文裡（ja ×8、en ×4）確實是
+# 沒翻到底，但它「是」出處區塊，這條 check 要問的是有沒有 cite，不是翻得夠不夠徹底。
+# vi/id/pt/hi 目前沒有任何一篇有 imageCredit，那四行樣式是照該語言常用詞先擺著、
+# 尚無語料佐證，標記為 provisional；猜錯的代價是一筆 warn，不擋 CI。
+_RE_IMAGE_SOURCES_H2 = re.compile(
+    r"^##[ \t]*(?:"
+    # zh-TW（SSOT）── 圖片／影片／照片 … 來源／出處
+    r"[^\n]*(?:圖片|图片|影片|照片)[^\n]*(?:來源|来源|出處|出处)"
+    # ja ── 画像／写真／動画／映像 … 出典／クレジット
+    r"|[^\n]*(?:画像|写真|動画|映像)[^\n]*(?:出典|出處|來源|来源|クレジット)"
+    # ko ── 이미지／사진／영상 … 출처／크레딧
+    r"|[^\n]*(?:이미지|사진|영상)[^\n]*(?:출처|크레딧)"
+    # en ── Image／Photo／Video／Media … Source(s)／Credit(s)
+    r"|(?i:[^\n]*\b(?:image|photo|video|media)\w*\b[^\n]*\b(?:sources?|credits?)\b)"
+    # es ── Fuentes／Créditos … imagen(es)／foto(s)／vídeo(s)
+    r"|(?i:[^\n]*\b(?:fuentes?|cr[ée]ditos?)\b[^\n]*\b(?:im[áa]genes?|imagen|fotos?|v[ií]deos?)\b)"
+    # fr ── Sources／Crédits … images／photographiques／vidéos
+    r"|(?i:[^\n]*\b(?:sources?|cr[ée]dits?)\b[^\n]*\b(?:images?|photographiques?|photos?|vid[ée]os?)\b)"
+    # pt（provisional，尚無語料）── Fontes／Créditos … imagem(ns)／foto(s)
+    r"|(?i:[^\n]*\b(?:fontes?|cr[ée]ditos?)\b[^\n]*\b(?:imagens?|imagem|fotos?|v[ií]deos?)\b)"
+    # id（provisional，尚無語料）── Sumber … gambar／foto
+    r"|(?i:[^\n]*\bsumber\b[^\n]*\b(?:gambar|foto|video)\w*\b)"
+    # vi（provisional，尚無語料）── Nguồn … ảnh／hình
+    r"|(?i:[^\n]*\bngu[ồo]n\b[^\n]*(?:ảnh|hình|video))"
+    # hi（provisional，尚無語料）── छवि／चित्र／तस्वीर … स्रोत／साभार
+    r"|[^\n]*(?:छवि|चित्र|तस्वीर)[^\n]*(?:स्रोत|साभार)"
+    r")[ \t]*$",
+    re.MULTILINE,
+)
 _RE_CJK = re.compile(r"[一-鿿㐀-䶿]")
 # length-scaling 用 prose-CJK (strip 參考資料 footnote 段) — footnotes 可 inflate CJK ~25%
 # → 過度要求媒體。對齊 paragraph_rhythm density 的 prose 基準 (校準保留 設研院/天下/黃魚鴞)。
@@ -96,8 +138,12 @@ def _is_excluded_from_count_gate(path_str: str) -> bool:
     p = path_str.replace("\\", "/")
     if not p.endswith(".md"):
         return True
-    # Translation files (knowledge/en|ja|ko|es|fr/...)
-    for lang in ("en", "ja", "ko", "es", "fr"):
+    # Translation files (knowledge/{lang}/...) — 語言清單吃 langs.py SSOT。
+    # 2026-07-24：原本寫死 ("en","ja","ko","es","fr") 停在出生戰役前的五語世界，
+    # vi/id/pt/hi 因此漏出這道排除，被套上只對 zh-TW SSOT 有意義的媒體數量門檻 ——
+    # 四語各 35 篇（共 140 筆）誤報，其中 136 筆是「0 媒體」。譯文不自備圖，
+    # 媒體是 zh 原文的責任，本來就該整條 skip。
+    for lang in TRANSLATION_LANGS:
         if f"knowledge/{lang}/" in p:
             return True
     # Hub pages — knowledge/{Category}/_X.md
@@ -212,7 +258,9 @@ def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
             severity=Severity.WARN,
             message=(
                 "frontmatter 有 imageCredit/imageLicense/imageSource 但缺 "
-                "`## 圖片來源` section (CC 圖片需 cite 來源)"
+                "`## 圖片來源` section (CC 圖片需 cite 來源)；譯文用該語言的說法即可"
+                "（Image Sources／画像出典／이미지 출처／Fuentes de imágenes／"
+                "Sources des images…）"
             ),
             editorial_ref=EDITORIAL_REF,
         )

--- a/scripts/tools/lib/article_health/checks/link_target.py
+++ b/scripts/tools/lib/article_health/checks/link_target.py
@@ -36,6 +36,7 @@ from pathlib import Path
 from typing import Any, Iterator
 from urllib.parse import unquote
 
+from ..langs import ALL_LANGS, TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -49,8 +50,17 @@ DEFAULT_SEVERITY = Severity.HARD
 EDITORIAL_REF = "src/pages/{lang}/[category]/[slug].astro CATEGORY_MAPPING (lowercase routing) + knowledge/{lang}/{Category}/*.md (existence)"
 APPLIES_TO = ["*"]
 
-_LANGS = {"en", "ja", "ko", "fr", "es", "zh-TW"}
-_TRANSLATION_LANGS = {"en", "ja", "ko", "fr", "es"}
+# 語言清單吃 langs.py SSOT，不寫死。2026-07-24：原本兩個集合都停在出生戰役前的
+# 五語，後果有二 ——
+#   (1) `_existing_link_targets()` 走 else 分支把 knowledge/{vi,id,pt,hi}/ 當成
+#       zh-TW 分類目錄，那 263 篇的 `/{lang}/{cat}/{slug}` 一條都沒進索引，
+#       任何指過去的連結都會被判定「目標不存在」。
+#   (2) Phase 1 的大小寫 HARD gate 由 `_LANGS` 組正則，四個新語言完全不在守備
+#       範圍 —— `](/pt/Technology/foo)` 這種該擋的大寫分類擋不到。
+# 目前 corpus 還沒有任何一條連結指向這四語，所以是潛伏而非正在誤報；但這道 gate
+# 存在的意義就是第一條連結寫錯時要當場接住。
+_LANGS = set(ALL_LANGS)
+_TRANSLATION_LANGS = set(TRANSLATION_LANGS)
 _KNOWLEDGE_ROOT = Path("knowledge")
 
 # High-confidence fuzzy auto-heal threshold (unique top match only).

--- a/scripts/tools/lib/article_health/checks/media_richness.py
+++ b/scripts/tools/lib/article_health/checks/media_richness.py
@@ -38,6 +38,7 @@ import os
 import re
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -73,7 +74,8 @@ def _is_excluded_path(path_str: str) -> bool:
     p = path_str.replace("\\", "/")
     if not p.endswith(".md"):
         return True
-    for lang in ("en", "ja", "ko", "es", "fr"):
+    # 語言清單吃 langs.py SSOT，不寫死（2026-07-24：原本停在出生戰役前的五語）。
+    for lang in TRANSLATION_LANGS:
         if f"knowledge/{lang}/" in p:
             return True
     if os.path.basename(p).startswith("_"):

--- a/scripts/tools/lib/article_health/checks/quote_fidelity.py
+++ b/scripts/tools/lib/article_health/checks/quote_fidelity.py
@@ -39,6 +39,7 @@ import os
 import re
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -63,7 +64,8 @@ _MAX_SUPERLATIVE_REPORTED = 12
 
 def _is_excluded_path(path: str) -> bool:
     p = str(path)
-    if any(f"/knowledge/{lg}/" in p for lg in ("en", "ja", "ko", "es", "fr")):
+    # 語言清單吃 langs.py SSOT，不寫死（2026-07-24：原本停在出生戰役前的五語）。
+    if any(f"/knowledge/{lg}/" in p for lg in TRANSLATION_LANGS):
         return True
     if os.path.basename(p).startswith("_") and p.endswith(".md"):
         return True

--- a/scripts/tools/lib/article_health/checks/wikilink_target.py
+++ b/scripts/tools/lib/article_health/checks/wikilink_target.py
@@ -13,6 +13,7 @@ import re
 from pathlib import Path
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -28,8 +29,10 @@ _RE_WIKILINK_FULL = re.compile(
 )
 
 # Directories to scan for valid article slugs (zh-TW only — translations
-# share the source slug, not target).
-_LANG_DIRS_SKIP = {"en", "ja", "ko", "es", "fr"}
+# share the source slug, not target). 語言清單吃 langs.py SSOT，不寫死
+# （2026-07-24：原本停在五語，vi/id/pt/hi 沒被 skip。今天無實害 —— 那四個目錄
+# 底下沒有直屬 .md，`entry.glob("*.md")` 掃不到東西 —— 但同一類寫死照樣要收）。
+_LANG_DIRS_SKIP = set(TRANSLATION_LANGS)
 _KNOWLEDGE_ROOT = Path("knowledge")
 
 

--- a/scripts/tools/lib/article_health/checks/word_count.py
+++ b/scripts/tools/lib/article_health/checks/word_count.py
@@ -31,6 +31,7 @@ import os
 import re
 from typing import Any, Iterator
 
+from ..langs import TRANSLATION_LANGS
 from ..types import FileTarget, Severity, Violation
 
 
@@ -82,8 +83,9 @@ def _is_excluded_path(path_str: str) -> bool:
     p = path_str.replace("\\", "/")
     if not p.endswith(".md"):
         return True
-    # Translation files (knowledge/en|ja|ko|es|fr/...)
-    for lang in ("en", "ja", "ko", "es", "fr"):
+    # Translation files (knowledge/{lang}/...) — 語言清單吃 langs.py SSOT，不寫死
+    # （2026-07-24：原本停在出生戰役前的五語）。
+    for lang in TRANSLATION_LANGS:
         if f"knowledge/{lang}/" in p:
             return True
     # Hub pages — knowledge/{Category}/_X.md

--- a/scripts/tools/lib/article_health/langs.py
+++ b/scripts/tools/lib/article_health/langs.py
@@ -1,0 +1,79 @@
+"""langs.py — article-health 這一層的語言清單 SSOT bridge。
+
+病根同 `scripts/tools/lang-sync/langs.py`（2026-07-18 vi/id/pt/hi 出生戰役）：
+語言清單散落各處硬編碼，新語言出生時感知系統不會自動更新。那次 sweep 修好了
+`scripts/tools/lang-sync/*`，但沒掃到 `scripts/tools/lib/article_health/*` ——
+八個 check plugin 各自寫死 `("en", "ja", "ko", "es", "fr")`，停在出生戰役之前的
+五語世界。本模組把 registry 接進來，讓 article-health 跟 lang-sync 吃同一份 SSOT。
+
+`loader.py` 原本自己有一份 `_load_lang_dirs()`，但它算錯了 registry 的相對位置
+（`parents[3]` 指到 `scripts/src/config/`，該路徑不存在），於是每次都靜默掉進
+`except` 分支沿用寫死的保底清單 —— 看起來會動，只是因為保底清單剛好是當時的
+九語。第十個語言出生時它一樣看不到。本模組把路徑修正並補上 fail-loud selftest。
+
+用法：
+
+    from .langs import TRANSLATION_LANGS, is_translation_path
+
+    if entry.name in TRANSLATION_LANGS: ...
+    if is_translation_path(str(target.path)): ...
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+#: langs.py 在 scripts/tools/lib/article_health/ 底下 → repo root 要往上四層。
+#: parents[0]=article_health  [1]=lib  [2]=tools  [3]=scripts  [4]=<repo root>
+REPO = Path(__file__).resolve().parents[4]
+_REGISTRY = REPO / "src" / "config" / "languages.mjs"
+
+#: registry 讀不到時的保底清單（2026-07-18 出生戰役當下的既知語言）。
+#: 只有在 checkout 不完整之類的情況才會用到，且會 warn 一次，不靜默。
+_FALLBACK = ("en", "ja", "ko", "es", "fr", "vi", "id", "pt", "hi")
+
+#: registry 讀得到卻 parse 出比這更少 → 格式改了，當場叫，不靜默沿用舊清單
+#: （對齊 lang-sync/langs.py 的 fail-loud selftest，REFLEXES #65 儀器自身要 cross-verify）。
+_MIN_EXPECTED = len(_FALLBACK) + 1  # +1 = zh-TW
+
+
+def _load() -> tuple[str, ...]:
+    if not _REGISTRY.exists():
+        print(
+            f"⚠️  article_health.langs: 找不到 {_REGISTRY} — 改用保底語言清單 "
+            f"{_FALLBACK}。新語言不會被感知，請確認 checkout 完整。",
+            file=sys.stderr,
+        )
+        return _FALLBACK
+    codes = re.findall(r"code:\s*'([\w-]+)'", _REGISTRY.read_text(encoding="utf-8"))
+    if len(codes) < _MIN_EXPECTED:
+        raise RuntimeError(
+            f"article_health.langs selftest FAIL: 只從 {_REGISTRY} parse 到 "
+            f"{len(codes)} 個語言（基線 ≥ {_MIN_EXPECTED}）。languages.mjs 格式可能改了，"
+            f"修 langs.py 的 parser 而不是靜默沿用舊清單。"
+        )
+    if codes[0] != "zh-TW":
+        raise RuntimeError(
+            "article_health.langs selftest FAIL: registry 第一個 entry 不是 zh-TW default"
+        )
+    return tuple(c for c in codes if c != "zh-TW")
+
+
+#: 所有翻譯語言（不含 zh-TW default），順序即 registry 權威順序。
+TRANSLATION_LANGS: frozenset[str] = frozenset(_load())
+
+#: 含 zh-TW 的完整語言集合。link 路由前綴之類的地方用這個。
+ALL_LANGS: frozenset[str] = TRANSLATION_LANGS | {"zh-TW"}
+
+
+def is_translation_path(path: str) -> bool:
+    """`knowledge/{lang}/...` 判定 —— 吃正反斜線皆可（Windows contributor）。"""
+    p = path.replace("\\", "/")
+    return any(f"knowledge/{lang}/" in p for lang in TRANSLATION_LANGS)
+
+
+if __name__ == "__main__":
+    print("TRANSLATION_LANGS =", sorted(TRANSLATION_LANGS))
+    print("ALL_LANGS         =", sorted(ALL_LANGS))

--- a/scripts/tools/lib/article_health/loader.py
+++ b/scripts/tools/lib/article_health/loader.py
@@ -14,6 +14,7 @@ import re
 from pathlib import Path
 from typing import Any
 
+from .langs import TRANSLATION_LANGS
 from .types import FileTarget
 
 
@@ -22,16 +23,13 @@ from .types import FileTarget
 # 語言清單從註冊表 SSOT derive，不寫死（2026-07-18：pt 出生時此處寫死漏掉，
 # knowledge/pt/ 被當成 zh-TW → cjk-punct 對葡文半形冒號報 31 hard，pre-commit 卡死；
 # 「新語言出生感知系統不會自動更新」在 article-health loader 的復發）。
-def _load_lang_dirs() -> set[str]:
-    try:
-        _reg = Path(__file__).resolve().parents[3] / "src" / "config" / "languages.mjs"
-        codes = re.findall(r"code:\s*'([\w-]+)'", _reg.read_text(encoding="utf-8"))
-        return {c for c in codes if c != "zh-TW"}
-    except Exception:  # noqa: BLE001 — fallback 保底，永不讓 loader 因 registry 讀取失敗而崩
-        return {"en", "ja", "ko", "es", "fr", "vi", "id", "pt", "hi"}
-
-
-_LANG_DIRS = _load_lang_dirs()
+#
+# 2026-07-24：原本 loader 自己有一份 `_load_lang_dirs()`，但 `parents[3]` 指到
+# `scripts/src/config/languages.mjs`（少算一層，該路徑不存在），`except` 又把
+# FileNotFoundError 吞掉 → registry 從來沒被讀到，一路靠寫死的保底清單在跑。
+# 保底清單剛好是出生戰役當下的九語，所以看起來會動；第十個語言出生時一樣瞎。
+# 現在改吃 langs.py 這個 SSOT bridge（路徑修正 + fail-loud selftest）。
+_LANG_DIRS = TRANSLATION_LANGS
 
 # Protected region patterns
 _RE_FENCED_CODE = re.compile(r"```[\s\S]*?```", re.MULTILINE)

--- a/tests/article_health/test_langs_ssot.py
+++ b/tests/article_health/test_langs_ssot.py
@@ -1,0 +1,182 @@
+"""test_langs_ssot — article-health 的語言清單必須跟 registry 同步。
+
+守的是 2026-07-18 vi/id/pt/hi 出生戰役那條神經迴路：「新語言出生時感知系統不會
+自動更新」。那次修好了 lang-sync，但 article_health 這層被漏掉；而且 loader 自己
+那份 registry reader 算錯路徑（parents[3] 少一層）並被 `except` 吞掉，實際上從來
+沒讀到 registry，一路靠寫死的保底清單在跑 —— 保底清單剛好等於當時的九語，所以
+看起來會動。這份測試就是不讓「看起來會動」再度成立。
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lib.article_health import ALL_LANGS, TRANSLATION_LANGS
+from lib.article_health.checks import (
+    cross_reference,
+    image_health,
+    link_target,
+    wikilink_target,
+)
+from lib.article_health import langs as langs_mod
+from lib.article_health import loader
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = REPO_ROOT / "src" / "config" / "languages.mjs"
+
+
+def _registry_codes() -> list[str]:
+    return re.findall(r"code:\s*'([\w-]+)'", REGISTRY.read_text(encoding="utf-8"))
+
+
+# ─── SSOT 本身 ────────────────────────────────────────────────────────────────
+
+
+def test_registry_path_actually_resolves():
+    """langs.py 指到的 registry 必須真的存在。
+
+    這是本次的病根：路徑算錯 + except 吞掉 → 靜默沿用保底清單。
+    """
+    assert langs_mod._REGISTRY == REGISTRY
+    assert langs_mod._REGISTRY.exists()
+
+
+def test_translation_langs_matches_registry():
+    codes = _registry_codes()
+    assert codes, "registry parse 不到任何語言"
+    assert set(TRANSLATION_LANGS) == {c for c in codes if c != "zh-TW"}
+    assert "zh-TW" not in TRANSLATION_LANGS
+    assert ALL_LANGS == TRANSLATION_LANGS | {"zh-TW"}
+
+
+def test_the_four_newer_languages_are_visible():
+    """出生戰役那四個語言必須在清單裡 —— 寫死五語的年代看不到它們。"""
+    for lang in ("vi", "id", "pt", "hi"):
+        assert lang in TRANSLATION_LANGS
+
+
+def test_no_check_hardcodes_the_five_language_world():
+    """任何 check plugin 都不准再寫死語言清單。
+
+    掃原始碼而不是行為，因為多數 plugin 的 APPLIES_TO 是 ["zh-TW"]，
+    寫死的清單今天不會被執行到 —— 靠行為測試抓不到，下一個語言出生時才發作。
+    """
+    hardcoded = re.compile(r'"en",\s*"ja",\s*"ko",\s*"(?:es|fr)"')
+    offenders = []
+    for py in sorted((REPO_ROOT / "scripts" / "tools" / "lib" / "article_health")
+                     .rglob("*.py")):
+        # langs.py 自己持有那份刻意的保底清單，是 SSOT 的一部分，不算違規
+        if py.name == "langs.py":
+            continue
+        # 只看程式碼，註解裡引述舊清單（「原本寫死 …」）不算違規
+        code = "\n".join(ln for ln in py.read_text(encoding="utf-8").splitlines()
+                         if not ln.lstrip().startswith("#"))
+        if hardcoded.search(code):
+            offenders.append(py.relative_to(REPO_ROOT).as_posix())
+    assert offenders == [], f"還有寫死語言清單的檔案：{offenders}"
+
+
+# ─── 各 check 的清單來源 ──────────────────────────────────────────────────────
+
+
+def test_loader_lang_dirs_is_the_ssot():
+    assert loader._LANG_DIRS == TRANSLATION_LANGS
+
+
+def test_link_target_indexes_every_language():
+    """`_existing_link_targets()` 必須認得每一個語言的路由前綴。
+
+    寫死五語時，knowledge/{vi,id,pt,hi}/ 會掉進 else 分支被當成 zh-TW 分類目錄，
+    那 263 篇一條都沒進索引 → 任何指過去的連結都被判定「目標不存在」。
+    """
+    assert link_target._TRANSLATION_LANGS == set(TRANSLATION_LANGS)
+    assert link_target._LANGS == set(ALL_LANGS)
+    for lang in ("vi", "id", "pt", "hi"):
+        if not (REPO_ROOT / "knowledge" / lang).is_dir():
+            pytest.skip(f"knowledge/{lang}/ 不存在（淺 checkout）")
+    link_target._reset_cache()
+    import os
+
+    cwd = os.getcwd()
+    os.chdir(REPO_ROOT)
+    try:
+        paths = link_target._existing_link_targets()
+    finally:
+        os.chdir(cwd)
+        link_target._reset_cache()
+    for lang in TRANSLATION_LANGS:
+        if list((REPO_ROOT / "knowledge" / lang).glob("*/*.md")):
+            assert any(p.startswith(f"/{lang}/") for p in paths), \
+                f"/{lang}/ 的文章沒有進 link 索引"
+
+
+def test_link_target_casing_gate_covers_every_language():
+    """Phase 1 大小寫 HARD gate 的守備範圍要跟語言清單一致。"""
+    for lang in sorted(TRANSLATION_LANGS):
+        assert link_target._RE_CASING.search(f"[x](/{lang}/Technology/tsmc)"), \
+            f"/{lang}/ 的大寫分類連結擋不到"
+
+
+def test_lang_dir_skips_are_the_ssot():
+    assert wikilink_target._LANG_DIRS_SKIP == set(TRANSLATION_LANGS)
+    assert cross_reference._LANG_DIRS_SKIP == set(TRANSLATION_LANGS)
+
+
+# ─── image_health §3 多語圖片出處小標 ────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "## 圖片來源",              # zh-TW SSOT
+        "## 圖片與影片來源",
+        "## Image Sources",         # en（語料 ×119）
+        "## Image Credits",         # en（語料 ×23）
+        "## 画像出典",              # ja（語料 ×138）
+        "## 写真出典",
+        "## 이미지 출처",           # ko（語料 ×141）
+        "## 사진 출처",
+        "## Fuentes de imágenes",   # es（語料 ×73）
+        "## Fuentes de las imágenes",
+        "## Créditos de imágenes",
+        "## Sources des images",    # fr（語料 ×130）
+        "## Crédits photographiques",
+        "## Sources d’images",
+    ],
+)
+def test_image_sources_heading_accepted(heading):
+    assert image_health._RE_IMAGE_SOURCES_H2.search(heading + "\n")
+
+
+@pytest.mark.parametrize(
+    "heading",
+    [
+        "## 參考資料",
+        "## References",
+        "## Further Reading",
+        "## Références",
+        "## Pour aller plus loin",
+        "## Referencias",
+        "## 参考文献",
+        "## 참고 자료",
+        "## 30-Second Overview",
+    ],
+)
+def test_non_image_heading_rejected(heading):
+    assert not image_health._RE_IMAGE_SOURCES_H2.search(heading + "\n")
+
+
+def test_translations_skip_the_media_count_gate():
+    """媒體數量門檻只對 zh-TW SSOT 有意義 —— 譯文不自備圖。"""
+    for lang in TRANSLATION_LANGS:
+        assert image_health._is_excluded_from_count_gate(
+            f"knowledge/{lang}/Technology/tsmc.md"
+        ), f"knowledge/{lang}/ 沒有被排除在媒體數量門檻外"
+        # Windows contributor 的反斜線路徑也要吃
+        assert image_health._is_excluded_from_count_gate(
+            f"knowledge\\{lang}\\Technology\\tsmc.md"
+        )
+    assert not image_health._is_excluded_from_count_gate(
+        "knowledge/Technology/台積電.md"
+    )


### PR DESCRIPTION
`scripts/tools/lib/article_health/` 這一層的語言清單還停在 2026-07-18 vi/id/pt/hi 出生戰役之前的五語世界。順著查下去，發現 `loader.py` 那份「從 registry derive、不寫死」的實作**從來沒有生效過**。

## 病根：loader 的 registry 路徑少算一層，錯誤被 except 吞掉

```python
# scripts/tools/lib/article_health/loader.py:27（修改前）
def _load_lang_dirs() -> set[str]:
    try:
        _reg = Path(__file__).resolve().parents[3] / "src" / "config" / "languages.mjs"
        codes = re.findall(r"code:\s*'([\w-]+)'", _reg.read_text(encoding="utf-8"))
        return {c for c in codes if c != "zh-TW"}
    except Exception:
        return {"en", "ja", "ko", "es", "fr", "vi", "id", "pt", "hi"}
```

`loader.py` 在 `scripts/tools/lib/article_health/` 底下，`parents[3]` 是 `scripts/`：

```
parents[0] = scripts/tools/lib/article_health
parents[1] = scripts/tools/lib
parents[2] = scripts/tools
parents[3] = scripts            ← 它找的是 scripts/src/config/languages.mjs
parents[4] = <repo root>        ← registry 在這裡
```

該路徑不存在 → `FileNotFoundError` → `except Exception` 靜默吞掉 → 每次都用寫死的保底清單。保底清單剛好等於出生戰役當下的九語，所以**看起來會動**。

實測（往 registry 加一個 `code: 'de'` 再讀回來，事後還原）：

```
registry (src/config/languages.mjs) says:
   ['zh-TW', 'en', 'ja', 'ko', 'es', 'fr', 'vi', 'id', 'pt', 'de', 'hi']
loader._load_lang_dirs() returns:
   ['en', 'es', 'fr', 'hi', 'id', 'ja', 'ko', 'pt', 'vi']
  -> 'de' present? False
```

第十個語言出生時，`knowledge/de/` 會被判成 `lang='zh-TW'` —— 正是那段註解說它要防的 pt 事故（cjk-punct 對非中文標點報 hard、pre-commit 卡死）。

同一層另外八個 check plugin 各自寫死 `("en", "ja", "ko", "es", "fr")`，同一類病。

## 改法

新增 `scripts/tools/lib/article_health/langs.py` 當這一層的 SSOT bridge，寫法對齊既有的 `scripts/tools/lang-sync/langs.py`：

- 路徑修正成 `parents[4]`
- registry 讀得到卻 parse 過少 → `raise`（fail-loud selftest，格式改了當場叫）
- 真的讀不到才用保底清單，且 warn 到 stderr，不再靜默

改吃 SSOT 的位置：`loader.py`、`image_health`、`link_target`、`wikilink_target`、`cross_reference`、`word_count`、`media_richness`、`quote_fidelity`、`article-health.py`。

## 順便修：`image_health` §3 的圖片出處小標寫死中文

`_RE_IMAGE_SOURCES_H2 = re.compile(r"^##\s*圖片來源")` 讓每一篇 frontmatter 有 `imageCredit` 的非中文譯文都必噴 warn。

改成各語言樣式的聯集比對。用**樣式**而不是逐字清單，因為既有語料本身就有變體：

| 語言 | 語料裡實際出現的說法 |
|---|---|
| en | `Image Sources` ×119、`Image Credits` ×23、`Image sources` ×5 |
| ja | `画像出典` ×138、`画像の出典` ×2、`写真出典` ×1 |
| ko | `이미지 출처` ×141、`사진 출처` ×4 |
| es | `Fuentes de imágenes` ×73、`Fuentes de las imágenes` ×39、`Créditos de imágenes` ×18 |
| fr | `Sources des images` ×130、`Crédits photographiques` ×10、`Sources d'images` ×5 |

逐字表會漏長尾（`Fuentes imágenes`、`Crédits images`、`画像と動画の出典`…）。

聯集比對、不看檔案本身的 lang：中文標題殘留在譯文裡（ja ×8、en ×4）確實是沒翻到底，但它**是**出處區塊 —— 這條 check 要問的是有沒有 cite，不是翻得夠不夠徹底。

vi/id/pt/hi 目前沒有任何一篇有 `imageCredit`，那四行樣式是照該語言常用詞先擺著、**尚無語料佐證**，程式碼裡標記為 provisional。猜錯的代價是一筆 warn，不擋 CI。

## 全 corpus 實測（4,571 篇譯文）

`image-health` warn：

| | en | ja | ko | es | fr | vi | id | pt | hi | 合計 |
|---|---|---|---|---|---|---|---|---|---|---|
| 修改前 | 198 | 195 | 204 | 197 | 203 | 35 | 35 | 35 | 35 | **1,032** |
| 修改後 | 48 | 46 | 49 | 48 | 48 | 0 | 0 | 0 | 0 | **239** |

消掉 **793 筆假陽性**，兩個來源：

1. 檔案其實有出處區塊、只是不叫中文名（en/ja/ko/es/fr，約 750 筆）
2. vi/id/pt/hi 漏出 `_is_excluded_from_count_gate` 的譯文排除，被套上只對 zh 原文有意義的媒體數量門檻（140 筆，其中 136 筆是「0 媒體」）。譯文不自備圖，媒體是 zh 原文的責任，本來就該整條 skip。

留下的 239 篇是真的沒有出處區塊 —— 逐篇看過，H2 只剩 `References` / `Références` / `참고 자료` 這類一般段落。假陽性從 74% 降到 0，這條 warn 對譯文才重新有訊號。

`link_target`：`/vi/` `/id/` `/pt/` `/hi/` 從 **0 條**變成各 54/54/54/49 條進 link 索引；Phase 1 大小寫 HARD gate 的守備從 6 語變 10 語。

```
修改前                          修改後
  /vi/... ->     0  <-- 全部隱形    /vi/... ->    54
  /id/... ->     0                 /id/... ->    54
  /pt/... ->     0                 /pt/... ->    54
  /hi/... ->     0                 /hi/... ->    49

[x](/pt/Technology/tsmc) 大小寫違規偵測：False  →  True
```

這兩項今天是**潛伏而非正在誤報** —— corpus 還沒有任何一條連結指向那四語（`git grep -E '\]\(/(vi|id|pt|hi)/'` 是 0）。但這道 gate 存在的意義就是第一條連結寫錯時要當場接住。`wikilink_target` 與 `article-health.py --all` 的同類寫死也一併收，兩者今天同樣無實害（那四個目錄底下沒有直屬 `.md`）。

## zh-TW SSOT 不動

862 篇跑 `--profile=pre-commit` 全 13 條 check 做 A/B：

```
                        修改前   修改後
format-structure/warn      569      569
frontmatter-format/warn      3        3
frontmatter-title/warn      85       85
image-health/warn          707      706   ← 一篇用「圖片與影片來源」的現在被正確接受
link-target/warn            59       59
link-url-mangle/warn         9        9
media-richness/warn        798      798
prose-health/warn         9306     9306
quote-fidelity/warn        389      389
rationale-presence/warn    365      365
viz-health/warn             51       51
word-count/warn            625      625
```

## 測試

新增 `tests/article_health/test_langs_ssot.py`，32 個 case。其中 `test_no_check_hardcodes_the_five_language_world` 掃**原始碼**而非行為 —— 多數 plugin 的 `APPLIES_TO` 是 `["zh-TW"]`，寫死的清單今天執行不到，靠行為測試抓不到，要等下一個語言出生才發作。

```
before: 8 failed, 221 passed, 8 skipped
after:  8 failed, 253 passed, 8 skipped
```

那 8 個是既有失敗，與本 PR 無關（`python3` 不在 Windows PATH、`link_target.fix()` 回傳 int 但測試 assert `is True` 等）。

## 順帶回報，本 PR 不修

1. **測試套件需要 Python 3.12+，3.11 連 collect 都過不了**：`tests/article_health/test_frontmatter_title_parity.py:101` 用了 3.12 才允許的 f-string 內反斜線，3.11 會 `SyntaxError` 中斷整個 collection。CI 用 3.12 所以看不出來，但 `package.json` 的 `article-health:test` 沒有標最低版本。
2. **`scripts/tools/lang-sync/flatten-translation-wikilinks.py` 之類同層工具還有約 20 處同類寫死路徑處理**（`str(relative_to())` 在 Windows 產生反斜線），已在 #1238 修了會寫入 SSOT 的那一處。
3. **`knowledge/fr/Food/portuguese-egg-tart-in-taiwan.md`** 目前 `article-health --profile=pre-commit` 是 hard=1（斜體 caption 內含 percent-encoded CJK Commons URL）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGZT4FDb3XyzKSYFCSYs48
