### PR TITLE
fix(dashboard): resolve git dates for CJK articles on Windows

### DIFF
--- a/scripts/core/generate-dashboard-immune.py
+++ b/scripts/core/generate-dashboard-immune.py
@@ -348,9 +348,10 @@ def compute_drift_velocity(articles: list[dict]) -> tuple[float, dict]:
     # Use git log to find articles added/modified in last 7d
     try:
         result = subprocess.run(
-            ["git", "log", "--since=7 days ago", "--name-only",
-             "--pretty=format:", "--diff-filter=A"],
-            capture_output=True, text=True, cwd=REPO_ROOT, timeout=30,
+            ["git", "-c", "core.quotepath=false", "log", "--since=7 days ago",
+             "--name-only", "--pretty=format:", "--diff-filter=A"],
+            capture_output=True, encoding="utf-8", errors="replace",
+            cwd=REPO_ROOT, timeout=30,
         )
         added_files = set(
             line for line in result.stdout.splitlines()
@@ -416,10 +417,10 @@ def compute_external_rulers(articles: list[dict]) -> tuple[float, dict]:
     # 點修，批次 heal/feature 掃過幾十篇不構成「這篇被外部尺量過」。
     try:
         out = subprocess.run(
-            ["git", "log", "--since=90 days ago", "--name-only",
-             "--grep=勘誤", "--grep=errata", "--grep=fact-fix",
+            ["git", "-c", "core.quotepath=false", "log", "--since=90 days ago",
+             "--name-only", "--grep=勘誤", "--grep=errata", "--grep=fact-fix",
              "--pretty=format:@@COMMIT@@"],
-            capture_output=True, text=True, timeout=60,
+            capture_output=True, encoding="utf-8", errors="replace", timeout=60,
         ).stdout
         for block in out.split("@@COMMIT@@"):
             zh_files = [

--- a/scripts/core/generate-newsroom-data.py
+++ b/scripts/core/generate-newsroom-data.py
@@ -69,11 +69,17 @@ def git_date(path):
     if _git_dates is None:
         _git_dates = {}
         try:
+            # core.quotepath=false + utf-8: knowledge paths are CJK, and git
+            # octal-escapes non-ASCII paths by default while text=True decodes
+            # with the locale codec (cp950 on Windows), so CJK articles never
+            # match the cache and art_date() silently falls back to filesystem
+            # mtime, which is unreliable in worktree/CI checkouts.
             out = subprocess.run(
-                ["git", "-C", ROOT, "log", "--since=6.months", "--format=\x01%aI", "--name-only",
+                ["git", "-C", ROOT, "-c", "core.quotepath=false", "log",
+                 "--since=6.months", "--format=\x01%aI", "--name-only",
                  "--", "reports/article-projection", "reports/editorial-room",
                  "reports/article-evolve", "reports/research", "knowledge"],
-                capture_output=True, text=True, timeout=60,
+                capture_output=True, encoding="utf-8", errors="replace", timeout=60,
             ).stdout
             cur = None
             for line in out.split("\n"):
@@ -118,7 +124,9 @@ def mtime_iso(path):
 
 
 def rel(path):
-    return os.path.relpath(path, ROOT)
+    # Forward slashes: git log --name-only always emits them, so a backslash
+    # key from os.path.relpath on Windows would never match the git_date cache.
+    return os.path.relpath(path, ROOT).replace(os.sep, "/")
 
 
 warnings = []


### PR DESCRIPTION
## What

Two core build-pipeline generators resolve the wrong dates for CJK articles on Windows. This is the same Windows path class as the merged fix in #1238, in the `scripts/core/` dashboard generators that PR did not touch.

Both `generate-newsroom-data.py` and `generate-dashboard-immune.py` build a `git log --name-only` cache and match it against article paths, but:

1. `generate-newsroom-data.py` builds its lookup keys with `os.path.relpath`, which yields backslash-separated paths on Windows (`knowledge\...`), while `git log --name-only` emits forward slashes, so every lookup misses.
2. Both scripts decode git output with the locale codec (cp950 on a zh-TW Windows box) and leave `core.quotepath` on, so CJK article paths are octal-escaped (`"knowledge/Culture/\344\270\255..."`) and never match.

Effect on Windows:

- `generate-newsroom-data.py` resolves a git commit date for 0 of 400 sampled CJK articles and falls back to filesystem mtime. The script's own docstring flags this as the root of local-dashboard vs CI-build classification drift, because worktree/CI checkouts reset mtimes.
- `generate-dashboard-immune.py` drops the CJK new-article commits from its `knowledge/` filter, so the drift-velocity metric under-counts new articles.

## Fix

- `generate-newsroom-data.py`: return forward-slash keys from `rel()` and read `git log` as UTF-8 with `core.quotepath=false`.
- `generate-dashboard-immune.py`: read both `git log --name-only` calls as UTF-8 with `core.quotepath=false`.

## Evidence

Run on Windows 11 (zh-TW), Python 3.

`generate-newsroom-data.py` `git_date()` over 400 sampled CJK knowledge articles, before (`main`) vs this branch:

```
before: git_date resolved: 0/400    cache octal-escaped keys: 1431   rel() sample: knowledge\About\台灣官方網站資源.md
after:  git_date resolved: 400/400  cache octal-escaped keys: 0      rel() sample: knowledge/About/台灣官方網站資源.md
```

`generate-dashboard-immune.py` `knowledge/*.md` new-article filter over 90 days, default `quotepath` vs `quotepath=false`:

```
default quotepath: startswith('knowledge/') and .md matched: 3046 / 3356
quotepath=false  : startswith('knowledge/') and .md matched: 3354 / 3356
```

## What was not tested

- Not re-verified on macOS/Linux. The `rel()` forward-slash change is a no-op there. The `core.quotepath=false` + UTF-8 change also affects POSIX, where git octal-escapes CJK paths by default too, so it is a correctness improvement for CJK articles everywhere, not only Windows.
- No unit-test harness exists for these generators in the repo, so Evidence is the before/after probes above.

## AI assistance

This change was prepared with AI assistance and reviewed by me. Reproduced and verified on a real Windows 11 zh-TW machine.
