### PR TITLE
fix(test): f-string 內反斜線讓 article-health 測試在 Python 3.11 無法 collect

### DIFF
--- a/tests/article_health/test_frontmatter_title_parity.py
+++ b/tests/article_health/test_frontmatter_title_parity.py
@@ -85,11 +85,16 @@ def _check_via_js(title: str, category: str, tmp_path: Path) -> tuple[int, int]:
     cat_dir = knowledge / category
     cat_dir.mkdir(exist_ok=True)
     test_md = cat_dir / "js-fixture.md"
+    # Precompute the escaped title outside the f-string: a backslash inside an
+    # f-string expression is a SyntaxError before Python 3.12 (PEP 701), which
+    # broke `pytest` collection of this whole module on 3.11. Behaviour is
+    # identical — this is purely moving the `.replace()` out of the `{...}`.
+    escaped_title = title.replace("'", "\\'")
     test_md.write_text(
         textwrap.dedent(
             f"""\
             ---
-            title: '{title.replace("'", "\\'")}'
+            title: '{escaped_title}'
             description: 'fixture description with anchor 2026 and number 100'
             date: 2026-05-04
             tags: ['test']


### PR DESCRIPTION
## 問題

`tests/article_health/test_frontmatter_title_parity.py:92` 在 f-string 運算式裡放了反斜線：

```python
title: '{title.replace("'", "\'")}'
```

f-string 運算式 `{...}` 內含反斜線是 [PEP 701](https://peps.python.org/pep-0701/)（Python 3.12）才放寬的語法。3.11 及更早會 `SyntaxError`，而且是在 **collection 階段**就中止 —— 連帶讓整個 `tests/article_health` 一個測試都跑不起來：

```
E   File ".../test_frontmatter_title_parity.py", line 101
E     ),
E     ^
E   SyntaxError: f-string expression part cannot include a backslash
=== short test summary info ===
ERROR tests/article_health/test_frontmatter_title_parity.py
!!! Interrupted: 1 error during collection !!!
```

CI 用 3.12（`.github/workflows/instrumentation-audit.yml`）所以看不出來，但 `package.json` 的 `article-health:test` 沒標最低版本，本機在 3.11 下整組 collection 直接中止。

## 改法

把 `.replace()` 移到 f-string 外面先算成 `escaped_title`，行為完全一致 —— 純粹把運算式挪出 `{...}`：

```python
escaped_title = title.replace("'", "\'")
...
            title: '{escaped_title}'
```

## 驗證

| | 修改前 | 修改後 |
|---|---|---|
| 3.11 `py_compile` | SyntaxError | OK |
| 3.11 `pytest --collect-only` | 0 collected（collection abort） | **269 collected** |
| 3.12 全套件 | 8 failed / 253 passed / 8 skipped | **同上，一致** |

- 3.12 結果與修改前逐項相同，證明零行為改變（那 8 個是既有的環境相關失敗，與本改動無關）。
- 掃過 `tests/` 其餘所有 `.py`，同類「f-string 運算式內反斜線」只有這一處。

這是我在 #1244 裡順帶回報的三件之一，拆成獨立小 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AGZT4FDb3XyzKSYFCSYs48
