### PR TITLE
fix(weekly-report): count CJK-named zh articles on all platforms

### DIFF
--- a/scripts/tools/weekly-report-prep.py
+++ b/scripts/tools/weekly-report-prep.py
@@ -30,10 +30,19 @@ TZ_TPE = timezone(timedelta(hours=8))
 
 
 def sh(cmd: list[str], cwd: Path | None = None) -> str:
-    """Run shell command, return stdout. Errors return empty string (caller decides)."""
+    """Run shell command, return stdout. Errors return empty string (caller decides).
+
+    core.quotepath=false + explicit utf-8 decode: knowledge paths are CJK, and
+    git octal-escapes non-ASCII paths by default while text=True decodes with
+    the locale codec (cp950 on Windows), either of which corrupts path output
+    so every CJK-named article gets dropped downstream.
+    """
+    if cmd and cmd[0] == "git":
+        cmd = [cmd[0], "-c", "core.quotepath=false", *cmd[1:]]
     try:
         r = subprocess.run(
-            cmd, cwd=cwd or REPO_ROOT, capture_output=True, text=True, timeout=60
+            cmd, cwd=cwd or REPO_ROOT, capture_output=True,
+            encoding="utf-8", errors="replace", timeout=60,
         )
         return r.stdout
     except Exception:


### PR DESCRIPTION
## What

`scripts/tools/weekly-report-prep.py` undercounts changed articles: every CJK-named zh article is dropped from the weekly "changed articles" tally. This is the same Windows/CJK path class as the merged fixes in #1242, #1243 and #1245, in a generator those PRs did not touch.

The `sh()` helper runs every git command with `text=True` and no `core.quotepath` override. git octal-escapes and quotes non-ASCII paths by default (842 of 5487 `knowledge/` paths), and `text=True` decodes with the locale codec (cp950 on a zh-TW Windows box). Downstream, `gather_articles_changed()` filters git output with `line.startswith("knowledge/") and line.endswith(".md")`. A quoted CJK line begins with `"` and ends with `"`, so it fails both checks and the article is dropped. The tally then falls back to unreliable data for every CJK article, which is almost the entire zh corpus.

## Fix

`sh()`: inject `-c core.quotepath=false` into git invocations and read output as `encoding="utf-8", errors="replace"`, matching the merged #1243 pattern in `status.py`. Applied at the wrapper so every git call in this file decodes CJK paths the same way. Non-git callers (`gh ...`) are left untouched.

## Evidence

Windows 11 (zh-TW), Python 3. `gather_articles_changed("2026-06-01")`, current `main` vs this branch:

```
before: touched_total 2648  zh-TW 313  CJK paths surviving: 0
after:  touched_total 3012  zh-TW 675  CJK paths clean (forward slash UTF-8, e.g. knowledge/About/文章如何誕生.md)
```

git quotes 842 of 5487 `knowledge/` paths (`git ls-files -- 'knowledge/*' | grep -c '^"'` = 842), which is why the `startswith` filter drops them.

Side effects checked. The wrapper touches every git call, so I exercised the other ones: `gather_commits_full` over 968 commits (509 with CJK commit bodies, 325 with CJK filenames in the stat) decodes correctly, because `core.quotepath` affects pathnames only, not `--pretty` message bodies. Full script run exits 0 and writes a valid dossier.

## What was not tested

- No unit-test harness exists for these scripts, so the Evidence is the before/after above.
- Not re-verified on macOS or Linux. git octal-escapes CJK paths by default on POSIX too, so this is a correctness fix for CJK articles on every platform, and a no-op for ASCII paths.

## AI assistance

Prepared with Claude Code assistance. The bug was located by reading the code and reproducing it, the fix follows the merged #1243 pattern, and an independent pass reproduced the before/after and checked the side effects on `gather_commits_full` and `git show --stat` before this PR was opened.
