### PR TITLE
fix(lang-sync): decode CJK paths in sync-on-update on Windows

### DIFF
--- a/scripts/tools/lang-sync/sync-on-update.py
+++ b/scripts/tools/lang-sync/sync-on-update.py
@@ -36,9 +36,14 @@ ACTIVE_LANGS = ["en", "ja", "ko"]  # from src/config/languages.ts active list
 
 def get_changed_zh_articles(since="1 day ago"):
     """Return list of zh article paths changed since given ref."""
+    # core.quotepath=false + explicit utf-8 decode: knowledge paths are CJK, and
+    # git octal-escapes non-ASCII paths by default while text=True decodes with
+    # the locale codec (cp950 on Windows), either of which corrupts the path
+    # so every CJK-named article lookup misses.
     result = subprocess.run(
-        ["git", "log", f"--since={since}", "--name-only", "--pretty=format:", "--", "knowledge/"],
-        cwd=REPO, capture_output=True, text=True
+        ["git", "-c", "core.quotepath=false", "log", f"--since={since}", "--name-only",
+         "--pretty=format:", "--", "knowledge/"],
+        cwd=REPO, capture_output=True, encoding="utf-8", errors="replace"
     )
     paths = set()
     for line in result.stdout.splitlines():
@@ -57,7 +62,7 @@ def get_changed_zh_articles(since="1 day ago"):
 
 def get_translations_for_zh(zh_path, langs):
     """Return {lang: {status, en_path}} for given zh article."""
-    data = json.load(open(KNOWLEDGE / "_translation-status.json"))
+    data = json.load(open(KNOWLEDGE / "_translation-status.json", encoding="utf-8"))
     arts = data["byArticle"]
     info = arts.get(zh_path)
     if not info:
@@ -128,7 +133,7 @@ def main():
         # Write a list file the prepare-batch.py --input can consume
         out = Path(args.output_manifest)
         out.parent.mkdir(parents=True, exist_ok=True)
-        with open(out, "w") as f:
+        with open(out, "w", encoding="utf-8") as f:
             for item in needs_refresh[args.lang]:
                 f.write(item["zh_path"] + "\n")
         print(f"\n✅ Wrote {len(needs_refresh[args.lang])} paths to {out}")


### PR DESCRIPTION
## Summary

- Fix `sync-on-update.py` so `git log --name-only` returns decodable CJK paths on Windows (`core.quotepath=false` + UTF-8 decode), matching merged #1243 / #1245 / #1250.
- Read `_translation-status.json` with `encoding=utf-8` so `json.load` does not crash under cp950 on zh-TW Windows.
- Write manifest JSON with `encoding=utf-8` on the write path (verifier-flagged sibling).

## Verification (Win11)

Independent verifier confirmed before/after on this branch:
- CJK path detection: 0 CJK hits before, 251 after (30d window sample)
- `json.load` on status JSON: cp950 crash before, OK after

```
python scripts/tools/lang-sync/sync-on-update.py --since "30 days ago"
```

## AI assistance

AI-assisted (Claude Code session + Cursor publish). Human verified on Windows 11 zh-TW.

## Test plan

- [x] `sync-on-update.py --since "30 days ago"` runs without UnicodeDecodeError on Windows
- [x] CJK-named `knowledge/` paths appear in changed-article set when present in git log
