### PR TITLE
fix(ui): scroll tall header dropdown menus (Fixes #1259)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1103,6 +1103,10 @@ const categoryList = [
       0 8px 20px var(--glass-shadow),
       inset 0 1px 0 var(--glass-inset);
     z-index: 1100;
+    /* #1259: tall menus (探索 + 12 分類) must scroll inside the panel on short viewports */
+    max-height: min(70vh, 520px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
     transition:
       opacity 0.25s cubic-bezier(0.16, 1, 0.3, 1),
       visibility 0.25s cubic-bezier(0.16, 1, 0.3, 1),


### PR DESCRIPTION
## Summary

- Add `max-height` + `overflow-y: auto` to desktop `.dropdown-menu` in `Header.astro`.
- Fixes **探索** dropdown clipping bottom categories (生活 / 政治) on short viewports when the menu cannot scroll.

Fixes #1259

## Verification

- Win11 + Chrome, viewport height ~768px: hover **探索 ▾**, scroll inside panel reaches 生活 / 政治.
- Mobile `.nav-mobile` already had internal scroll (#1142); unchanged.

## AI assistance

AI-assisted (Cursor/Grok). Product-path check on https://taiwan.md/

## Test plan

- [x] Short viewport: explore dropdown scrolls internally
- [ ] Other dropdowns (關於/地圖/數據) still open and scroll if needed
