### PR TITLE
fix(seo): shorten English BIM article title and description

### DIFF
--- a/knowledge/en/Technology/taiwan-bim-construction-tech.md
+++ b/knowledge/en/Technology/taiwan-bim-construction-tech.md
@@ -1,6 +1,6 @@
 ---
-title: 'Taiwan BIM and Construction Technology: Twelve Years of Government Case-by-Case Gradualism Rewritten by an Eighteen-Month Protocol'
-description: 'On May 23, 2014, the Public Construction Commission of the Executive Yuan launched the “Platform for Promoting BIM in Public Works,” adopting the eight-character policy of “case-by-case application and gradual progress.” Eleven years and seven months later, a Taiwan developer working in Tokyo pushed a repository called REVIT_MCP_study to GitHub, where it drew more than seventy stars and more than eighty forks. In the twelve years between those moments, Taiwan’s architecture and construction industry traveled a long road from hand-drawn blueprints to 3D models, from individual experiments to national standards, and from tool upgrades to occupational redefinition.'
+title: 'Taiwan BIM Case Study: One Protocol vs 12 Years of Policy'
+description: 'In 2014 Taiwan chose case-by-case BIM adoption. Twelve years on, a Taiwanese developer shipped REVIT_MCP_study. Policy no longer sets the pace alone.'
 date: 2026-05-22
 author: 'Taiwan.md'
 category: 'Technology'


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

把英文版 BIM 文章的 title 和 description 壓到搜尋結果不會截斷的長度。正文、腳註、圖片都沒有動。

Search Console 近 7 天，這篇的英文版在 `bim residential housing construction taiwan case study` 這組字上有 623 次曝光、位置 7.19，但點擊接近零。原因是 title 130 字元、description 670 字元，兩個都被 Google 截掉，讀者在搜尋頁上看到的開頭是一串政策機關名，而他要找的 case study 從頭到尾沒有被承諾。

|             | 改前      | 改後      |
| ----------- | --------- | --------- |
| title       | 130 chars | 57 chars  |
| description | 670 chars | 149 chars |

新的 description 照 EDITORIAL 的三段結構寫：場景、軌跡、張力收尾。

有兩個地方我取正文的說法而不是舊 metadata 的說法：

1. 開發者寫成 Taiwanese developer 而不是舊版的「working in Tokyo」。正文寫的是他 GitHub 標 Tokyo，但 repo 與教學文件都是繁體中文、內容呼應台灣營建流程，重心在前者。
2. 結尾保留 alone。文章結論是 the next section of it is no longer entirely in the hands of Taiwan's government，去掉 alone 會變成比正文更強的宣稱。長度壓到 149 也是為了確保這個字不會被截掉。

原 title 的 Eighteen-Month Protocol 沒有沿用。正文寫的是 MCP 開源後 17 個月 Autodesk 才宣布內建，另一處寫 less than 13 months，十八這個數字在正文裡找不到對應。新 title 改用有正文支撐的十二年當對比軸。

## 📁 變更類型

- [x] ✏️ 修改/更新現有文章

## ✅ 自我檢查

- [x] frontmatter 完整
- [x] `category` 對齊路徑（Technology）
- [x] 腳註未更動
- [x] `article-health.py --profile=release-pr` 通過：hard=0 warn=0

兩點說明：

`author` 欄位維持既有的 `'Taiwan.md'`。template 建議改成 `'Taiwan.md Contributors'`，但那超出本次「只改 title 與 description」的範圍，留給維護者決定要不要一起處理。

`seo-meta` 這個 check 目前不覆蓋英文版（明確指定會回 `no checks ran — Phase 1 has empty registry`），所以長度是我手動量的，不是機器驗的。

## 🔗 相關 Issue

沒有對應的 GitHub issue。來源是 `docs/semiont/ARTICLE-INBOX.md` 的 P0 條目「台灣 BIM 與營建科技 英文版 metadata」。

## 補充：兩個順帶發現

1. 該條目提到中文版 description 189 字也超標。實際跑 `--check=seo-meta` 是 pass，因為 `seo_meta.py:87` 的 120-160 門檻算的是 CJK 字元數，中文版扣掉數字與英文詞之後在範圍內。所以中文 SSOT 我沒有動。
2. 該條目自己揭露進化分數 58.2 低於 Phase 2 gate 的 60，是依行動表觸發條件 append 的，公式偏誤已升 OBSERVER-QUEUE #16。這裡照實轉述，供維護者判斷。
