### PR TITLE
fix(i18n): 目錄與引用標籤接回早就存在的 key：11 語 6,026 頁的寫死中文

### DIFF
--- a/src/components/ArticleCard.astro
+++ b/src/components/ArticleCard.astro
@@ -39,6 +39,8 @@
  *   route 站點繼承本元件 base + 附加 stop-number 視覺
  */
 
+import { useTranslations, getLangFromUrl } from '../i18n/utils';
+
 export interface Props {
   /** Article URL — wraps card in <a> when present. */
   href?: string;
@@ -99,6 +101,16 @@ const {
   extraClass = '',
   dataAttrs = {},
 } = Astro.props;
+
+// 2026-07-26: the citation-count tooltip was a hardcoded zh-TW「引用」, so every
+// non-zh page showed Chinese on hover. `category.citations` already existed for
+// all 12 languages and carries the count, so the tooltip also stops being a
+// bare noun ("12 citations" instead of "citations").
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
+const citationsLabel = footnotes
+  ? t('category.citations').replace('{n}', String(footnotes))
+  : undefined;
 
 const target = openIn === 'new-tab' ? '_blank' : '_self';
 const rel = openIn === 'new-tab' ? 'noopener noreferrer' : undefined;
@@ -251,7 +263,7 @@ const classes = ['article-card', densityClass, imgSideClass, extraClass]
             {(!!footnotes || !!readingTime) && (
               <span class="article-card-stats">
                 {!!footnotes && (
-                  <span class="article-card-stat" title="引用">
+                  <span class="article-card-stat" title={citationsLabel}>
                     <svg
                       width="13"
                       height="13"
@@ -297,7 +309,7 @@ const classes = ['article-card', densityClass, imgSideClass, extraClass]
     density === 'row' && (footnotes || readingTime || date) && (
       <span class="article-card-rowmeta">
         {!!footnotes && (
-          <span class="article-card-stat" title="引用">
+          <span class="article-card-stat" title={citationsLabel}>
             <svg
               width="13"
               height="13"

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -4,6 +4,8 @@
  * Parses h2/h3 headings from HTML content string, builds nested list.
  * Highlights active section on scroll via IntersectionObserver.
  */
+import { useTranslations, getLangFromUrl } from '../i18n/utils';
+
 interface Heading {
   id: string;
   text: string;
@@ -15,6 +17,14 @@ interface Props {
 }
 
 const { content } = Astro.props;
+
+// 2026-07-26: the heading and the nav's accessible name were hardcoded zh-TW,
+// so all 11 non-zh languages rendered 目錄 / aria-label="文章目錄" (6,026 pages
+// in dist). `article.toc` already existed in ui.ts, translated for all 12
+// languages -- the component simply never used it. Lang comes from the URL, the
+// same way Footer.astro and Header.astro do it, so no call site has to change.
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslations(lang);
 
 // Extract h2 / h3 headings from HTML
 function extractHeadings(html: string): Heading[] {
@@ -61,11 +71,11 @@ const headings = extractHeadings(content);
   headings.length > 1 && (
     <nav
       class="sticky top-24 max-h-[calc(100vh-8rem)] overflow-y-auto py-6 [scrollbar-color:rgba(26,60,52,0.15)_transparent] [scrollbar-width:thin]"
-      aria-label="文章目錄"
+      aria-label={t('article.toc')}
       id="toc"
     >
       <p class="mb-5 px-1 font-['Inter',system-ui,sans-serif] text-[0.68rem] font-bold uppercase tracking-[0.2em] text-[#9aa89e]">
-        目錄
+        {t('article.toc')}
       </p>
       <ol class="m-0 flex list-none flex-col gap-[0.1rem] p-0">
         {/* 2026-07-25 (OBSERVER-QUEUE #12 (a) 到期預設「hairline 極簡版」，

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -2483,7 +2483,12 @@ export const ui = {
     'categoryConfig.politics.description':
       '30-річний експеримент островної демократії — як формуються інституції, як структурована влада, чому демократична інфраструктура — це не лише голосування',
     // Article page
-    'article.toc': 'Зміст',
+    // 2026-07-26: was 'Зміст', which is Ukrainian, not Russian. Fixed here
+    // because this change is what makes the string visible on 316 ru pages
+    // (they previously rendered a hardcoded 目錄), and trading one wrong
+    // language for another is not a fix. Wider issue reported in the PR body:
+    // 55 of the 193 ru keys carry the Ukrainian-only letters і/ї/є/ґ.
+    'article.toc': 'Содержание',
     'article.sources': 'Джерела',
     'article.imageCredit': 'Фото',
     'article.imageSource': 'Першоджерело',

--- a/src/templates/article.template.astro
+++ b/src/templates/article.template.astro
@@ -303,7 +303,7 @@ const encodedTitle = encodeURIComponent(title);
     >
       <!-- Left: Table of Contents (h-full lets the wrapper inherit grid row height,
            giving the inner sticky nav room to scroll within) -->
-      <div class="h-full [grid-area:toc] max-lg:hidden" aria-label="目錄欄">
+      <div class="h-full [grid-area:toc] max-lg:hidden">
         <TableOfContents content={processedContent} />
       </div>
 


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修掉共用元件裡寫死的 zh-TW 字串。**這不是「缺翻譯」，是接線漏掉**：`article.toc` 與 `category.citations` 兩個 key 早就在 `ui.ts` 裡、12 語全都有翻譯，元件只是從來沒用它們。

發現於 #1265 的 RTL 實測：`/ar/` 頁面右側目錄上方頂著一個中文「目錄」。追下去發現不只 ar，**每個非中文語言都是中文**。

### 三處，以及各自的性質

| 位置 | 原本 | 性質 |
|---|---|---|
| `TableOfContents.astro` 可見標題 | `目錄` | 視覺瑕疵，11 個非中文語言都看得到 |
| `TableOfContents.astro` `<nav>` 的 `aria-label` | `"文章目錄"` | **實質 a11y 問題**：阿拉伯文 / 俄文 / 印地文讀者的螢幕閱讀器會唸出中文 |
| `ArticleCard.astro` 引用數 tooltip（兩處） | `title="引用"` | hover 提示，出現在分類頁 / `/latest` / 首頁的卡片上 |

在 build 出來的 `dist/` 上數過，**非中文語言共 6,026 頁**帶著寫死的中文（en 834 / ja 858 / ko 861 / es 861 / fr 862 / vi 161 / id 270 / pt 420 / hi 318 / ar 265 / ru 316）。

## 🔧 修法

`article.toc` 與 `category.citations` 兩個 key 已存在且 12 語齊全，所以**沒有新增任何 i18n key，也沒有我自己編的翻譯**：

```
article.toc         zh-TW 目錄 / en Table of Contents / ja 目次 / ko 목차 /
                    es Índice / fr Table des matières / vi Mục lục /
                    id Daftar isi / pt Sumário / hi विषय-सूची /
                    ar فهرس المحتويات / ru Содержание
category.citations  '{n} citations' 體例，12 語齊全
```

語言來源用 `getLangFromUrl(Astro.url)`，跟 `Header.astro` / `Footer.astro` 同一個既有做法，所以**呼叫端一行都不用改**。

引用 tooltip 順便從單一名詞變成帶數字（`category.citations` 本來就吃 `{n}`），hover 會顯示「12 citations」而不是光一個「引用」。

## 🗑️ 移掉一個沒有作用的 aria-label

`article.template.astro:306` 的 `<div class="h-full [grid-area:toc]" aria-label="目錄欄">`：`aria-label` 在沒有 role 的 generic 元素上不生效（ARIA in HTML 明文不允許放在 generic role 上），所以這個字串**從來沒有被任何輔助技術唸出來**，只是把一句寫死的中文送進所有語言的 HTML。裡面的 `<nav>` 已經帶了 landmark 的 accessible name，所以直接移掉而不是翻譯它：為一個不生效的標籤補 12 語翻譯沒有意義。

如果你其實想保留這個 wrapper 的語意，正解是給它 `role="complementary"` 之類再配 label，而不是留著現在這個形式。要的話我改。

## 🇷🇺 附帶修一個字，以及一個比較大的發現

`ui.ts` 的 ru `article.toc` 原本是 `'Зміст'`，**那是烏克蘭文不是俄文**（俄文是 `Содержание`）。這一條我修了，因為**本 PR 正是讓這個字串在 316 個 ru 頁面上現形的原因**（它們原本顯示寫死的中文），把一種錯的語言換成另一種錯的語言不算修好。

順著查下去發現這不是單一筆。ru bundle 193 個 key 裡，**55 個含有俄文字母表根本沒有的烏克蘭專屬字母 `і` / `ї` / `є` / `ґ`**，另有 19 個含俄文專屬的 `ы` / `э` / `ъ`：這是一個混了兩種語言的 bundle。這是機器可判的，不是語感問題：

```bash
node -e "
const s=require('fs').readFileSync('src/i18n/ui.ts','utf8');
const i=s.indexOf('\n  ru: {');
const seg=s.slice(i, s.indexOf('\n  },', i));
const lines=seg.split('\n').filter(l=>/'[^']+':/.test(l));
const uk=lines.filter(l=>/[іїєґ]/.test(l.split(':').slice(1).join(':')));
console.log(uk.length + ' / ' + lines.length + ' ru keys are Ukrainian');
uk.forEach(l=>console.log(l.trim()));
"
```

抽樣（都是烏克蘭文）：`nav.aria-home: 'Головна сторінка Taiwan.md'`、`nav.explore: 'Досліджувати 🕸️'`、`nav.data: 'Дані 📊'`、`article.sources: 'Джерела'`。

**我只修了 `article.toc` 那一個**，其餘 54 個沒動：那是翻譯工作、量也不小，交給你的翻譯機隊比我在這個 PR 裡順手改合適。ru 是 2026-07-25 出生的，時間點上像是出生時的 UI bundle 生成就漂掉了，值得回頭看一下當時的 prompt。

## 🔍 比 TOC 大得多的同類問題（量測過，沒動，附上偵測方法）

修完 TOC 之後我沒有靠「猜哪個元件會被哪個 template 用到」，而是**直接掃 build 出來的 `dist/`**：讀 11 個非中文語言的頁面，找出所有 `aria-label` / `title` / `alt` / `placeholder` 值裡含漢字的（ja 因為本來就用漢字，單獨標示不列入判定）。

結果是：**跨 3 個以上非 ja 語言的結構性字串，合計約 53,000 次出現。** 排掉內容性的（YouTube 影片標題、政府資料集名稱、人名等中文專有名詞 —— 那些留中文是對的），真正的 UI chrome 洩漏是這幾條：

| 字串 | 出現次數 | 影響語言數 | 來源 |
|---|---|---|---|
| `腳註 <N>` | 24,561 | 6 | `src/utils/article-render.ts` |
| `返回引用 <N>` | 16,433 | 6 | 同上 |
| `查看 Raw Markdown 版本` | 5,492 | 10 | `src/layouts/Layout.astro:1093` |
| `Taiwan.md RSS 動態消息` | 4,625 | 9 | Layout 的 RSS 連結 |
| `腳註`（區塊 aria-label） | 1,194 | 6 | `src/utils/article-render.ts` |
| `每月定額贊助者` / `匿名支持者` 等 | 約 100 | 10 | `SupporterGrid.astro`（about 頁是 localized 路由） |

腳註那三條是最嚴重的：**阿拉伯文 / 印地文 / 俄文讀者的螢幕閱讀器，在每一個腳註連結上都會唸出中文。**

### 根因不是「忘了翻譯」，是新語言出生沒有更新硬編碼的語言表

`src/utils/article-render.ts:42-45`：

```ts
const VIZ_STRINGS: Record<
  'zh-TW' | 'en' | 'ja' | 'ko' | 'es' | 'fr',
  VizStrings
> = { ... }
```

查找是 `VIZ_STRINGS[lang] ?? VIZ_STRINGS['zh-TW']`（:1257），所以 **vi / id / pt / hi / ar / ru 這 6 個較新的語言全部退回中文**。這正好對上 dist 掃出來的「6 個非 ja 語言」。本地化的接縫本來就在（`fnAria` / `fnBackAria` / `fnSection` 三個欄位都是為此設計的），只是表裡沒有這 6 語。

### 你們自己的 SSOT gate 抓不到這個形狀

`check-hardcoded-langs.sh` v2（今天剛從「開頭必須是 en,ja,ko」放寬成「任意三個相鄰語言碼」）仍然假設**逗號分隔的 array literal**。上面那個是 **TypeScript type union，用 `|` 分隔**，所以結構上看不到。補一條 pattern 就能抓：

```bash
"['\"]($LANGCODES)['\"][[:space:]]*\|[[:space:]]*['\"]($LANGCODES)['\"][[:space:]]*\|[[:space:]]*['\"]($LANGCODES)['\"]"
```

這一條在全 repo 命中 5 處，其中 4 處是真的同一個 bug（第 5 處是 `languages.ts:141` 的說明註解，本來就在 ALLOWLIST）：

- `src/utils/article-render.ts:43` ← 上面那 42,000 次的來源
- `src/templates/elections-2026.template.astro:122`
- `src/data/opendata-content.ts:13`（`OpendataLang`）
- `src/data/mcp-content.ts:19`（`McpLang`）

四處都是站上只有 6 語時寫的，新語言出生後沒人回來補。

### 為什麼這個 PR 只報不修

修它要補 6 語 × 11 個字串（含 `縣市` / `數值` / `資料來源` / `方格圖` / `過半` 這些資料視覺化用詞），那是**翻譯工作，而且是我自己生翻譯** —— 這個 PR 的前提正好相反（上面四處修改一個新翻譯都沒生）。而且 ru bundle 55 條混進烏克蘭文這件事，剛好證明這個 repo 裡「LLM 順手生翻譯」的失敗率不是零。

`Layout.astro:1093` 的 `查看 Raw Markdown 版本` 與 RSS 那條同理：`ui.ts` 沒有對應 key，修它就得由我決定 12 語措辭。

**我可以接的話，兩件都做**：①補一條 union pattern 進 `check-hardcoded-langs.sh` + 把這 4 處用附日期的 allowlist 掛號（照你們「掛號要附行號與日期，還清就刪乾淨」的體例）②`VIZ_STRINGS` 補 6 語 + `ui.ts` 補 Raw Markdown / RSS 兩個 key。給我一句「照做」或指定措辭我就送 PR。刻意不在這個 PR 裡動，是因為 #1265 已經帶了一支新 gate，在你還沒看過之前不適合再擴散。

偵測指令（可重跑）：

```bash
grep -rnoE '(aria-label|title|alt|placeholder)="[^"{}]*[一-龥ぁ-んァ-ン][^"{}]*"' \
  src/components src/templates src/layouts --include="*.astro"
```

## ✅ 驗證

- `npm run build` exit 0（10,756 頁）。`dist/` 逐語抽驗目錄標題與 `<nav>` 的 aria-label 兩者都對：

  | | 標題 / aria-label | | 標題 / aria-label |
  |---|---|---|---|
  | zh-TW | `目錄`（行為不變） | id | `Daftar isi` |
  | en | `Table of Contents` | pt | `Sumário` |
  | ja | `目次` | hi | `विषय-सूची` |
  | ko | `목차` | ar | `فهرس المحتويات` |
  | es | `Índice` | ru | `Содержание`（不再是 `Зміст`） |
  | fr | `Table des matières` | vi | `Mục lục` |

- `dist` 全站寫死字串歸零：`文章目錄` 0 頁、`目錄欄` 0 頁（改前分別是 6,026 / 6,895 頁）
- 順帶記一個我自己踩到的：一開始把「為什麼移掉 aria-label」寫成 markup 裡的 `<!-- -->` 註解，結果 Astro 把它照樣送到瀏覽器 —— 等於用中文註解換掉中文 aria-label，6,895 頁還是帶中文。已改成 frontmatter 的 `//` 註解（實測輸出為 0 頁）。
- `npx prettier --check` 改動檔全通過
- 沒有新增 i18n key，所以 `i18n-coverage-audit` 的覆蓋率不會動
- 本分支從 `upstream/main` 開出，**不含 #1265 的改動**，兩個 PR 互相獨立、哪個先合都行（`TableOfContents.astro` 在兩邊各動不同的行：這裡改 frontmatter 與兩個標籤，#1265 改 class 字串）

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）
- [x] 🐛 修復錯誤（寫死的 zh-TW UI 字串 + 一個語言標錯）

## 🔗 相關

跟 #1265（阿拉伯文 RTL 排版）是同一次實測發現的，但議題獨立（i18n 接線 vs RTL 排版），所以分開送。#1265 不需要先合。
