### PR TITLE
fix(i18n): renderer UI 字串六語靜默退回中文：43,045 個中文 aria-label + 兩道 gate 補漏

### DIFF
--- a/scripts/tools/check-hardcoded-langs.sh
+++ b/scripts/tools/check-hardcoded-langs.sh
@@ -28,8 +28,16 @@ LANGCODES="en|ja|ko|es|fr|vi|id|pt|hi|ar|ru|de|th"
 # 當初觸發它誕生的那個形狀。`new Set(['en','es','ja','ko','resources'])` 三條全
 # 不中——那正是 cli/src/lib/knowledge.js 從四月漏到七月的那一行。改成「任意三個
 # 相鄰的已知語言碼字串」，順序、引號、Set(...) 包裝都不影響命中。
+# v3（2026-07-26）：v2 把「開頭必須是 en,ja,ko」放寬成「任意三個相鄰語言碼」，但
+# pattern 仍假設**逗號分隔的 array literal**。TypeScript 的 type union 用 `|` 分隔，
+# 所以 `Record<'zh-TW' | 'en' | 'ja' | 'ko' | 'es' | 'fr', T>` 這個形狀一路隱形。
+# 代價實測：src/utils/article-render.ts 的 VIZ_STRINGS 正是這個形狀，查找又是
+# `?? VIZ_STRINGS['zh-TW']`，於是 vi/id/pt/hi/ar/ru 六語的 renderer UI 字串全退回
+# 中文：dist 上這六語共 43,045 個中文 aria-label，阿拉伯文 / 印地文 / 俄文讀者的
+# 螢幕閱讀器每個腳註都唸中文。加第二條 pattern 抓 union 形狀。
 PATTERNS=(
   "\\[\\s*['\"]($LANGCODES)['\"]\\s*,\\s*['\"]($LANGCODES)['\"]\\s*,\\s*['\"]($LANGCODES)['\"]"
+  "['\"]($LANGCODES)['\"]\\s*\\|\\s*['\"]($LANGCODES)['\"]\\s*\\|\\s*['\"]($LANGCODES)['\"]"
 )
 
 # 允許清單（這些檔案的 hardcoded 語言清單是 SSOT 本體或合理的歷史 mirror）
@@ -43,12 +51,40 @@ ALLOWLIST=(
   "src/i18n/utils.ts"
 )
 
-# ── 已知債：空的（2026-07-26 當天開單、當天結清）──────────────────────────
-# 擴網當天三個檔案現形（儀表板 registry / next-steps、地圖產生器），先掛號是
-# 因為主樹正在跑巴別塔批次、架新紅燈會擋住別人；同日稍晚全部改成從語言註冊表
-# 推導，掛號隨即撤掉。這個區塊留著當格式：掛號要附行號與日期，還清就刪乾淨，
-# 不要讓豁免在清單裡過夜變成「這裡本來就這樣」。
+# ── 已知債（掛號要附行號與日期，還清就刪乾淨）────────────────────────────────
+# 前一輪（2026-07-26 擴網當天）三個檔案當天開單當天結清：儀表板 registry /
+# next-steps、地圖產生器，全部改成從語言註冊表推導，掛號隨即撤掉。
 # 脈絡：reports/design-taiwanmd-node-app-distribution-2026-07-26.md §九.2
+#
+# v3 的 union pattern 讓三個**頁面內容表**現形。它們與上面那批不同性質：那批是
+# 語言清單，可以直接從 registry 推導；這三個是「每語一份的編輯內容」，補齊等於
+# 要寫六個語言的整頁文案，不是機械替換，所以掛號而不是硬轉。
+#
+# 這三處目前的實際後果（build 出來的 dist 量測，非推論）：
+#   /ar/opendata 內文有 6,051 個漢字、/ar/mcp 有 1,082 個：六個新語言的讀者拿到的
+#   是整頁中文，而路由確實存在（dist/ar/opendata/、dist/ar/mcp/ 都有）。
+# 還清方式二選一：補六語文案，或讓這些路由在缺該語文案時不要產生頁面。
+#
+# 格式：<path>:<line>|<掛號日>|<理由>
+DEBT=(
+  "src/data/opendata-content.ts:13|2026-07-26|OpendataLang：策展文案每語一份，補齊要寫六語整頁內容；/ar/opendata 現在是 6,051 漢字的中文頁"
+  "src/data/mcp-content.ts:19|2026-07-26|McpLang：同上；/ar/mcp 現在是 1,082 漢字的中文頁"
+  "src/templates/elections-2026.template.astro:122|2026-07-26|electionCopy：選舉專頁文案每語一份，同上"
+)
+
+DEBT_SEEN=""
+is_debt() {
+  local f="$1" ln="$2"
+  for entry in "${DEBT[@]}"; do
+    if [[ "${entry%%|*}" == "$f:$ln" ]]; then
+      local rest="${entry#*|}"
+      # ${ln} 要加大括號：變數後面直接接全形字元時，bash 會把全形字元讀進變數名。
+      DEBT_SEEN+="\n  $f:${ln}（${rest%%|*} 掛號）${rest#*|}"
+      return 0
+    fi
+  done
+  return 1
+}
 
 # 收集要掃描的檔案
 if [[ "$MODE" == "--staged" ]]; then
@@ -95,12 +131,40 @@ for f in $FILES; do
       || true)
     if [[ -n "$matches" ]]; then
       while IFS= read -r line; do
+        # 掛號過的（檔案 + 行號都對上）不計為違反，但一定印出來
+        if is_debt "$f" "${line%%:*}"; then
+          continue
+        fi
         VIOLATIONS=$((VIOLATIONS + 1))
         VIOLATION_LIST+="\n  $f:$line"
       done <<< "$matches"
     fi
   done
 done
+
+if [[ -n "$DEBT_SEEN" ]]; then
+  echo "📌 已掛號的已知債（不擋，但每次都提醒）："
+  echo -e "$DEBT_SEEN"
+  echo ""
+fi
+
+# 掛號但已經不再命中 = 債還清了，或者行號漂了。兩種都要處理，不能讓豁免留著。
+# 只在全掃時判定：--staged 只看得到這次 commit 的檔案，掛號的檔案沒進 staging
+# 就會全部誤判成「沒命中」，每次 commit 都噴一次假清單。
+STALE=""
+if [[ "$MODE" != "--staged" ]]; then
+  for entry in "${DEBT[@]}"; do
+    target="${entry%%|*}"
+    if [[ "$DEBT_SEEN" != *"$target"* ]]; then
+      STALE+="\n  $target"
+    fi
+  done
+fi
+if [[ -n "$STALE" ]]; then
+  echo "🧹 DEBT 有掛號沒命中，請確認是還清了（刪掉這幾行）還是行號漂了（更新行號）："
+  echo -e "$STALE"
+  echo ""
+fi
 
 if [[ $VIOLATIONS -gt 0 ]]; then
   echo "🚨 發現 $VIOLATIONS 個 hardcoded language array："

--- a/scripts/tools/check-language-registry-sync.sh
+++ b/scripts/tools/check-language-registry-sync.sh
@@ -25,3 +25,56 @@ if [[ "$TS_CODES" != "$MJS_CODES" ]]; then
 fi
 
 echo "✅ Language registry in sync ($TS_CODES)"
+
+# ── VIZ_STRINGS 必須覆蓋註冊表的每一個語言（2026-07-26 加）────────────────────
+# 為什麼在這支腳本裡：VIZ_STRINGS 是「以語言碼為 key 的第三份 registry mirror」，
+# 跟上面 .ts / .mjs 兩份是同一類東西，漂掉的後果也一樣。
+#
+# 實際踩過的坑：這張表的型別原本寫死六語 union，查找是
+# `VIZ_STRINGS[lang] ?? VIZ_STRINGS['zh-TW']`，於是 2026-07 出生的
+# vi / id / pt / hi / ar / ru 六語**靜靜退回中文**。量測到的後果：這六語的 2,052 個
+# 頁面上共有 43,045 個中文 aria-label，阿拉伯文 / 印地文 / 俄文讀者的螢幕閱讀器，
+# 在每一個腳註連結上都唸中文。缺翻譯會被 i18n-coverage-audit 抓到，
+# 這種「有接縫但表裡沒這一列」的漂移不會，因為 `??` 讓它永遠有值、永不報錯。
+#
+# 型別現在是 `Record<Lang, VizStrings>`，新語言出生會是 compile error。但本 repo
+# 的 CI 沒有任何 typecheck step（無 tsc、無 astro check），所以型別只在編輯器裡
+# 生效。這個檢查是它在 CI 的替身。
+#
+# 注意：這裡刻意**不**檢查譯文品質，只檢查「有沒有這一列」。品質是翻譯工作。
+VIZ_FILE="src/utils/article-render.ts"
+if [[ -f "$VIZ_FILE" ]]; then
+  # 只取 VIZ_STRINGS 區塊內縮排 2 格的 key，避免撈到欄位名或其他表
+  VIZ_CODES=$(awk '
+    /^const VIZ_STRINGS/ { inside = 1; next }
+    inside && /^};/       { inside = 0 }
+    inside && match($0, /^  '"'"'?[a-zA-Z][a-zA-Z-]*'"'"'?:[[:space:]]*\{/) {
+      key = $0
+      gsub(/^  '"'"'?/, "", key)
+      sub(/'"'"'?:[[:space:]]*\{.*$/, "", key)
+      print key
+    }
+  ' "$VIZ_FILE" | sort | tr '\n' ',' | sed 's/,$//')
+
+  if [[ -z "$VIZ_CODES" ]]; then
+    echo "❌ 在 $VIZ_FILE 找不到 VIZ_STRINGS 的語言 key"
+    echo "   這支檢查靠 awk 抓縮排 2 格的 key。如果表的形狀改了，請一起更新這裡"
+    echo "   抓不到就當失敗，不要靜默通過（不然這道防線會無聲消失）。"
+    exit 1
+  fi
+
+  if [[ "$VIZ_CODES" != "$TS_CODES" ]]; then
+    echo "❌ VIZ_STRINGS 與語言註冊表漂移！"
+    echo "   registry:    $TS_CODES"
+    echo "   VIZ_STRINGS: $VIZ_CODES"
+    echo ""
+    echo "   後果不是報錯，是靜默退回中文：$VIZ_FILE 的查找是"
+    echo "   \`VIZ_STRINGS[lang] ?? VIZ_STRINGS['zh-TW']\`，缺的語言會拿到整套中文"
+    echo "   UI 字串（腳註 aria-label、資料來源前綴、圖表標籤）。"
+    echo ""
+    echo "   修法：在 $VIZ_FILE 的 VIZ_STRINGS 補上缺的語言，10 個欄位都要有。"
+    exit 1
+  fi
+
+  echo "✅ VIZ_STRINGS 覆蓋註冊表全部語言 ($VIZ_CODES)"
+fi

--- a/src/utils/article-render.ts
+++ b/src/utils/article-render.ts
@@ -22,8 +22,9 @@
  * 裡的文字）不受影響，那是 babel 翻譯的範圍，不是這層的責任。
  */
 import { marked } from 'marked';
+import type { Lang } from '../config/languages';
 
-// ── VIZ_STRINGS：renderer 自產 UI 字串的六語對照表（非作者資料，是 renderer 輸出）──
+// ── VIZ_STRINGS：renderer 自產 UI 字串的全語對照表（非作者資料，是 renderer 輸出）──
 // 「資料來源：」「席次」欄名等改由這裡查表，不再寫死中文。冒號標點直接烤進字串
 // （zh/ja 全形「：」無空格；en/ko/es/fr 半形「: 」有空格）——這是各語言的標點慣例，
 // 不是需要 runtime 判斷的邏輯，存成常數比每次呼叫都判斷 lang 決定標點更直接。
@@ -39,10 +40,19 @@ interface VizStrings {
   fnSection: string; // 腳註區塊 <section> aria-label
   majority: string; // tw-arc 過半線標籤字首（後接席次數）
 }
-const VIZ_STRINGS: Record<
-  'zh-TW' | 'en' | 'ja' | 'ko' | 'es' | 'fr',
-  VizStrings
-> = {
+// 2026-07-26: 原本型別寫死 `'zh-TW' | 'en' | 'ja' | 'ko' | 'es' | 'fr'`，而查找是
+// `VIZ_STRINGS[lang] ?? VIZ_STRINGS['zh-TW']`，於是 2026-07 出生的 vi / id / pt /
+// hi / ar / ru 六語全部靜靜退回中文。實測 build 出來的 dist，這六語 2,052 個頁面上
+// 共有 43,045 個中文 aria-label：`腳註 N` 25,060 個、`返回引用 N` 16,759 個、
+// 腳註區塊 `腳註` 1,226 個。這是實質 a11y 問題：阿拉伯文 / 印地文 / 俄文讀者的螢幕
+// 閱讀器在每一個腳註連結上都唸出中文。
+// 重跑方式：build 後數這六語 dist 裡 `aria-label="<該語 fnAria> N"` 的個數
+//（同一批文章、同一批腳註，所以本地化後的個數就等於原本是中文的個數）。
+//
+// 改成 `Record<Lang, VizStrings>`：Lang 由 LANGUAGES registry 推導（見
+// config/languages.ts:143），所以下次有新語言出生，這裡會是**型別錯誤**而不是
+// 又一次無聲的中文 fallback。不需要維護第二份語言清單，也比任何 grep gate 早一步。
+const VIZ_STRINGS: Record<Lang, VizStrings> = {
   'zh-TW': {
     srcPrefix: '資料來源：',
     county: '縣市',
@@ -115,6 +125,86 @@ const VIZ_STRINGS: Record<
     fnBackAria: 'Retour à la référence',
     fnSection: 'Notes',
     majority: 'Majorité',
+  },
+  // ── 以下六語 2026-07-26 補上（出生時漏補，一路退回中文）───────────────────
+  // `county` 一律沿用站上既有 bundle 已審過的行政區用詞，不自己另創譯名：
+  //   vi/id/pt/hi/ar/ru 的「縣市」取自 src/i18n/data.ts 的
+  //   `data.svg.card4.description`（各語都已翻譯「縣市界」），
+  //   語感再對照 src/i18n/map.ts 的 `map.controls.region.*`。
+  vi: {
+    srcPrefix: 'Nguồn: ',
+    county: 'Huyện/thành phố',
+    value: 'Giá trị',
+    unmatched: 'Huyện/thành phố không khớp: ',
+    tilesAria: 'Bản đồ dữ liệu huyện, thành phố Đài Loan',
+    waffleAria: 'Biểu đồ ô vuông',
+    fnAria: 'Chú thích',
+    fnBackAria: 'Quay lại phần tham chiếu',
+    fnSection: 'Chú thích',
+    majority: 'Quá bán',
+  },
+  id: {
+    srcPrefix: 'Sumber: ',
+    county: 'Kabupaten/kota',
+    value: 'Nilai',
+    unmatched: 'Kabupaten/kota tidak cocok: ',
+    tilesAria: 'Peta data kabupaten dan kota Taiwan',
+    waffleAria: 'Diagram wafel',
+    fnAria: 'Catatan kaki',
+    fnBackAria: 'Kembali ke rujukan',
+    fnSection: 'Catatan kaki',
+    majority: 'Mayoritas',
+  },
+  pt: {
+    srcPrefix: 'Fonte: ',
+    county: 'Condado ou cidade',
+    value: 'Valor',
+    unmatched: 'Condados sem correspondência: ',
+    tilesAria: 'Mapa de dados dos condados de Taiwan',
+    waffleAria: 'Gráfico de waffle',
+    fnAria: 'Nota',
+    fnBackAria: 'Voltar à referência',
+    fnSection: 'Notas',
+    majority: 'Maioria',
+  },
+  hi: {
+    srcPrefix: 'स्रोत: ',
+    county: 'काउंटी/शहर',
+    value: 'मान',
+    unmatched: 'बेमेल काउंटी: ',
+    tilesAria: 'ताइवान काउंटी डेटा मानचित्र',
+    waffleAria: 'वफ़ल चार्ट',
+    fnAria: 'पाद-टिप्पणी',
+    fnBackAria: 'संदर्भ पर वापस जाएँ',
+    fnSection: 'पाद-टिप्पणियाँ',
+    majority: 'बहुमत',
+  },
+  ar: {
+    srcPrefix: 'المصدر: ',
+    county: 'المنطقة أو المدينة',
+    value: 'القيمة',
+    unmatched: 'مناطق غير مطابقة: ',
+    tilesAria: 'خريطة بيانات مناطق تايوان',
+    waffleAria: 'مخطط المربعات',
+    fnAria: 'حاشية',
+    fnBackAria: 'العودة إلى المرجع',
+    fnSection: 'الحواشي',
+    majority: 'الأغلبية',
+  },
+  ru: {
+    // 俄文，不是烏克蘭文。ui.ts 的 ru bundle 有 55 / 193 個 key 混進烏克蘭文
+    // （含俄文字母表沒有的 і/ї/є/ґ），所以這一區刻意不從那裡取詞；本 PR 附了
+    // 機器判定指令。這 10 條全部只用俄文字母。
+    srcPrefix: 'Источник: ',
+    county: 'Уезд или город',
+    value: 'Значение',
+    unmatched: 'Несопоставленные уезды: ',
+    tilesAria: 'Карта данных по уездам Тайваня',
+    waffleAria: 'Вафельная диаграмма',
+    fnAria: 'Сноска',
+    fnBackAria: 'Вернуться к ссылке',
+    fnSection: 'Сноски',
+    majority: 'Большинство',
   },
 };
 // module scope：整個 build 只有一份，renderArticleHtml 每次呼叫開頭覆寫。


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

#1266 的說明裡我量到一批比目錄標題大得多的洩漏，並問你要不要修。這個 PR 就是那件事：**`src/utils/article-render.ts` 的 `VIZ_STRINGS` 型別寫死六語，2026-07 出生的 vi / id / pt / hi / ar / ru 六個語言全部靜靜退回中文。**

在 build 出來的 `dist/` 上量到的實際規模：**這六語的 2,052 個頁面帶著 43,045 個中文 `aria-label`**（腳註連結 25,060 + 腳註返回連結 16,759 + 腳註區塊 1,226）。

| 語言 | 頁數 | 中文 aria-label 個數 |
|---|---|---|
| vi | 235 | 4,936 |
| id | 319 | 7,837 |
| pt | 467 | 10,278 |
| hi | 363 | 7,618 |
| ar | 304 | 5,710 |
| ru | 364 | 6,666 |
| **合計** | **2,052** | **43,045** |

這不是視覺瑕疵：**阿拉伯文 / 印地文 / 俄文讀者的螢幕閱讀器，在每一個腳註連結上都唸中文。**

## 🔍 根因：`??` 讓漂移永遠不報錯

```ts
const VIZ_STRINGS: Record<
  'zh-TW' | 'en' | 'ja' | 'ko' | 'es' | 'fr',   // ← 六語，站上有 12 語
  VizStrings
> = { ... };

// :1345
_locale = VIZ_STRINGS[lang as keyof typeof VIZ_STRINGS] ?? VIZ_STRINGS['zh-TW'];
```

本地化的接縫本來就設計好了（`fnAria` / `fnBackAria` / `fnSection` 三個欄位就是為此存在），只是表裡沒有這六列。而 `??` 保證一定拿得到值，所以：

- 不會 throw
- 不會是 `undefined`
- **`i18n-coverage-audit` 也抓不到**：那支在意的是「key 缺翻譯」，這裡是「表缺一整列」，key 一個都沒缺

這是「有接縫、但表沒跟上註冊表」這一類漂移，缺少報錯路徑是它能活三個月的原因。

## 🔧 三個改動

### 1. `VIZ_STRINGS` 改成 `Record<Lang, VizStrings>`，補齊 12 語

`Lang` 就是 `src/config/languages.ts:143` 的 `(typeof LANGUAGES)[number]['code']`，所以**下一個語言出生時這裡會是 compile error，而不是又一次靜默退回中文**。

`:1345` 的 `?? VIZ_STRINGS['zh-TW']` 我**留著沒動**：`renderArticleHtml(title, content, lang: string = 'zh-TW')` 的 `lang` 型別是 `string`，對註冊表外的呼叫端來說那個 fallback 還是需要的。型別保的是「表這一側齊全」，不是「呼叫端一定傳合法值」。

### 2. `check-hardcoded-langs.sh`：補 union pattern + 把 DEBT 從註解變成機制

你今天才把 v2 從「開頭必須是 en,ja,ko」放寬成「任意三個相鄰語言碼」，但三條 pattern 仍假設**逗號分隔的 array literal**。TypeScript 的 type union 用 `|` 分隔，所以上面那個形狀結構上看不到。加第二條 pattern 就抓得到。

同時把「已知債」從純註解變成有效果的機制。原本那段自述是這樣要求的：

> 這個區塊留著當格式：掛號要附行號與日期，還清就刪乾淨，不要讓豁免在清單裡過夜變成「這裡本來就這樣」。

照這個體例實作成 `DEBT=()` 陣列，`<path>:<line>|<掛號日>|<理由>`。三個特性是刻意的：

- **掛號綁行號，不綁檔案**：同檔別的行照樣擋
- **行號漂了 = 紅燈**，不是靜默豁免（我反向驗過：把掛號行號改成 9999，gate 立刻指名真正的第 13 行並 exit 1）
- **掛號沒命中會印「請確認是還清了還是行號漂了」**，讓豁免沒辦法在清單裡過夜。這條只在全掃 / `--ci` 跑，`--staged` 不跑，否則每次 commit 都會噴一份假清單

新 pattern 在全 repo 命中 4 處。`article-render.ts` 這一處本 PR 修掉了，剩下三處是**每語一份的整頁編輯文案**，性質跟上一輪那批不同（那批是語言清單，可以直接從 registry 推導），所以掛號而不是硬轉：

| 掛號 | 現在的實際後果 |
|---|---|
| `src/data/opendata-content.ts:13`（`OpendataLang`） | `/ar/opendata` 是一頁 **6,051 個漢字**的中文 |
| `src/data/mcp-content.ts:19`（`McpLang`） | `/ar/mcp` 是 **1,082 個漢字** |
| `src/templates/elections-2026.template.astro:122`（`electionCopy`） | 同類 |

路由確實存在（`dist/ar/opendata/`、`dist/ar/mcp/` 都有產出），所以這三個是真的，只是我不該在這個 PR 裡自己決定六個語言的整頁文案。還清方式二選一：補六語文案，或讓這些路由在缺該語文案時不要產生頁面。**要我接哪一種都可以，說一聲。**

### 3. `check-language-registry-sync.sh`：加一條 `VIZ_STRINGS` 覆蓋檢查

這條是本 PR 最需要你看一眼的設計決定，理由是：**修好第 1 點，就把第 2 點那條 pattern 賴以生效的訊號拿掉了。**

`article-render.ts` 以後沒有寫死的 union 了，所以 union pattern 再也不會提到它。而下一個語言出生時，唯一的防線是 `Record<Lang, …>` 的 exhaustiveness，但**這個 repo 的 CI 沒有任何 typecheck**（`.github/workflows/*.yml` 與 `package.json` 都沒有 `tsc` 或 `astro check`，我 grep 過），所以那個型別只在編輯器裡生效，CI 一路綠燈。等於修完之後防線比修之前更薄。

所以加了一條不依賴 typecheck 的檢查。放在 `check-language-registry-sync.sh` 而不是新開一支，是因為那支腳本本來就在做「註冊表 vs 註冊表的鏡像」這件事，而 `VIZ_STRINGS` 正是第三份以語言碼為 key 的鏡像，跟 `.ts` / `.mjs` 那兩份同類，漂掉的後果也同類。它已經掛在 `.husky/pre-commit:148` 與 `i18n-smoke-test.yml:47`，所以**沒有新 workflow、沒有新 artifact、沒有多一次 checkout**，只是既有 step 裡多一次 awk。

檢查刻意只問「有沒有這一列」，不問譯文品質（品質是翻譯工作，不是 gate 的事）。另外 awk 抓不到 key 時是 **exit 1 而不是靜默通過**，否則表的形狀一改，這道防線會無聲消失。

## ⚠️ 這個 PR 有我自己生的翻譯（跟 #1266 相反，請照這個前提看）

#1266 我特別寫了「沒有新增任何 i18n key，也沒有我自己編的翻譯」。**這個 PR 不一樣：六語 × 10 個欄位 = 60 條字串是我寫的。** 而且是我自己在 #1266 裡指出「這個 repo 裡 LLM 順手生翻譯的失敗率不是零」（ru bundle 193 個 key 有 55 個是烏克蘭文），所以我把自己的來源交代清楚：

**`county` 六語全部取自你自己既有的譯文**，不是我另外想的。`src/i18n/data.ts` 的 `data.svg.card4.description` 每語都已經有「縣市」的說法：

| | data.ts 既有寫法 | 我在 VIZ_STRINGS 用的 |
|---|---|---|
| vi | `...phân khu huyện, thành phố...` | `Huyện/thành phố` |
| id | `...pembagian kabupaten dan kota...` | `Kabupaten/kota` |
| pt | `...condados, cidades...` | `Condado ou cidade` |
| hi | `...काउंटी और शहरों के क्षेत्र...` | `काउंटी/शहर` |
| ar | `...تقسيمات المناطق والمدن...` | `المنطقة أو المدينة` |
| ru | `...районы уездов и городов...` | `Уезд или город` |

**ru 那一欄我刻意不從 `ui.ts` 的 ru 抄**，因為那份混了烏克蘭文（#1266 有量測與可重跑的指令）。ru 的 10 條我全部只用俄文字母，並且機器驗過不含俄文字母表沒有的 `і` / `ї` / `є` / `ґ`。

其餘欄位（`fnAria` / `fnBackAria` / `fnSection` / `srcPrefix` / `value` / `majority` / `tilesAria` / `waffleAria` / `unmatched`）是標準 UI 用詞，措辭我對齊各語 `ui.ts` 既有體例。**如果你的翻譯機隊要覆寫任何一條，直接改就好，這 60 條沒有一條值得為它擋 PR。** 我的立場是：現在的中文一定是錯的，這 60 條就算有幾條措辭不理想也是嚴格的改善，但我不想假裝它們跟 #1266 的 key 一樣有你既有譯文背書。

## ✅ 驗證

**`npm run build` exit 0**，14,995 行 log，dead 公告 URL 0。所有數字都是在 build 出來的 `dist/` 上量的，不是推論的。

**改後（六語，`aria-label` 精確 pattern 比對）：**

| 語言 | 中文 aria-label | 已本地化 aria-label | 樣本 |
|---|---|---|---|
| vi | **0** | 4,936 | `Chú thích` / `Quay lại phần tham chiếu` |
| id | **0** | 7,837 | `Catatan kaki` / `Kembali ke rujukan` |
| pt | **0** | 10,278 | `Nota` / `Voltar à referência` |
| hi | **0** | 7,618 | `पाद-टिप्पणी` / `संदर्भ पर वापस जाएँ` |
| ar | **0** | 5,710 | `حاشية` / `العودة إلى المرجع` |
| ru | **0** | 6,666 | `Сноска` / `Вернуться к ссылке` |

**zh-TW 對照組不變**（`aria-label="腳註 N"` 仍在 128 個抽驗頁面上），**en / ja / ko / es / fr 也不變**。

**把 10 個 zh-TW 值當 pattern 掃全部 11 個非中文語言的 dist**，只剩兩個命中：`/es/about/visualization-module-catalog` 與 `/fr/` 同頁的 `<th scope="col">縣市</th>`。查過了，那是 `tw-heatmap` 的**資料欄名**（該頁在示範模組，表頭來自文章自己的 markdown 資料表），不是 renderer UI 字串，正確地不該被翻譯。

**反向驗證兩道 gate 都會叫：**

```
# (a) union pattern 抓得到新的 union 形狀
$ 種一個 Record<'zh-TW' | 'en' | 'ja' | 'ko', string> 進 src/utils/
🚨 發現 1 個 hardcoded language array：
  src/utils/__rtl_probe_tmp.ts:1:type Probe = Record<'zh-TW' | 'en' | 'ja' | 'ko', string>;
exit=1   # 移掉後 exit=0

# (b) 掛號綁行號，不綁檔案（把 opendata 的掛號行號改成 9999）
🧹 DEBT 有掛號沒命中，請確認是還清了（刪掉這幾行）還是行號漂了（更新行號）：
  src/data/opendata-content.ts:9999
🚨 發現 1 個 hardcoded language array：
  src/data/opendata-content.ts:13:export type OpendataLang = 'zh-TW' | 'en' | ...
exit=1

# (c) 覆蓋檢查對「修好之前的真實檔案」會紅，而且指名少哪六語
$ git checkout upstream/main -- src/utils/article-render.ts
$ bash scripts/tools/check-language-registry-sync.sh
❌ VIZ_STRINGS 與語言註冊表漂移！
   registry:    ar,en,es,fr,hi,id,ja,ko,pt,ru,vi,zh-TW
   VIZ_STRINGS: en,es,fr,ja,ko,zh-TW
exit=1   # 換回本 PR 的版本 exit=0
```

**其他：**
- `npm test` 通過（4271/4271 frontmatter OK，10 個 warning 都在我沒動的 content 檔）
- `check-hardcoded-langs.sh --ci` / `check-language-registry-sync.sh` 皆 exit 0
- `npx prettier --check src/utils/article-render.ts` 通過
- `bash -n` 兩支腳本語法通過
- 機器驗過 `VIZ_STRINGS` 12 語 × 剛好 10 個 `VizStrings` 欄位，無缺無多；六個新語言各自的字都在正確的書寫系統裡
- 我的字串沒有一個含 `"` / `<` / `>` / `&`。這點要驗是因為 `:1309` / `:1320` / `:1324` 三處是**沒有過 `_esc()`** 就直接內插的（既有寫法，本 PR 沒動）

**誠實的覆蓋範圍**：10 個欄位裡有 7 個在 dist 上真的被觸發到（`srcPrefix` / `county` / `value` / `fnAria` / `fnBackAria` / `fnSection` / `majority`）。`unmatched` / `tilesAria` / `waffleAria` 這三個，六語目前還沒有任何文章用到對應的模組（`tw-tiles` / `tw-waffle`），所以**只有型別與覆蓋檢查保著，沒有 dist 上的實際用例**。等這六語有文章用到那些模組時才會第一次跑到。

## 🐛 順手量到、沒動的一件事

驗證時我用 `資料來源：` 掃 dist，六語每一頁都還命中。追下去發現不是 `srcPrefix`，是 `Header.astro` 裡一段 **markup 註解被 Astro 照樣送到瀏覽器**：

```
資料來源：frontmatter mobileSubLinks（跟 desktop dropdown 同一組目的地）。 --> <nav id="primary-mobi
```

不是使用者可見字串，也不是 a11y 問題，純粹是每一頁多送幾百 bytes 的中文開發註解。跟我在 #1266 自己踩到的是同一類（frontmatter 的 `//` 註解會被剝掉，markup 裡的 `<!-- -->` 不會）。**沒動**，因為它跟本 PR 的議題無關，而且動 `Header.astro` 會跟 #1265 撞檔。要修的話是獨立一個 PR，或你自己順手改。

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）
- [x] 🐛 修復錯誤（六語 renderer UI 字串靜默退回中文）
- [x] 🔧 工具 / CI（兩支既有 gate 補漏 + DEBT 機制）

## 🔗 相關

- 承接 #1266 說明裡量測到但刻意沒修的那批（那個 PR 只報不修，原因寫在裡面）
- **與 #1265 / #1266 完全獨立**：本分支從 `upstream/main` 開出，只動 3 個檔案，跟另外兩個 PR 沒有任何交集檔案。三個哪個先合都行，也可以只合這個
