### PR TITLE
docs(i18n): localize healthcare article subcategory breadcrumbs

### DIFF
--- a/knowledge/en/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
+++ b/knowledge/en/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
@@ -4,7 +4,7 @@ description: 'The National Health Insurance card used on March 1, 1995, was rush
 date: 2026-06-04
 author: 'Taiwan.md'
 category: 'Lifestyle'
-subcategory: '醫療與健保'
+subcategory: 'Healthcare and NHI'
 tags:
   [
     'National Health Insurance',

--- a/knowledge/es/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
+++ b/knowledge/es/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
@@ -4,7 +4,7 @@ description: 'La tarjeta del Seguro Nacional de Salud del 1 de marzo de 1995 se 
 date: 2026-06-04
 author: 'Taiwan.md'
 category: 'Lifestyle'
-subcategory: '醫療與健保'
+subcategory: 'Salud y seguro médico'
 tags:
   [
     'Seguro Nacional de Salud',

--- a/knowledge/fr/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
+++ b/knowledge/fr/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
@@ -4,7 +4,7 @@ description: "La carte d'assurance maladie du 1er mars 1995 a été produite dan
 date: 2026-06-04
 author: 'Taiwan.md'
 category: 'Lifestyle'
-subcategory: '醫療與健保'
+subcategory: 'Santé et assurance maladie'
 tags:
   [
     'Assurance maladie nationale',

--- a/knowledge/ja/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
+++ b/knowledge/ja/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
@@ -4,7 +4,7 @@ description: '1995 年 3 月 1 日の健康保険カードは、尻に火がつ�
 date: 2026-06-04
 author: 'Taiwan.md'
 category: 'Lifestyle'
-subcategory: '醫療與健保'
+subcategory: '医療と健康保険'
 tags:
   [
     '全民健康保険',

--- a/knowledge/ko/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
+++ b/knowledge/ko/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
@@ -4,7 +4,7 @@ description: '1995년 3월 1일의 건강보험 카드는 발등에 불이 떨�
 date: 2026-06-04
 author: 'Taiwan.md'
 category: 'Lifestyle'
-subcategory: '醫療與健保'
+subcategory: '의료와 건강'
 tags:
   [
     '국민건강보험',

--- a/knowledge/pt/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
+++ b/knowledge/pt/Lifestyle/taiwan-healthcare-and-national-health-insurance.md
@@ -15,7 +15,7 @@ tags:
     'Yang Chih-liang',
     'base de dados do seguro saúde',
   ]
-subcategory: '醫療與健保'
+subcategory: 'Saúde e seguro de saúde'
 author: 'Taiwan.md'
 featured: true
 lastVerified: 2026-06-04


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修正《台灣醫療與全民健保》各語系 frontmatter `subcategory` 仍殘留繁中「醫療與健保」的問題。麵包屑會直接顯示該欄位，導致韓文等語系頁面出現中文段落。

對照既有慣例（韓文溫泉文化篇已用 `의료와 건강` 作為同一繁中 subcategory 的譯名），更新如下：

| 語系 | subcategory |
|------|-------------|
| en | Healthcare and NHI |
| ja | 医療と健康保険 |
| ko | 의료와 건강 |
| es | Salud y seguro médico |
| fr | Santé et assurance maladie |
| pt | Saúde e seguro de saúde |

繁中 SSOT 維持 `醫療與健保` 不變。未改內文、註腳或圖片。

## 📁 變更類型

- [ ] 📄 新增文章
- [x] ✏️ 修改/更新現有文章
- [x] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（事實更正、錯字、連結失效）
- [ ] 💻 技術改動（程式碼、樣式、設定）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [x] 文章有完整的 frontmatter（title, description, date, tags, category）
- [x] `category` 用英文 + 對齊路徑
- [x] `author` / `featured` 欄位未改動
- [x] 本 PR 不改動腳註內容
- [x] 沒有抄襲或版權問題
- [ ] 在本地 build 測試通過（`npm run build`，非必要但建議）

## 🎨 如果動到樣式（非內容 PR 才需要）

- [ ] 不適用

## 🔗 相關 Issue

Closes #

## 📸 截圖（如果是視覺改動）

合併後建議抽查：`/ko/lifestyle/taiwan-healthcare-and-national-health-insurance/` 麵包屑第三層應為「의료와 건강」。
