### PR TITLE
fix(lang-sync): cp950-safe console output in sync-on-update, status, verify-*

### DIFF
--- a/scripts/tools/lang-sync/status.py
+++ b/scripts/tools/lang-sync/status.py
@@ -426,7 +426,7 @@ def build_status(active_langs: list[str]) -> dict:
 # ---------- output formatting ----------
 
 def print_summary_table(status: dict, lang_filter: str | None):
-    print(f"\n📊 Translation status @ {status['_meta']['zhCommitHead']}")
+    print(f"\nTranslation status @ {status['_meta']['zhCommitHead']}")
     print(f"   zh-TW canonical articles: {status['_meta']['totalZh']}")
     print(f"   Updated: {status['_meta']['lastUpdated']}\n")
 
@@ -473,7 +473,7 @@ def print_article_list(status: dict, lang: str, status_filter: set[str], top: in
         print(f"   (no articles match filter)")
         return
 
-    print(f"\n📋 {len(rows)} articles ({', '.join(status_filter)}) for [{lang}]")
+    print(f"\n{len(rows)} articles ({', '.join(status_filter)}) for [{lang}]")
     print(f"{'Status':<10} {'Behind':>7} {'Diff':<14} {'zh-TW article'}")
     print("-" * 80)
     for rel, t in rows:
@@ -498,7 +498,7 @@ def main():
 
     active = LANG_DIRS if not args.lang else [args.lang]
     if args.lang and args.lang not in LANG_DIRS:
-        print(f"❌ Unknown lang: {args.lang}. Available: {LANG_DIRS}", file=sys.stderr)
+        print(f"FAIL: Unknown lang: {args.lang}. Available: {LANG_DIRS}", file=sys.stderr)
         sys.exit(1)
 
     # Always scan all 5 langs for the JSON cache; --lang filter is for display only
@@ -518,7 +518,7 @@ def main():
 
     if args.list or args.status:
         if not args.lang:
-            print("⚠️  --list / --status needs --lang to be useful. Showing 'en' by default.")
+            print("WARN: --list / --status needs --lang to be useful. Showing 'en' by default.")
             args.lang = "en"
         sf = set(args.status.split(",")) if args.status else {"stale", "missing"}
         print_article_list(status, args.lang, sf, args.top)

--- a/scripts/tools/lang-sync/sync-on-update.py
+++ b/scripts/tools/lang-sync/sync-on-update.py
@@ -98,8 +98,8 @@ def main():
         print(f"No zh articles changed in '{args.since}'")
         return
 
-    print(f"📋 Changed zh articles: {len(articles)}")
-    print(f"📋 Active langs to check: {', '.join(langs)}\n")
+    print(f"Changed zh articles: {len(articles)}")
+    print(f"Active langs to check: {', '.join(langs)}\n")
 
     needs_refresh = {lang: [] for lang in langs}
     for zh in articles:
@@ -119,7 +119,7 @@ def main():
         print(f"  {lang}: {len(items)} need refresh")
         if not args.summary_only:
             for item in items[:10]:
-                marker = "🆕" if item["status"] == "missing" else "🔄"
+                marker = "[NEW]" if item["status"] == "missing" else "[STALE]"
                 print(f"    {marker} {item['zh_path']} ({item['status']})")
             if len(items) > 10:
                 print(f"    ... +{len(items)-10} more")
@@ -128,7 +128,7 @@ def main():
     # Write mini-manifest if requested
     if args.output_manifest:
         if not args.lang:
-            print("⚠️ --output-manifest requires --lang", file=sys.stderr)
+            print("WARN: --output-manifest requires --lang", file=sys.stderr)
             sys.exit(1)
         # Write a list file the prepare-batch.py --input can consume
         out = Path(args.output_manifest)
@@ -136,7 +136,7 @@ def main():
         with open(out, "w", encoding="utf-8") as f:
             for item in needs_refresh[args.lang]:
                 f.write(item["zh_path"] + "\n")
-        print(f"\n✅ Wrote {len(needs_refresh[args.lang])} paths to {out}")
+        print(f"\nOK: Wrote {len(needs_refresh[args.lang])} paths to {out}")
         print(f"   Next: python3 scripts/tools/lang-sync/prepare-batch.py --lang {args.lang} --input {out} --groups 5")
 
 

--- a/scripts/tools/lang-sync/verify-batch.py
+++ b/scripts/tools/lang-sync/verify-batch.py
@@ -35,7 +35,7 @@ def main():
     args = ap.parse_args()
 
     manifest_path = Path(args.manifest) if args.manifest else REPO / ".lang-sync-tasks/en/_batch-manifest.json"
-    manifest = json.load(open(manifest_path))
+    manifest = json.load(open(manifest_path, encoding="utf-8"))
     articles = manifest["articles"]
     lang = manifest["lang"]
     en_paths = [a["en_path"] for a in articles]
@@ -56,7 +56,7 @@ def main():
                 p.unlink()
                 purged.append(a["en_path"])
             else:
-                errors.append(f"❌ 0-byte file (use --purge-empty to delete): {a['en_path']}")
+                errors.append(f"FAIL: 0-byte file (use --purge-empty to delete): {a['en_path']}")
     if purged:
         log(f"   Purged {len(purged)} 0-byte file(s):")
         for p in purged:
@@ -72,7 +72,7 @@ def main():
         if not p.exists():
             missing_files.append(a["zh_path"])
             continue
-        text = p.read_text()
+        text = p.read_text(encoding="utf-8")
         for key in ["translatedFrom", "sourceCommitSha", "sourceContentHash", "translatedAt"]:
             if not re.search(rf"^{key}:\s*['\"]?[^'\"\s]", text, re.M):
                 if not re.search(rf"^{key}:", text, re.M):
@@ -90,17 +90,17 @@ def main():
                     f"{a['en_path']}: translatedFrom='{actual_tf}' ≠ zh_path='{expected_tf}'"
                 )
     if missing_files:
-        log(f"   ❌ {len(missing_files)} file(s) not written:")
+        log(f"   FAIL: {len(missing_files)} file(s) not written:")
         for f in missing_files:
             log(f"      {f}")
             errors.append(f"missing: {f}")
     if bad_frontmatter:
-        log(f"   ❌ {len(bad_frontmatter)} frontmatter issue(s):")
+        log(f"   FAIL: {len(bad_frontmatter)} frontmatter issue(s):")
         for b in bad_frontmatter[:10]:
             log(f"      {b}")
             errors.append(b)
     if translated_from_mismatch:
-        log(f"   ❌ {len(translated_from_mismatch)} translatedFrom value mismatch (LLM regression risk):")
+        log(f"   FAIL: {len(translated_from_mismatch)} translatedFrom value mismatch (LLM regression risk):")
         for m in translated_from_mismatch[:10]:
             log(f"      {m}")
             errors.append(m)
@@ -114,7 +114,7 @@ def main():
         full = REPO / p
         if not full.exists():
             continue
-        text = full.read_text()
+        text = full.read_text(encoding="utf-8")
         if not text.startswith("---"):
             continue
         end = text.find("---", 3)
@@ -184,12 +184,12 @@ def main():
         zh_full = REPO / "knowledge" / a["zh_path"]
         if not en_full.exists() or not zh_full.exists():
             continue
-        src_fns = len(fn_def_re.findall(zh_full.read_text()))
-        out_fns = len(fn_def_re.findall(en_full.read_text()))
+        src_fns = len(fn_def_re.findall(zh_full.read_text(encoding="utf-8")))
+        out_fns = len(fn_def_re.findall(en_full.read_text(encoding="utf-8")))
         if src_fns > 0 and out_fns < src_fns:
             fn_losses.append((a["en_path"], src_fns, out_fns))
     if fn_losses:
-        log(f"   ❌ {len(fn_losses)} translation(s) with footnote loss (likely truncated):")
+        log(f"   FAIL: {len(fn_losses)} translation(s) with footnote loss (likely truncated):")
         for p, s, o in fn_losses[:10]:
             log(f"      {p}: {s}→{o} footnote defs")
             errors.append(f"footnote loss: {p} ({s}→{o} defs)")
@@ -203,7 +203,7 @@ def main():
         full = REPO / p
         if not full.exists():
             continue
-        text = full.read_text()
+        text = full.read_text(encoding="utf-8")
         wls = re.findall(r"\[\[([^\]]+)\]\]", text)
         if wls:
             residue += len(wls)
@@ -217,7 +217,7 @@ def main():
         full = REPO / p
         if not full.exists():
             continue
-        text = full.read_text()
+        text = full.read_text(encoding="utf-8")
         # 2026-07-27 盲區修復：原 regex 是 `\]\((/{lang}/...)\)`，**只檢查已經帶
         # 語言前綴的連結**。而譯文最常見的壞連結恰恰是沒有前綴的
         # `[大罷免](/history/大罷免)`（模型照著 zh 源原樣保留），它完全不在
@@ -255,7 +255,7 @@ def main():
                     broken.append((p, match + "  ← 目標不存在"))
     if broken:
         for src, link in broken[:5]:
-            log(f"   ❌ {src}: → {link}")
+            log(f"   FAIL: {src}: → {link}")
             warnings.append(f"broken cross-link: {src} → {link}")
     log(f"   {ok} OK, {len(broken)} broken")
 

--- a/scripts/tools/lang-sync/verify-translation.py
+++ b/scripts/tools/lang-sync/verify-translation.py
@@ -191,15 +191,15 @@ def check(checks: list[dict], json_out: bool):
         }, ensure_ascii=False, indent=2))
     else:
         for c in checks:
-            icon = {"PASS": "✅", "WARN": "⚠️ ", "FAIL": "❌"}[c["level"]]
+            icon = {"PASS": "[OK]", "WARN": "[WARN]", "FAIL": "[FAIL]"}[c["level"]]
             print(f"  {icon} {c['name']}: {c['detail']}")
         print(f"\n{'='*60}")
         if hard_fail:
-            print(f"❌ FAIL: {hard_fail} hard / {warns} warn / {passed} pass")
+            print(f"FAIL: {hard_fail} hard / {warns} warn / {passed} pass")
         elif warns:
-            print(f"⚠️  WARN: {warns} warn / {passed} pass (no hard fail)")
+            print(f"WARN: {warns} warn / {passed} pass (no hard fail)")
         else:
-            print(f"✅ ALL PASS: {passed}/{len(checks)}")
+            print(f"ALL PASS: {passed}/{len(checks)}")
     return hard_fail
 
 


### PR DESCRIPTION
## What

Several `lang-sync` helper scripts still print emoji status markers. On zh-TW Windows 11 the default console codec is cp950, so `sync-on-update.py` and `status.py` crash with `UnicodeEncodeError` before showing useful output.

Merged #1275 fixed `sync-translations-json.py`. This PR applies the same pattern to the sibling scripts flagged in #1281.

## Fix

- `sync-on-update.py`, `status.py`, `verify-translation.py`: replace emoji markers with ASCII labels (`[OK]`, `[WARN]`, `[FAIL]`, `[NEW]`, `[STALE]`).
- `verify-batch.py`: explicit `encoding="utf-8"` on manifest JSON and translation file reads; ASCII error prefixes in log lines.

## Evidence

Windows 11 (zh-TW), Python 3.

`status.py --no-write --lang en` (before: `UnicodeEncodeError` on the summary line; after: table prints):

```
Translation status @ d6070e947
   zh-TW canonical articles: 875
...
en        818     34       22       0      97.4%
```

`sync-on-update.py --article About/文章如何誕生.md --summary-only` (after):

```
Changed zh articles: 1
Active langs to check: en, ja, ko
=== Refresh needed by language ===
  en: 0 need refresh
```

## What was not tested

- No unit-test harness exists for these scripts; Evidence is the before/after console runs above.
- `verify-batch.py` full pipeline not re-run (needs a live batch manifest and bash ratio script).

## AI assistance

Prepared with Cursor assistance. Reproduced cp950 crash class on Win11 zh-TW, matched the ASCII output pattern from merged #1275.

Fixes #1281
