### PR TITLE
fix(prebuild): cp950-safe console output in 7 prebuild generators

### DIFF
--- a/scripts/core/generate-dashboard-forks.py
+++ b/scripts/core/generate-dashboard-forks.py
@@ -15,6 +15,12 @@ dashboard 資料。
 """
 import json
 import pathlib
+import sys
+
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
 
 SRC = pathlib.Path("reports/fork-census/registry.json")
 OUT = pathlib.Path("public/api/dashboard-forks.json")

--- a/scripts/core/generate-fork-graph-data.py
+++ b/scripts/core/generate-fork-graph-data.py
@@ -18,6 +18,11 @@ import sys
 
 import yaml
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
 TERM_DIR = os.path.join(ROOT, "data", "terminology")
 FEATURED = os.path.join(TERM_DIR, "_fork-graph-featured.yaml")

--- a/scripts/core/generate-newsroom-data.py
+++ b/scripts/core/generate-newsroom-data.py
@@ -26,6 +26,11 @@ import re
 import sys
 from datetime import datetime, timezone
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 OUT = os.path.join(ROOT, "public/api/dashboard-newsroom.json")
 

--- a/scripts/tools/generate-dashboard-spores.py
+++ b/scripts/tools/generate-dashboard-spores.py
@@ -25,6 +25,11 @@ from datetime import datetime, date, timedelta, timezone
 from pathlib import Path
 from collections import defaultdict
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SPORE_LOG_JSON = REPO_ROOT / "docs" / "factory" / "spore-log.json"
 SPORE_METRICS_JSON = REPO_ROOT / "docs" / "factory" / "spore-metrics.json"

--- a/scripts/tools/generate-spore-records.py
+++ b/scripts/tools/generate-spore-records.py
@@ -39,6 +39,11 @@ from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 REPO = Path(__file__).resolve().parents[2]
 LOG_PATH = REPO / "docs/factory/spore-log.json"
 METRICS_PATH = REPO / "docs/factory/spore-metrics.json"

--- a/scripts/tools/refresh-llms-txt.py
+++ b/scripts/tools/refresh-llms-txt.py
@@ -32,6 +32,11 @@ import re
 import sys
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 ROOT = Path(__file__).resolve().parent.parent.parent
 LLMS_TXT = ROOT / "public" / "llms.txt"
 VITALS_JSON = ROOT / "public" / "api" / "dashboard-vitals.json"
@@ -54,7 +59,7 @@ def load_vitals() -> dict:
     if not VITALS_JSON.exists():
         print(f"⚠️  {VITALS_JSON} not found — run prebuild first", file=sys.stderr)
         sys.exit(2)
-    return json.loads(VITALS_JSON.read_text())
+    return json.loads(VITALS_JSON.read_text(encoding="utf-8"))
 
 
 def load_i18n_fresh_pct() -> dict:
@@ -62,7 +67,7 @@ def load_i18n_fresh_pct() -> dict:
     if not I18N_JSON.exists():
         return {}
     try:
-        data = json.loads(I18N_JSON.read_text())
+        data = json.loads(I18N_JSON.read_text(encoding="utf-8"))
         # Schema: data['languages'] = [{lang: 'en', freshPct: 96.0, ...}, ...]
         out = {}
         for entry in data.get("languages", []):
@@ -158,7 +163,7 @@ def main():
         print(f"❌ {LLMS_TXT} not found", file=sys.stderr)
         sys.exit(2)
 
-    original = LLMS_TXT.read_text()
+    original = LLMS_TXT.read_text(encoding="utf-8")
     vitals = load_vitals()
     fresh = load_i18n_fresh_pct()
     people = count_people_articles()
@@ -185,7 +190,7 @@ def main():
         sys.stdout.writelines(diff)
         return 0
 
-    LLMS_TXT.write_text(updated)
+    LLMS_TXT.write_text(updated, encoding="utf-8")
     cov = vitals["languageCoverage"]
     print(f"✓ llms.txt refreshed: zh {cov['zh-TW']} / en {cov['en']} / ja {cov['ja']} / ko {cov['ko']} / es {cov['es']} / fr {cov['fr']} / contributors {vitals['contributors']} / People ~{round_to_tens(people)}+")
     return 0

--- a/scripts/tools/sync-spore-links.py
+++ b/scripts/tools/sync-spore-links.py
@@ -51,6 +51,11 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 REPO = Path(__file__).resolve().parents[2]
 SPORE_LOG_JSON = REPO / "docs/factory/spore-log.json"
 KNOWLEDGE_ROOT = REPO / "knowledge"


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修 7 支 prebuild generator 在 Windows cp950 console 下 `UnicodeEncodeError` 直接 exit 1 的問題。
同 #1275 / #1282 的病灶，這批是掃完 prebuild 鏈剩下的全部。

Closes #1293

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）

## 修法

照 `scripts/core/extract-china-terms.py:30-33` 既有的寫法：只在 `sys.stdout.encoding`
不是 UTF-8 時才 reconfigure，所以 Linux 跟 macOS 行為完全不變。
`refresh-llms-txt.py` 另外把 3 個 `read_text()` 跟 1 個 `write_text()` 補上
`encoding="utf-8"`，它在 cp950 下是 `UnicodeDecodeError`（讀不開 UTF-8 內容），
而且寫回會把 CJK 寫成 cp950 bytes。

沒有動任何產出資料的邏輯。

## Evidence（Win11 zh-TW，Python 3.13.3，console code page 950）

Before，`PYTHONUTF8=0`：

```
scripts/core/generate-fork-graph-data.py     exit=1  UnicodeEncodeError: 'cp950' ... '✅'
scripts/core/generate-dashboard-forks.py     exit=1  UnicodeEncodeError: 'cp950' ... '✅'
scripts/core/generate-newsroom-data.py       exit=1  UnicodeEncodeError: 'cp950' ... '✅'
scripts/tools/generate-spore-records.py      exit=1  UnicodeEncodeError: 'cp950' ... '✓'
scripts/tools/generate-dashboard-spores.py   exit=1  UnicodeEncodeError: 'cp950' ... '✅'
scripts/tools/sync-spore-links.py            exit=1  UnicodeEncodeError: 'cp950' ... '⚠'
scripts/tools/refresh-llms-txt.py            exit=1  UnicodeDecodeError: 'cp950' ... 0xe2
```

After，同樣 `PYTHONUTF8=0`，7 支全部 exit=0，例如：

```
✅ fork-graph.json：精選 41 詞｜密度層 198 條（fork_point parse 失敗 0）｜詞庫 2392 條
✅ dashboard-forks.json: 5 public 具名 + 7 private 計數 (total 12 forks, 3 active)
✅ dashboard-newsroom.json: 273 篇上板（warnings 5）→ public/api/dashboard-newsroom.json
✓ llms.txt 已是最新 (zh 881 / contributors 68 / People ~240+)
```

UTF-8 回歸（模擬 Linux/CI，`PYTHONUTF8=1`）：全部 exit=0。`py_compile` 全過。

對照組：先前修過的 `lang-sync/status.py`、`sync-translations-json.py`、`utils/i18n-status.py`
在同樣條件下 exit=0，確認 repro 條件本身有效。

## 已知限制

- 本機 `PYTHONUTF8=1` 會遮蔽這個 bug，所以 repro 用 `PYTHONUTF8=0` 模擬預設安裝。
- 沒有跑完整 `npm run prebuild`（需要完整 astro 依賴），驗證是逐支腳本跑。
- 只掃 python 腳本。prebuild 鏈上的 `*.mjs` / `*.js` 沒有跑過（worktree 沒裝 node_modules）；Node 不會因為 console code page 丟編碼例外，最多是顯示成亂碼，所以沒有放進這個 PR。