### PR TITLE
fix(husky): make pre-commit gates actually see staged CJK-named articles

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -95,7 +95,9 @@ fi
 # If fix() actually modifies a file, we re-stage it so the commit reflects
 # the canonical version. Contributors see one harmless re-staging step
 # instead of fighting bulk repair conflicts later.
-staged_md=$(git diff --cached --name-only --diff-filter=ACM | grep '^knowledge/.*\.md$' | grep -vE '^knowledge/(en|ja|ko|es|fr)/' || true)
+# core.quotepath=false：git 預設會把 CJK 檔名 octal-escape 並加雙引號，
+# zh-TW 文章 867/903 是 CJK 檔名，不加這個旗標整條 grep 全 miss，gate 靜默不跑。
+staged_md=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=ACM | grep '^knowledge/.*\.md$' | grep -vE '^knowledge/(en|ja|ko|es|fr)/' || true)
 if [ -n "$staged_md" ]; then
   fix_output=$(python3 scripts/tools/article-health.py --staged --check=frontmatter-format --fix 2>&1)
   fixed_count=$(echo "$fix_output" | grep -oE 'Modified [0-9]+ file' | grep -oE '[0-9]+' | head -1 || echo "0")
@@ -188,7 +190,7 @@ fi
 # 同一個 commit 理論上只該動一個 narrative domain。多 domain 通常表示
 # 並行 agent 互相污染。警告模式（不擋），要求 commit message 聲明。
 # 詳見 docs/semiont/SESSION-SCOPE.md
-staged_for_scope=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
+staged_for_scope=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
 if [ -n "$staged_for_scope" ]; then
   domains_touched=""
   while IFS= read -r f; do
@@ -243,7 +245,7 @@ fi
 # ═══ 憑證外洩防護（2026-04-11 session α）═══════
 # 掃描 staged 檔案的 credential pattern。這是 .gitignore 之外的第二層防護——
 # 即使 .gitignore 漏設或有人 git add -f，這裡會擋下
-staged_any=$(git diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
+staged_any=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
 if [ -n "$staged_any" ]; then
   cred_fail=0
   for f in $staged_any; do

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -39,6 +39,9 @@ fi
 # MEMORY.md / DIARY.md 最新 index row 長度 gate（只 enforce 最新列，歷史層不回頭改）
 # per MEMORY-PIPELINE §Index row 寫法 + DIARY-PIPELINE Stage 5 gate
 staged_files=$(git diff --cached --name-only)
+# staged_any 在下面的 language registry sync check（第一個消費者）之前就要有值；
+# 原本只在檔案末段的憑證掃描前才賦值，那個 check 因此永遠拿到空字串。
+staged_any=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
 if echo "$staged_files" | grep -q "^docs/semiont/MEMORY.md$"; then
   python3 scripts/tools/memory-index-lint.py || exit 1
 fi
@@ -245,7 +248,6 @@ fi
 # ═══ 憑證外洩防護（2026-04-11 session α）═══════
 # 掃描 staged 檔案的 credential pattern。這是 .gitignore 之外的第二層防護——
 # 即使 .gitignore 漏設或有人 git add -f，這裡會擋下
-staged_any=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=ACM 2>/dev/null || true)
 if [ -n "$staged_any" ]; then
   cred_fail=0
   for f in $staged_any; do


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修 `.husky/pre-commit` 裡三個「靜默不跑」的閘門，加上一個從來沒觸發過的檢查。

Closes #1297

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）

## 兩個獨立成因

**一、staged 路徑被 quote 加 octal-escape**

`git diff --cached --name-only` 在 `core.quotepath` 為預設 true 時，會把非 ASCII 路徑轉義並包上雙引號。zh-TW 文章 867/903 是 CJK 檔名，所以這是常態不是邊角案例。

| 位置 | 消費者 | 原本的行為 |
| --- | --- | --- |
| `staged_md` | frontmatter auto-fix ＋ **article-health hard gate** | 變數為空，兩個 `if` 區塊都跳過，閘門不執行 |
| `staged_any` | 憑證掃描 | `[ ! -f "$f" ]` 成立，檔案在比對任何 pattern 之前就被跳過 |
| `staged_for_scope` | session-scope domain 分類 | `case "$f" in knowledge/*)` 對不上開頭是 `"` 的字串，落到 fallback |

**二、`staged_any` 在賦值之前就被讀**

language registry sync check 讀 `$staged_any`，但賦值在檔案更下面的憑證掃描前。這個 check 一直拿到空字串，所以改了 `languages.ts` 沒同步 `languages.mjs` 也過得了 hook。

## 修法

三處 `git diff --cached` 補 `-c core.quotepath=false`；`staged_any` 的賦值搬到第一個消費者之前，移除後面重複的那份。

其餘三處讀 staged 路徑的地方消費的是今天仍為 ASCII 的路徑（`docs/semiont/` 檔名、翻譯檔照 en canonical slug 命名、程式碼副檔名），沒有動。

## Evidence

Before，stage 一篇 CJK 檔名文章後跑各消費者自己的邏輯：

```
$ git diff --cached --name-only --diff-filter=ACM
"knowledge/Technology/AI\344\272\272\345\267\245\346\231\272\346\205\247\347\224\242\346\245\255.md"

98  staged_md = []
246 憑證掃描: SKIPPED（檔案不存在）
191 domain: 落到 fallback，沒認出 knowledge/
```

After，同一篇文章：

```
98  staged_md = [knowledge/Technology/AI人工智慧產業.md]
246 憑證掃描: scanned knowledge/Technology/AI人工智慧產業.md
191 domain -> content-ssot
```

`staged_any` 那條，stage `src/config/languages.ts`：

```
staged_any=[src/config/languages.ts]
=> registry sync check 會觸發
```

`bash -n .husky/pre-commit` 通過。

## 補充

`scripts/core/build-content-dates.mjs:149-155` 的註解已經記錄過同一個陷阱的另一個版本（「it worked locally only because this dev's git config had core.quotepath=false, but CI's default is TRUE」）。同樣的坑，不同層。

## 已知限制

- 沒有跑完整的真實 commit 流程驗證（本機 husky 需要 bun 與完整 node_modules），驗證方式是把 hook 裡各消費者的判斷邏輯原樣抽出來對同一份 staged index 跑。
- 這個 PR 不改任何 check 的判準，只讓它們真的拿到檔案清單。閘門開始生效後，本來就違規的既有檔案可能第一次被擋下來。
