### PR TITLE
fix(gates): cp950-safe console output in the pre-commit and CI gate scripts

### DIFF
--- a/scripts/tools/article-health.py
+++ b/scripts/tools/article-health.py
@@ -25,6 +25,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 # Make `lib.article_health` importable when running this file directly.
 _THIS = Path(__file__).resolve()
 _TOOLS_DIR = _THIS.parent

--- a/scripts/tools/check-canonical-frontmatter.py
+++ b/scripts/tools/check-canonical-frontmatter.py
@@ -26,6 +26,11 @@ import subprocess
 import sys
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 
 REQUIRED_FIELDS = [

--- a/scripts/tools/check-slug-consistency.py
+++ b/scripts/tools/check-slug-consistency.py
@@ -20,6 +20,11 @@ import sys
 from collections import defaultdict
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 ROOT = Path(__file__).resolve().parents[2]
 CHECK_LANGS = {"ja", "ko", "es", "fr"}
 

--- a/scripts/tools/instrumentation-audit.py
+++ b/scripts/tools/instrumentation-audit.py
@@ -31,6 +31,11 @@ import re
 import sys
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 # Re-exec in venv if present (so --live 的 google import 能用)。CI 沒 venv → 留在 system
 # python 跑 --static（純 stdlib）。必須在 google import 前，且只在直接執行時。
 VENV_DIR = Path.home() / ".config" / "taiwan-md" / "venv"
@@ -121,7 +126,7 @@ def parse_fired_events(files):
         if not f.exists():
             print(f"⚠️  tracker not found: {f}", file=sys.stderr)
             continue
-        text = f.read_text()
+        text = f.read_text(encoding="utf-8")
         injected.update(inject_re.findall(text))
         for m in call_re.finditer(text):
             call_start = m.start()
@@ -160,7 +165,7 @@ def load_live_dims():
 
     cred_dir = Path.home() / ".config" / "taiwan-md" / "credentials"
     pid = None
-    for line in (cred_dir / ".env").read_text().splitlines():
+    for line in (cred_dir / ".env").read_text(encoding="utf-8").splitlines():
         if line.startswith("GA4_PROPERTY_ID="):
             pid = line.split("=", 1)[1].strip().strip("\"'")
     creds = service_account.Credentials.from_service_account_file(

--- a/scripts/tools/memory-index-lint.py
+++ b/scripts/tools/memory-index-lint.py
@@ -25,6 +25,11 @@ import re
 import sys
 from pathlib import Path
 
+# Windows cp950 console 強制 UTF-8（不影響 Linux/macOS）
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 REPO = Path(__file__).resolve().parents[2]
 DEFAULT = REPO / "docs/semiont/MEMORY.md"
 DIARY = REPO / "docs/semiont/DIARY.md"


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

修 5 支自動執行的閘門腳本在 Windows cp950 console 下 `UnicodeEncodeError` 直接 exit 1 的問題。其中 `article-health.py` 是 `.husky/pre-commit` 的 hard gate，所以 Windows 貢獻者現在根本 commit 不了文章。

同 #1275 / #1282 / #1294 的病灶，這批是 hook 與 CI 那一層。

Closes #1299

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）

## 影響範圍

| 腳本 | 執行位置 |
| --- | --- |
| `article-health.py` | `.husky/pre-commit:118` hard gate、`:100` auto-fix、`pre-push`、CI `ci-deploy` mirror |
| `check-canonical-frontmatter.py` | `.husky/pre-commit:27` |
| `check-slug-consistency.py` | `.husky/pre-commit:133` |
| `memory-index-lint.py` | `.husky/pre-commit:43` |
| `instrumentation-audit.py` | `instrumentation-audit.yml`，另有兩處 `read_text()` 沒給 encoding |

hook 把非零 exit 當成違規，所以貢獻者看到的是 traceback，不是他文章哪裡有問題，唯一出路是 `git commit --no-verify`，那會把所有閘門一起關掉。

## 修法

照 `scripts/core/extract-china-terms.py:30-33` 既有的寫法：只在 `sys.stdout.encoding` 不是 UTF-8 時才 reconfigure，Linux 與 macOS 行為不變。`instrumentation-audit.py` 的兩處 `read_text()` 補上 `encoding="utf-8"`。沒有動任何檢查判準。

## Evidence（Win11 zh-TW，Python 3.13.3，console code page 950）

Before，`PYTHONUTF8=0`：

```
article-health.py --staged --profile=pre-commit --quiet   exit=1  UnicodeEncodeError '\U0001f50d'
article-health.py --list-checks                           exit=1  UnicodeEncodeError '✓'
article-health.py <file> --check=prose-health             exit=1  UnicodeEncodeError '\U0001f9ec'
check-canonical-frontmatter.py                            exit=1  UnicodeEncodeError '✅'
check-slug-consistency.py                                 exit=1  UnicodeEncodeError '❌'
memory-index-lint.py                                      exit=1  UnicodeEncodeError '✅'
instrumentation-audit.py                                  exit=1  UnicodeDecodeError 0xe2
```

After，同樣 `PYTHONUTF8=0`，UnicodeError 全部消失：

```
article-health.py --staged --profile=pre-commit --quiet   exit=0
article-health.py --list-checks                           exit=0
check-canonical-frontmatter.py --staged --quiet           exit=0
memory-index-lint.py                                      exit=0
instrumentation-audit.py                                  exit=0
article-health.py <file> --check=prose-health             exit=1  ← 真的檢查結果
check-slug-consistency.py                                 exit=1  ← 真的檢查結果
```

剩下的兩個 exit=1 是實際發現，不是崩潰：prose-health 報 `hard=0 warn=9`（年份 0 個、塑膠句 1 個、首先其次三件套），slug-consistency 報一筆 `computex.md` 命名漂移。

Exit code 兩種模式一致，證明行為沒被改動：

| | `PYTHONUTF8=1` | `PYTHONUTF8=0` |
| --- | --- | --- |
| prose-health | exit=1 | exit=1 |
| slug-consistency | exit=1 | exit=1 |

`py_compile` 五支全過。

## 已知限制

- 本機 `PYTHONUTF8=1` 會完全遮蔽這一類 bug，所以重現用 `PYTHONUTF8=0` 模擬預設安裝。
- 沒有跑真實的 husky commit 流程（需要 bun 與完整 node_modules），驗證是照 hook 的確切指令逐支跑。
- 這批只處理閘門路徑。`scripts/` 底下還有其他腳本有同樣的 emoji print，但它們不在自動執行的路徑上，沒有放進來。
