### PR TITLE
refactor(article-health): one source for a check's language scope

### DIFF
--- a/scripts/tools/article-health.py
+++ b/scripts/tools/article-health.py
@@ -45,6 +45,7 @@ from lib.article_health import (  # noqa: E402
     TRANSLATION_LANGS,
     run_checks,
 )
+from lib.article_health.runner import resolve_applies_to  # noqa: E402
 from lib.article_health.config import Config, ProfileConfig  # noqa: E402
 
 
@@ -140,11 +141,13 @@ def _cmd_fix(args) -> int:
         if not f.exists():
             continue
         target = load_target(f)
-        # APPLIES_TO filter — only run plugins that match this file's lang
-        applicable = [
-            m for m in fix_capable
-            if "*" in getattr(m, "APPLIES_TO", ["*"]) or target.lang in m.APPLIES_TO
-        ]
+        # APPLIES_TO filter — 走 runner 的同一個解析點，不在這裡自己抄一份，
+        # 否則 config 覆寫只對 run_checks 生效、對 --fix 不生效（又一組兩道尺）。
+        applicable = []
+        for m in fix_capable:
+            applies = resolve_applies_to(m, config, profile)
+            if "*" in applies or target.lang in applies:
+                applicable.append(m)
         if not applicable:
             continue
         any_change = False

--- a/scripts/tools/lib/article_health/checks/seo_meta.py
+++ b/scripts/tools/lib/article_health/checks/seo_meta.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import re
 from typing import Any, Iterator
 
+from ..langs import is_translation_path
 from ..types import FileTarget, Severity, Violation
 
 
@@ -63,20 +64,32 @@ _BRAND_PREFIX_PATTERNS = [
 ]
 
 
-def _is_excluded_path(path: str) -> bool:
-    """Hub pages 跟非 zh-TW 文章 skip."""
+def _is_excluded_path(path: str, applies_to: list[str] | None = None) -> bool:
+    """Hub pages 跟不在 scope 內的語言 skip.
+
+    `applies_to` 是 runner 解析後的語言範圍（見 runner.resolve_applies_to）。
+    給 None 時維持模組預設，也就是所有翻譯都排除，等同今天的行為。
+
+    這裡刻意不自己持有語言清單。原本寫死 en/ja/ko/es/fr 五語，停在出生戰役之前，
+    而且被 APPLIES_TO 完全遮住所以是死碼，放寬 APPLIES_TO 的那一刻覆蓋範圍會反過來
+    （issue #1264 的「兩道尺」）。語言清單吃 langs.py SSOT，語言政策吃 applies_to。
+    """
+    # Windows 的 str(Path) 是反斜線，不正規化的話下面每一條 "knowledge/" 比對都落空，
+    # 整支 check 在 Windows 開發機上等於沒跑過（Linux/CI 正常，所以一直沒被發現）。
+    path = path.replace("\\", "/")
     if "/_" in path:
         return True
     if path.endswith("_index.md"):
         return True
     if "knowledge/" not in path:
         return True
-    # Translation files
-    for prefix in ("knowledge/en/", "knowledge/ja/", "knowledge/ko/",
-                   "knowledge/es/", "knowledge/fr/"):
-        if prefix in path:
-            return True
-    return False
+    if not is_translation_path(path):
+        return False
+    if applies_to is None:
+        return True
+    if "*" in applies_to:
+        return False
+    return not any(f"knowledge/{lang}/" in path for lang in applies_to)
 
 
 _RE_CJK_CHAR = re.compile(r"[一-鿿㐀-䶿]")
@@ -99,7 +112,7 @@ def _looks_like_brand_prefix(desc: str) -> str | None:
 
 def check(target: FileTarget, config: dict[str, Any]) -> Iterator[Violation]:
     """Detect SEO metadata length + template issues."""
-    if _is_excluded_path(str(target.path)):
+    if _is_excluded_path(str(target.path), config.get("applies_to")):
         return
 
     fm = target.frontmatter or {}

--- a/scripts/tools/lib/article_health/runner.py
+++ b/scripts/tools/lib/article_health/runner.py
@@ -14,6 +14,26 @@ from .types import (
 )
 
 
+def resolve_applies_to(
+    mod: Any,
+    config: Config,
+    profile: ProfileConfig | None,
+) -> list[str]:
+    """這支 check 要跑哪些語言 —— 語言範圍的唯一解析點。
+
+    優先序：profile 的 options_override > checks.<name>.options > 模組常數 > ["*"]。
+    沒有任何 config 時回傳模組自己宣告的 APPLIES_TO，所以預設行為不變。
+
+    語言範圍原本寫死在模組常數裡，同一份清單又在各 check 的路徑排除函式裡抄一次
+    （issue #1264 的「兩道尺」）。放到 config 之後，要放寬或依 profile 分流是設定
+    改動而不是程式改動，也不必再動兩個地方。
+    """
+    override = _resolve_options(config, profile, mod.CHECK_NAME).get("applies_to")
+    if override is not None:
+        return list(override)
+    return list(getattr(mod, "APPLIES_TO", ["*"]))
+
+
 def _select_checks(
     profile: ProfileConfig | None,
     config: Config,
@@ -30,8 +50,8 @@ def _select_checks(
 
     selected = []
     for mod in candidates:
-        # Respect APPLIES_TO lang filter
-        applies = getattr(mod, "APPLIES_TO", ["*"])
+        # Respect APPLIES_TO lang filter (config-overridable, single resolution point)
+        applies = resolve_applies_to(mod, config, profile)
         if "*" not in applies and target.lang not in applies:
             continue
         # Respect global checks.X.enabled

--- a/tests/article_health/test_lang_scope.py
+++ b/tests/article_health/test_lang_scope.py
@@ -1,0 +1,203 @@
+"""語言範圍的單一來源 —— APPLIES_TO 與各 check 自己的排除清單不准各說各話。
+
+背景：issue #1264 追出來的「兩道尺」。擋住非中文的其實有兩層：
+
+  1. `seo_meta.APPLIES_TO = ["zh-TW"]` —— registry 層過濾，今天真正生效的那道。
+  2. `seo_meta._is_excluded_path()` 的前綴清單 —— 被第一道完全遮住，是死碼。
+
+死碼那份停在五語年代（en/ja/ko/es/fr），站上現在有 12 語。放寬 APPLIES_TO 的
+那一刻它就復活，而且覆蓋範圍剛好相反：後出生的 ar/ru/hi/id/pt/vi 被放行進來
+（`_cjk_count()` 對西里爾與阿拉伯字母一律回 0，等於量了但沒量），實測過的
+en/ja/ko/es/fr 反而繼續被擋。所以收斂成一道尺是任何門檻決定的共同前置。
+
+本檔測三件事：
+  - 各 check 的路徑排除吃 langs.py SSOT，不自己抄一份語言清單
+  - APPLIES_TO 可由 config 覆寫，且**預設行為與今天完全相同**
+  - 語言範圍只有一個解析點，runner 與 --fix 不各自實作
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from lib.article_health import runner
+from lib.article_health.checks import seo_meta
+from lib.article_health.config import CheckConfig, Config, ProfileConfig
+from lib.article_health.langs import TRANSLATION_LANGS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKS_DIR = REPO_ROOT / "scripts" / "tools" / "lib" / "article_health"
+
+
+# ─── 尺一：路徑排除必須吃 SSOT ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("lang", sorted(TRANSLATION_LANGS))
+def test_seo_meta_excludes_every_translation_language(lang):
+    """每一個翻譯語言都要被排除，不只五語年代那五個。
+
+    這條在 APPLIES_TO 放寬之前是死碼路徑，但它決定放寬那天的覆蓋範圍。
+    """
+    assert seo_meta._is_excluded_path(f"knowledge/{lang}/foo.md") is True
+
+
+def test_seo_meta_still_accepts_zh_tw():
+    assert seo_meta._is_excluded_path("knowledge/Technology/台積電.md") is False
+
+
+def test_seo_meta_accepts_windows_path_separators():
+    """Windows 上 `str(Path(...))` 是反斜線，守衛不能因此把每一篇都當成非 knowledge。
+
+    原本的 `"knowledge/" not in path` 對 `knowledge\\Technology\\台積電.md` 成立，
+    於是 seo-meta 在 Windows 開發機上一篇都沒量過（Linux/CI 正常，所以沒人發現）。
+    """
+    assert seo_meta._is_excluded_path("knowledge\\Technology\\台積電.md") is False
+    assert seo_meta._is_excluded_path("knowledge\\en\\foo.md") is True
+
+
+def test_check_guard_follows_the_configured_scope():
+    """守衛跟著解析後的 scope 走，不自己另訂一套語言政策。
+
+    只放寬 APPLIES_TO 而守衛仍寫死「所有翻譯都擋」的話，config 旋鈕轉了不會動，
+    等於兩道尺還在，只是換一種形狀。
+    """
+    scope = ["zh-TW", "en"]
+    assert seo_meta._is_excluded_path("knowledge/en/foo.md", scope) is False
+    # 沒被列進 scope 的語言照舊擋著
+    assert seo_meta._is_excluded_path("knowledge/ja/foo.md", scope) is True
+    # hub page 不因為 scope 放寬就進來
+    assert seo_meta._is_excluded_path("knowledge/en/_index.md", scope) is True
+
+
+def test_widening_scope_makes_the_check_actually_run(tmp_path):
+    """端到端：config 放寬 scope 之後，en 文章真的會被 seo-meta 量到。"""
+    from lib.article_health import registry
+    from lib.article_health.loader import load_target
+    from lib.article_health.runner import run_checks
+
+    registry.reset_registry()
+    registry.discover_checks()
+
+    f = tmp_path / "knowledge" / "en" / "x.md"
+    f.parent.mkdir(parents=True)
+    f.write_text(
+        "---\ntitle: 'T'\ndescription: 'D'\n---\n\nbody\n", encoding="utf-8"
+    )
+    target = load_target(f)
+
+    def violations(report):
+        return [v for r in report.results for v in r.violations]
+
+    default_report = run_checks(target, Config(), check_name="seo-meta")
+    assert violations(default_report) == [], "預設行為必須維持今天的 zh-TW only"
+
+    widened = Config(checks={
+        "seo-meta": CheckConfig(options={"applies_to": ["zh-TW", "en"]}),
+    })
+    widened_report = run_checks(target, widened, check_name="seo-meta")
+    assert violations(widened_report), "放寬 scope 後 seo-meta 應該真的量到這個檔"
+
+
+def test_no_check_hardcodes_language_path_prefixes():
+    """寫死 `knowledge/en/` 這種路徑前綴清單，跟寫死 `"en", "ja"` 是同一個病。
+
+    既有的 test_langs_ssot.test_no_check_hardcodes_the_five_language_world 掃的是
+    `"en", "ja", "ko", "es"` 這種裸語言碼字面，所以 seo_meta 用的
+    `("knowledge/en/", "knowledge/ja/", ...)` 形式整個溜過去了。補上這一面。
+    """
+    prefix_form = re.compile(
+        r'knowledge/en/["\']\s*,\s*["\']knowledge/ja/'
+    )
+    offenders = []
+    for py in sorted(CHECKS_DIR.rglob("*.py")):
+        if py.name == "langs.py":
+            continue
+        code = "\n".join(
+            ln for ln in py.read_text(encoding="utf-8").splitlines()
+            if not ln.lstrip().startswith("#")
+        )
+        if prefix_form.search(code):
+            offenders.append(py.relative_to(REPO_ROOT).as_posix())
+    assert offenders == [], f"還有寫死語言路徑前綴的檔案：{offenders}"
+
+
+# ─── 尺二：APPLIES_TO 可由 config 覆寫，預設不變 ─────────────────────────────
+
+
+class _FakeMod:
+    CHECK_NAME = "fake-check"
+    APPLIES_TO = ["zh-TW"]
+
+
+def test_resolve_applies_to_defaults_to_module_constant():
+    """沒有任何 config 時，解析結果等同今天的模組常數。"""
+    assert runner.resolve_applies_to(_FakeMod, Config(), None) == ["zh-TW"]
+
+
+def test_resolve_applies_to_defaults_to_wildcard_when_module_is_silent():
+    class NoAppliesTo:
+        CHECK_NAME = "quiet-check"
+
+    assert runner.resolve_applies_to(NoAppliesTo, Config(), None) == ["*"]
+
+
+def test_check_options_can_widen_the_language_scope():
+    config = Config(checks={
+        "fake-check": CheckConfig(options={"applies_to": ["zh-TW", "en"]}),
+    })
+    assert runner.resolve_applies_to(_FakeMod, config, None) == ["zh-TW", "en"]
+
+
+def test_profile_options_override_wins_over_check_options():
+    """per-profile 控制是重點：pre-commit 嚴、ci-deploy 維持現狀之類的分流。"""
+    config = Config(checks={
+        "fake-check": CheckConfig(options={"applies_to": ["zh-TW", "en"]}),
+    })
+    profile = ProfileConfig(
+        name="pre-commit",
+        options_overrides={"fake-check": {"applies_to": ["zh-TW", "en", "ja"]}},
+    )
+    assert runner.resolve_applies_to(_FakeMod, config, profile) == [
+        "zh-TW", "en", "ja",
+    ]
+
+
+def test_seo_meta_default_scope_is_unchanged():
+    """預設行為 = 今天的 zh-TW only。這條是整個重構的安全網。"""
+    assert runner.resolve_applies_to(seo_meta, Config(), None) == ["zh-TW"]
+
+
+# ─── 尺三：解析點只有一個 ────────────────────────────────────────────────────
+
+
+def test_applies_to_is_enforced_in_exactly_one_place():
+    """決定「這支 check 跑不跑這個語言」的 APPLIES_TO 讀取只准有一處。
+
+    article-health.py 的 `--fix` 路徑原本自己抄了一份過濾
+    （`"*" in getattr(m, "APPLIES_TO", ["*"]) or target.lang in m.APPLIES_TO`），
+    跟 runner 那份是兩個獨立實作。加了 config 覆寫之後，只改一邊就是新的兩道尺。
+
+    `registry.py` 那處不算：它把 APPLIES_TO 放進 `--list-checks` 的 metadata，是
+    顯示模組宣告值，不參與任何選擇決策，而且 registry 這一層拿不到 config。
+    """
+    reader = re.compile(r'getattr\(\s*\w+\s*,\s*["\']APPLIES_TO["\']')
+    sources = [p for p in CHECKS_DIR.rglob("*.py") if p.name != "registry.py"]
+    sources.append(REPO_ROOT / "scripts" / "tools" / "article-health.py")
+
+    hits = []
+    for py in sorted(set(sources)):
+        for lineno, line in enumerate(
+            py.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if line.lstrip().startswith("#"):
+                continue
+            if reader.search(line):
+                hits.append(f"{py.relative_to(REPO_ROOT).as_posix()}:{lineno}")
+
+    assert len(hits) == 1, (
+        f"APPLIES_TO 的執行點應該只有一處，實際有 {len(hits)} 處：{hits}"
+    )
+    assert "runner.py" in hits[0], f"執行點跑到別的檔案去了：{hits[0]}"


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

把「一支 check 要跑哪些語言」收斂成單一來源。這是 #1264 討論出來的共同前置：(a) 到 (d) 哪條路都要先走這一步，而且它不訂任何門檻數字。

Refs #1264 — **刻意不寫 Closes**。門檻方向仍掛在 OBSERVER-QUEUE #27，這支只處理前置。

## 📁 變更類型

- [x] 💻 技術改動（程式碼、樣式、設定）

## 兩道尺長什麼樣

`seo_meta` 在 registry 層宣告 `APPLIES_TO = ["zh-TW"]`，它自己的 `_is_excluded_path()` 又帶了第二份翻譯前綴清單。第一道把第二道完全遮住，所以那份清單今天是死碼，而且停在五語年代，站上現在有 12 語。放寬 `APPLIES_TO` 的那一刻它復活，覆蓋範圍剛好相反：後出生的六個語言被放行進來（`_cjk_count()` 對西里爾與阿拉伯字母一律回 0，等於量了但沒量），實測過的 en/ja/ko/es/fr 反而繼續被擋。

## 修法

- `runner.resolve_applies_to()` 成為唯一解析點。優先序：profile 的 `options_override` → `checks.<name>.options` → 模組常數 → `["*"]`。沒有 config 時回傳模組常數，所以**預設行為不變**。
- `article-health.py` 的 `--fix` 路徑原本自己抄了一份 `getattr(mod, "APPLIES_TO", ...)` 過濾，改成共用同一個解析點。不然 config 覆寫會對 `run_checks` 生效、對 `--fix` 不生效，就是新的兩道尺。
- `seo_meta._is_excluded_path()` 不再持有語言清單。它接收解析後的 scope，翻譯路徑判定交給 `langs.py` 的 `is_translation_path()`，那是另外八支 plugin 已經在吃的 SSOT。

守衛本身保留。另外七支 check 也各有自己的 `_is_excluded_path`，`chronicle_lead` 還有測試釘著，把語言邏輯整個從 check 拆掉是改全 repo 慣例，不在這支的範圍。

`registry.py` 那處讀 `APPLIES_TO` 沒動：它是 `--list-checks` 的 metadata，顯示模組宣告值，不參與選擇決策，而且 registry 那一層拿不到 config。

## 順手修掉的兩件事

**一、`seo-meta` 在 Windows 上從來沒跑過任何一篇。** `_is_excluded_path()` 比對 `"knowledge/"` 沒有正規化路徑分隔符，而 Windows 的 `str(Path)` 是反斜線：

```
str(Path("knowledge/Technology/台積電.md")) = 'knowledge\\Technology\\台積電.md'
"knowledge/" not in path  → True  → 整篇被當成非 knowledge 路徑排除
```

Linux 與 CI 正常，所以一直沒被發現。它就在本 PR 要改的那個函式裡，一併修。

**二、既有的 SSOT 守門測試有個洞。** `test_langs_ssot.test_no_check_hardcodes_the_five_language_world` 掃的是 `"en", "ja", "ko", "es"` 這種裸語言碼字面，而 `seo_meta` 寫的是 `("knowledge/en/", "knowledge/ja/", ...)`，形式不同所以整個溜過去。新測試補上這一面。

## 測試

新增 `tests/article_health/test_lang_scope.py`，22 條，先確認全部紅燈再實作：

- 每一個翻譯語言都要被排除，不只五語年代那五個（`ar/hi/id/pt/ru/vi` 六條在修之前是紅的，`en/ja/ko/es/fr` 是綠的 — 覆蓋範圍反過來的直接證據）
- 沒有 config 時解析結果等同模組常數，`seo-meta` 預設仍是 zh-TW only
- check options 與 profile `options_overrides` 各自能覆寫，後者優先
- 端到端：放寬 scope 之後 en 文章真的被 seo-meta 量到（第一版這條寫成斷言 `results` 非空，會因為「有一筆零違規的結果」而假綠，改成斷言 violations）
- `APPLIES_TO` 的執行點只有一處（`registry.py` 的 metadata 用途明文排除）
- Windows 反斜線路徑不被誤判

## Evidence

全套 `tests/article_health`：**290 passed / 7 failed / 8 skipped**。那 7 個失敗在乾淨的 `origin/main` 上逐條相同（`test_frontmatter_title` ×2、`test_frontmatter_title_parity`、`test_link_target` ×2、`test_phase6`、`test_prose_health`），diff 過只差計時那一行，跟本 PR 無關。

行為 A/B：對 35 個檔（30 篇 zh-TW ＋ 5 篇 en/vi）跑 `--profile=ci-deploy --output=json`，正規化後比對。

| 平台 | 結果 |
| --- | --- |
| Linux（WSL Ubuntu 24.04, Python 3.12） | **逐字相同** |
| Windows 11（Python 3.13） | 32/35 檔有差異，**差異只來自 `seo-meta`** |

Windows 那邊會變是預期的，因為 seo-meta 從「完全沒跑」變成「跑了」，也就是跟 Linux/CI 本來的行為對齊。安全性：

```
hard 增加的檔案數: 0
passed 由 True 翻 False 的檔案數: 0
warn 總增加 21、info 總增加 32
```

`pre-commit` 與 `ci-deploy` 兩個 profile 都是 `fail_on = "hard"`，`seo-meta` 沒有 severity override（plugin 預設 WARN），所以新出現的都是 advisory，不擋任何 commit 或 deploy。CI 那側本來就在跑這支，沒有新東西被強制。

## 已知限制

- 另外七支 check 的 `_is_excluded_path` 也各自帶語言邏輯與同一個路徑分隔符寫法，本 PR 沒碰，避免把範圍撐大。要不要把守衛層整批收斂是另一個決定。
- A/B 比對是 35 檔抽樣，不是全站 4,888 篇全掃。
- 新的 `applies_to` 選項目前沒有任何 profile 在用，預設等同現狀；它是給門檻方向定案後用的。
