### PR TITLE
Keep language contributor surfaces in sync

### DIFF
--- a/.github/ISSUE_TEMPLATE/translation.yml
+++ b/.github/ISSUE_TEMPLATE/translation.yml
@@ -1,6 +1,6 @@
 name: 🌐 翻譯投稿 Translation Submission
 description: 提交翻譯好的文章（不會 Git 也能貢獻！）
-title: "translate({語言代碼}): {中文文章名} → {英文檔名}"
+title: "translate({語言代碼}): {中文文章名} → {slug}"
 labels: ["translation"]
 body:
   - type: markdown
@@ -8,9 +8,9 @@ body:
       value: |
         ## 🌐 翻譯投稿
 
-        感謝你用 AI 幫台灣說故事！把翻譯好的文章貼在下面，維護者會幫你轉成 PR。
+        感謝你幫忙把台灣的故事帶給更多讀者。把完整譯文貼在下面，維護者會協助整理成 PR。
 
-        > 💡 如果你會 Git，推薦直接開 PR — 更快被 merge！
+        > 💡 如果你熟悉 Git，也可以直接開 PR，維護者會更容易逐行檢視變更。
 
   - type: dropdown
     id: language
@@ -18,15 +18,16 @@ body:
       label: 翻譯語言 Target Language
       options:
         - 🇬🇧 English (en)
-        - 🇪🇸 Español (es)
         - 🇯🇵 日本語 (ja)
         - 🇰🇷 한국어 (ko)
+        - 🇪🇸 Español (es)
         - 🇫🇷 Français (fr)
-        - 🇩🇪 Deutsch (de)
         - 🇻🇳 Tiếng Việt (vi)
-        - 🇵🇹 Português (pt)
-        - 🇹🇭 ไทย (th)
         - 🇮🇩 Bahasa Indonesia (id)
+        - 🇵🇹 Português (pt)
+        - 🇮🇳 हिन्दी (hi)
+        - 🇸🇦 العربية (ar)
+        - 🇷🇺 Русский (ru)
         - Other（請在下方說明）
     validations:
       required: true
@@ -35,8 +36,8 @@ body:
     id: source-article
     attributes:
       label: 原文文章 Source Article
-      description: 你翻譯的是哪篇中文文章？
-      placeholder: "例：珍珠奶茶、半導體產業、台灣民主化"
+      description: 你翻譯的是哪篇中文文章？請填寫相對於 knowledge/ 的路徑，這會成為 translatedFrom。
+      placeholder: "例：Food/珍珠奶茶.md"
     validations:
       required: true
 
@@ -64,6 +65,7 @@ body:
         tags: [food, bubble-tea]
         category: Food
         author: 'Taiwan.md Translation Team'
+        translatedFrom: 'Food/珍珠奶茶.md'
         ---
 
         # Bubble Tea

--- a/.github/workflows/i18n-smoke-test.yml
+++ b/.github/workflows/i18n-smoke-test.yml
@@ -22,8 +22,16 @@ on:
       - 'src/pages/ko/**'
       - 'src/pages/fr/**'
       - 'src/pages/es/**'
+      - 'src/pages/vi/**'
+      - 'src/pages/id/**'
+      - 'src/pages/pt/**'
+      - 'src/pages/hi/**'
+      - 'src/pages/ar/**'
+      - 'src/pages/ru/**'
       - 'src/pages/404.astro'
       - 'scripts/tools/check-hardcoded-langs.sh'
+      - 'scripts/tools/check-language-registry-sync.sh'
+      - 'scripts/tools/compare-language-registries.mjs'
       - 'scripts/tools/i18n-coverage-audit.sh'
 
 jobs:
@@ -34,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '22'
+          node-version-file: '.nvmrc'
           cache: 'npm'
 
       - name: Install dependencies
@@ -84,20 +92,21 @@ jobs:
       - name: Cascade prevention test (B1 regression)
         run: |
           echo "::group::Cascade URLs check on /fr/people"
+          LANG_PATTERN=$(node --input-type=module -e "import { ENABLED_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ENABLED_LANGUAGE_CODES.filter((code) => code !== 'zh-TW').join('|'))")
           F="dist/fr/people/index.html"
           if [ ! -f "$F" ]; then
             echo "❌ Missing $F"
             exit 1
           fi
           # Look for cascade URL patterns: /ja/fr/, /ko/fr/, etc.
-          BAD=$(grep -oE 'href="/(en|ja|ko|fr|es)/(en|ja|ko|fr|es)/' "$F" || true)
+          BAD=$(grep -oE "href=\"/($LANG_PATTERN)/($LANG_PATTERN)/" "$F" || true)
           if [ -n "$BAD" ]; then
             echo "❌ Cascade URLs found:"
             echo "$BAD"
             exit 1
           fi
           # Verify lang dropdown contains expected URLs
-          DROPDOWN=$(grep -oE '"/(en|ja|ko|fr|es)/people"' "$F" | sort -u)
+          DROPDOWN=$(grep -oE "\"/($LANG_PATTERN)/people\"" "$F" | sort -u)
           echo "Lang dropdown URLs from /fr/people:"
           echo "$DROPDOWN"
           # Should have at least 3 langs (en/ja/ko at minimum)
@@ -127,9 +136,10 @@ jobs:
 
       - name: Structural alignment check (B3 regression)
         run: |
-          echo "::group::5 langs all contain core homepage components"
-          for L in '' en ja ko fr es; do
-            if [ -z "$L" ]; then F="dist/index.html"; LANG="zh-TW"; else F="dist/$L/index.html"; LANG="$L"; fi
+          LANGS=$(node --input-type=module -e "import { ENABLED_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ENABLED_LANGUAGE_CODES.join(' '))")
+          echo "::group::Enabled languages all contain core homepage components"
+          for LANG in $LANGS; do
+            if [ "$LANG" = "zh-TW" ]; then F="dist/index.html"; else F="dist/$LANG/index.html"; fi
             if [ ! -f "$F" ]; then
               echo "❌ Missing $F"
               exit 1

--- a/.github/workflows/pr-frontmatter-gate.yml
+++ b/.github/workflows/pr-frontmatter-gate.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Node (with npm cache)
         uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version-file: '.nvmrc'
           cache: npm
 
       - name: Install dependencies (gray-matter for test-frontmatter)
@@ -96,7 +96,7 @@ jobs:
             FILES=$(git -c core.quotePath=false diff --name-only --diff-filter=ACMR HEAD^1...HEAD^2)
           fi
 
-          # 全語系 knowledge/*.md（給 test-frontmatter，它自己驗 en/es/ja/ko 結構）
+          # 全語系 knowledge/*.md（給 test-frontmatter，它自己驗翻譯檔結構）
           ALL_KN=""
           # 只 zh-TW root knowledge/<Category>/*.md（給 article-health --profile=pre-commit，
           # 該 profile 是 zh-TW 導向；翻譯檔交給 test-frontmatter）

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -64,15 +64,17 @@ jobs:
           TRANSLATION_ONLY=true
           HAS_CONTENT=false
           HAS_ENGINEERING=false
+          TRANSLATION_LANG_PATTERN=$(node --input-type=module -e "import { ALL_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ALL_LANGUAGE_CODES.filter((code) => code !== 'zh-TW').join('|'))")
+          KNOWLEDGE_TRANSLATION_RE="^knowledge/($TRANSLATION_LANG_PATTERN)/"
+          CONTENT_TRANSLATION_RE="^src/content/($TRANSLATION_LANG_PATTERN)/"
 
           while IFS= read -r f; do
             [[ -z "$f" ]] && continue
             if [[ "$f" =~ ^knowledge/.*\.md$ ]] || [[ "$f" =~ ^src/content/.*\.md$ ]]; then
               HAS_CONTENT=true
               # Translation locale segment (knowledge/<lang>/… or src/content/<lang>/…)
-              # Keep locales in sync with .github/workflows/translation-check.yml (+ pt/th/id/ar from its validator)
-              if [[ "$f" =~ ^knowledge/(en|es|ja|ko|fr|de|vi|pt|th|id|ar)/ ]] || \
-                 [[ "$f" =~ ^src/content/(en|es|ja|ko|fr|de|vi|pt|th|id|ar)/ ]]; then
+              if [[ "$f" =~ $KNOWLEDGE_TRANSLATION_RE ]] || \
+                 [[ "$f" =~ $CONTENT_TRANSLATION_RE ]]; then
                 :
               else
                 TRANSLATION_ONLY=false

--- a/.github/workflows/translation-check.yml
+++ b/.github/workflows/translation-check.yml
@@ -8,19 +8,28 @@ on:
       - 'knowledge/ja/**'
       - 'knowledge/ko/**'
       - 'knowledge/fr/**'
-      - 'knowledge/de/**'
       - 'knowledge/vi/**'
+      - 'knowledge/id/**'
+      - 'knowledge/pt/**'
+      - 'knowledge/hi/**'
+      - 'knowledge/ar/**'
+      - 'knowledge/ru/**'
 
 jobs:
   check-translation:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
       issues: write
     steps:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: '.nvmrc'
 
       - name: Auto-label translation PR
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
@@ -47,9 +56,10 @@ jobs:
           echo "🔍 Checking translation files..."
           
           ERRORS=0
+          ACTIVE_LANGS=$(node --input-type=module -e "import { ENABLED_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ENABLED_LANGUAGE_CODES.filter((code) => code !== 'zh-TW').join('|'))")
           
-          # Get changed translation files
-          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- 'knowledge/en/' 'knowledge/es/' 'knowledge/ja/' 'knowledge/ko/' 'knowledge/fr/' 'knowledge/de/' 'knowledge/vi/' 2>/dev/null || echo "")
+          # Get changed files under enabled translation directories.
+          FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} -- 'knowledge/' 2>/dev/null | grep -E "^knowledge/($ACTIVE_LANGS)/" || true)
           
           if [ -z "$FILES" ]; then
             echo "No translation files changed."
@@ -70,9 +80,11 @@ jobs:
               echo "  ❌ Missing frontmatter (must start with ---)"
               ERRORS=$((ERRORS + 1))
             fi
+
+            FRONTMATTER=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$FILE")
             
-            # Check title in frontmatter
-            if ! grep -q "^title:" "$FILE"; then
+            # Check required frontmatter fields
+            if ! printf '%s\n' "$FRONTMATTER" | grep -q "^title:"; then
               echo "  ❌ Missing title in frontmatter"
               ERRORS=$((ERRORS + 1))
             else
@@ -80,18 +92,24 @@ jobs:
             fi
             
             # Check description in frontmatter
-            if ! grep -q "^description:" "$FILE"; then
+            if ! printf '%s\n' "$FRONTMATTER" | grep -q "^description:"; then
               echo "  ⚠️ Missing description (recommended)"
             else
               echo "  ✅ Has description"
             fi
             
             # Check category in frontmatter
-            if ! grep -q "^category:" "$FILE"; then
+            if ! printf '%s\n' "$FRONTMATTER" | grep -q "^category:"; then
               echo "  ⚠️ Missing category (recommended)"
             fi
+
+            if ! printf '%s\n' "$FRONTMATTER" | grep -q "^translatedFrom:"; then
+              echo "  ❌ Missing translatedFrom in frontmatter"
+              echo "     Add the zh-TW source path, for example: translatedFrom: 'Food/珍珠奶茶.md'"
+              ERRORS=$((ERRORS + 1))
+            fi
             
-            # Check minimum content length (at least 50 lines for real article)
+            # Check minimum content length (at least 20 lines for a reviewable article)
             LINES=$(wc -l < "$FILE")
             if [ "$LINES" -lt 20 ]; then
               echo "  ❌ Too short ($LINES lines, minimum 20)"
@@ -102,8 +120,8 @@ jobs:
             
             # Check file is in correct directory structure
             LANG=$(echo "$FILE" | sed 's|knowledge/\([^/]*\)/.*|\1|')
-            if ! echo "$LANG" | grep -qE '^(en|es|ja|ko|fr|de|vi|pt|th|id|ar)$'; then
-              echo "  ❌ Unknown language directory: $LANG"
+            if ! echo "$LANG" | grep -qE "^($ACTIVE_LANGS)$"; then
+              echo "  ❌ $LANG is not an enabled language in src/config/languages.mjs"
               ERRORS=$((ERRORS + 1))
             else
               echo "  ✅ Language: $LANG"
@@ -137,8 +155,8 @@ jobs:
           echo ""
           echo "━━━━━━━━━━━━━━━━━━━━"
           if [ $ERRORS -gt 0 ]; then
-            echo "❌ Found $ERRORS error(s). Please fix before merge."
+            echo "❌ Found $ERRORS error(s). Fix the items above, then push the updated files."
             exit 1
           else
-            echo "✅ All translation checks passed!"
+            echo "✅ All translation checks passed."
           fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -57,7 +57,8 @@ fi
 #   - 不需要查中央表 = self-documentation
 # core.quotepath=false 必帶：譯文檔名跟中文原文同名（knowledge/ja/鬍鬚張.md），
 # 不帶的話 git 會把路徑加引號轉義，^knowledge/ 這個錨永遠對不上 → 這道 gate 靜默全跳
-staged_translations=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=AMR | grep -E '^knowledge/(en|ja|ko|es|fr)/.*\.md$' || true)
+translation_lang_pattern=$(node --input-type=module -e "import { ALL_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ALL_LANGUAGE_CODES.filter((code) => code !== 'zh-TW').join('|'))")
+staged_translations=$(git -c core.quotepath=false diff --cached --name-only --diff-filter=AMR | grep -E "^knowledge/($translation_lang_pattern)/.*\.md$" || true)
 if [ -n "$staged_translations" ]; then
   tf_fail=0
   for f in $staged_translations; do

--- a/scripts/core/build-latest.mjs
+++ b/scripts/core/build-latest.mjs
@@ -27,9 +27,10 @@
 import { readdir, readFile, writeFile, mkdir } from 'node:fs/promises';
 import { resolve, join, basename } from 'node:path';
 import matter from 'gray-matter';
+import { ENABLED_LANGUAGE_CODES } from '../../src/config/languages.mjs';
 
 const ROOT = process.cwd();
-const LANGS = ['zh-TW', 'en', 'ja', 'ko', 'fr', 'es'];
+const LANGS = ENABLED_LANGUAGE_CODES;
 const PER_LANG = 30;
 
 // category slug (lowercase, matches URL + content-dates key) → knowledge/ folder

--- a/scripts/core/generate-contributors-data.js
+++ b/scripts/core/generate-contributors-data.js
@@ -41,6 +41,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import https from 'node:https';
+import { ALL_LANGUAGE_CODES } from '../../src/config/languages.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -48,6 +49,14 @@ const PROJECT_ROOT = path.resolve(__dirname, '../..');
 const OUTPUT_PATH = path.join(PROJECT_ROOT, 'public/api/contributors.json');
 const REPO = 'frank890417/taiwan-md';
 const GH_TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+const TRANSLATION_LANGUAGE_CODES = new Set(
+  ALL_LANGUAGE_CODES.filter((code) => code !== 'zh-TW'),
+);
+
+function isTranslationPath(filePath) {
+  const [root, language] = filePath.split('/');
+  return root === 'knowledge' && TRANSLATION_LANGUAGE_CODES.has(language);
+}
 
 // ─── Step 1: GitHub API contributors ─────────────────────────────────────────
 
@@ -153,13 +162,7 @@ function parseGitLog() {
         f === '.gitignore',
     );
     const hasTranslation = files.some(
-      (f) =>
-        f.startsWith('knowledge/en/') ||
-        f.startsWith('knowledge/ja/') ||
-        f.startsWith('knowledge/ko/') ||
-        f.startsWith('knowledge/es/') ||
-        f.startsWith('knowledge/fr/') ||
-        f.startsWith('src/i18n/'),
+      (f) => isTranslationPath(f) || f.startsWith('src/i18n/'),
     );
 
     if (hasTranslation) entry.translationCommits += 1;

--- a/scripts/core/test-frontmatter.mjs
+++ b/scripts/core/test-frontmatter.mjs
@@ -16,6 +16,7 @@
 import { readdir, readFile } from 'node:fs/promises';
 import { resolve, join, basename } from 'node:path';
 import matter from 'gray-matter';
+import { ALL_LANGUAGE_CODES } from '../../src/config/languages.mjs';
 
 const KNOWLEDGE = resolve(process.cwd(), 'knowledge');
 const CATEGORIES = [
@@ -34,10 +35,7 @@ const CATEGORIES = [
   'Economy',
   'Lifestyle',
 ];
-// NOTE: 'fr' deliberately excluded until the 119-file apostrophe frontmatter
-// heal lands (project_babel_frontmatter_apostrophe, dedicated session spawned
-// 2026-06-04) — adding it now would hard-fail CI on known pre-existing damage.
-const LANGS = ['', 'en', 'es', 'ja', 'ko']; // '' = zh-TW root
+const LANGS = ALL_LANGUAGE_CODES.map((code) => (code === 'zh-TW' ? '' : code));
 
 const STRICT = process.argv.includes('--strict');
 const CI_MODE = process.argv.includes('--ci');
@@ -198,12 +196,21 @@ for (const lang of LANGS) {
       // per user request — missing subcategory breaks knowledge-graph
       // clustering + Hub navigation, so block instead of grandfather）
       // - zh-TW（default lang）: 強制必填 → 用 docs/taxonomy/SUBCATEGORY.md 對應分類
-      // - 翻譯檔（en/ja/ko/fr/es）：跳過（subcategory 在原文 SSOT 已定義）
+      // - 翻譯檔：跳過（subcategory 在原文 SSOT 已定義）
       // - About 分類：免（沒有 subcategory 概念）
       // - _Hub.md / _ 開頭檔案：filter 已排除，不會到這
       if (!lang && cat !== 'About' && !fm.subcategory) {
         errors.push(
           `${label}: missing 'subcategory' (見 docs/taxonomy/SUBCATEGORY.md 對應 ${cat} 子分類表)`,
+        );
+      }
+
+      if (
+        lang &&
+        (!fm.translatedFrom || typeof fm.translatedFrom !== 'string')
+      ) {
+        errors.push(
+          `${label}: missing or invalid 'translatedFrom' (例如 'Music/原中文檔名.md')`,
         );
       }
 

--- a/scripts/tools/bulk-pr-analyze.sh
+++ b/scripts/tools/bulk-pr-analyze.sh
@@ -44,12 +44,17 @@ if $JSON_OUT; then
 fi
 
 # Use python for analysis (more readable than bash)
-python3 - "$PRS_JSON" "$FILTER_AUTHOR" <<'PYEOF'
+LANG_CODES_JSON=$(node --input-type=module -e "import { ALL_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(JSON.stringify(ALL_LANGUAGE_CODES.filter((code) => code !== 'zh-TW')))") || {
+  echo "❌ 無法從 src/config/languages.mjs 讀取語言清單" >&2
+  exit 1
+}
+python3 - "$PRS_JSON" "$FILTER_AUTHOR" "$LANG_CODES_JSON" <<'PYEOF'
 import json, sys, re
 from collections import defaultdict
 
 prs = json.loads(sys.argv[1])
 filter_author = sys.argv[2] if len(sys.argv) > 2 else ""
+registered_langs = set(json.loads(sys.argv[3]))
 
 if filter_author:
     prs = [p for p in prs if p['author']['login'] == filter_author]
@@ -69,30 +74,21 @@ def detect_type(p):
     files = [f['path'] for f in p.get('files', [])]
     if any(re.match(r'(translate|add \w+ translation)', title) or 'translation' in title for _ in [1]):
         return 'translation'
-    if any(f.startswith('knowledge/') and '/' in f[10:] for f in files):
-        # Check if it's adding to knowledge/<Lang>/
-        first_seg = files[0][10:].split('/')[0] if files else ''
-        if first_seg in ('en', 'ja', 'ko', 'es', 'fr'):
-            return 'translation'
-        if first_seg in ('History','Geography','Culture','Food','Art','Music','Technology','Nature','People','Society','Economy','Lifestyle','About'):
-            return 'content'
+    knowledge_parts = [f.split('/') for f in files if f.startswith('knowledge/')]
+    if any(len(parts) >= 3 and parts[1] in registered_langs for parts in knowledge_parts):
+        return 'translation'
+    if any(len(parts) >= 3 and parts[1] and parts[1][0].isupper() for parts in knowledge_parts):
+        return 'content'
     return 'other'
 
 # === Language extraction ===
 def extract_lang_cat(p):
-    """Return (lang, category) from translation PR title or files."""
-    title = p['title']
-    m = re.search(r'Add (\w+) translations?: (\w+)', title)
-    if m:
-        lang_name = m.group(1)
-        lang_map = {'Korean':'ko','Japanese':'ja','English':'en','Spanish':'es','French':'fr','German':'de'}
-        return lang_map.get(lang_name, lang_name.lower()[:2]), m.group(2)
-    # Fallback: look at files
+    """Return (lang, category) from changed translation paths."""
     for f in p.get('files', []):
         path = f['path']
-        m = re.match(r'knowledge/(en|ja|ko|es|fr)/([A-Z][a-z]+)/', path)
-        if m:
-            return m.group(1), m.group(2)
+        parts = path.split('/')
+        if len(parts) >= 4 and parts[0] == 'knowledge' and parts[1] in registered_langs:
+            return parts[1], parts[2]
     return None, None
 
 # === Mergeability ===

--- a/scripts/tools/check-cjk-punct.py
+++ b/scripts/tools/check-cjk-punct.py
@@ -66,6 +66,7 @@ def main() -> int:
         # call the plugin's fix() directly.
         sys.path.insert(0, str(Path(__file__).resolve().parent))
         from lib.article_health import load_target  # noqa: E402
+        from lib.article_health.langs import TRANSLATION_LANGS  # noqa: E402
         from lib.article_health.checks import cjk_punct  # noqa: E402
 
         files: list[Path] = []
@@ -85,9 +86,9 @@ def main() -> int:
             for line in out.splitlines():
                 if not line.startswith("knowledge/"):
                     continue
-                if line.startswith(
-                    ("knowledge/en/", "knowledge/ja/", "knowledge/ko/",
-                     "knowledge/es/", "knowledge/fr/")
+                if any(
+                    line.startswith(f"knowledge/{lang}/")
+                    for lang in TRANSLATION_LANGS
                 ):
                     continue
                 if not line.endswith(".md"):
@@ -98,7 +99,7 @@ def main() -> int:
         elif args.all:
             root = Path("knowledge")
             for cat in root.iterdir():
-                if not cat.is_dir() or cat.name in ("en", "ja", "ko", "es", "fr"):
+                if not cat.is_dir() or cat.name in TRANSLATION_LANGS:
                     continue
                 for md in cat.glob("*.md"):
                     if not md.name.startswith("_"):

--- a/scripts/tools/check-language-registry-sync.sh
+++ b/scripts/tools/check-language-registry-sync.sh
@@ -2,29 +2,18 @@
 # check-language-registry-sync.sh
 #
 # 確認 src/config/languages.ts 和 languages.mjs 的 LANGUAGES 列表同步。
-# 兩者的 code 列表必須一致。pre-commit hook 應該跑這個。
+# 語言順序與每個欄位都必須一致。pre-commit hook 應該跑這個。
 #
 # 為什麼有兩份檔案：Vite SSR prerender chunks 會 bundle .mjs 但破壞 filesystem
 # 相對路徑，所以不能用 readFileSync 讀 JSON。最可靠的方式是兩個檔案都 inline 資料。
 set -uo pipefail
 cd "$(dirname "$0")/../.."
 
-# Extract codes from .ts (regex: code: '...')
+# 比對完整 registry entry；只比 code 會漏掉 enabled / hreflang / dir 等漂移。
+node scripts/tools/compare-language-registries.mjs || exit 1
+
+# Extract codes for the VIZ_STRINGS coverage check below.
 TS_CODES=$(grep -oE "code: '[^']+'" src/config/languages.ts | sed "s/code: '//;s/'$//" | sort | tr '\n' ',' | sed 's/,$//')
-
-# Extract codes from .mjs
-MJS_CODES=$(grep -oE "code: '[^']+'" src/config/languages.mjs | sed "s/code: '//;s/'$//" | sort | tr '\n' ',' | sed 's/,$//')
-
-if [[ "$TS_CODES" != "$MJS_CODES" ]]; then
-  echo "❌ Language registry drift detected!"
-  echo "   languages.ts codes:  $TS_CODES"
-  echo "   languages.mjs codes: $MJS_CODES"
-  echo ""
-  echo "Both files must have the same code list. Edit BOTH when adding a language."
-  exit 1
-fi
-
-echo "✅ Language registry in sync ($TS_CODES)"
 
 # ── VIZ_STRINGS 必須覆蓋註冊表的每一個語言（2026-07-26 加）────────────────────
 # 為什麼在這支腳本裡：VIZ_STRINGS 是「以語言碼為 key 的第三份 registry mirror」，

--- a/scripts/tools/check-slug-consistency.py
+++ b/scripts/tools/check-slug-consistency.py
@@ -5,7 +5,7 @@
 98 檔 slug 漂移，成為 hreflang / 語言切換器死鏈家族的土壤（歷史清償見
 unify-translation-slugs.py）。本 gate 讓漂移在 commit 時就被擋下。
 
-規則：knowledge/{ja,ko,es,fr}/{Cat}/{slug}.md 若其 translatedFrom 對應
+規則：knowledge/{registered non-en language}/{Cat}/{slug}.md 若其 translatedFrom 對應
 的 en 版存在，basename 必須與 en 版相同。en 是 canonical，不受檢。
 
 用法：
@@ -26,7 +26,10 @@ if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
     sys.stderr.reconfigure(encoding="utf-8")
 
 ROOT = Path(__file__).resolve().parents[2]
-CHECK_LANGS = {"ja", "ko", "es", "fr"}
+sys.path.insert(0, str(ROOT / "scripts" / "tools" / "lang-sync"))
+from langs import ALL_TRANSLATION_LANGS  # noqa: E402
+
+CHECK_LANGS = set(ALL_TRANSLATION_LANGS) - {"en"}
 
 # unify-translation-slugs.py 2026-07-17 review 保留的歷史漂移（zh path）。
 # 清償一案就從這裡刪一行；新檔案不得加入。

--- a/scripts/tools/compare-language-registries.mjs
+++ b/scripts/tools/compare-language-registries.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/** Compare every field in the TypeScript and Node language registries. */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { fileURLToPath } from 'node:url';
+import { LANGUAGES as MJS_LANGUAGES } from '../../src/config/languages.mjs';
+
+const SCRIPT_PATH = fileURLToPath(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(SCRIPT_PATH), '../..');
+const TS_REGISTRY = path.join(REPO_ROOT, 'src/config/languages.ts');
+const FIELDS = [
+  'code',
+  'displayName',
+  'hreflang',
+  'isDefault',
+  'enabled',
+  'notes',
+  'dir',
+];
+
+function extractArrayLiteral(source) {
+  const marker = 'export const LANGUAGES =';
+  const markerIndex = source.indexOf(marker);
+  const start = source.indexOf('[', markerIndex + marker.length);
+  if (markerIndex === -1 || start === -1) {
+    throw new Error('找不到 `export const LANGUAGES = [...]`');
+  }
+
+  let depth = 0;
+  let quote = null;
+  let escaped = false;
+  let lineComment = false;
+  let blockComment = false;
+
+  for (let index = start; index < source.length; index += 1) {
+    const char = source[index];
+    const next = source[index + 1];
+
+    if (lineComment) {
+      if (char === '\n') lineComment = false;
+      continue;
+    }
+    if (blockComment) {
+      if (char === '*' && next === '/') {
+        blockComment = false;
+        index += 1;
+      }
+      continue;
+    }
+    if (quote) {
+      if (escaped) escaped = false;
+      else if (char === '\\') escaped = true;
+      else if (char === quote) quote = null;
+      continue;
+    }
+    if (char === '/' && next === '/') {
+      lineComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === '/' && next === '*') {
+      blockComment = true;
+      index += 1;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      quote = char;
+      continue;
+    }
+    if (char === '[') depth += 1;
+    if (char === ']') {
+      depth -= 1;
+      if (depth === 0) return source.slice(start, index + 1);
+    }
+  }
+
+  throw new Error('LANGUAGES array 沒有完整結束');
+}
+
+function normalize(entries) {
+  return entries.map((entry) =>
+    Object.fromEntries(
+      FIELDS.map((field) => [
+        field,
+        entry[field] === undefined ? null : entry[field],
+      ]),
+    ),
+  );
+}
+
+export function readTsLanguages(source = fs.readFileSync(TS_REGISTRY, 'utf8')) {
+  const literal = extractArrayLiteral(source);
+  return vm.runInNewContext(`(${literal})`, Object.create(null), {
+    timeout: 1_000,
+  });
+}
+
+export function compareRegistries(tsLanguages, mjsLanguages) {
+  const ts = normalize(tsLanguages);
+  const mjs = normalize(mjsLanguages);
+  if (JSON.stringify(ts) === JSON.stringify(mjs)) return null;
+
+  const length = Math.max(ts.length, mjs.length);
+  for (let index = 0; index < length; index += 1) {
+    if (!ts[index] || !mjs[index]) {
+      return {
+        index,
+        field: 'entry',
+        ts: ts[index] ?? null,
+        mjs: mjs[index] ?? null,
+      };
+    }
+    const field = FIELDS.find(
+      (name) =>
+        JSON.stringify(ts[index][name]) !== JSON.stringify(mjs[index][name]),
+    );
+    if (field) {
+      return { index, field, ts: ts[index][field], mjs: mjs[index][field] };
+    }
+  }
+  return { index: -1, field: 'unknown', ts, mjs };
+}
+
+export function main() {
+  let tsLanguages;
+  try {
+    tsLanguages = readTsLanguages();
+  } catch (error) {
+    console.error(
+      `❌ 無法讀取 ${path.relative(REPO_ROOT, TS_REGISTRY)}：${error.message}`,
+    );
+    console.error(
+      '   如果 LANGUAGES 的結構改了，請一起更新 compare-language-registries.mjs。',
+    );
+    return 1;
+  }
+
+  const mismatch = compareRegistries(tsLanguages, MJS_LANGUAGES);
+  if (mismatch) {
+    const code =
+      tsLanguages[mismatch.index]?.code ??
+      MJS_LANGUAGES[mismatch.index]?.code ??
+      'unknown';
+    console.error('❌ Language registry drift detected.');
+    console.error(
+      `   Entry ${mismatch.index + 1} (${code}), field: ${mismatch.field}`,
+    );
+    console.error(`   languages.ts:  ${JSON.stringify(mismatch.ts)}`);
+    console.error(`   languages.mjs: ${JSON.stringify(mismatch.mjs)}`);
+    console.error(
+      '   Update both registry files so their order and field values match.',
+    );
+    return 1;
+  }
+
+  console.log(
+    `✅ Language registry fields are in sync (${tsLanguages.length} languages)`,
+  );
+  return 0;
+}
+
+if (path.resolve(process.argv[1] || '') === SCRIPT_PATH) {
+  process.exitCode = main();
+}

--- a/scripts/tools/generate-dashboard-analytics.py
+++ b/scripts/tools/generate-dashboard-analytics.py
@@ -27,6 +27,7 @@ dashboard changes.
 from __future__ import annotations
 
 import json
+import re
 import sys
 from datetime import datetime
 from pathlib import Path
@@ -34,6 +35,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CACHE = Path.home() / ".config" / "taiwan-md" / "cache"
 TARGET = REPO_ROOT / "public" / "api" / "dashboard-analytics.json"
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "tools" / "lang-sync"))
+from langs import ENABLED_TRANSLATION_LANGS  # noqa: E402
 
 
 def load_json(path: Path):
@@ -85,12 +88,10 @@ def clean_title(title: str) -> str:
     return (title or "").replace(" | Taiwan.md", "").strip()
 
 
-# Language detection from URL path prefix.
-# zh-TW = no prefix (default); en/ja/ko/es/fr = explicit prefix.
-import re as _re
-
-LANG_PREFIX_PATTERN = _re.compile(r"^/(en|ja|ko|es|fr)(/|$)")
-ALL_LANGS = ("zh-TW", "en", "ja", "ko", "es", "fr")
+# Language detection from URL path prefix. zh-TW has no prefix.
+ALL_LANGS = ("zh-TW", *ENABLED_TRANSLATION_LANGS)
+_PREFIXES = "|".join(re.escape(lang) for lang in ENABLED_TRANSLATION_LANGS)
+LANG_PREFIX_PATTERN = re.compile(rf"^/({_PREFIXES})(/|$)")
 
 
 def derive_lang_from_path(path: str) -> str:
@@ -113,7 +114,7 @@ def aggregate_by_lang(rows):
 
     Returns:
         dict: {lang: {views, users, sessions, avgEngagementSeconds, pageCount}}
-        Always includes all 6 langs (zh-TW + 5 translation langs), with 0 for
+        Always includes every enabled language, with 0 for
         unobserved langs so dashboard can render consistent shape.
     """
     buckets = {

--- a/scripts/tools/lang-sync/prioritize-batch.py
+++ b/scripts/tools/lang-sync/prioritize-batch.py
@@ -41,9 +41,10 @@ import re
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+from langs import ALL_TRANSLATION_LANGS
 
 REPO = Path(__file__).resolve().parents[3]
-LANGS = ["en", "ja", "ko", "es", "fr"]
+LANGS = ALL_TRANSLATION_LANGS
 
 # PRC-sensitive keyword pattern (title / category / tags hit → escalate)
 SENSITIVE_KEYWORDS = re.compile(

--- a/scripts/tools/lang-sync/sync-on-update.py
+++ b/scripts/tools/lang-sync/sync-on-update.py
@@ -28,10 +28,11 @@ Usage:
 """
 import argparse, json, subprocess, sys
 from pathlib import Path
+from langs import ENABLED_TRANSLATION_LANGS
 
 REPO = Path(__file__).resolve().parent.parent.parent.parent
 KNOWLEDGE = REPO / "knowledge"
-ACTIVE_LANGS = ["en", "ja", "ko"]  # from src/config/languages.ts active list
+ACTIVE_LANGS = ENABLED_TRANSLATION_LANGS
 
 
 def get_changed_zh_articles(since="1 day ago"):
@@ -52,7 +53,7 @@ def get_changed_zh_articles(since="1 day ago"):
             continue
         # Filter to zh articles (knowledge/Category/X.md, not knowledge/en/...)
         if line.startswith("knowledge/") and not any(
-            line.startswith(f"knowledge/{lang}/") for lang in ACTIVE_LANGS + ["es", "fr"]
+            line.startswith(f"knowledge/{lang}/") for lang in ACTIVE_LANGS
         ):
             zh_path = line[len("knowledge/"):]
             if zh_path.endswith(".md") and "/" in zh_path:

--- a/scripts/tools/lib/article_health/checks/chronicle_lead.py
+++ b/scripts/tools/lib/article_health/checks/chronicle_lead.py
@@ -27,7 +27,7 @@ APPLIES_TO 設計：
     zh-TW articles 在 knowledge/{Category}/ 路徑下。
     Skip:
       - Hub pages (`_*.md`) — index pages 用 timeline 結構合法
-      - Translation files (knowledge/en|ja|ko|es|fr/) — 非中文 prose
+      - Translation files (`knowledge/{registered language}/`) — 非中文 prose
       - SPORE blueprints / harvests — handled by spore_writing.py
       - Memory / diary — timeline templates legit
       - reports/research/ — research notes 用日期合法
@@ -47,6 +47,7 @@ from __future__ import annotations
 import re
 from typing import Any, Iterator
 
+from ..langs import is_translation_path
 from ..types import FileTarget, Severity, Violation
 
 
@@ -101,9 +102,7 @@ def _is_excluded_path(path: str) -> bool:
     import os
     p = str(path)
     # Translation files
-    if "/knowledge/en/" in p or "/knowledge/ja/" in p or "/knowledge/ko/" in p:
-        return True
-    if "/knowledge/es/" in p or "/knowledge/fr/" in p:
+    if is_translation_path(p):
         return True
     # Hub pages — knowledge/{Category}/_X.md hub pattern
     if os.path.basename(p).startswith("_") and p.endswith(".md"):

--- a/scripts/tools/lib/article_health/checks/paragraph_rhythm.py
+++ b/scripts/tools/lib/article_health/checks/paragraph_rhythm.py
@@ -52,7 +52,7 @@ Rules:
 
 Skipped paths:
   - Hub pages (knowledge/{Category}/_*.md)
-  - Translation files (knowledge/{en,ja,ko,es,fr}/)
+  - Translation files (`knowledge/{registered language}/`)
   - Spore artifacts (docs/factory/SPORE-*)
   - Reports / memory / diary
 
@@ -68,6 +68,7 @@ import re
 from statistics import median
 from typing import Any, Iterator
 
+from ..langs import is_translation_path
 from ..types import FileTarget, Severity, Violation
 
 
@@ -149,7 +150,7 @@ def _is_applicable_path(path: str) -> bool:
     if base.startswith("_"):
         return False
     # Translation files (under knowledge/{lang}/)
-    if re.search(r"(?:^|/)knowledge/(en|ja|ko|es|fr)/", p):
+    if is_translation_path(p):
         return False
     # Only knowledge/ articles (relative or absolute)
     if not re.search(r"(?:^|/)knowledge/", p):
@@ -218,7 +219,7 @@ def _split_paragraphs(section_body: str) -> list[str]:
     Skip:
       - empty lines (used as paragraph delimiters)
       - blockquote-only paragraphs (start with `>` — usually callout meta)
-      - bullet-list paragraphs (start with `- ` or `* ` or `\d.`)
+      - bullet-list paragraphs (start with `- ` or `* ` or `\\d.`)
       - HTML-only paragraphs (iframe div wrappers)
       - heading-like lines (`##`, `###`)
       - italic caption lines `_..._`

--- a/scripts/tools/lib/article_health/langs.py
+++ b/scripts/tools/lib/article_health/langs.py
@@ -32,7 +32,7 @@ _REGISTRY = REPO / "src" / "config" / "languages.mjs"
 
 #: registry 讀不到時的保底清單（2026-07-18 出生戰役當下的既知語言）。
 #: 只有在 checkout 不完整之類的情況才會用到，且會 warn 一次，不靜默。
-_FALLBACK = ("en", "ja", "ko", "es", "fr", "vi", "id", "pt", "hi")
+_FALLBACK = ("en", "ja", "ko", "es", "fr", "vi", "id", "pt", "hi", "ar", "ru")
 
 #: registry 讀得到卻 parse 出比這更少 → 格式改了，當場叫，不靜默沿用舊清單
 #: （對齊 lang-sync/langs.py 的 fail-loud selftest，REFLEXES #65 儀器自身要 cross-verify）。

--- a/scripts/tools/monitor-404.py
+++ b/scripts/tools/monitor-404.py
@@ -57,6 +57,9 @@ from importlib import import_module
 fc = import_module("fetch-cloudflare")
 
 REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts/tools/lang-sync"))
+from langs import ENABLED_TRANSLATION_LANGS  # noqa: E402
+
 KNOWLEDGE_DIR = REPO / "knowledge"
 LANG_SWITCH_MAP_PATH = REPO / "public/api/lang-switch-map.json"
 STATE_DIR = REPO / "reports/404-monitor"
@@ -67,7 +70,7 @@ MAX_STATE_DAYS = 60
 TOP_PATHS_LIMIT = 300
 CF_ROW_LIMIT = 10000
 
-LANGS = ["en", "ja", "ko", "es", "fr"]
+LANGS = list(ENABLED_TRANSLATION_LANGS)
 
 # 抄自 scripts/core/generate-lang-switch-map.mjs 的 CATEGORY_FOLDER_TO_SLUG
 # （同一份對照表，不可跟原檔 drift）。
@@ -81,6 +84,7 @@ CATEGORY_FOLDER_TO_SLUG = {
     "Technology": "technology",
     "Nature": "nature",
     "People": "people",
+    "Politics": "politics",
     "Society": "society",
     "Economy": "economy",
     "Lifestyle": "lifestyle",
@@ -105,7 +109,8 @@ MISSING_ASSET_RE = re.compile(r"^/(assets|images|img|fonts)/")
 MD_EXT_RE = re.compile(r"\.md$")
 WELLKNOWN_RE = re.compile(r"^/(cdn-cgi|\.well-known)/")
 BAD_PCT_RE = re.compile(r"%(?![0-9A-Fa-f]{2})")
-LANG_PREFIX_RE = re.compile(r"^/(en|ja|ko|es|fr)(/.*)?$")
+_LANG_PREFIXES = "|".join(re.escape(lang) for lang in LANGS)
+LANG_PREFIX_RE = re.compile(rf"^/({_LANG_PREFIXES})(/.*)?$")
 BOT_UA_RE = re.compile(
     r"bot|crawl|spider|curl|python|scan|go-http|java|okhttp", re.IGNORECASE
 )

--- a/scripts/tools/review-pr.sh
+++ b/scripts/tools/review-pr.sh
@@ -1,15 +1,21 @@
 #!/usr/bin/env bash
 # review-pr.sh v1.1 — Taiwan.md PR 自動審核（五層免疫系統）
-# 用法: bash scripts/review-pr.sh file1.md file2.md ...
-# 或:   bash scripts/review-pr.sh --pr 123
+# 用法: bash scripts/tools/review-pr.sh file1.md file2.md ...
+# 或:   bash scripts/tools/review-pr.sh --pr 123
 set -uo pipefail
 cd "$(dirname "$0")/../.."
 
 RED='\033[0;31m'; YEL='\033[0;33m'; GRN='\033[0;32m'
 BLU='\033[0;34m'; DIM='\033[0;90m'; RST='\033[0m'
 
-VALID_CATS=("About" "History" "Geography" "Culture" "Food" "Art" "Music" "Technology" "Nature" "People" "Society" "Economy" "Lifestyle")
-LOCALES=("en" "es" "ja" "ko" "fr" "de" "vi" "pt" "th" "id" "ar")
+VALID_CATS=()
+for category_dir in knowledge/[A-Z]*; do
+  [[ -d "$category_dir" ]] && VALID_CATS+=("${category_dir##*/}")
+done
+LOCALE_PATTERN=$(node --input-type=module -e "import { ALL_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ALL_LANGUAGE_CODES.filter((code) => code !== 'zh-TW').join('|'))") || {
+  echo "❌ 無法從 src/config/languages.mjs 讀取語言清單" >&2
+  exit 1
+}
 SIMP_PAT='关|为|国|会|发|时|过|来|说|经|间|现|业|务|样|门|问|产|从|进|设|张|总|给|应|数|开|场|变|团|员|电|话|传|统|级|项|节|历'
 
 TOTAL=0; L0=0; L1=0; L2=0; L3=0
@@ -18,10 +24,7 @@ REPORT=""
 
 is_locale() {
   local part="$1"
-  for v in "${LOCALES[@]}"; do
-    [[ "$part" == "$v" ]] && return 0
-  done
-  return 1
+  [[ "$part" =~ ^($LOCALE_PATTERN)$ ]]
 }
 
 is_translation_path() {
@@ -97,7 +100,9 @@ layer1() {
     echo "$fm" | grep -q '^date:' || err+=("缺 date")
     echo "$fm" | grep -q '^tags:' || err+=("缺 tags")
     # featured: true rule — only enforced on ZH SSOT; translations mirror source
-    if ! is_translation_path "$f"; then
+    if is_translation_path "$f"; then
+      echo "$fm" | grep -q '^translatedFrom:' || err+=("缺 translatedFrom")
+    else
       echo "$fm" | grep -q '^featured: true' && err+=("featured 不可 true")
     fi
     # category from path

--- a/scripts/tools/terminology-prose-fix.py
+++ b/scripts/tools/terminology-prose-fix.py
@@ -7,6 +7,7 @@ Taiwan.md 用語全站修正：A 類中國用語 → 台灣用語
 
 import os
 import re
+import sys
 from pathlib import Path
 from collections import defaultdict
 
@@ -16,6 +17,8 @@ from collections import defaultdict
 
 # BASE_DIR derives from script location (was hardcoded, fixed 2026-05-04 audit O5).
 BASE_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(BASE_DIR / "scripts" / "tools"))
+from lib.article_health.langs import TRANSLATION_LANGS  # noqa: E402
 
 SCAN_DIRS = [
     BASE_DIR / "knowledge",
@@ -31,7 +34,7 @@ EXCLUDE_PATHS = {
 }
 
 # 排除翻譯目錄（在 knowledge/ 底下）
-EXCLUDE_SUBDIRS = {"en", "es", "ja"}
+EXCLUDE_SUBDIRS = set(TRANSLATION_LANGS)
 
 # ──────────────────────────────────────────────
 # A 類替換：直接替換，無語境判斷
@@ -88,7 +91,7 @@ def is_excluded(path: Path) -> bool:
 
 
 def is_in_translation_subdir(path: Path) -> bool:
-    """檢查是否在 en/es/ja 翻譯子目錄"""
+    """檢查是否在已註冊的翻譯子目錄。"""
     parts = path.parts
     for excl in EXCLUDE_SUBDIRS:
         if excl in parts:

--- a/scripts/tools/update-stats.sh
+++ b/scripts/tools/update-stats.sh
@@ -32,38 +32,67 @@ FORKS=$(python3 -c "import json;print(json.load(open('public/api/dashboard-vital
 # 2026-06-13: was .all-contributorsrc (manual, a month stale at 57). contributors.json
 # .totals.contributors is the live committer count; fall back to the rc file → 30.
 CONTRIBUTORS=$(python3 -c "import json;print(json.load(open('public/api/contributors.json'))['totals']['contributors'])" 2>/dev/null || grep -c '"login"' .all-contributorsrc 2>/dev/null || echo 30)
-# 各語言精確文章數（zh = 大寫分類目錄無 lang prefix；其他 = knowledge/{lang}/）。
+# 各語言精確文章數（zh = 大寫分類目錄無 lang prefix；其他從 language registry 迭代）。
 # 舊版 ZH_PAGES 用 `! -path '*/en/*'` 把 ja/ko/es/fr 全算進 zh（3977 假數）— 修正。
 ZH_PAGES=$(find knowledge -maxdepth 2 -name '*.md' ! -name '_*' -regex 'knowledge/[A-Z][a-zA-Z]*/.*' | wc -l | tr -d ' ')
-EN_PAGES=$(find knowledge/en -name '*.md' ! -name '_*' 2>/dev/null | wc -l | tr -d ' ')
-JA_PAGES=$(find knowledge/ja -name '*.md' ! -name '_*' 2>/dev/null | wc -l | tr -d ' ')
-KO_PAGES=$(find knowledge/ko -name '*.md' ! -name '_*' 2>/dev/null | wc -l | tr -d ' ')
-ES_PAGES=$(find knowledge/es -name '*.md' ! -name '_*' 2>/dev/null | wc -l | tr -d ' ')
-FR_PAGES=$(find knowledge/fr -name '*.md' ! -name '_*' 2>/dev/null | wc -l | tr -d ' ')
+CAT_COUNT=$(find knowledge -maxdepth 1 -type d -regex 'knowledge/[A-Z][a-zA-Z]*' | wc -l | tr -d ' ')
+LANGUAGE_STATS_JSON=$(node --input-type=module <<'NODEEOF'
+import fs from 'node:fs';
+import path from 'node:path';
+import { LANGUAGES } from './src/config/languages.mjs';
+
+function countArticles(root) {
+  if (!fs.existsSync(root)) return 0;
+  let count = 0;
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const child = path.join(root, entry.name);
+    if (entry.isDirectory()) count += countArticles(child);
+    else if (entry.name.endsWith('.md') && !entry.name.startsWith('_')) count += 1;
+  }
+  return count;
+}
+
+const rows = LANGUAGES
+  .filter((language) => language.enabled && !language.isDefault)
+  .map(({ code, displayName }) => ({
+    code,
+    displayName,
+    count: countArticles(path.join('knowledge', code)),
+  }));
+process.stdout.write(JSON.stringify(rows));
+NODEEOF
+)
 TOTAL_PAGES=$ZH_PAGES
 # 近 7/30 天新文章：dashboard-vitals.json（routine 算好），fallback 0
 D7=$(python3 -c "import json;print(json.load(open('public/api/dashboard-vitals.json')).get('articlesLast7Days',0))" 2>/dev/null || echo 0)
 D30=$(python3 -c "import json;print(json.load(open('public/api/dashboard-vitals.json')).get('articlesLast30Days',0))" 2>/dev/null || echo 0)
 
 echo "Stars: $STARS | Forks: $FORKS | Contributors: $CONTRIBUTORS"
-echo "zh:$ZH_PAGES en:$EN_PAGES ja:$JA_PAGES ko:$KO_PAGES es:$ES_PAGES fr:$FR_PAGES | 7d:$D7 30d:$D30"
+echo "zh-TW:$ZH_PAGES translations:$LANGUAGE_STATS_JSON | 7d:$D7 30d:$D30"
 
 # 2. Regenerate README stats table between STATS:START/END markers.
 # 2026-06-13: full-block regen replaces the old per-row sed, which had drifted
 # off README's row names (only Contributors still matched → whole table sat
 # stale). Markers make it row-name-agnostic — robust against future renames.
-python3 - "$ZH_PAGES" "$EN_PAGES" "$JA_PAGES" "$KO_PAGES" "$ES_PAGES" "$FR_PAGES" "$CONTRIBUTORS" "$STARS" "$FORKS" "$D7" "$D30" <<'PYEOF'
-import sys, re
-zh, en, ja, ko, es, fr, contrib, stars, forks, d7, d30 = sys.argv[1:12]
+python3 - "$ZH_PAGES" "$LANGUAGE_STATS_JSON" "$CAT_COUNT" "$CONTRIBUTORS" "$STARS" "$FORKS" "$D7" "$D30" <<'PYEOF'
+import json
+import re
+import sys
+
+zh, language_stats_json, cats, contrib, stars, forks, d7, d30 = sys.argv[1:9]
+language_stats = json.loads(language_stats_json)
+flags = {
+    "en": "🇺🇸", "ja": "🇯🇵", "ko": "🇰🇷", "es": "🇪🇸", "fr": "🇫🇷",
+    "vi": "🇻🇳", "id": "🇮🇩", "pt": "🇵🇹", "hi": "🇮🇳", "ar": "🇸🇦", "ru": "🇷🇺",
+}
 rows = [
     ("📄 Total articles (zh-TW SSOT)", zh),
     ("🇹🇼 Chinese (zh-TW)", zh),
-    ("🇺🇸 English (en)", en),
-    ("🇯🇵 日本語 (ja)", ja),
-    ("🇰🇷 한국어 (ko)", ko),
-    ("🇪🇸 Español (es)", es),
-    ("🇫🇷 Français (fr)", fr),
-    ("📂 Categories", "14"),
+    *[
+        (f"{flags.get(item['code'], '🌐')} {item['displayName']} ({item['code']})", item["count"])
+        for item in language_stats
+    ],
+    ("📂 Categories", cats),
     ("🕸️ Knowledge graph nodes", "220+"),
     ("🔗 Resource websites", "146+"),
     ("👥 Contributors", contrib),
@@ -153,9 +182,7 @@ sedi "s/'about.stats.contributors.number': '[^']*'/'about.stats.contributors.num
 # README Features 行曾停在 793、SEO.astro 752、home.ts 750（實際 828）——這些
 # marketing prose 不在 STATS 標記內，從未被本 script 接管。root cure = 接管，
 # 不是一次性改數字（改完還是會腐）。counts-drift-lint.py 對賬這些位置。
-LANG_DIRS=$(find knowledge -maxdepth 1 -type d -regex 'knowledge/[a-z][a-z]' | wc -l | tr -d ' ')
-LANG_COUNT=$((LANG_DIRS + 1)) # + zh-TW SSOT
-CAT_COUNT=$(find knowledge -maxdepth 1 -type d -regex 'knowledge/[A-Z][a-zA-Z]*' | wc -l | tr -d ' ')
+LANG_COUNT=$(node --input-type=module -e "import { ENABLED_LANGUAGE_CODES } from './src/config/languages.mjs'; console.log(ENABLED_LANGUAGE_CODES.length)")
 PROJECTED=$((TOTAL_PAGES * LANG_COUNT))
 python3 - "$TOTAL_PAGES" "$CAT_COUNT" "$LANG_COUNT" "$PROJECTED" <<'PYEOF'
 import re, sys
@@ -193,8 +220,12 @@ PYEOF
 # 4. Merge GitHub stats into public/api/stats.json (preserve existing fields!)
 # stats.json is primarily generated by generate-content-stats.js with rich data
 # (categories, tags, etc). We only update the GitHub-sourced fields here.
-python3 << PYEOF
-import json, os
+python3 - "$STARS" "$FORKS" "$CONTRIBUTORS" "$ZH_PAGES" "$TOTAL_PAGES" "$LANGUAGE_STATS_JSON" <<'PYEOF'
+import json
+import os
+import sys
+
+stars, forks, contributors, zh_pages, total_pages, language_stats_json = sys.argv[1:7]
 stats_path = 'public/api/stats.json'
 if os.path.exists(stats_path):
     with open(stats_path) as f:
@@ -202,12 +233,15 @@ if os.path.exists(stats_path):
 else:
     stats = {}
 # Only update GitHub-sourced fields, preserve everything else
-stats['stars'] = $STARS
-stats['forks'] = $FORKS
-stats['estimatedContributors'] = $CONTRIBUTORS
-stats['zhPages'] = $ZH_PAGES
-stats['enPages'] = $EN_PAGES
-stats['totalPages'] = $TOTAL_PAGES
+stats['stars'] = int(stars)
+stats['forks'] = int(forks)
+stats['estimatedContributors'] = int(contributors)
+stats['zhPages'] = int(zh_pages)
+language_stats = json.loads(language_stats_json)
+language_pages = {'zh-TW': int(zh_pages), **{row['code']: row['count'] for row in language_stats}}
+stats['languagePages'] = language_pages
+stats['enPages'] = language_pages.get('en', 0)
+stats['totalPages'] = int(total_pages)
 with open(stats_path, 'w') as f:
     json.dump(stats, f, indent=2, ensure_ascii=False)
 print("✅ stats.json merged (preserved existing fields)")

--- a/src/pages/hi/[category]/[slug].astro
+++ b/src/pages/hi/[category]/[slug].astro
@@ -84,7 +84,7 @@ export async function getStaticPaths() {
     } catch {}
   }
   if (paths.length === 0) {
-    throw new Error('[es getStaticPaths] Generated 0 paths.');
+    throw new Error('[hi getStaticPaths] Generated 0 paths.');
   }
   return paths;
 }

--- a/src/pages/id/[category]/[slug].astro
+++ b/src/pages/id/[category]/[slug].astro
@@ -84,7 +84,7 @@ export async function getStaticPaths() {
     } catch {}
   }
   if (paths.length === 0) {
-    throw new Error('[es getStaticPaths] Generated 0 paths.');
+    throw new Error('[id getStaticPaths] Generated 0 paths.');
   }
   return paths;
 }

--- a/src/pages/pt/[category]/[slug].astro
+++ b/src/pages/pt/[category]/[slug].astro
@@ -84,7 +84,7 @@ export async function getStaticPaths() {
     } catch {}
   }
   if (paths.length === 0) {
-    throw new Error('[es getStaticPaths] Generated 0 paths.');
+    throw new Error('[pt getStaticPaths] Generated 0 paths.');
   }
   return paths;
 }

--- a/src/pages/vi/[category]/[slug].astro
+++ b/src/pages/vi/[category]/[slug].astro
@@ -84,7 +84,7 @@ export async function getStaticPaths() {
     } catch {}
   }
   if (paths.length === 0) {
-    throw new Error('[es getStaticPaths] Generated 0 paths.');
+    throw new Error('[vi getStaticPaths] Generated 0 paths.');
   }
   return paths;
 }

--- a/tests/article_health/test_langs_ssot.py
+++ b/tests/article_health/test_langs_ssot.py
@@ -17,6 +17,7 @@ from lib.article_health.checks import (
     cross_reference,
     image_health,
     link_target,
+    paragraph_rhythm,
     wikilink_target,
 )
 from lib.article_health import langs as langs_mod
@@ -184,3 +185,11 @@ def test_translations_skip_the_media_count_gate():
     assert not image_health._is_excluded_from_count_gate(
         "knowledge/Technology/台積電.md"
     )
+
+
+def test_translations_skip_paragraph_rhythm():
+    for lang in TRANSLATION_LANGS:
+        assert not paragraph_rhythm._is_applicable_path(
+            f"knowledge/{lang}/Technology/tsmc.md"
+        )
+    assert paragraph_rhythm._is_applicable_path("knowledge/Technology/台積電.md")

--- a/tests/article_health/test_language_contributor_surfaces.py
+++ b/tests/article_health/test_language_contributor_surfaces.py
@@ -1,0 +1,79 @@
+"""Contributor-facing language lists must follow the enabled registry."""
+
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REGISTRY = REPO_ROOT / "src" / "config" / "languages.mjs"
+
+
+def _enabled_translation_codes() -> set[str]:
+    text = REGISTRY.read_text(encoding="utf-8")
+    entries = re.findall(r"\{\s*code:\s*'([\w-]+)'.*?enabled:\s*(true|false)", text, re.S)
+    return {code for code, enabled in entries if enabled == "true" and code != "zh-TW"}
+
+
+def test_translation_workflow_paths_match_enabled_registry():
+    text = (REPO_ROOT / ".github" / "workflows" / "translation-check.yml").read_text(
+        encoding="utf-8"
+    )
+    paths = set(re.findall(r"knowledge/([a-z]{2})/\*\*", text))
+    assert paths == _enabled_translation_codes()
+
+
+def test_translation_submission_options_match_enabled_registry():
+    text = (REPO_ROOT / ".github" / "ISSUE_TEMPLATE" / "translation.yml").read_text(
+        encoding="utf-8"
+    )
+    options = set(re.findall(r"^\s+- .*\(([a-z]{2})\)$", text, re.M))
+    assert options == _enabled_translation_codes()
+
+
+def test_i18n_page_triggers_match_enabled_registry():
+    text = (REPO_ROOT / ".github" / "workflows" / "i18n-smoke-test.yml").read_text(
+        encoding="utf-8"
+    )
+    paths = set(re.findall(r"src/pages/([a-z]{2})/\*\*", text))
+    assert paths == _enabled_translation_codes()
+
+
+def test_language_registry_mirrors_match_every_field():
+    result = subprocess.run(
+        ["node", "scripts/tools/compare-language-registries.mjs"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_current_build_and_review_tools_use_the_language_registry():
+    expected_imports = {
+        "scripts/core/test-frontmatter.mjs": "ALL_LANGUAGE_CODES",
+        "scripts/core/build-latest.mjs": "ENABLED_LANGUAGE_CODES",
+        "scripts/core/generate-contributors-data.js": "ALL_LANGUAGE_CODES",
+        "scripts/tools/generate-dashboard-analytics.py": "ENABLED_TRANSLATION_LANGS",
+        "scripts/tools/monitor-404.py": "ENABLED_TRANSLATION_LANGS",
+        "scripts/tools/check-slug-consistency.py": "ALL_TRANSLATION_LANGS",
+        "scripts/tools/review-pr.sh": "ALL_LANGUAGE_CODES",
+        "scripts/tools/bulk-pr-analyze.sh": "ALL_LANGUAGE_CODES",
+        "scripts/tools/terminology-prose-fix.py": "TRANSLATION_LANGS",
+        "scripts/tools/lang-sync/sync-on-update.py": "ENABLED_TRANSLATION_LANGS",
+        "scripts/tools/lang-sync/prioritize-batch.py": "ALL_TRANSLATION_LANGS",
+        ".husky/pre-commit": "ALL_LANGUAGE_CODES",
+        ".github/workflows/pr-review.yml": "ALL_LANGUAGE_CODES",
+    }
+    for relative_path, symbol in expected_imports.items():
+        source = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+        assert symbol in source, f"{relative_path} 未使用語言 registry 的 {symbol}"
+
+
+def test_localized_article_route_errors_name_the_right_language():
+    for code in _enabled_translation_codes():
+        route = REPO_ROOT / "src" / "pages" / code / "[category]" / "[slug].astro"
+        assert route.exists(), f"缺少 {code} article route"
+        source = route.read_text(encoding="utf-8")
+        assert f"[{code} getStaticPaths]" in source


### PR DESCRIPTION
## What changed

- Derive language sets from `src/config/languages` across current build, review, monitoring, statistics, and pre-commit surfaces instead of maintaining separate hardcoded lists.
- Compare every field in the TypeScript and JavaScript language registries, not only their language codes.
- Add regression tests for translation workflows, the submission form, localized routes, and tools that consume the registry.
- Add the enabled `ar` and `ru` languages to contributor-facing checks and correct mislabeled route diagnostics for `hi`, `id`, `pt`, and `vi`.

## Why

The registry is intended to be the source of truth, but several tools and workflows kept their own language subsets. Those copies had drifted: newly enabled languages were absent from some contributor paths, and the existing sync check could not detect field-level differences between the two registry files.

## Impact

Translation contributors can select and validate every enabled language. Future registry changes will fail a focused test if a build, review, or submission surface falls out of sync.

## Checks

- Focused Python tests: `42 passed, 1 skipped`
- `bash scripts/tools/check-language-registry-sync.sh` — 12 registry entries and all `VIZ_STRINGS` entries in sync
- `node --check scripts/tools/compare-language-registries.mjs`
- `git diff --check`
