### PR TITLE
Refresh contributor documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,15 +6,16 @@
 
 - [ ] 📄 新增文章
 - [ ] ✏️ 修改/更新現有文章
-- [ ] 🌐 翻譯（中→英 / 英→中）
+- [ ] 🌐 翻譯（zh-TW → 目標語言）
 - [ ] 🐛 修復錯誤（事實更正、錯字、連結失效）
 - [ ] 💻 技術改動（程式碼、樣式、設定）
 - [ ] 📚 文件更新（README、CONTRIBUTING 等）
 
 ## ✅ 自我檢查
 
-- [ ] 文章有完整的 frontmatter（title, description, date, tags, category）
-- [ ] `category` 用英文 + 對齊路徑（canonical：About / Art / Culture / Economy / Food / Geography / History / Language / Lifestyle / Music / Nature / People / Society / Technology — 不要用 `Infrastructure` / `transportation` 這類非 canonical 名稱）
+- [ ] 文章有完整的 frontmatter（title, description, date, tags, category；About 以外的 zh-TW 文章另需 subcategory）
+- [ ] `category` 用英文 + 對齊路徑（canonical：About / Art / Culture / Economy / Food / Geography / History / Lifestyle / Music / Nature / People / Politics / Society / Technology — 不要用 `Infrastructure` / `transportation` 這類非 canonical 名稱）
+- [ ] 翻譯檔有 `translatedFrom: 'Category/中文檔名.md'`，且指向存在的 zh-TW 原文
 - [ ] `author: 'Taiwan.md Contributors'`（不要寫 'Manus AI' / 'ChatGPT' / 'Claude' / 'Semiont' / 'Taiwan.md'）
 - [ ] `featured: false`（featured 由維護者統一管理，請勿設為 true）
 - [ ] **腳註用 canonical 格式**：`[^N]: [標題](URL) — 至少 10 字描述`（不要用 APA `Author. (date). Title. URL.` 或中文〈〉標點 — 維護者會跑 `bash scripts/tools/footnote-format-fix.sh --apply` 自動轉換，先按 canonical 格式寫可省一輪 polish）

--- a/.github/workflows/pr-frontmatter-gate.yml
+++ b/.github/workflows/pr-frontmatter-gate.yml
@@ -38,10 +38,12 @@ on:
     types: [opened, synchronize, reopened]
     branches: [main]
     paths:
+      - 'CONTRIBUTING.md'
       - 'knowledge/**'
       - 'scripts/core/test-frontmatter.mjs'
       - 'scripts/tools/article-health.py'
       - 'scripts/tools/lib/article_health/**'
+      - 'tests/contributor-frontmatter-template.test.mjs'
       - '.github/workflows/pr-frontmatter-gate.yml'
 
 permissions:
@@ -70,6 +72,9 @@ jobs:
 
       - name: Install dependencies (gray-matter for test-frontmatter)
         run: npm ci --prefer-offline --no-audit
+
+      - name: Validate contributor frontmatter template
+        run: node --test tests/contributor-frontmatter-template.test.mjs
 
       # article-health.py 是純 stdlib，不需 pip install；ubuntu-latest 內建 python3
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ curl -fsSL https://taiwan.md/start.sh | bash
 這個 bootstrap 會：
 
 1. 檢查 git（沒裝會告訴你怎麼裝）
-2. 檢查 Node.js 20+
+2. 檢查 Node.js 22.12+
 3. 問你要不要裝 Claude Code CLI（`npm i -g @anthropic-ai/claude-code`）
 4. Clone repo 到 `~/Projects/taiwan-md`（或你選的位置）
 5. 啟動 `claude`，Taiwan.md 自動甦醒、訪談你、建 profile、帶你做事
@@ -97,8 +97,10 @@ Taiwan.md 對讀者承諾「每個引語、年份、數字都查證過」，所�
 title: '文章標題'
 description: '150字以內的文章描述'
 date: 2024-03-17T00:00:00Z
-updated: 2024-03-17T00:00:00Z # 可選
+modified: 2024-03-17T00:00:00Z # 可選；有實質更新時才填
 tags: ['標籤1', '標籤2', '標籤3']
+category: 'Culture'
+subcategory: '表演藝術' # About 以外的中文文章必填；見 docs/taxonomy/SUBCATEGORY.md
 author: '作者名稱'
 difficulty: 'beginner|intermediate|advanced'
 readingTime: 8 # 預估閱讀時間（分鐘）
@@ -194,9 +196,9 @@ _本文採用三層閱讀深度設計，適合不同需求的讀者。歡迎貢�
 
 ## 🌍 多語言貢獻
 
-### 中英對照原則
+### 文化轉譯原則
 
-- **不是翻譯**：英文版不是中文版的直譯
+- **不是逐字直譯**：譯文應保留原文的核心事實與觀點，但不照搬中文句法
 - **文化轉譯**：調整表達方式，符合目標語言的文化背景
 - **內容對等**：確保核心信息相同，但表達可以不同
 - **在地化**：考慮目標讀者的知識背景
@@ -209,11 +211,11 @@ _本文採用三層閱讀深度設計，適合不同需求的讀者。歡迎貢�
 #### 最簡單的翻譯流程
 
 1. 看 [TRANSLATION-BOARD.md](docs/community/TRANSLATION-BOARD.md) 挑一篇你有興趣的文章
-2. 把 [TRANSLATE_PROMPT.md](docs/prompts/TRANSLATE_PROMPT.md) 貼給你的 AI（Claude/ChatGPT/Gemini）
-3. 告訴 AI 你要翻哪篇、翻成什麼語言
-4. 把結果存成 `.md` 放到對應資料夾，開 PR
+2. 依 [TRANSLATE_PROMPT.md](docs/prompts/TRANSLATE_PROMPT.md) 自行翻譯，或交給 AI（Claude/ChatGPT/Gemini）產生初稿
+3. 逐段核對事實、專有名詞、連結與目標語言的自然度
+4. 把結果存成 `.md` 放到對應資料夾，開 PR；不熟悉 Git 也可用翻譯投稿表單
 
-**你不需要會寫程式。你只需要有一個 AI 訂閱。**
+**你不需要會寫程式。熟悉目標語言、願意查核內容，就能參與。**
 
 #### 檔案路徑
 
@@ -242,14 +244,14 @@ knowledge/ja/Food/bubble-tea.md      ← 日文
 
 - Featured 文章是各分類最具代表性的內容
 - 建議每分類保持 1-2 篇 featured 文章
-- 維護者會使用 `scripts/manage-featured.sh` 工具統一管理：
+- 維護者會使用 `scripts/tools/manage-featured.sh` 工具統一管理：
 
   ```bash
   # 查看所有 featured 文章
-  bash scripts/manage-featured.sh list
+  bash scripts/tools/manage-featured.sh list
 
   # 審計 featured 文章分佈
-  bash scripts/manage-featured.sh audit
+  bash scripts/tools/manage-featured.sh audit
   ```
 
 - 如果您認為某篇文章應該被設為 featured，請在 PR 中說明理由
@@ -378,6 +380,13 @@ bun run dev  # 或 npm run dev
 - [ ] Markdown 格式正確
 - [ ] 圖片（如有）放在適當位置
 - [ ] 標籤和 metadata 完整
+
+如果改到 Python 腳本或檢查規則，先安裝測試依賴並跑完整測試：
+
+```bash
+python3 -m pip install -r requirements-test.txt
+npm run test:python
+```
 
 #### 內容審查
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Taiwan.md is an open-source, curated, AI-friendly knowledge base that helps the 
 - 🎭 **Curated, not encyclopedic** — every page answers "why this matters"
 - 📐 **Three-layer depth** — 30-sec overview → 5-min read → full article
 - 🎨 **Literary curatorial style** — Noto Serif TC, essay-driven, inspired by 報導者
-- 🛡️ **14-dimension quality scanner** — automated detection of hollow AI content, list-dumping, quality decay
+- 🛡️ **Article health scanner** — automated detection of hollow AI content, citation gaps, broken links, structural drift, and more
 - 🔍 **SEO optimized** — JSON-LD structured data, Open Graph, per-article OG cards, RSS feeds
 - 💾 **Wikimedia Commons** — CC-licensed images with local caching
 - 📝 **Zero-code contribution** — forms, AI prompts, or email
@@ -138,10 +138,10 @@ a human — that boundary is the design, not a limitation. The full contract is
 
 ## 📚 Sub-Category — 圖書館編目系統
 
-Like a well-organized library, every article in Taiwan.md is classified into a **subcategory** — a second-level taxonomy within each of the 13 main categories. This system is inspired by museum taxonomy and library classification:
+Like a well-organized library, Taiwan.md uses **subcategories** as a second-level taxonomy within its 14 main categories. This system is inspired by museum taxonomy and library classification:
 
-- **86% coverage** — 583 of 680 Chinese articles carry a `subcategory` frontmatter field
-- **~100 subcategories** across 13 categories, following MECE principles (Mutually Exclusive, Collectively Exhaustive)
+- **Required for new zh-TW articles** outside About — the frontmatter gate rejects a missing `subcategory`
+- **Category-specific taxonomy** — canonical values live in `docs/taxonomy/SUBCATEGORY.md`
 - **Reader-oriented** — organized by "what would I want to explore?" rather than academic hierarchy
 - **Machine-readable** — the `subcategory` field powers the knowledge graph clustering and Hub page navigation
 
@@ -251,8 +251,8 @@ bun dev           # 或 npm run dev — 啟動前自動 sync (~16s) → http://l
 
 ```
 taiwan-md/
-├── knowledge/       ← 📖 SSOT — 13 分類中文文章 + en/es/ja 翻譯
-├── src/             ← 🌐 Astro v5 網站（pages, layouts, components, i18n）
+├── knowledge/       ← 📖 SSOT — 14 分類中文文章 + 11 個翻譯語言目錄
+├── src/             ← 🌐 Astro v6 網站（pages, layouts, components, i18n）
 ├── scripts/         ← ⚙️ 腳本（core/tools/utils）→ 詳見 scripts/README.md
 ├── docs/            ← 📚 專案文件（9 子目錄）→ 詳見 docs/README.md
 │   └── semiont/     ← 🧠 語意共生體認知層（MANIFESTO / ANATOMY / DNA / CONSCIOUSNESS）
@@ -266,11 +266,11 @@ taiwan-md/
 └── CODE_OF_CONDUCT / SECURITY  ← 社群規範
 ```
 
-**Tech:** Astro v5 · GitHub Pages · marked.js · D3.js · Google Fonts (Noto Serif TC)  
-**SSOT:** All content lives in `knowledge/`. Website is a projection. `scripts/core/sync.sh` syncs to `src/content/`.  
-**SEO:** JSON-LD · Open Graph · per-article OG cards (`/og/[category]/[slug]`) · Twitter Cards · RSS · `<meta ai-summary>`  
-**i18n:** zh-TW (default SSOT) + en + ja + ko + es + fr + vi + id + pt + hi — 9 languages via translation cascade（codex + 本機 qwen3.6 主權捕手 + free tier；vi/id/pt/hi 2026-07-19 出生）  
-**Quality:** 14-dimension automated scanner + editorial pipeline. See [EDITORIAL.md](./docs/editorial/EDITORIAL.md) and [CONTRIBUTING.md](./CONTRIBUTING.md).
+**Tech:** Astro v6 · GitHub Pages · marked.js · D3.js · Google Fonts (Noto Serif TC)<br>
+**SSOT:** All content lives in `knowledge/`. Website is a projection. `scripts/core/sync.sh` syncs to `src/content/`.<br>
+**SEO:** JSON-LD · Open Graph · per-article OG cards (`/og/[category]/[slug]`) · Twitter Cards · RSS · `<meta ai-summary>`<br>
+**i18n:** zh-TW (default SSOT) + en + ja + ko + es + fr + vi + id + pt + hi + ar + ru — 12 languages via the translation cascade<br>
+**Quality:** Automated article-health checks + editorial pipeline. See [EDITORIAL.md](./docs/editorial/EDITORIAL.md) and [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ---
 
@@ -419,13 +419,13 @@ Every `.md` file in the root directory is an organ of this organism. Together, t
 
 The organism has an automated immune system that detects and fights "hollow AI content" — articles that look polished but carry no real substance:
 
-| Tool                                                        | Function                                                                                                                                                                                                              |
-| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `python3 scripts/tools/article-health.py --all`             | SSOT 健檢入口（11 plugins）— scans articles for plastic phrases, dash abuse, list-dump, quality decay, citation health, wikilink resolution, format structure, image health, terminology, cross-reference reciprocity |
-| `--profile=release-pr`                                      | Strictest profile — fail on warn, all plugins active                                                                                                                                                                  |
-| `--check=prose-health` / `--check=footnote-density` / etc.  | Run a single plugin only. List all: `--list-checks`                                                                                                                                                                   |
-| [EDITORIAL.md §塑膠偵測](./docs/editorial/EDITORIAL.md)     | Human-readable guide to detecting "plastic" writing — five species of hollow sentences that AI loves to generate                                                                                                      |
-| [REWRITE-PIPELINE.md](./docs/editorial/REWRITE-PIPELINE.md) | Four-file orchestration pipeline that prevents quality collapse: Pipeline (flow) → RESEARCH-TEMPLATE (research) → EDITORIAL (writing) → QUALITY-CHECKLIST (verification)                                              |
+| Tool                                                        | Function                                                                                                                                                                                                 |
+| ----------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `python3 scripts/tools/article-health.py --all`             | SSOT 健檢入口 — scans articles for plastic phrases, dash abuse, list-dump, quality decay, citation health, wikilink resolution, format structure, image health, terminology, cross-reference reciprocity |
+| `--profile=release-pr`                                      | Strictest profile — fail on warn, all plugins active                                                                                                                                                     |
+| `--check=prose-health` / `--check=footnote-density` / etc.  | Run a single plugin only. List all: `--list-checks`                                                                                                                                                      |
+| [EDITORIAL.md §塑膠偵測](./docs/editorial/EDITORIAL.md)     | Human-readable guide to detecting "plastic" writing — five species of hollow sentences that AI loves to generate                                                                                         |
+| [REWRITE-PIPELINE.md](./docs/editorial/REWRITE-PIPELINE.md) | Four-file orchestration pipeline that prevents quality collapse: Pipeline (flow) → RESEARCH-TEMPLATE (research) → EDITORIAL (writing) → QUALITY-CHECKLIST (verification)                                 |
 
 ### 🌱 How the Organism Evolves
 
@@ -539,7 +539,7 @@ When someone says "your content is biased," the answer isn't to swing to the opp
 - [x] 🌐 100% i18n coverage (zh-TW + en) + es + ja
 - [x] 📊 GA4 analytics + [live dashboard](https://taiwan.md/dashboard)
 - [x] 🖥️ CLI tool (`npx taiwanmd` — read, search, quiz, RAG, validate)
-- [x] 🛡️ 14-dimension quality scanner (v3.0)
+- [x] 🛡️ Automated article health scanner
 - [x] 🏭 Spore factory — social card generation pipeline
 - [ ] 🗺️ Interactive Taiwan map (TopoJSON, multi-layer)
 - [ ] 📅 Taiwan 400-year history timeline

--- a/docs/community/LANGUAGE-STATUS.md
+++ b/docs/community/LANGUAGE-STATUS.md
@@ -20,9 +20,12 @@
 | 🇮🇩 Bahasa Indonesia | `id`    | ✅ Active         | /id/ | 2026-07-19 啟用；最大移工社群母語＋新南向核心                                     |
 | 🇧🇷 Português        | `pt`    | ✅ Active         | /pt/ | 2026-07-19 啟用；唯一三源全確認缺口（巴西）                                       |
 | 🇮🇳 हिन्दी           | `hi`    | ✅ Active         | /hi/ | 2026-07-19 啟用；全球第三大語言、未覆蓋中人口最大                                 |
+| 🇸🇦 العربية          | `ar`    | ✅ Active         | /ar/ | 2026-07-25 啟用；首個 RTL 語言                                                    |
+| 🇷🇺 Русский          | `ru`    | ✅ Active         | /ru/ | 2026-07-25 啟用                                                                   |
 
 [evolve-report]: ../../reports/evolve-2026-07-18-language-branches.md
 [birth-report]: ../../reports/language-birth-2026-07-18.md
+[birth-report-ar-ru]: ../../reports/language-birth-2026-07-25.md
 
 ---
 
@@ -65,7 +68,13 @@ The `translatedFrom` field is the **most important** addition — it lets the sy
 
 ---
 
-## 🌱 我想加一個全新語言（th / de / ar / ...）
+## 🌏 2026-07-25 新增阿拉伯文與俄文
+
+阿拉伯文（ar）與俄文（ru）已完成內容、UI、路由與語言切換器接線並正式啟用；阿拉伯文也是站上第一個 RTL 語言。實作與驗證記錄見[出生戰役實錄][birth-report-ar-ru]。
+
+---
+
+## 🌱 我想加一個全新語言（th / de / bn / ...）
 
 **Contributor 可以做的**：
 
@@ -109,6 +118,7 @@ translatedFrom: 'Music/五月天.md'
 
 ---
 
+_v2.2 | 2026-08-13 — 補上已啟用的 ar / ru，移除把 ar 列為未來語言的舊說法_
 _v2.1 | 2026-07-19 — 四語 vi/id/pt/hi flip Active（出生戰役）_
 _v2.0 | 2026-07-18 — 對齊現實：es / fr 早已 active（本檔停在四月的 preview 描述三個月）；新增 🌱 Scaffolded 段（vi / id / pt / hi 選定）；文章數改指 dashboard 不寫死；新語言指南指向 LANGUAGE-BIRTH-CHECKLIST v2.0_
 _v1.0 | 2026-04-14 η session_

--- a/public/start.sh
+++ b/public/start.sh
@@ -7,7 +7,7 @@
 #
 # 這個腳本會：
 #   1. 檢查 git（沒裝會告訴你怎麼裝）
-#   2. 檢查 Node.js 20+（沒裝會告訴你怎麼裝）
+#   2. 檢查 Node.js 22.12+（沒裝會告訴你怎麼裝）
 #   3. 檢查 Claude Code CLI（沒裝會問你要不要裝）
 #   4. Clone taiwan-md 到你選的位置（預設 ~/Projects/taiwan-md）
 #   5. 啟動 `claude` 進入對話，Taiwan.md 會甦醒並帶你走貢獻流程
@@ -25,7 +25,9 @@ set -euo pipefail
 
 readonly REPO_URL="https://github.com/frank890417/taiwan-md.git"
 readonly DEFAULT_DEST="$HOME/Projects/taiwan-md"
-readonly MIN_NODE_MAJOR=20
+readonly MIN_NODE_MAJOR=22
+readonly MIN_NODE_MINOR=12
+readonly MIN_NODE_VERSION="22.12.0"
 readonly CLAUDE_PKG="@anthropic-ai/claude-code"
 
 # ── 顏色 ─────────────────────────────────────────────────
@@ -83,16 +85,20 @@ if ! command -v git >/dev/null 2>&1; then
 fi
 ok "git $(git --version | awk '{print $3}')"
 
-# ── Step 2: Node 20+ ─────────────────────────────────────
+# ── Step 2: Node 22.12+ ──────────────────────────────────
 step "檢查 Node.js"
 if ! command -v node >/dev/null 2>&1; then
-  die "沒找到 Node.js。請先裝 Node $MIN_NODE_MAJOR+：
+  die "沒找到 Node.js。請先裝 Node $MIN_NODE_VERSION 或更新版本：
   https://nodejs.org/   （或用 nvm / fnm）
 裝完再跑這個腳本一次。"
 fi
-node_major=$(node -v | sed -E 's/v([0-9]+)\..*/\1/')
-if [ "$node_major" -lt "$MIN_NODE_MAJOR" ]; then
-  die "Node 版本太舊（$(node -v)），需要 $MIN_NODE_MAJOR+。見 .nvmrc"
+node_version=$(node -v | sed 's/^v//')
+node_major=${node_version%%.*}
+node_rest=${node_version#*.}
+node_minor=${node_rest%%.*}
+if [ "$node_major" -lt "$MIN_NODE_MAJOR" ] || \
+  { [ "$node_major" -eq "$MIN_NODE_MAJOR" ] && [ "$node_minor" -lt "$MIN_NODE_MINOR" ]; }; then
+  die "Node 版本太舊（$(node -v)），需要 $MIN_NODE_VERSION 或更新版本。見 .nvmrc"
 fi
 ok "Node $(node -v)"
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,41 +18,43 @@ scripts/
 
 ## 🔴 core/ — Build Pipeline（npm run build 自動觸發）
 
-| 腳本                          | 語言 | 用途                                                          |
-| ----------------------------- | ---- | ------------------------------------------------------------- |
-| `sync.sh`                     | bash | 同步 knowledge/ → src/content/（SSOT 複製）                   |
-| `generate-api.js`             | node | 產生 `public/api/*.json`（文章列表、搜尋索引）                |
-| `generate-dashboard-data.js`  | node | 產生 Dashboard 4 支 JSON API                                  |
-| `generate-map-markers.js`     | node | 產生地圖標記資料                                              |
-| `generate-content-stats.js`\* | node | 被 generate-api 呼叫，統計各分類文章數                        |
-| `build-search-index.mjs`      | node | 建構全文搜尋索引                                              |
-| `post-build-check.mjs`        | node | Build 後煙霧測試（驗證頁面數量、分類健康）                    |
-| `test-frontmatter.mjs`        | node | Pre-commit hook：驗證 frontmatter 格式                        |
-| `generate-og-images.mjs`      | node | **自動化 OG 圖產生器 v3** — 支援多語系、增量生成、JPG 85 壓縮 |
+| 腳本                         | 語言 | 用途                                                          |
+| ---------------------------- | ---- | ------------------------------------------------------------- |
+| `sync.sh`                    | bash | 同步 knowledge/ → src/content/（SSOT 複製）                   |
+| `generate-api.js`            | node | 產生 `public/api/*.json`（文章列表、搜尋索引）                |
+| `generate-dashboard-data.js` | node | 產生 Dashboard 4 支 JSON API                                  |
+| `generate-map-markers.js`    | node | 產生地圖標記資料                                              |
+| `build-search-index.mjs`     | node | 建構全文搜尋索引                                              |
+| `post-build-check.mjs`       | node | Build 後煙霧測試（驗證頁面數量、分類健康）                    |
+| `test-frontmatter.mjs`       | node | Pre-commit hook：驗證 frontmatter 格式                        |
+| `generate-og-images.mjs`     | node | **自動化 OG 圖產生器 v3** — 支援多語系、增量生成、JPG 85 壓縮 |
 
 **執行順序**：`sync.sh` → `generate-*.js` → `generate-og-images.mjs` → Astro build → `post-build-check.mjs`
 
 ## 🟡 tools/ — 日常操作
 
-| 腳本                     | 語言 | 用途                                                                                                                                                 |
-| ------------------------ | ---- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `article-health.py`      | py   | **SSOT 11 plugin 健檢入口** — prose-health / footnote-density / format-structure / wikilink-target / image-health / terminology / cross-reference 等 |
-| `review-pr.sh`           | bash | PR 自動初審（frontmatter + 品質 + 安全 4 層檢查）                                                                                                    |
-| `rewrite-pipeline.sh`    | bash | 文章改寫流程輔助（Stage 1-5 互動引導）                                                                                                               |
-| `translate.sh`           | bash | 翻譯文章（呼叫 AI + 品質驗證）                                                                                                                       |
-| `update-stats.sh`        | bash | 更新 README 統計數字（文章數/語言覆蓋等）                                                                                                            |
-| `manage-featured.sh`     | bash | 管理 featured 文章標記                                                                                                                               |
-| `assign-subcategory.cjs` | node | 批次指派子分類（讀 taxonomy → 寫 frontmatter）                                                                                                       |
-| `check-freshness.js`     | node | 檢查文章新鮮度（lastVerified 過期預警）                                                                                                              |
+| 腳本                        | 語言 | 用途                                                                                                                                       |
+| --------------------------- | ---- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `article-health.py`         | py   | **SSOT 健檢入口** — prose-health / footnote-density / format-structure / wikilink-target / image-health / terminology / cross-reference 等 |
+| `review-pr.sh`              | bash | PR 自動初審（frontmatter + 品質 + 安全 4 層檢查）                                                                                          |
+| `rewrite-pipeline.sh`       | bash | 文章改寫流程輔助（Stage 1-5 互動引導）                                                                                                     |
+| `translate.sh`              | bash | 翻譯文章（呼叫 AI + 品質驗證）                                                                                                             |
+| `update-stats.sh`           | bash | 更新 README 統計數字（文章數/語言覆蓋等）                                                                                                  |
+| `manage-featured.sh`        | bash | 管理 featured 文章標記                                                                                                                     |
+| `assign-subcategory.cjs`    | node | 批次指派子分類（讀 taxonomy → 寫 frontmatter）                                                                                             |
+| `check-freshness.js`        | node | 檢查文章新鮮度（lastVerified 過期預警）                                                                                                    |
+| `generate-content-stats.js` | node | 統計各分類文章數並產生 `src/data/content-stats.json`                                                                                       |
 
 **常用指令**：
 
 ```bash
-python3 scripts/tools/article-health.py --all                            # 全量掃描（11 plugin）
+python3 scripts/tools/article-health.py --all                            # 全量掃描
 python3 scripts/tools/article-health.py knowledge/Art/X.md               # 單檔掃描
 python3 scripts/tools/article-health.py knowledge/Art/X.md --check=prose-health  # 單一 plugin
 python3 scripts/tools/article-health.py --all --profile=release-pr       # release strict mode
 bash scripts/tools/review-pr.sh 123                                      # 審核 PR #123
+python3 -m pip install -r requirements-test.txt                          # 首次安裝測試依賴
+python3 -m pytest tests -q                                               # 完整 Python 測試
 
 # --- OG Image 相關 (v3 統一架構) ---
 npm run og:generate                                   # 增量產圖 (JPG 85, ?shot=1 模式)
@@ -101,4 +103,4 @@ npm run og:generate -- --lang ko --category food      # 產出韓文食物系列
 
 ---
 
-_最後更新：2026-04-23 (v3 OG 自動化)_
+_最後更新：2026-08-13_

--- a/tests/article_health/test_contributor_onboarding.py
+++ b/tests/article_health/test_contributor_onboarding.py
@@ -1,0 +1,17 @@
+"""Contributor onboarding instructions must match executable project requirements."""
+
+import json
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_onboarding_node_requirement_matches_package_engine():
+    package = json.loads((REPO_ROOT / "package.json").read_text(encoding="utf-8"))
+    minimum = package["engines"]["node"].removeprefix(">=")
+    bootstrap = (REPO_ROOT / "public" / "start.sh").read_text(encoding="utf-8")
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+
+    assert f'MIN_NODE_VERSION="{minimum}"' in bootstrap
+    assert f"Node.js {minimum.removesuffix('.0')}+" in contributing

--- a/tests/article_health/test_contributor_onboarding.py
+++ b/tests/article_health/test_contributor_onboarding.py
@@ -1,8 +1,6 @@
 """Contributor onboarding instructions must match executable project requirements."""
 
 import json
-import os
-import subprocess
 from pathlib import Path
 
 
@@ -17,30 +15,3 @@ def test_onboarding_node_requirement_matches_package_engine():
 
     assert f'MIN_NODE_VERSION="{minimum}"' in bootstrap
     assert f"Node.js {minimum.removesuffix('.0')}+" in contributing
-
-
-def test_article_template_passes_frontmatter_validator(tmp_path):
-    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
-    template_section = contributing.split("### 文章結構範本", 1)[1]
-    article_template = template_section.split("```markdown", 1)[1].split("```", 1)[0]
-
-    article_path = tmp_path / "knowledge" / "Culture" / "contributor-template.md"
-    article_path.parent.mkdir(parents=True)
-    article_path.write_text(article_template.strip() + "\n", encoding="utf-8")
-
-    env = os.environ.copy()
-    env["TWMD_VALIDATE_FILES"] = "knowledge/Culture/contributor-template.md"
-    result = subprocess.run(
-        [
-            "node",
-            str(REPO_ROOT / "scripts" / "core" / "test-frontmatter.mjs"),
-            "--strict",
-        ],
-        cwd=tmp_path,
-        env=env,
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-
-    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/article_health/test_contributor_onboarding.py
+++ b/tests/article_health/test_contributor_onboarding.py
@@ -1,6 +1,8 @@
 """Contributor onboarding instructions must match executable project requirements."""
 
 import json
+import os
+import subprocess
 from pathlib import Path
 
 
@@ -15,3 +17,30 @@ def test_onboarding_node_requirement_matches_package_engine():
 
     assert f'MIN_NODE_VERSION="{minimum}"' in bootstrap
     assert f"Node.js {minimum.removesuffix('.0')}+" in contributing
+
+
+def test_article_template_passes_frontmatter_validator(tmp_path):
+    contributing = (REPO_ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
+    template_section = contributing.split("### 文章結構範本", 1)[1]
+    article_template = template_section.split("```markdown", 1)[1].split("```", 1)[0]
+
+    article_path = tmp_path / "knowledge" / "Culture" / "contributor-template.md"
+    article_path.parent.mkdir(parents=True)
+    article_path.write_text(article_template.strip() + "\n", encoding="utf-8")
+
+    env = os.environ.copy()
+    env["TWMD_VALIDATE_FILES"] = "knowledge/Culture/contributor-template.md"
+    result = subprocess.run(
+        [
+            "node",
+            str(REPO_ROOT / "scripts" / "core" / "test-frontmatter.mjs"),
+            "--strict",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/contributor-frontmatter-template.test.mjs
+++ b/tests/contributor-frontmatter-template.test.mjs
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const ARTICLE_PATH = 'knowledge/Culture/contributor-template.md';
+
+test('CONTRIBUTING article template passes the strict frontmatter validator', async (t) => {
+  const sandbox = await mkdtemp(join(tmpdir(), 'twmd-contributor-template-'));
+  t.after(() => rm(sandbox, { recursive: true, force: true }));
+
+  const contributing = await readFile(
+    join(REPO_ROOT, 'CONTRIBUTING.md'),
+    'utf8',
+  );
+  const section = contributing.split('### 文章結構範本', 2)[1];
+  assert.ok(
+    section,
+    'CONTRIBUTING.md must contain the article template section',
+  );
+
+  const template = section.match(/```markdown\n([\s\S]*?)\n```/u)?.[1];
+  assert.ok(
+    template,
+    'the article template must remain a fenced Markdown example',
+  );
+
+  const article = join(sandbox, ARTICLE_PATH);
+  await mkdir(dirname(article), { recursive: true });
+  await writeFile(article, `${template.trim()}\n`, 'utf8');
+
+  const result = spawnSync(
+    process.execPath,
+    [join(REPO_ROOT, 'scripts/core/test-frontmatter.mjs'), '--strict'],
+    {
+      cwd: sandbox,
+      env: { ...process.env, TWMD_VALIDATE_FILES: ARTICLE_PATH },
+      encoding: 'utf8',
+    },
+  );
+
+  assert.equal(result.status, 0, `${result.stdout}${result.stderr}`);
+});


### PR DESCRIPTION
## What changed

- Update the README, contribution guide, language status, PR checklist, and script index to match the current repository configuration.
- Correct the documented Node.js minimum, Astro version, category count, enabled languages, frontmatter fields, and tool paths.
- Make the onboarding script enforce Node.js 22.12 rather than accepting any 22.x release.
- Add a regression test that keeps the bootstrap script and contribution guide aligned with `package.json`.
- Clarify that translation contributions require review and fact-checking, whether the first draft is written by a person or generated with an AI tool.

## Why

Several entry-point documents still described earlier versions of the project. The most consequential mismatch was setup: `package.json` requires Node.js 22.12, while the bootstrap script and contribution guide accepted Node.js 20 or any 22.x release.

## Impact

New contributors get commands and requirements that match the code they will run, reducing avoidable setup and review failures. This PR documents the Python test command introduced by #1330, so #1330 should merge first.

## Checks

- Onboarding regression test: `1 passed`
- `bash -n public/start.sh`
- Prettier check for all edited Markdown files
- `git diff --check`
