### PR TITLE
fix(cli): 終端機的 CJK 粗體不再漏出字面 `**`（taiwanmd 0.8.1）

### DIFF
--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -27,7 +27,7 @@
         "vitest": "^2.1.9"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@colors/colors": {

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "taiwanmd",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "taiwanmd",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chalk": "^5.3.0",
         "cli-table3": "^0.6.5",
         "commander": "^12.1.0",
-        "marked": "^15.0.0",
+        "marked": "^17.0.4",
+        "marked-cjk-friendly": "0.1.0",
         "marked-terminal": "^7.3.0",
         "minisearch": "^7.2.0",
         "yaml": "^2.8.3",
@@ -1961,15 +1962,27 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "17.0.6",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
+      "integrity": "sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
+      }
+    },
+    "node_modules/marked-cjk-friendly": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/marked-cjk-friendly/-/marked-cjk-friendly-0.1.0.tgz",
+      "integrity": "sha512-YhJ97F3GaKKMVEEdJ7HkpT1xJNUQ0Bys83AJA1w+NpS8Ml3NTz2zInx1pZgZ3ZAJk6dbcjoPkvNx+lDq+V7bIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "marked": ">=15.0.0"
       }
     },
     "node_modules/marked-terminal": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://taiwan.md",
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=20.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
@@ -43,5 +43,11 @@
     "minisearch": "^7.2.0",
     "yaml": "^2.8.3",
     "zod": "^4.3.6"
+  },
+  "//overrides": "marked-terminal@7.3.0 宣告 peer marked '>=1 <16'（沒有更新的 release），但 marked-cjk-friendly 需要 marked 16+ 的 rules.inline.delLDelim。實測 marked-terminal 在 marked 17 上功能正常（英文與 CJK 粗體都有 ANSI），所以這裡把它的 peer 對齊本套件的 marked，讓 npm ci / npm install 在本 workspace 能解析。此欄位對安裝 taiwanmd 的使用者無效（npm 忽略依賴的 overrides），使用者端本來就會 nest 一份 marked@15 給這兩個 plugin 用而不影響執行；上游修好 peer 範圍後可移除。",
+  "overrides": {
+    "marked-terminal": {
+      "marked": "$marked"
+    }
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taiwanmd",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest"
@@ -37,7 +37,8 @@
     "chalk": "^5.3.0",
     "cli-table3": "^0.6.5",
     "commander": "^12.1.0",
-    "marked": "^15.0.0",
+    "marked": "^17.0.4",
+    "marked-cjk-friendly": "0.1.0",
     "marked-terminal": "^7.3.0",
     "minisearch": "^7.2.0",
     "yaml": "^2.8.3",

--- a/cli/src/lib/render.js
+++ b/cli/src/lib/render.js
@@ -6,11 +6,26 @@
  */
 
 import chalk from 'chalk';
-import { marked } from 'marked';
+import { Marked } from 'marked';
 import { markedTerminal } from 'marked-terminal';
+import markedCjkFriendly from 'marked-cjk-friendly';
 
-// Configure marked with terminal renderer
-marked.use(markedTerminal());
+/**
+ * 終端機用的 marked 實例（2026-08-14）。
+ *
+ * 兩個刻意的決定：
+ *
+ * 1. `markedCjkFriendly()`：CommonMark／GFM 的 delimiter flanking 規則把 CJK
+ *    標點當一般標點，於是 `**完整句。**下一句` 的收尾 `**` 不算 right-flanking，
+ *    整組 `**` 就原封不動印在讀者的終端機上。站台端同一個病由
+ *    `src/utils/marked-cjk.mjs` 修掉；CLI 走自己的依賴樹，所以要各修一次。
+ *    （commonmark/commonmark-spec#650，2020 年開到現在。）
+ *
+ * 2. `new Marked(...)` 而不是對 marked 模組單例跑 `marked.use()`：
+ *    單例污染會讓行為變成「誰先 import 誰決定」的隱性耦合。用獨立實例，
+ *    這支檔案就是 CLI 唯一的 marked 設定點。
+ */
+const marked = new Marked(markedTerminal(), markedCjkFriendly());
 
 /**
  * Category to emoji mapping

--- a/cli/test/render-cjk.test.js
+++ b/cli/test/render-cjk.test.js
@@ -1,0 +1,91 @@
+/**
+ * Contract tests for lib/render.js — CJK emphasis must not leak literal `**`
+ * into the reader's terminal.
+ *
+ * Why this file exists: CommonMark/GFM's delimiter flanking rules treat CJK
+ * punctuation as ordinary punctuation, so a closing `**` that sits after 「。」
+ * and before a 漢字 is not right-flanking. The pair never closes and both
+ * asterisks are printed verbatim — `**沒有人組織，沒有人指揮。**g0v社群` reached
+ * readers with the stars visible. It is an engine gap for languages that do not
+ * separate words with spaces (commonmark/commonmark-spec#650, open since 2020),
+ * not an authoring mistake, so the fix belongs in the parser configuration.
+ *
+ * The website hit the identical bug and fixes it in `src/utils/marked-cjk.mjs`.
+ * The CLI ships as its own npm package with its own dependency tree, so it
+ * needs its own fix — and its own test, because nothing in the site's suite
+ * covers this module.
+ *
+ * The negative control matters: without `marked-cjk-friendly` an unconfigured
+ * marked still leaks the stars, which is what proves the configuration (rather
+ * than luck or a marked version bump) is doing the work.
+ *
+ * Run with: cd cli && npx vitest run
+ */
+
+import { describe, it, expect } from 'vitest';
+import { Marked, marked as globalMarked } from 'marked';
+import { markedTerminal } from 'marked-terminal';
+import { renderMarkdown } from '../src/lib/render.js';
+
+/** Strip ANSI escapes so assertions read against visible text. */
+function visible(str) {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+describe('CJK emphasis in terminal output', () => {
+  it('closes ** that follows CJK sentence punctuation', () => {
+    const out = renderMarkdown('**沒有人組織，沒有人指揮。**g0v社群的參與者');
+    expect(visible(out)).toContain('沒有人組織，沒有人指揮。g0v社群的參與者');
+    expect(out).not.toContain('**');
+  });
+
+  it('closes ** that follows a CJK closing quote', () => {
+    const out = renderMarkdown(
+      '結果是：**立委開始在意自己的「資料」。**出席率',
+    );
+    expect(out).not.toContain('**');
+  });
+
+  it('opens ** that precedes a CJK bracket', () => {
+    const out = renderMarkdown('詩名是**〈等待航線〉**。');
+    expect(out).not.toContain('**');
+  });
+
+  it('still applies terminal styling to the emphasised span', () => {
+    // Guards against "fixing" the leak by dropping the emphasis entirely:
+    // the span must remain styled, not silently flattened to plain text.
+    const out = renderMarkdown('**沒有人組織，沒有人指揮。**g0v社群');
+    // marked-terminal only emits escapes when colour is enabled; when it is
+    // disabled the text must still be clean, which the assertions above cover.
+    if (/\u001b\[/.test(out)) {
+      expect(out).toMatch(/\u001b\[1m沒有人組織，沒有人指揮。/);
+    }
+  });
+
+  it('leaves non-CJK emphasis behaviour unchanged', () => {
+    const out = renderMarkdown('**English.** Next');
+    expect(visible(out)).toContain('English. Next');
+    expect(out).not.toContain('**');
+  });
+
+  it('keeps deliberately escaped asterisks literal', () => {
+    // Redacted titles and censored profanity are supposed to show stars.
+    const out = renderMarkdown(String.raw`\*\*不是粗體\*\*`);
+    expect(visible(out)).toContain('**不是粗體**');
+  });
+
+  it('an unconfigured marked still leaks the stars (negative control)', () => {
+    const bare = new Marked(markedTerminal());
+    expect(bare.parse('**沒有人組織，沒有人指揮。**g0v社群')).toContain('**');
+  });
+
+  it('does not pollute the global marked singleton', () => {
+    // render.js builds its own `new Marked(...)`. If it ever regresses to
+    // `marked.use(...)` on the singleton, behaviour becomes dependent on
+    // import order across the whole package. This test is that guarantee.
+    expect(
+      globalMarked.parseInline('**沒有人組織，沒有人指揮。**g0v社群'),
+    ).toContain('**');
+  });
+});


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

`taiwanmd` 0.8.0 → 0.8.1。

站台端在 #1336 修掉的同一個病，**CLI 也有**：CommonMark／GFM 的 delimiter flanking 規則把 CJK 標點當成一般標點，`**沒有人組織，沒有人指揮。**g0v社群` 的收尾 `**` 前面是「。」後面是漢字，不算 right-flanking，於是整組 `**` 原封不動印在讀者的終端機上（commonmark/commonmark-spec#650，2020 開到現在）。

CLI 是獨立發佈的 npm 套件、自帶依賴樹，所以站台的修正救不到它，得各修一次。

實跑 `taiwanmd read 開源社群與g0v` 的 before / after：

```
before   **沒有人組織，沒有人指揮。**g0v社群的參與者自發性地做了這些事
after    沒有人組織，沒有人指揮。g0v社群的參與者自發性地做了這些事
         ^^^^^^^^^^^^^^^^^^^^^^^^ ESC[1m … ESC[22m（粗體收在句末「。」之後）
```

### 改了什麼

- **marked `^15` → `^17.0.4`。** 這是必要的：`marked-cjk-friendly` 需要 marked 16+ 的 `rules.inline.delLDelim`，但它自己宣告 peer `>=15.0.0`（宣告過寬）。在 15.0.12 上實測會 `TypeError: Cannot read properties of undefined (reading 'exec')`。
- **加 `marked-cjk-friendly`（pin `0.1.0`）** — CommonMark CJK-friendly 修正案的 marked 移植，非 CJK 輸入逐字元同輸出。
- **`render.js` 改用 `new Marked(markedTerminal(), markedCjkFriendly())`**，不對 marked 模組單例跑 `use()`。單例污染會讓行為變成「誰先 import 誰決定」的隱性耦合（這點是 #1336 的 Copilot review 指出來的，站台端已同步改掉）。
- **新增 `cli/test/render-cjk.test.js`**（8 條）：含 negative control（未設定的 marked 仍會漏 `**`，證明修正來自設定而非 marked 版本），以及「全域單例未被污染」斷言。

### 關於 `marked-terminal` 的 peer 範圍（**已於 cecb5bcf 修正，見下**）

`marked-terminal@7.3.0` 宣告 peer `marked >=1 <16`（沒有更新的 release），與 `marked@^17` 衝突。

⚠️ **本 PR 初版在這裡寫「安裝沒問題」，那是驗錯的**：我把 npm 輸出接進 pipeline 之後才讀 `$?`，量到的是 `tail` 的結束碼。重新直接取 exit code 之後，真實情況是：

```
workspace npm install       exit 1
npm ci                      exit 1   ← npm-publish-cli.yml 跑的就是這個
fresh install（無 lockfile） exit 1
消費者安裝 tarball           exit 0   （這項本來就是對的）
```

也就是初版會讓 **CLI 的發佈流程斷掉**。已加 scoped overrides 把 marked-terminal 的 peer 對齊本套件的 marked：

```json
"overrides": { "marked-terminal": { "marked": "$marked" } }
```

只影響本 workspace；npm 忽略依賴的 overrides，所以對使用者無效——使用者端本來就解得開，npm 會 nest 一份 `marked@15` 滿足那兩個 plugin 的 peer，而 `render.js` 仍載入 `marked@17.0.6`（那份 15 是惰性的，`npm ls` 已確認）。上游放寬 peer 後可移除。

另依 review 把 `engines.node` 從 `>=18.0.0` 改成 `>=20.0.0`——查過所有依賴宣告的 engines，`marked@17` 的 `>= 20` 是最高下限，所以這是剛好對齊、沒有多加限制。（Node 18 已於 2025-04-30 EOL。）

## ⚠️ 已知未修（刻意不夾帶）

同一篇文章跑完，字面 `**` 從 **82 → 70**。減掉的 12 個正好是那 6 段 CJK 粗體（每段 2 個 marker）。

剩下的 70 個**不是** CJK 問題，是 `marked-terminal` 的 list item 不解析 inline markdown：

```
$ taiwanmd read …
    * **即時轉播**：架設多機位直播系統        ← 上游既有缺陷
```

證據是這個缺陷與語言無關、也與版本無關：英文 `- **bold**` 一樣會漏，而且 marked 15 與 marked 17 的輸出逐字相同（所以不是這次升版造成的）。

要修它得覆寫 marked-terminal 的 `listitem` renderer，那會動到它的縮排／bullet 邏輯，風險與這個 PR 無關 → **應該另開 PR**。我沒有順手塞進來。

## 📁 變更類型

- [ ] 📄 新增文章
- [ ] ✏️ 修改/更新現有文章
- [ ] 🌐 翻譯（中→英 / 英→中）
- [x] 🐛 修復錯誤（讀者在終端機看到裸的 `**`）
- [x] 💻 技術改動（程式碼、依賴、測試）
- [ ] 📚 文件更新（README、CONTRIBUTING 等）

## ✅ 自我檢查

- [x] 沒有動 `knowledge/**`、frontmatter、站台程式碼 — 只動 `cli/`
- [x] **本機測過**（每項直接取 exit code，不經 pipeline）：
      `cd cli && npx vitest run` → **49/49 通過**（含既有 4 個測試檔，marked 17 沒弄壞它們）
      實跑 `node src/index.js read 開源社群與g0v` → 目標段落 ANSI 粗體正確收尾
      `npm pack` + 乾淨目錄安裝 tarball → exit 0，且安裝後實測渲染正確
- [x] `npx prettier --check` 對所有變更檔案乾淨
- [x] 版號有 bump（`npm-publish-cli.yml` 要求 tag 對上 `cli/package.json` 版號）
- [x] 沒有抄襲或版權問題

## 🔗 相關 Issue

與 #1336 同一個根因（引擎層 CJK flanking），但這是獨立的 release train，所以分開送。

## 📸 截圖（如果是視覺改動）

上面的 before/after 是實跑輸出。需要終端機截圖說一聲。

