### PR TITLE
fix(ci): frontmatter-gate RAW_KN 對賬 predicate 與過濾器對齊

### DIFF
--- a/.github/workflows/pr-frontmatter-gate.yml
+++ b/.github/workflows/pr-frontmatter-gate.yml
@@ -147,13 +147,18 @@ jobs:
           echo "count=$ALL_COUNT" >> "$GITHUB_OUTPUT"
           echo "🔍 PR 改動 knowledge/ 檔：$ALL_COUNT（其中 zh-TW root $ZH_COUNT）"
 
-          # Fail-loud：diff 裡明明提到 knowledge/，過濾完卻一個都不剩 = 過濾器瞎了，
+          # Fail-loud：diff 裡明明提到 knowledge/ 下的 .md，過濾完卻一個都不剩 = 過濾器瞎了，
           # 不是「這個 PR 沒動文章」。沒有這道對賬的話，任何新的檔名形狀（中文、
           # 空白、引號、未來的 emoji）都會讓本 gate 靜靜退化成綠燈裝飾品。
           # 量的是「我抓到的」對得上「diff 說有的」，不是只量我抓到幾個（REFLEXES #82）。
-          RAW_KN=$(printf '%s' "$FILES" | grep -c 'knowledge/' || true)
+          #
+          # ⚠️ 2026-08-25 校正（PR #1583 觸發）：原本 grep 'knowledge/' 會把非 .md
+          # 檔（如 knowledge/_translations.json）也算進 RAW_KN——但過濾器只收 .md，
+          # 於是「純改 JSON」的 PR 一定被誤判成「過濾器壞了」。RAW_KN 的語意應與
+          # 過濾器對齊：只 count 應當被抓到的 .md，才是「該進來卻沒進來」的訊號。
+          RAW_KN=$(printf '%s' "$FILES" | grep -Ec '^knowledge/.*\.md$' || true)
           if [ "$RAW_KN" != "0" ] && [ "$ALL_COUNT" = "0" ]; then
-            echo "::error::diff 有 $RAW_KN 條 knowledge/ 路徑，過濾後卻是 0——檔名解析壞了，不是沒有改動。原始 diff："
+            echo "::error::diff 有 $RAW_KN 條 knowledge/*.md 路徑，過濾後卻是 0——檔名解析壞了，不是沒有改動。原始 diff："
             printf '%s\n' "$FILES" | sed 's/^/    /'
             exit 1
           fi


### PR DESCRIPTION
## 問題

PR #1583（純改 `knowledge/_translations.json` 4 個 key）被 `frontmatter-gate` 誤判紅 X：

```
🔍 PR 改動 knowledge/ 檔：0（其中 zh-TW root 0）
::error::diff 有 1 條 knowledge/ 路徑，過濾後卻是 0——檔名解析壞了
    knowledge/_translations.json
```

## 根因

fail-loud 對賬兩邊用了**不對稱的 predicate**：

- 過濾器（L122）：`[[ "$f" =~ ^knowledge/.*\.md$ ]]` — 只收 `.md`
- RAW_KN（L154）：`grep -c 'knowledge/'` — 連 `.json` 也算

於是任何 **純改 non-`.md` 檔於 `knowledge/` 下** 的 PR，raw > 0 而 filtered = 0，穩定觸發「檔名解析壞了」false alarm。REFLEXES #82「對賬只在兩邊同尺時才成立」的變體——fail-loud 反而變 cry-wolf。

## 修法

一行：RAW_KN 也套 `.md` 過濾，語意與過濾器對齊。

```diff
-RAW_KN=$(printf '%s' "$FILES" | grep -c 'knowledge/' || true)
+RAW_KN=$(printf '%s' "$FILES" | grep -Ec '^knowledge/.*\.md$' || true)
```

合了之後 PR #1583 重跑 CI 就會綠。

## 未來的類似 case

任何新增在 `knowledge/` 下的非 `.md` 產物檔（sitemap、index、metadata、locale registry⋯）改動時都會撞到。這修法一勞永逸。
