### PR TITLE
translate(fr): 國際品牌在台的味蕾變革 → international-brand-localization-taiwan

### DIFF
--- a/knowledge/fr/Food/international-brand-localization-taiwan.md
+++ b/knowledge/fr/Food/international-brand-localization-taiwan.md
@@ -1,0 +1,186 @@
+---
+title: "La révolution des papilles : comment les marques internationales se sont taïwanisées, de la soupe de maïs de McDonald's au « Wanjiafu » de Carrefour"
+description: "De la soupe de maïs de McDonald's aux pizzas « insolites » de Pizza Hut, comment les marques internationales se sont-elles intégrées à la vie taïwanaise par la localisation ? Cet article traverse la restauration rapide, la grande distribution et les supérettes pour analyser la manière dont ces enseignes transforment les tensions culturelles en atouts, avec une mise à jour sur le repositionnement de Carrefour, rebaptisé « Wanjiafu » et « Lejiakang »."
+date: 2026-07-29
+category: 'Food'
+tags:
+  [
+    'Localisation',
+    'Marques internationales',
+    'Gastronomie taïwanaise',
+    "McDonald's",
+    'KFC',
+    'Pizza Hut',
+    '7-ELEVEN',
+    'Sushi tournant',
+    'Starbucks',
+    'Costco',
+    'MOS Burger',
+    'IKEA',
+    'Carrefour',
+    'Wanjiafu',
+  ]
+subcategory: '飲食場景'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-07-29
+lastHumanReview: false
+readingTime: 15
+curation: incubating
+translatedFrom: 'Food/國際品牌在地化.md'
+sourceCommitSha: '03b3aaae8'
+sourceContentHash: 'sha256:d2bd210c796c69a8'
+translatedAt: '2026-08-26T20:32:54Z'
+---
+
+> **L'essentiel en 30 secondes :** Lorsqu'une marque internationale entre sur le marché taïwanais, elle n'apporte pas seulement des produits mondialisés : par une stratégie de localisation poussée, elle intègre à son offre la culture alimentaire et les habitudes de consommation propres à Taïwan. De la soupe de maïs de McDonald's aux pastéis de nata de KFC, en passant par les pizzas de Pizza Hut qui poussent les papilles dans leurs derniers retranchements, les plats mijotés lu wei et la mascotte OPEN-chan de 7-ELEVEN, ou encore la passion des chaînes de sushis tournants pour le saumon, ces exemples témoignent du respect et de la souplesse dont ces enseignes font preuve à l'égard du marché taïwanais. Plus loin encore, les boutiques d'exception de Starbucks, le statut de premier magasin mondial de Costco, la culture du riz chez MOS Burger, le miracle de la restauration chez IKEA, et jusqu'à la transformation de Carrefour après son rachat et son changement de nom : tous dessinent ensemble la manière dont les marques internationales fabriquent, par la fusion culturelle, leur propre équation du succès.
+
+Dans leur expansion mondiale, les marques internationales se heurtent presque toujours à la même difficulté : trouver l'équilibre entre standardisation et localisation. À Taïwan, ce défi a donné naissance à quantité de produits et de services uniques, qui ont non seulement rapproché ces enseignes du quotidien des consommateurs taïwanais, mais ont aussi créé, presque par accident, une foule d'expériences « exclusives à Taïwan » qui surprennent les visiteurs étrangers. Ces stratégies de localisation ne sont pas seulement une réussite commerciale : elles reflètent la richesse et la diversité de la culture alimentaire et des habitudes de consommation taïwanaises.
+
+## McDonald's : la soupe de maïs réconfortante et le charme de la patate douce locale
+
+Leader mondial de la restauration rapide, McDonald's a fait preuve à Taïwan d'une réelle souplesse en matière de localisation. Le cas le plus connu reste sans conteste la **soupe de maïs** et les **frites de patate douce dorées** inscrites à sa carte. La soupe de maïs fait figure d'exception parmi tous les McDonald's du monde ; son origine remonte à 1978, avant même l'arrivée officielle du McDonald's américain à Taïwan (1984) : une chaîne de restauration rapide locale nommée « McDonly » (麥當樂) proposait déjà une « soupe de maïs au poulet effiloché »[^1][^6]. Après son implantation à Taïwan, McDonald's a délibérément conservé et perfectionné ce produit pour épouser l'habitude taïwanaise d'accompagner le repas d'un bol de soupe, au point d'en faire un classique de l'accompagnement à la taïwanaise[^6].
+
+> 📝 **Note du curateur :** La localisation de la soupe de maïs ne relève pas seulement d'un ajustement gustatif ; elle traduit une compréhension profonde des habitudes alimentaires taïwanaises. Un bol de soupe chaude porte en lui tout ce que les Taïwanais attendent d'un vrai repas : de la substance et du réconfort.
+
+McDonald's Taïwan a par ailleurs lancé des **frites de patate douce dorées** élaborées à partir de la patate douce à chair rouge Tainong n° 64, cultivée localement[^1]. Ce produit répond au goût prononcé des consommateurs taïwanais pour la patate douce tout en affichant le lien de la marque avec l'agriculture du pays dans le choix de ses matières premières. Ces produits localisés ont réussi à faire glisser McDonald's du statut de simple « fast-food à l'américaine » vers celui d'une offre de restauration au « goût taïwanais » assumé.
+
+## KFC : le règne du pastel de nata et l'innovation du poulet en papillote
+
+À Taïwan, la stratégie de localisation de KFC est incarnée par l'immense succès de ses **pastéis de nata**, ces flans portugais que la chaîne vend en si grande quantité qu'on la surnomme, non sans ironie, « la pâtisserie à pastéis de nata que le poulet frit a détournée de sa vocation »[^7]. Leur introduction remonte à l'engouement pour le pastel de nata qui a déferlé sur Taïwan dans les années 1990 : KFC a importé en 1998 la recette de la pâtisserie Margaret's Café e Nata de Macao, qui est très vite devenue son produit signature[^7]. Cette stratégie a élargi l'image de KFC à Taïwan, la faisant passer de simple spécialiste du poulet frit à une enseigne où « le dessert compte autant que le plat principal », le pastel de nata devenant même pour beaucoup de clients la première raison de pousser la porte.
+
+Au-delà des pastéis de nata, KFC a également lancé à Taïwan une **gamme de poulet en papillote**, une cuisson au four sous papier qui retient les sucs et reste relativement rare dans les KFC du monde entier, mais qui correspond au goût taïwanais pour les textures tendres et juteuses[^2]. De même, les **boules moelleuses de patate douce** et les **frites de patate douce** mobilisent elles aussi la patate douce locale et empruntent au vocabulaire de la street-food des marchés de nuit, approfondissant encore l'ancrage taïwanais de la marque[^2].
+
+## Pizza Hut : des pizzas créatives qui repoussent les limites du goût
+
+La stratégie de localisation de Pizza Hut Taïwan est sans doute la plus expérimentale et la plus commentée de toutes les marques internationales présentes dans le pays. De la « pizza coriandre, œuf de cent ans et gâteau de sang de porc » à la « pizza tofu puant » ou à la « pizza bubble tea », ces créations qui mettent les papilles à l'épreuve déclenchent régulièrement des vagues de discussions sur les réseaux sociaux[^3][^8]. La pizza coriandre-œuf de cent ans-gâteau de sang de porc, lancée en 2021, a par exemple établi un record en dépassant les 100 000 recherches Google en une seule journée, le jour même de sa sortie[^3].
+
+Derrière ces parfums en apparence « bizarres » se trouve la « pensée e-commerce » et la « stratégie WOW Pizza » impulsées par le directeur général de Pizza Hut Taïwan, Leung Ka-chun (梁家俊), originaire de Hong Kong[^3]. Pour lui, sur un marché taïwanais dominé par les plateformes de livraison, Pizza Hut est de fait un acteur du commerce en ligne : d'où une stratégie articulée autour de trois T — « talkability » (le volume de conversation), « traffic » (le trafic) et « transaction » (la vente)[^3]. En lançant sans relâche des produits localisés à fort potentiel viral, la marque augmente sa notoriété et son attention en ligne même lorsque les consommateurs n'achètent pas nécessairement ces saveurs particulières, ce qui finit par tirer l'ensemble des ventes[^3]. Cette approche a non seulement fait voler en éclats l'idée reçue selon laquelle « à Taïwan, on ne mange de la pizza que pour les fêtes », mais elle a aussi façonné l'image d'une marque inventive et pleine d'énergie[^3].
+
+## 7-ELEVEN : le praticien de la « proposition de vie » et le charme d'OPEN-chan
+
+Emblème de la culture taïwanaise de la supérette, 7-ELEVEN a depuis longtemps dépassé le seul registre du produit pour s'installer au cœur du quotidien taïwanais. Outre ses fameux **œufs marinés au thé** (plus de cent millions d'unités vendues par an), l'enseigne a lancé ces dernières années une gamme de plats mijotés lu wei « dignes d'un festin étoilé », qui standardise la culture du lu wei des marchés de nuit traditionnels et la rend accessible vingt-quatre heures sur vingt-quatre[^4][^9].
+
+> 📝 **Note du curateur :** Le succès de 7-ELEVEN ne tient pas seulement à la diversité de son assortiment, mais à sa capacité à transformer la supérette en plateforme de « propositions de vie », répondant à la double exigence taïwanaise de commodité et de saveurs locales.
+
+Autre cas de localisation réussie : sa mascotte maison, **OPEN-chan**. Créée en 2005 conjointement par President Chain Store Corporation et l'agence japonaise Dentsu, elle possède une identité et un univers narratif complets et s'est imposée dans la culture populaire taïwanaise à travers produits dérivés et événements thématiques, allant jusqu'à générer pour 7-ELEVEN un chiffre d'affaires annuel d'un milliard de dollars taïwanais[^4][^10][^11]. Le succès d'OPEN-chan démontre l'énorme potentiel des mascottes de marque sur le marché taïwanais, ainsi que leur rôle dans la construction d'un lien affectif avec le public.
+
+## Sushis tournants : la folie taïwanaise du saumon
+
+Les enseignes de sushis tournants qui ont connu une ascension fulgurante à Taïwan ces dernières années, comme Sushiro ou Kura Sushi, révèlent elles aussi un phénomène de localisation intéressant : l'engouement démesuré des consommateurs taïwanais pour le **saumon**. Comparé au Japon, les restaurants de sushis tournants taïwanais proposent et vendent bien davantage de saumon que de n'importe quelle autre espèce[^5]. Ce phénomène a même provoqué en 2021 la fameuse « affaire du saumon » : Sushiro ayant lancé une promotion réservée aux clients portant ce nom, plus de trois cents personnes dans tout le pays ont modifié le nom inscrit sur leur carte d'identité pour y faire figurer « saumon » (鮭魚) et profiter de sushis gratuits[^5][^12].
+
+Cette préférence taïwanaise pour le saumon s'explique par la perception largement partagée d'un poisson « au rapport qualité-prix imbattable et à la chair grasse et fondante », mais aussi par le fait qu'aux débuts de la diffusion de la cuisine japonaise à Taïwan, le saumon était le sashimi le plus accessible[^5]. Les chiffres parlent d'eux-mêmes : Sushi Express (爭鮮), premier importateur de saumon de Taïwan, en importe environ 2 500 tonnes par an, soit près de 20 % du volume national[^5][^13]. Cet amour du saumon pousse les chaînes de sushis tournants à multiplier les déclinaisons à base de ce poisson pour répondre à la demande.
+
+## Starbucks : l'esthétique locale du « troisième lieu »
+
+À Taïwan, la localisation de Starbucks ne se limite pas aux boissons : elle irrigue en profondeur sa philosophie du « troisième lieu ». Starbucks Taïwan réhabilite des monuments historiques ou compose avec le paysage local pour créer des boutiques au caractère unique — la boutique Bao'an installée dans l'ancienne demeure Ye Jin-tu à Dadaocheng, celle aménagée dans l'ancien bâtiment administratif commun (合同廳舍) de Huwei, dans le comté de Yunlin, ou encore la boutique du domaine Promisedland à Hualien[^14][^15]. Ces adresses ne servent pas que du café : elles deviennent les dépositaires de la culture et de l'histoire locales, réduisant la distance entre une marque internationale et son environnement d'accueil tout en enrichissant l'expérience spatiale du client[^15].
+
+Starbucks lance également des coffrets festifs aux couleurs de Taïwan — gâteaux de lune pour la fête de la Mi-Automne, zongzi pour la fête des Bateaux-Dragons — ainsi que des produits élaborés à partir d'ingrédients locaux, comme sa gamme de thés taïwanais ou son mont-blanc au taro[^14]. Ces lancements visent à épouser l'attachement des consommateurs taïwanais aux coutumes calendaires et leur préférence pour les saveurs du terroir, resserrant d'autant le lien entre la marque et la culture taïwanaise.
+
+## Costco : premier magasin mondial et alliance parfaite avec le service localisé
+
+La réussite de Costco, l'enseigne américaine de vente en gros, constitue à Taïwan un cas d'école de localisation. Les entrepôts taïwanais, et tout particulièrement celui du sud de Taichung, ont décroché le titre de « magasin le plus rentable au monde », tandis que ceux de Neihu et de Zhonghe figurent depuis des années dans le top dix mondial[^16][^17]. Costco compte plus de quatre millions de membres à Taïwan ; à raison de 1 350 dollars taïwanais de cotisation annuelle, les seules recettes d'abonnement atteignent 5,4 milliards de dollars taïwanais, ce qui confirme un modèle économique où 80 % du profit provient des cotisations et non de la marge sur les marchandises[^17].
+
+La localisation des services est elle aussi remarquable : les magasins taïwanais disposent par exemple de stations-service, une rareté à l'échelle mondiale, celle du nord de Taichung affichant le plus gros volume de carburant distribué du pays[^18]. Par ailleurs, si Costco vend avant tout de gros conditionnements, ses magasins taïwanais ont élargi leur offre de plats préparés et de snacks appréciés localement pour s'adapter à la structure des foyers taïwanais[^17]. Cette stratégie vise juste : elle épouse à la fois la quête taïwanaise du meilleur rapport qualité-prix et la logique des grandes courses familiales, ce qui explique le succès considérable de l'enseigne sur ce marché.
+
+## MOS Burger : le porte-drapeau oriental d'une culture du riz
+
+Née au Japon, la chaîne MOS Burger a su faire fructifier à Taïwan sa double signature : « saveurs orientales » et « service à haute technicité ». Son produit le plus emblématique est sans conteste le **burger de riz**. MOS Burger Taïwan a lancé en 1991 le « burger perle au porc grillé », élaboré à partir de riz taïwanais, faisant entrer la culture du riz dans l'univers de la restauration rapide et en faisant l'un des produits identitaires de la marque[^19][^20].
+
+MOS Burger s'emploie aussi à promouvoir les ingrédients locaux : l'enseigne est ainsi devenue en 2020 la première du pays à obtenir le label « porc taïwanais certifié », et elle met en avant ses produits portant le label du riz taïwanais[^19]. Comparée aux autres chaînes de fast-food américaines, MOS Burger colle davantage à l'attachement taïwanais à une restauration rapide soignée et à la culture du riz, ce qui lui a permis de se tailler un positionnement singulier sur ce marché.
+
+## IKEA : le restaurant que le mobilier a détourné de sa vocation
+
+L'enseigne suédoise d'ameublement IKEA s'est ancrée à Taïwan sous les traits du « restaurant que les meubles ont détourné de sa vocation ». La restauration représente 12 % du chiffre d'affaires d'IKEA Taïwan, soit près du triple de la moyenne mondiale (4 à 5 %) et le premier rang planétaire[^21][^22]. À elle seule, la **glace à l'italienne** vendue 10 dollars taïwanais dépasse le million d'unités écoulées par an et pèse 30 % du chiffre d'affaires de la restauration[^23]. Cette « stratégie du produit d'appel » attire le flux par une offre bon marché : elle améliore l'expérience d'achat tout en installant chez le consommateur l'impression que « chez IKEA, tout est bon marché »[^24].
+
+Le marketing localisé d'IKEA à Taïwan ne manque pas d'inventivité : la peluche **requin (BLÅHAJ)** y a déclenché un véritable engouement, et l'enseigne décline des spécialités calées sur le calendrier festif taïwanais, avec des parfums de glace aussi insolites que le wasabi ou le lait de soja à la sauce soja sucrée[^25]. Ces initiatives ont réussi à convertir la visite d'un magasin de meubles en « sortie repas en famille », répondant au goût prononcé des Taïwanais pour la table.
+
+## Carrefour : de la marque internationale à l'enracinement local sous le nom de « Wanjiafu »
+
+La stratégie de localisation de l'enseigne française Carrefour à Taïwan a connu une mutation majeure, des acquisitions offensives à la transformation de la marque elle-même. En 2020, Carrefour a racheté pour 3,2 milliards de dollars taïwanais les supermarchés Wellcome (頂好) et Jasons, afin de renforcer sa position sur le segment des « supermarchés de quartier » et de tenir tête à une concurrence féroce sur le marché de détail taïwanais[^26][^27]. Ces acquisitions lui ont permis d'étendre rapidement son réseau de magasins, de pénétrer plus profondément les quartiers résidentiels et de proposer des services plus proches des besoins des habitants.
+
+Carrefour a également porté son programme de « centre d'impact », en collaborant étroitement avec les petits producteurs taïwanais pour promouvoir les ingrédients locaux et les œufs issus d'élevages respectueux du bien-être animal, affichant ainsi son soutien à l'agriculture du pays[^28]. Mais le 30 juin 2023, le groupe Uni-President a bouclé la transaction lui donnant 100 % du capital de Carrefour Taïwan, qui est devenu une société entièrement taïwanaise[^29][^30]. Ce changement d'actionnariat a entraîné celui du nom : le contrat de licence de marque avec Carrefour France arrivant à échéance, Carrefour Taïwan a décidé le 19 décembre 2025 d'y mettre fin et de changer officiellement de nom à compter du **1ᵉʳ juillet 2026**[^31][^32][^33].
+
+Les hypermarchés deviennent **« Wanjiafu » (萬家福, Prosperity Plaza)** et les supermarchés **« Lejiakang » (樂家康, Uni-Prosperity)**[^34][^35]. Ce changement ne se limite pas aux enseignes lumineuses : il marque l'intégration formelle de Carrefour dans le système de distribution d'Uni-President, avec des synergies plus fortes avec 7-ELEVEN, Cosmed et les autres marques du groupe. Il signale aussi le glissement d'une image de « marque française » vers celle d'une « marque locale », les deux nouveaux noms jouant sur des connotations de prospérité et de bonheur familial plus conformes aux préférences culturelles des consommateurs taïwanais[^36][^37].
+
+## Conclusion
+
+La localisation des marques internationales à Taïwan est une révolution des papilles où se mêlent vision globale et compréhension fine du terrain. De la soupe de maïs de McDonald's aux pastéis de nata de KFC, des pizzas créatives de Pizza Hut au lu wei et à OPEN-chan de 7-ELEVEN, jusqu'à la folie du saumon dans les sushis tournants, ces exemples ne sont pas seulement des réussites commerciales : ils sont le portrait vivant d'une culture alimentaire et d'habitudes de consommation proprement taïwanaises. Plus loin encore, les boutiques d'exception de Starbucks, le statut de premier magasin mondial de Costco, la culture du riz de MOS Burger, le miracle de la restauration chez IKEA, et jusqu'aux acquisitions locales et à la refonte de marque de Carrefour, dessinent ensemble la façon dont les enseignes internationales fabriquent sur cette terre, par la fusion culturelle et l'innovation commerciale, leur propre équation du succès. À force d'inventer et de s'ajuster, ces marques démontrent une chose : seule une compréhension profonde et une adoption sincère de la culture locale permettent de se distinguer sur un marché aussi disputé et de nouer avec les consommateurs un lien affectif durable.
+
+🧬
+
+## Références
+
+[^1]: [Le McDonald's taïwanais est-il bon ? Soupe de maïs, poulet croustillant et frites de patate douce introuvables aux États-Unis ? (YouTube)](https://www.youtube.com/watch?v=Qc7_vRIQFx4) — Examine les produits propres au McDonald's taïwanais et leurs différences avec le marché américain, en analysant les raisons du succès de la soupe de maïs et des frites de patate douce à Taïwan.
+
+[^2]: [KFC sélectionne la patate douce bicolore de Taïwan (Facebook)](https://www.facebook.com/kfctaiwan/posts/7321510847921414/) — KFC explique officiellement comment l'enseigne sélectionne la patate douce bicolore taïwanaise et intègre les produits du terroir à son processus de développement.
+
+[^3]: [Exclusif : une pizza coriandre, œuf de cent ans et sang de porc ? Pourquoi ce Hongkongais aime-t-il jouer avec la nourriture taïwanaise ? (CommonWealth Magazine)](https://www.cw.com.tw/article/5115560) — Entretien approfondi avec Leung Ka-chun, directeur général de Pizza Hut Taïwan, qui dévoile la pensée e-commerce et la logique de localisation derrière la stratégie « WOW Pizza ».
+
+[^4]: [7-Eleven (Wikipédia en chinois)](https://zh.wikipedia.org/zh-hant/7-Eleven) — Retrace en détail l'histoire de 7-ELEVEN à Taïwan, et notamment la manière dont President Chain Store Corporation en a fait une plateforme de services multifonctionnelle.
+
+[^5]: [À Taïwan, un saumon importé sur cinq vient de Sushi Express ! (Manager Today)](https://www.managertoday.com.tw/articles/view/70748) — Analyse la position dominante du saumon sur le marché taïwanais des sushis tournants et la façon dont Sushi Express influence les préférences alimentaires taïwanaises grâce à sa chaîne d'approvisionnement.
+
+[^6]: [La « soupe de maïs » du McDonald's taïwanais serait un produit exclusif : les raisons dévoilées (Yahoo News)](https://tw.news.yahoo.com/%E5%8F%B0%E7%81%A3%E9%BA%A5%E7%95%B6%E5%8B%9E-%E7%8E%89%E7%B1%B3%E6%BF%83%E6%B9%AF-%E7%AB%9F%E6%98%AF%E9%99%90%E5%AE%9A%E5%95%86%E5%93%81-%E7%8D%A8%E5%AE%B6%E8%B2%A9%E5%94%AE%E5%8E%9F%E5%9B%A0%E6%9B%9D%E5%85%89-051800318.html) — Remonte aux origines de la soupe de maïs chez McDonald's Taïwan et explique comment elle est devenue une soupe permanente, chose rare à l'échelle mondiale.
+
+[^7]: [Les internautes surnomment KFC « la pâtisserie à pastéis de nata que le poulet frit a détournée de sa vocation » (Instagram)](https://www.instagram.com/p/DThlbJHAouU/) — Documente l'excellente réputation des pastéis de nata de KFC sur les réseaux sociaux, révélatrice de la place singulière du produit sur le marché taïwanais du dessert.
+
+[^8]: [Que les Italiens ne se fâchent pas ! Ces pizzas aux saveurs improbables, les avez-vous goûtées ? (LINE Today)](https://today.line.me/tw/v3/article/wDL86a) — Recense les pizzas insolites lancées au fil des ans par Pizza Hut et interroge leur rapport de défi et de fusion avec la culture pizzaïole traditionnelle.
+
+[^9]: [Le lu wei « festin étoilé » de 7-ELEVEN (Instagram)](https://www.instagram.com/p/DB1A-LTSUvS/) — Présente la standardisation par 7-ELEVEN du lu wei traditionnel des marchés de nuit, qui approfondit l'ancrage local des plats préparés en supérette.
+
+[^10]: [OPEN-chan (Wikipédia en chinois)](https://zh.wikipedia.org/zh-hant/OPEN%E5%B0%8F%E5%B0%87) — Présente l'univers et l'influence culturelle d'OPEN-chan, porte-parole de 7-ELEVEN, et en fait un cas d'école de la mascotte de marque à Taïwan.
+
+[^11]: [Le génie du marketing Liu Hong-zheng enseigne les 4 étapes du succès d'une IP de personnage (CommonWealth Magazine)](https://www.cw.com.tw/article/5137665) — Un professionnel chevronné du marketing décrypte la façon dont des IP de marque telles qu'OPEN-chan ou l'ours Fuli créent un lien affectif et de la valeur commerciale.
+
+[^12]: [L'affaire du saumon (Wikipédia en cantonais)](https://zh-yue.wikipedia.org/wiki/%E9%AE%AD%E9%AD%9A%E4%B9%8B%E4%BA%82) — Retrace la vague de changements de prénom déclenchée en 2021 par l'opération promotionnelle de Sushiro, révélatrice de la passion taïwanaise pour le saumon et de la psychologie du consommateur.
+
+[^13]: [Le saumon de « Sushiro » comme de « Kura Sushi » vient de « Sushi Express » (Threads)](https://www.threads.com/@head_bro_5.0/post/DT25_mfD1q5/) — Met au jour les relations d'approvisionnement en saumon des grandes chaînes de sushis taïwanaises et l'influence de Sushi Express sur le marché des produits de la mer.
+
+[^14]: [Boutiques d'exception (Starbucks Taïwan)](https://www.starbucks.com.tw/stores/special.jspx) — Recense les boutiques Starbucks taïwanaises qui associent monuments historiques, paysages naturels et culture locale, illustrant son esthétique du « troisième lieu ».
+
+[^15]: [Étude sur la localisation des marques mondiales par la stratégie de conception de l'expérience spatiale (Journal of Humanities and Social Sciences, NDHU)](https://journal.ndhu.edu.tw/%E6%98%9F%E5%B7%B4%E5%85%8B%E7%89%B9%E8%89%B2%E9%96%80%E5%B8%82%E8%88%87%E5%9C%B0%E5%9C%96%E8%B1%A1%E7%9A%84%E5%BB%BA%E6%A7%8B/) — Travail universitaire sur la manière dont Starbucks réduit la distance perçue avec la marque par la conception de ses boutiques et enrichit l'expérience spatiale des consommateurs taïwanais.
+
+[^16]: [Le Costco le plus rentable au monde se trouve à Taïwan (Instagram)](https://www.instagram.com/reel/DWIbZnQEuZH/) — Rend compte du statut de premier magasin mondial de l'entrepôt Costco du sud de Taichung et analyse le modèle économique et les leviers de rentabilité qui le sous-tendent.
+
+[^17]: [Analyse : la méthode de localisation dans la stratégie mondiale de Costco (Manager Today)](https://www.managertoday.com.tw/columns/view/70961) — Décryptage approfondi de la manière dont Costco combine les habitudes de consommation taïwanaises pour bâtir un système de distribution par abonnement à forte fidélité.
+
+[^18]: [Le Costco taïwanais est-il numéro un mondial en chiffre d'affaires ? (Threads)](https://www.threads.com/@kore.sugoi/post/C7nUUAcP2Dh) — Une discussion en ligne qui reflète le très fort taux de pénétration de Costco à Taïwan, en particulier l'impact de services localisés comme les stations-service.
+
+[^19]: [Historique de l'entreprise (MOS Burger Taïwan)](https://www.mos.com.tw/invest/history.html) — Consigne les jalons du développement de MOS Burger à Taïwan, dont le lancement du burger de riz et l'obtention des labels d'ingrédients locaux.
+
+[^20]: [MOS Burger (Wikipédia en chinois)](https://zh.wikipedia.org/zh-hant/%E6%91%A9%E6%96%AF%E6%BC%A2%E5%A0%A1) — Présente MOS Burger comme figure de proue de la restauration rapide japonaise et montre comment la culture du riz lui a permis de se différencier sur le marché taïwanais.
+
+[^21]: [La glace à l'italienne d'IKEA dépasse le million d'unités vendues par an (ET Fashion)](https://fashion.ettoday.net/news/2332430) — Analyse la stratégie du produit d'appel appliquée à la glace d'IKEA et explique comment une offre bon marché génère du trafic dans un magasin de meubles.
+
+[^22]: [Les Taïwanais sont les champions du monde du repas chez IKEA ! (CommonWealth Magazine)](https://www.cw.com.tw/article/5113137) — Explore le fait qu'IKEA Taïwan affiche la part de restauration la plus élevée au monde et analyse la culture taïwanaise du repas en grande surface.
+
+[^23]: [« Le restaurant que les meubles ont détourné de sa vocation » : la directrice générale d'IKEA répond (NOWnews)](https://www.nownews.com/news/6258293) — IKEA réagit officiellement aux chiffres de sa restauration et confirme la place centrale de l'offre alimentaire dans l'activité de ses magasins taïwanais.
+
+[^24]: [Pourquoi IKEA vend-elle des glaces si bon marché ? Les 3 grands secrets marketing (Yahoo Finance)](https://tw.stock.yahoo.com/news/ikea%E7%82%BA%E4%BD%95%E8%B3%A3%E4%BE%BF%E5%AE%9C%E9%9C%9C%E6%B7%87%E6%B7%8B-%E8%83%8C%E5%BE%8C%E9%9A%B1%E8%97%8F3%E5%A4%A7%E7%87%9F%E9%8A%B7%E7%A7%98%E5%AF%86-024600491.html) — Analyse, sous l'angle de la psychologie marketing, la façon dont l'offre alimentaire à bas prix d'IKEA façonne l'image globale d'une marque au très bon rapport qualité-prix.
+
+[^25]: [Une glace en forme de requin ! (Threads)](https://www.threads.com/@solo_guide/post/DPLeO2JCSJK/) — Documente le marketing créatif d'IKEA, qui associe IP populaires et saveurs locales, et son interaction avec la culture populaire taïwanaise.
+
+[^26]: [Carrefour rachète Wellcome : pourquoi PX Mart n'a-t-il pas peur ? (Manager Today)](https://www.managertoday.com.tw/articles/view/59989) — Analyse le paysage concurrentiel après le rachat de Wellcome par Carrefour et explicite son objectif d'expansion dans les circuits de proximité.
+
+[^27]: [Carrefour investit 3,2 milliards pour racheter Wellcome et Jasons (YouTube)](https://www.youtube.com/watch?v=SY1pGgGm9og) — Reportage vidéo sur la décision de Carrefour de racheter les supermarchés Wellcome et sur ses effets sur la distribution taïwanaise.
+
+[^28]: [Centre d'impact Carrefour (Carrefour Taïwan)](https://www.carrefour.com.tw/impact-center.html) — Présente le programme de développement durable porté par Carrefour à Taïwan, incluant la coopération avec les petits producteurs et le bien-être animal.
+
+[^29]: [Carrefour Taïwan (Wikipédia en chinois)](https://zh.wikipedia.org/zh-hant/%E5%8F%B0%E7%81%A3%E5%AE%B6%E6%A8%82%E7%A6%8F) — Retrace en détail l'évolution actionnariale de Carrefour Taïwan, du capital français au capital taïwanais.
+
+[^30]: [L'acquisition de Carrefour par Uni-President pour 30,2 milliards (SinoPac Securities)](https://www.sinotrade.com.tw/richclub/hotstock/691d5748219006395e9999cc) — Analyse le dispositif de distribution du groupe Uni-President après le rachat de Carrefour et la valeur commerciale des synergies inter-marques.
+
+[^31]: [Carrefour va lui aussi changer de nom ! (Threads)](https://www.threads.com/@tainan_style/post/DScSDB5jwCV/) — Rapporte la décision du groupe Uni-President de mettre fin à la licence de marque Carrefour et les discussions qu'elle suscite en ligne.
+
+[^32]: [Carrefour in Taiwan to adopt new name from July (Taipei Times)](https://www.taipeitimes.com/News/taiwan/archives/2026/05/20/2003857675) — Article en anglais sur le calendrier et les modalités du changement de nom de Carrefour Taïwan, avec un regard international sur ce marché.
+
+[^33]: [Carrefour entre définitivement dans l'histoire : « changement d'enseignes à partir du milieu de l'année prochaine » (UpMedia)](https://www.upmedia.mg/tw/focus/comprehensive/247726) — Rend compte du lancement officiel par Uni-President du plan de changement de marque de Carrefour, symbole de la fin d'une époque.
+
+[^34]: [À partir du 1er juillet, Carrefour change officiellement de nom ! (Threads)](https://www.threads.com/@poethero/post/DaMx9BqGXgH/) — Message communautaire confirmant les derniers développements du changement de nom de Carrefour en « Wanjiafu » et « Lejiakang ».
+
+[^35]: [La page officielle vend la mèche : le « nouveau nom en quatre caractères » de Carrefour dévoilé (Mirror Media)](https://www.mirrormedia.mg/story/amp/20260523edi002) — Rapporte la divulgation anticipée des nouveaux noms de marque sur les réseaux sociaux officiels de Carrefour et l'attention considérable qu'elle a suscitée.
+
+[^36]: [Après 38 ans aux côtés de Taïwan, Carrefour tire sa révérence (Instagram)](https://www.instagram.com/reel/DaSisGUyzZi/) — Revient sur l'histoire de Carrefour à Taïwan et présente les connotations propitiatoires de la nouvelle marque « Wanjiafu ».
+
+[^37]: [Carrefour ferme et regroupe des magasins, et changerait de nom pour « Lejiakang » (Yahoo Finance)](https://tw.stock.yahoo.com/news/%E3%80%90%E5%AE%B6%E6%A8%82%E7%A6%8F%E6%94%B9%E5%90%8D1%E3%80%91%E7%B5%B1%E4%B8%80%E6%8E%A5%E6%89%8B%E5%BE%8C%E8%AE%8A%E4%BA%86%EF%BC%9F%E5%AE%B6%E6%A8%82%E7%A6%8F%E9%97%9C%E5%BA%97%E6%95%B4%E4%BD%B5%E5%8F%88%E5%82%B3%E6%94%B9%E5%90%8D%E3%80%8C%E6%A8%82%E5%AE%B6%E5%BA%B7%E3%80%8D-3%E5%A4%A7%E8%AE%8A%E5%8C%96%E4%B8%80%E6%AC%A1%E7%9C%8B-044558370.html) — Examine en profondeur les ajustements de formats de magasins et la refonte de marque de Carrefour après sa reprise par Uni-President.


### PR DESCRIPTION
﻿Adds French translation of `Food/國際品牌在地化.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`. Note: `i18n/fr/STYLE.md` does not exist in the repo yet (only `en` and `ja` are present), so this translation followed the shared TRANSLATE_PROMPT rules plus the frontmatter and glossing conventions already used across `knowledge/fr/`.

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is a native Chinese speaker with some French proficiency)

**Length ratio**: 2.881 (body chars 30,001 / 10,412) — inside the 2.0–4.0 healthy band for zh→fr

**Structure alignment**: 12 `##` sections / 37 footnote definitions / 37 URLs (exact multiset) — 100% preserved. `scripts/tools/lang-sync/verify-translation.py` reports 17 PASS / 0 FAIL (the single WARN is the ratio sub-tool failing to run under a Windows shell, not a content issue; the ratio was computed manually and is shown above).

**Conventions followed**:

- `subcategory` left as `飲食場景`, `curation: incubating` and all passthrough fields copied verbatim
- Taiwanese proper nouns glossed with the Chinese in parentheses on first mention (麥當樂, 爭鮮, 頂好, 合同廳舍, 萬家福, 樂家康 …), per the "keep the Chinese + explain" rule
- Both curator-note callouts and the `🧬` marker preserved

Uncertain terminology flagged for reviewer:

- 滷味 → lu wei · kept romanised with a short French gloss rather than translated as "plats mijotés à la sauce soja", which loses the category
- 葡式蛋撻 → pastel de nata / pastéis de nata · used the Portuguese term, which is the form current in French
- 萬家福 → « Wanjiafu » (Prosperity Plaza) and 樂家康 → « Lejiakang » (Uni-Prosperity) · kept pinyin plus the official English names given in the source; if there is a preferred French handling for new Taiwanese retail brand names, tell me and I will align
- 米漢堡 → burger de riz · straightforward, but MOS Burger France may use another wording
- 帶路雞策略 → « stratégie du produit d'appel » · the French marketing term rather than a literal rendering of the Taiwanese idiom
- 台農 64 號 → Tainong n° 64 · kept the cultivar designation untranslated
- CP 值 → rapport qualité-prix · the Taiwanese "CP value" shorthand has no French equivalent, so it is rendered by sense

Please review. Happy to iterate.
