### PR TITLE
translate(es): 台灣海關報關與 EZ WAY → ezway

### DIFF
--- a/knowledge/es/Lifestyle/ezway.md
+++ b/knowledge/es/Lifestyle/ezway.md
@@ -1,0 +1,401 @@
+---
+title: 'La aduana taiwanesa y EZ WAY: cuando pulsas «declaración conforme», ¿a quién estás dando poder?'
+description: 'El móvil vibra, la notificación muestra una lista de artículos que apenas entiendes, pulsas «declaración conforme» y lo que has completado, legalmente, es un mandato de despacho aduanero. En Taiwán hay 7,59 millones de personas registradas en esa app; en agosto de 2026, tras una publicación que estalló en redes, muchas fueron por primera vez a averiguar quién la opera: Trade-Van Information Services, una empresa cotizada en la que el Ministerio de Finanzas posee el 36,11 %, sin llegar a la mayoría. Al mismo tiempo, el Gobierno propone por segunda vez rebajar el umbral de exención de 2.000 NT$. ¿Quién ha pagado la factura de este atajo y quién no ha llegado a tomar la palabra en ningún momento?'
+date: 2026-08-04
+category: 'Lifestyle'
+tags:
+  [
+    'Aduanas',
+    'Despacho aduanero',
+    'EZ WAY',
+    'Yilewei',
+    'Comercio electrónico transfronterizo',
+    'Umbral de exención',
+    'Trade-Van',
+    'Gobernanza de datos personales',
+    'Administración de Aduanas',
+  ]
+subcategory: '消費與生活制度'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-08-04
+lastHumanReview: false
+readingTime: 16
+researchReport: 'reports/research/2026-08/台灣海關報關制度與EZWAY.md'
+image: '/article-images/lifestyle/ezway-customs-taoyuan-airport-2024.webp'
+imageCredit: 'Meutnake Ah ManHO / Wikimedia Commons'
+imageLicense: 'CC0 1.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:TW_台灣_Taiwan_台北_Taipei_臺灣桃園機場_Taoyuan_Airport_Terminal_One_入境區_Customs_counter_March_2024_R12S.jpg'
+rationale:
+  why_this_hook: '從「按下申報相符」這個全民共同手勢切入，把制度史、治理歸屬、免稅門檻三條線都掛在同一個動作上，避免寫成「EZ WAY 好不好用」的使用心得或「該不該課稅」的政策論戰。'
+  whats_excluded: '出口／寄件端制度（另一套法規體系，姊妹題候選）；未成年人委任的法律定性（公共討論尚未成形，無一手材料）；免稅門檻調降的量化經濟影響試算（政策未定案，無官方或學術推估）；台灣與日韓委外治理架構比較（會使文章滑向比較行政學）；X1-X4 與 C1/C3 完整技術分類表（只留「簡易申報沒有 C2」一句洞見）。'
+  where_it_hedges: '冒名報關 1,723／474／39 三個數字標明只見於二手媒體、官方新聞稿未載；手續費 0.8-3.5 元三版本互斥不簡化成單一費率；中國占小額免稅報單 64.4% 標明單一來源；國際門檻的美元換算標「概略、僅供量級比較」；年進口包裹量用「五千八百多萬件」的量級寫法不寫死精確數字；「亞洲第三個通關自動化」網路流傳說法查無一手出處，全文不使用。'
+  whos_pushing_back: '關務署長彭英偉三點澄清（非強制／防個資外洩／不向民眾收費）逐字完整呈現；官方否認「逕行收回公營」的措辭差異照實寫；「獨家壟斷」框架被汎宇電商自願退出的事實削弱；質疑方林岱樺與被質詢的關務署同屬執政體系，不套藍綠攻防；EZ WAY 至今無已發生的個資外洩或資安裁罰紀錄，與治理疑慮並陳。'
+relatedDiary:
+  - 2026-08-04-092431-ezway-rewrite
+  - 2026-08-04-142845-manual
+sporeLinks:
+  - id: 169
+    platform: 'facebook'
+    date: '2026-08-04'
+    url: 'https://www.facebook.com/61576525376323/posts/pfbid0BG8mE9DJ9JBrryDXSSnXDDLJZUVZmycvsMAzea6MuVcK2gMhUCtF9Bx9x9iXtHNAl'
+  - id: 167
+    platform: 'threads'
+    date: '2026-08-04'
+    url: 'https://www.threads.com/@taiwandotmd/post/Dbm5PdXE181'
+  - id: 168
+    platform: 'x'
+    date: '2026-08-04'
+    url: 'https://x.com/taiwandotmd/status/2084520918441951650'
+translatedFrom: 'Lifestyle/台灣海關報關制度與EZWAY.md'
+sourceCommitSha: '258412070'
+sourceContentHash: 'sha256:76dffd172486f9a9'
+translatedAt: '2026-08-26T20:41:59Z'
+---
+
+# La aduana taiwanesa y EZ WAY: cuando pulsas «declaración conforme», ¿a quién estás dando poder?
+
+> **En 30 segundos:** Cuando pulsas «declaración conforme» en la notificación de EZ WAY, lo que completas jurídicamente es un mandato de despacho aduanero: prestas tu nombre a un agente de aduanas para que declare ante la Aduana que esa mercancía es tuya. El proceso arranca en 1992, cuando la Aduana comprimió el tiempo de despacho de cuatro horas a tres minutos, y ha acabado convertido, desde el 1 de marzo de 2026, en un gesto obligatorio para toda la población. Hay 7,59 millones de personas registradas, más de cuatro millones de declaraciones al mes y alrededor del setenta por ciento de todos los expedientes de despacho pasan por ahí; quien lo gestiona es Trade-Van Information Services, una empresa cotizada en la que el Ministerio de Finanzas tiene el 36,11 %, sin mayoría. Al mismo tiempo, el Gobierno propone por segunda vez rebajar el umbral de exención de 2.000 NT$. ¿Quién ha pagado la factura de este atajo y quién no ha llegado a tomar la palabra en ningún momento?
+
+![Mostradores de aduana en la zona de llegadas de la Terminal 1 del Aeropuerto Internacional de Taoyuan, con la señalización de los canales verde y rojo y viajeros pasando por delante](/article-images/lifestyle/ezway-customs-taoyuan-airport-2024.webp)
+_Marzo de 2024, mostradores de aduana en la zona de llegadas de la Terminal 1 del Aeropuerto Internacional de Taoyuan. La imagen muestra el paso de viajeros; los paquetes de compras personales de los que habla este artículo siguen otro circuito, el de la declaración simplificada de mensajería, pero ambos comparten el mismo marco institucional: la Aduana. Photo: Meutnake Ah ManHO, Wikimedia Commons, CC0 1.0 (fuente completa al final del artículo)._
+
+## El móvil vibra y pulsas «declaración conforme»
+
+Cuando salta la notificación, lo más probable es que estés haciendo otra cosa. El titular dice que hay un mandato de despacho de importación pendiente de confirmación; al entrar aparece una descripción de artículos en letras y números que no acabas de entender, el nombre de un agente de aduanas del que nunca has oído hablar y una cifra: 1.870 NT$, justo por debajo del umbral de exención. Compruebas que efectivamente es lo que pediste hace tres semanas, pulsas «declaración conforme» y guardas el móvil. Todo el asunto no llega a diez segundos.
+
+Esos diez segundos tienen una descripción oficial. La Administración de Aduanas lo formula así: «primero el agente de aduanas envía por la app "EZ Way 易利委" la información de la mercancía al ciudadano; una vez que este confirma que coincide con lo que compró realmente y completa el mandato en línea, el agente tramita el resto del procedimiento de despacho»[^1]. Traducido: lo que estás pulsando no es «he recibido el paquete», sino «doy mandato a este agente de aduanas para que declare esta mercancía ante la Aduana en mi nombre». El mandato en sí ya existía en el artículo 22 de la Ley de Aduanas[^2]; lo único que ha cambiado es que antes vivía en un papel que había que firmar y acompañar de una fotocopia del documento de identidad.
+
+Ese 1.870 tampoco es una cifra cualquiera: los paquetes importados con un valor en aduana de hasta 2.000 NT$ están exentos de arancel, impuesto sobre consumos específicos e impuesto sobre el valor añadido, según el artículo 7 del Reglamento de Despacho Aduanero de Envíos Postales[^3]. Y el valor en aduana se calcula sumando al precio efectivamente pagado por la mercancía el flete y el seguro[^4], no la cifra que aparece en la página del carrito. Mucha gente descubre en la pantalla de pago que la franquicia se la ha comido el envío internacional. Además, una misma persona solo puede usar esa franquicia seis veces por semestre, con recuentos independientes de enero a junio y de julio a diciembre[^5]. Entre el 1 de julio y el 23 de agosto de 2020, en menos de dos meses, 126.000 personas ya habían agotado sus seis usos[^6].
+
+```tw-stat
+Cómo se calcula la línea de la exención: no es la cifra de tu carrito
+2.000 NT$ | Límite de exención sobre el valor en aduana | Exento de arancel, impuesto sobre consumos específicos e IVA
+Mercancía + flete + seguro | Cómo se calcula el valor en aduana | No es el precio de venta del producto
+6 veces por semestre | Número de usos exentos por persona | Enero-junio y julio-diciembre se cuentan por separado
+126.000 personas | Agotaron las 6 veces en menos de dos meses | Del 1/7 al 23/8 de 2020
+Fuentes: artículo 7 del Reglamento de Despacho Aduanero de Envíos Postales, artículo 29 de la Ley de Aduanas, notas de prensa de la Administración de Aduanas, Liberty Times Finance
+```
+
+En esa pantalla tu poder se reduce a dos botones. La descripción y el importe los rellena el agente de aduanas; el destinatario solo puede marcar «conforme» o «no conforme», sin poder modificar nada. En un hilo de Mobile01, un usuario descubrió que la descripción y el importe declarados no coincidían con lo que había comprado. Otro contó que marcó «no conforme», anotó el importe correcto en las observaciones y el paquete llegó igualmente sin retrasos apreciables[^7]. Lo único que puedes hacer es notificar la discrepancia; si se corrige y cómo se corrige vuelve a estar en manos del agente.
+
+Desde el 1 de marzo de 2026, este gesto ha pasado de «confirmar cuando llega la mercancía» a «sin confirmación previa no entra»: las mercancías de mensajería con declaración simplificada importadas por particulares exigen completar el mandato de confirmación previa antes de la declaración[^8]. A principios de agosto, una publicación en Threads puso el asunto sobre la mesa. Su autor contaba que llevaba años usando la app y que solo hacía poco se había enterado de quién la operaba; el mensaje acumuló más de cuatro mil «me gusta» y los comentarios repitieron el mismo desconcierto centenares de veces: «o sea que cuando compro en iHerb tengo que despachar en aduana con una empresa privada»[^9].
+
+Al mediodía siguiente, el director general de la Administración de Aduanas del Ministerio de Finanzas, Peng Ying-wei, convocó una rueda de prensa. Su primera frase fue: «Últimamente circulan por internet tres grandes malentendidos sobre EZ Way que se repiten sin comprobarse.»[^10] Para entender qué es lo que se malinterpreta, hay que volver treinta y cuatro años atrás.
+
+## En 1992, cuatro horas se convirtieron en tres minutos; después llegaron los paquetes
+
+![Mostrador de atención aduanera del aeropuerto de Songshan, en Taipéi, con el rótulo de la Aduana de Taipéi de la Administración de Aduanas y el recorrido de paso de viajeros](/article-images/lifestyle/ezway-customs-songshan-airport-2017.webp)
+_Febrero de 2017, mostrador de atención aduanera del aeropuerto de Songshan, en Taipéi. Aunque el trámite se haya trasladado al móvil, estas ventanillas físicas siguen ahí; solo que la mayoría de la gente ya no se acerca a ellas. Photo: Yuriy Kosygin, Wikimedia Commons, CC BY-SA 4.0 (fuente completa al final del artículo)._
+
+El 9 de noviembre de 1992, la Aduana de Taipéi dejó constancia de una sola frase: «Esta Aduana implantó oficialmente la automatización del despacho de mercancías el 9 de noviembre de 1992»[^11]. Antes de esa fecha, cada declaración circulaba a mano de un mostrador a otro. Después, las declaraciones se transmitían en línea y un sistema experto informático decidía su recorrido según la categoría del operador, el origen y la naturaleza de la mercancía. El boletín de notas que el propio Ministerio de Finanzas dejó en su sala de archivo histórico dice así: «para los despachos por la vía C1, el tiempo de tramitación se ha reducido de 4 horas a los 3 minutos actuales»[^12].
+
+![Unidades de cinta magnética y armarios de cintas expuestos en el Museo de Aduanas, el equipo de almacenamiento de datos usado en los primeros años de la automatización del despacho](/article-images/lifestyle/ezway-customs-museum-tape-drives-2017.webp)
+_Unidades y armarios de cinta magnética en el Museo de Aduanas. Cuando en 1992 las declaraciones pasaron al ordenador, los datos se guardaban en máquinas como estas. Photo: 林高志, Wikimedia Commons, CC BY-SA 4.0 (fuente completa al final del artículo)._
+
+El precio de convertir cuatro horas en tres minutos fue dejar en manos del sistema, y en tiempo real, la decisión de «mirar o no mirar». C1 es despacho directo sin revisión documental ni inspección física; C3 es apertura e inspección. La declaración simplificada por la que pasan los paquetes de compras personales solo tiene esos dos desenlaces: no existe el nivel intermedio, el examen documental C2. El C2 queda reservado a las mercancías con valor en aduana superior a 50.000 NT$, que van por declaración ordinaria[^13]. Tu paquete o sale en tres minutos, o lo abren.
+
+Ese diseño aguantó más de veinte años. Y entonces llegaron los paquetes. Hace diez años Taiwán importaba al año paquetes pequeños en un orden de magnitud de diez y pico millones de unidades; en 2024 la cifra superaba los cincuenta y ocho millones. Los criterios estadísticos varían bastante según la institución, pero la dirección es la misma. Más revelador todavía dentro de esas mismas series es el valor unitario: el importe medio por paquete cayó de 1.396 NT$ en 2014 a 1.122 NT$ en 2024[^14]. Volumen disparado y precio unitario a la baja: así es como el comercio electrónico transfronterizo de bajo precio se manifiesta en la aduana.
+
+A partir de ahí, el sistema se fue apretando una vez tras otra, y en cada vuelta de tuerca la razón oficial fue la misma: impedir las declaraciones con identidad suplantada. El 15 de junio de 2018, el Ministerio de Finanzas publicó las directrices del programa piloto y se abrió oficialmente la autenticación de identidad del destinatario de mensajería y el mandato en línea[^15]. Desde el 16 de mayo de 2020, la Aduana dejó de admitir la declaración simplificada de quien no hubiera completado el registro con verificación de identidad ni entregado un mandato en papel[^16]. Mucha gente toma esa fecha como el estreno de EZ WAY; en realidad es el día en que se levantó la barrera del «sin mandato no hay despacho». Las tres fases posteriores dibujan una ampliación constante: en diciembre de 2021 se apuntó primero a quienes habían sufrido suplantaciones o no respondían repetidamente a las notificaciones; en septiembre de 2022 se abrió la adhesión voluntaria al público general; en agosto de 2023 se amplió el universo obligatorio, hasta llegar al 1 de marzo de 2026, cuando pasó a ser obligatorio para todo el mundo[^17][^18][^19].
+
+En treinta y cuatro años, el proceso pasó de «que la mercancía entre más rápido» a «que la persona demuestre primero quién es». Ambas cosas se sostienen. Lo que nadie explicó a la vez fue esto: eso que acredita tu identidad por ti, ¿quién lo hace y quién lo mantiene?
+
+```tw-timeline
+De la lista nominal a la obligación universal: ocho años, tres fases, una ampliación continua
+1992 | Arranca la automatización del despacho de carga aérea | Por la vía C1, sin revisión ni inspección, el tiempo baja de 4 horas a 3 minutos
+2018 | Programa piloto de verificación de identidad y mandato en línea | El 15 de junio se publican las directrices y EZ WAY empieza a admitir registros
+2020 | Sin mandato no hay tramitación | Desde el 16 de mayo, sin registro completo ni mandato en papel, la Aduana no admite la declaración simplificada
+2021 | Mandato previo 1.0 | Desde el 28 de diciembre, dirigido a quienes sufrieron suplantación o no respondieron reiteradamente a las notificaciones
+2022 | Mandato previo 2.0 | Desde el 15 de septiembre, el público general puede adherirse voluntariamente
+2023 | Mandato previo 3.0 | Desde el 22 de agosto se amplía el universo obligatorio
+2026 | Obligatorio para todos | Desde el 1 de marzo, toda mercancía de mensajería con declaración simplificada importada por particulares exige mandato de confirmación previa
+Fuentes: páginas oficiales de la Administración de Aduanas, notas de prensa y órdenes normativas del Ministerio de Finanzas
+```
+
+## El Ministerio de Finanzas tiene el 36,11 % y la Aduana dice que «no obliga a nadie»
+
+![Puerta principal del edificio de la Aduana de la Administración de Aduanas del Ministerio de Finanzas, un edificio de piedra blanca con el rótulo del organismo sobre el dintel](/article-images/lifestyle/ezway-customs-administration-hq-taipei-2017.webp)
+_Agosto de 2017, puerta principal del edificio de la Aduana de la Administración de Aduanas del Ministerio de Finanzas. La controversia sobre a quién corresponde la gobernanza de EZ WAY pregunta precisamente por la distancia entre este edificio y Trade-Van. Photo: 林高志, Wikimedia Commons, CC BY-SA 4.0 (fuente completa al final del artículo)._
+
+En la rueda de prensa del mediodía del 3 de agosto, lo primero que Peng Ying-wei quiso aclarar fue la obligatoriedad: «La Aduana no obliga a los ciudadanos a usar EZ Way; EZ Way es solo una de las herramientas para que el ciudadano confirme la relación de mandato con el agente de aduanas.» Lo segundo, los datos personales: «antes solo existía el mandato en papel, y precisamente porque era fácil suplantar identidades se impulsó el mandato en línea», de modo que ahora el ciudadano no tiene que entregar una fotocopia de su documento de identidad al agente. Lo tercero, el dinero: «actualmente EZ Way cobra a los agentes de aduanas y no cobra nada al ciudadano común.»[^10] Cada una de esas tres frases tiene respaldo comprobable.
+
+La empresa que hace la app se llama Trade-Van Information Services. Nació como «Grupo de Planificación y Promoción de la Automatización del Despacho de Mercancías del Ministerio de Finanzas» y en agosto de 1996 se transformó en una sociedad participada conjuntamente por el Ministerio de Finanzas y accionistas privados[^20]; cotizó en el mercado OTC en 2000 y en bolsa en 2011. El Ministerio de Finanzas posee hoy 54.162.436 acciones, un 36,11 %: es el mayor accionista, pero no alcanza la mayoría[^21], y ocupa seis de los doce puestos del consejo de administración[^22]. Las dos cifras, participación y asientos, se detienen justo antes de la mayoría.
+
+El volumen que Trade-Van gestiona hoy es este: a finales de julio de 2026, unos 7,59 millones de personas habían completado su registro en EZ WAY, y cada mes se tramitan por ahí más de cuatro millones de declaraciones simplificadas de importación por mensajería, alrededor del setenta por ciento del total de expedientes de despacho[^21]. Una de cada tres personas en Taiwán se ha registrado alguna vez.
+
+```tw-stat
+Una empresa cotizada sin mayoría pública sostiene un trámite obligatorio para toda la población
+36,11 % | Participación del Ministerio de Finanzas | Mayor accionista, sin mayoría
+6 de 12 asientos | Puestos del Ministerio de Finanzas en el consejo de Trade-Van | Exactamente la mitad, sin mayoría
+7,59 millones | Registros acumulados en EZ WAY | A finales de julio de 2026
+Cerca del 70 % | Proporción sobre el total de expedientes de despacho | Más de cuatro millones de declaraciones al mes
+Fuentes: Global Views Monthly (participación, registros y proporción), Mirror Media (asientos del consejo)
+```
+
+La versión que circula por internet dice que «el Gobierno ha entregado los datos personales de 7,59 millones de personas a una empresa privada». Ese relato falla en dos puntos. Trade-Van no fue elegida por el Gobierno: cuando en 2018 se abrió el mandato en línea, existía otro operador con licencia de red de despacho aduanero, Universal EC. Un funcionario de la Administración de Aduanas recuerda aquellos años: «Universal EC lo evaluó y, por consideraciones de su propia operación, no participó; Trade-Van decidió asumirlo», y describe a Trade-Van como quien «prácticamente puso recursos por delante para apagar el fuego»[^20].
+
+La licencia tampoco salió de una licitación. El Reglamento de Autorización y Gestión de las Redes de Despacho Aduanero exige un capital desembolsado de 500 millones de NT$, somete la solicitud a una comisión evaluadora del Ministerio de Finanzas y obliga a recertificar la acreditación cada cinco años[^23]. La aclaración oficial del 3 de agosto se apoyó justamente en ese marco: cualquier operador con licencia de red de despacho puede desarrollar su propia app, sin necesidad de designación de la Aduana, y tanto Trade-Van como Universal EC figuraban entonces en esa lista[^24].
+
+Este proceso obligatorio para toda la población nunca ha sido presupuestado por nadie como infraestructura pública. La puerta ha estado siempre abierta: la otra empresa que en su día cumplía los requisitos evaluó la situación y decidió no entrar, después no ha entrado nadie más y, ocho años más tarde, solo queda un operador dentro.
+
+> **💡 ¿Lo sabías?**
+> Hay camino sin usar la app, solo que requiere unos cuantos pasos más. La alternativa que la Administración citó el 3 de agosto al insistir en que EZ WAY «es solo una herramienta más» es entrar con el certificado digital de persona física en la Ventanilla Única de Aduanas, Puertos y Comercio y otorgar el mandato en línea[^24]. La otra vía es el papel: la página explicativa de la Administración de 2020 recoge que el ciudadano puede entregar un mandato en papel junto con fotocopias del anverso y el reverso de su documento de identidad al agente de aduanas responsable de esa mercancía, sin necesidad de desplazarse él mismo a la Aduana[^25]. Cómo funcionan estas dos vías bajo el régimen de 2026 es algo que la Administración no ha vuelto a explicar con el mismo nivel de detalle operativo.
+
+En PTT circula una comparación: para irte de viaje al extranjero nadie te obliga a tener pasaporte, simplemente no vas a poder pasar la aduana[^26]. Después del 1 de marzo de 2026, ninguna norma dice que tengas que usar EZ WAY. Pero, salvo que hayas preparado de antemano una de esas dos alternativas, si no pulsas esa notificación tu paquete no sale del almacén.
+
+Pasar al mandato en línea ha evitado, es cierto, tener que entregar la fotocopia del documento de identidad al agente de aduanas. Pero esos datos del mandato están ahora en los sistemas de una empresa cotizada, no en los de un organismo público.
+
+## Una comisión de entre 0,8 y 3,5 NT$ por expediente
+
+Trade-Van cobra a los agentes de aduanas entre 0,8 y 3,5 NT$ por expediente. Cómo se escalona ese intervalo y qué tramo se suma a cuál tiene al menos tres versiones públicas distintas que no cuadran entre sí[^27][^28]. La diputada Lin Tai-hua multiplicó esos céntimos por el volumen total: «calculando sobre 60 millones de paquetes al año, prácticamente cada agente de aduanas paga cada mes a Trade-Van una cantidad equivalente al precio de un coche importado»[^29].
+
+El dinero sale del bolsillo de los agentes de aduanas, pero ese coste vuelve a la declaración y acaba repartido en el flete o en los gastos de gestión que paga el consumidor. «No te cobra directamente a ti» y «tú no has pagado ese dinero» no son lo mismo. En su interpelación ante la Comisión de Finanzas del Yuan Legislativo, Lin Tai-hua señaló que este sistema de despacho con verificación de identidad, previsto por la ley, se externalizó sin ni siquiera un contrato, dejando que una empresa privada cobrase comisiones a los ciudadanos y a las pymes taiwanesas[^30]. Ella es diputada del Partido Democrático Progresista[^31], y la Administración de Aduanas a la que interpela pertenece al mismo bloque gobernante.
+
+El dato de eficacia que más se cita del lado oficial es una serie descendente: los casos de despacho con identidad suplantada bajaron de 1.723 en 2023 y 474 en 2024 a 39 entre enero y octubre de 2025. La serie circula mucho, pero su origen solo puede rastrearse hasta una noticia de segunda mano[^32]. Y quienes plantean dudas tampoco tienen en la mano ninguna filtración real ni ninguna sanción que señalar. La inquietud de agosto apunta a un «y si», no a un «ya ha pasado».
+
+> **💡 ¿Lo sabías?**
+> En este asunto hay dos tipos de «suplantación», y van en direcciones opuestas. Una son las bandas de estafadores que se hacen pasar por la Aduana y te mandan un SMS pidiéndote una transferencia para pagar impuestos; la norma general de los organismos públicos es que los tributos se cobran mediante liquidación formal y nunca por enlaces enviados por SMS o mensajería social, y los mensajes sospechosos pueden verificarse o denunciarse en la web antifraude 165[^33]. La otra son las agencias de consolidación de envíos o los agentes de aduanas que usan tus datos personales para declarar sin tu consentimiento: Business Next documentó casos reales de consumidores cuya mercancía fue agrupada sin aviso con otros paquetes para pasar la aduana, y otro caso en el que una agencia usó directamente el nombre de un cliente que ni siquiera había pedido esa mercancía[^34]. El mandato previo pretende frenar esta segunda modalidad.
+
+Quién opera EZ WAY y quién cobra por ello se ha puesto sobre la mesa por primera vez en ocho años. Al mismo tiempo, ha vuelto a plantearse otro umbral, más antiguo. Y esta vez quien ha abierto la boca primero ha sido el Gobierno; los consumidores se han enterado después.
+
+## El umbral de 2.000 NT$: las dos veces ha sido el Gobierno quien ha querido bajarlo
+
+El 4 de mayo de 2017, una internauta que firmaba como «Duo-er» abrió una propuesta en la Plataforma de Participación Pública en Políticas titulada «En contra de reducir a 2.000 NT$ la franquicia de las compras en línea en el extranjero». Entre sus razones no hay una sola frase de lenguaje institucional; solo una frase de alguien que está echando cuentas de la vida diaria[^35].
+
+> **✦** «Los salarios de la gente ya no son altos; ahora resulta que el Gobierno tampoco nos deja buscar fuera un producto económico y decente»
+
+Cinco mil doscientas veintiséis personas la respaldaron. Aquella rebaja venía preparada del año anterior: en 2016 el Yuan Legislativo aprobó en tercera lectura la reforma del artículo 49 de la Ley de Aduanas, que dio a la vez base legal para ajustar el límite exento y para considerar «importación frecuente» las seis veces por semestre[^36][^3]. Las razones que dio el Ministerio de Finanzas fueron la competencia desleal entre operadores nacionales y extranjeros, la fuerte caída de los costes de recaudación, la reimportación de mercancía nacional para eludir impuestos y las quejas de los operadores nacionales. Estaba previsto que entrara en vigor el 1 de septiembre de 2017; el Ministerio fijó después el límite exento en 2.000 NT$ mediante el anuncio n.º 1061018778 de 7 de septiembre de 2017 y aplazó la entrada en vigor efectiva al 1 de enero de 2018[^35]. Cinco mil y pico nombres se tradujeron en cuatro meses.
+
+Desde que bajó a 2.000 NT$, el umbral no se ha vuelto a mover. En 2022 algún medio preguntó a la Administración de Aduanas si pensaba reajustarlo, y la respuesta fue que «si el límite exento para envíos de bajo valor es demasiado alto, es fácil que se produzcan reimportaciones de mercancía nacional para eludir impuestos», pero que «por ahora no hay planes de modificar el límite superior de la franquicia»[^37].
+
+El 10 de abril de 2025, en la Comisión de Finanzas del Yuan Legislativo, el diputado Wu Ping-jui puso en duda que ese umbral fuera justo para la industria manufacturera taiwanesa, y la ministra de Finanzas, Chuang Tsui-yun, respondió que «lo estamos analizando y sopesando»[^38]. Seis días más tarde, el diputado Kuo Kuo-wen propuso rebajar el umbral de forma diferenciada a 1.000 NT$ para países de origen con dumping de bajo precio, como China, y Chuang Tsui-yun contestó que «también incorporaremos esa dirección a nuestras consideraciones»[^39]. El mismo umbral de 2.000 NT$: hace ocho años eran los consumidores quienes frenaban al Gobierno; ocho años después es el propio Gobierno quien quiere bajarlo, y esta vez acotando el objetivo a determinados países de origen.
+
+La cifra que sostiene esa orientación es esta: la proporción de China en las declaraciones exentas de mensajería por debajo de 2.000 NT$ ha pasado en tres años del 50,4 % al 64,4 %, y sumando Hong Kong supera el 88 %[^40].
+
+En ese mismo periodo, otros países también están desmontando su propio umbral. Estados Unidos lo ha suprimido por completo y la Unión Europea ha pasado a cobrar un arancel transitorio; el motivo es en ambos casos la misma frase: la exención de bajo valor se diseñó para que la mercancía entrase más rápido y ahora se usa como un agujero[^41][^42][^43]. Japón lo fija en un valor imponible de hasta 10.000 yenes y Corea del Sur en 150 dólares para mercancías generales; puestos todos en la misma lista, los 2.000 NT$ de Taiwán (unos 63 dólares) quedan claramente en el extremo más bajo[^44][^45].
+
+```tw-bars
+Entre los países que aún mantienen umbral, Taiwán tiene el más bajo; Estados Unidos ha borrado la línea entera (equivalencia aproximada en dólares)
+Unión Europea | 175 | 150 euros; desde el 1 de julio de 2026 se añaden 3 euros por envío
+Corea del Sur | 150 | Mercancías generales; 200 dólares para envíos exprés desde Estados Unidos
+Japón | 67 | Valor imponible de hasta 10.000 yenes
+*Taiwán | 63 | Valor en aduana de 2.000 NT$, flete y seguro incluidos
+Estados Unidos | 0 | Eran 800 dólares; suprimido por completo desde el 29 de agosto de 2025
+Fuentes: Orden Ejecutiva 14324 de la Casa Blanca, Consejo de la Unión Europea, Oficina de Aduanas y Aranceles del Ministerio de Finanzas de Japón, guías de despacho de Corea del Sur y el Reglamento de Despacho Aduanero de Envíos Postales de Taiwán. Las divisas distintas del dólar se convierten a tipos aproximados, solo para comparar órdenes de magnitud
+```
+
+> **📝 Nota del curador**
+> La mayoría de las informaciones presentan el movimiento del Ministerio de Finanzas como «suprimir la exención»; lo que realmente se estudia es una rebaja diferenciada a 1.000 NT$ para determinados países de origen. Esa diferencia, que suena muy técnica, deja al descubierto el dilema de quien decide: quiere frenar los paquetes baratos sin tocar la comodidad que los consumidores ya tienen para comprar en Europa, Estados Unidos o Japón, y por eso elige una fórmula más fina y también más difícil de aplicar. ¿Cómo se determina el país de origen? ¿Y qué pasa con lo que se envía primero a un tercer territorio y entra desde ahí? Cuanto más preciso es el umbral, más coste de ejecución se acumula sobre el mostrador de la Aduana; y esa factura, en las dos polémicas, no se la ha calculado nadie en voz alta.
+
+En estas dos rondas de rebaja, entre las razones que cita la Administración aparece siempre la misma frase: «los operadores lo han manifestado».
+
+## La Administración convoca rueda de prensa; a los demás solo les queda el «según se informa»
+
+La rueda de prensa de la Administración de Aduanas del 3 de agosto terminó a mediodía y por la tarde todos los medios ya podían citar la formulación completa de las tres aclaraciones. Ese mismo día el Taipei Times publicó su versión en inglés, con las palabras del director general traducidas frase a frase, de modo que incluso quien no lee chino puede comprobar qué dijo[^46]. Las demás voces de esta polémica han quedado bastante más apagadas.
+
+Del lado de los diputados hubo interpelaciones, pero lo que ha circulado son sobre todo frases reelaboradas por los periodistas. De lo que Lin Tai-hua dijo en la Comisión de Finanzas, lo que la gente ha leído es una versión referida[^30].
+
+La industria manufacturera nacional es la más mencionada y la que menos habla por sí misma. En la rebaja de 2018, entre las razones del Ministerio de Finanzas figuraba que «los operadores nacionales lo han manifestado». En la reapertura del debate en 2025, lo que funcionarios y diputados repiten desde el estrado sigue siendo «el sector manifiesta competencia desleal». Qué operadores concretos, en ninguna de las dos ocasiones aparece un nombre. Desde que Shein y Temu entraron en el mercado taiwanés hasta hoy, ninguna asociación empresarial, ningún gremio del comercio minorista, ninguna federación industrial ha dado la cara con nombre propio.
+
+Los funcionarios de primera línea están aún más callados. La Administración de Aduanas ha publicado el número de personal que interpreta imágenes de rayos X: a fecha de 2023, 368 en nivel inicial, 591 en nivel intermedio y 184 en nivel avanzado; en ese mismo documento, las incautaciones de drogas pasan de 355 casos en 2018 a 558 en 2023[^47]. En esta década los paquetes han crecido de diez y pico millones a más de cincuenta y ocho millones de unidades, y quienes miran las imágenes en la pantalla siguen siendo esos pocos cientos de personas; pero no hay ningún comunicado sindical ni ningún funcionario que dé su nombre para contar en qué se ha convertido ese trabajo.
+
+Las agencias de consolidación y los intermediarios de compras aparecen en las noticias casi siempre cuando los pillan: paquetes agrupados para pasar la aduana, declaraciones hechas con el nombre de otra persona. Si el umbral de exención baja de verdad, el primer negocio que se resentirá será el suyo, y sin embargo en toda la polémica no han dicho una sola palabra.
+
+En cuanto a los consumidores, la ronda de 2017 dejó 5.226 nombres de apoyo y un texto de propuesta que puede citarse literalmente. En la de 2025-2026, lo más ruidoso ha sido una publicación en Threads con más de cuatro mil «me gusta» y una alfombra de reseñas de una estrella en la tienda de aplicaciones: fallos en el reconocimiento del documento de identidad, registro engorroso, atención al cliente inalcanzable[^48]. En esta ronda no hay recogida de firmas, ni encuesta, ni nadie que dé su nombre.
+
+```tw-versus
+El mismo colectivo de consumidores, dos rondas de polémica, dos registros distintos
+La ronda de 2017 | La ronda de 2025-2026
+Una propuesta formal en la Plataforma de Participación Pública | Una publicación en Threads
+5.226 firmas de apoyo | Más de cuatro mil «me gusta»
+Un texto de propuesta que puede citarse literalmente | Reseñas de una estrella en la tienda de aplicaciones
+Todavía consultable, con el número de personas contabilizado | Cuando el algoritmo se enfría, se dispersa en el feed
+Fuentes: página de la propuesta en la Plataforma de Participación Pública en Políticas, China Times, tienda taiwanesa de la App Store
+```
+
+La factura pendiente no es solo de dinero, también de palabra. En la parte del dinero, con la versión más citada: entre 0,8 y 3,5 NT$ por expediente, más de cincuenta y ocho millones de envíos al año, repercutidos capa a capa. La parte de la palabra es más difícil de seguir: cuando esta polémica haya pasado, lo único que podrá recuperar quien venga después será la versión completa de una sola de las partes.
+
+> **📝 Nota del curador**
+> Esta asimetría no es maldad de nadie. Una institución con rueda de prensa puede poner tres frases en manos de todos los medios el mismo día, y hasta un lector en inglés puede comprobar qué dijo; quien no tiene rueda de prensa solo puede esperar a que otro lo cuente por él, y lo contado se desvirtúa, desaparece y a los seis meses ya no se encuentra. En una polémica, todas «las posturas de las partes» parecen estar ahí, pero el grosor del registro que queda difiere en varios órdenes de magnitud: la diferencia no está en quién tiene más razón, sino en quién tiene capacidad de dejar constancia de sus palabras.
+
+## A finales de octubre hay que entregar la primera respuesta
+
+![Entrada de la Aduana de Keelung de la Administración de Aduanas del Ministerio de Finanzas, con la placa del organismo colgada en la puerta](/article-images/lifestyle/ezway-keelung-customs-entrance-2026.webp)
+_Marzo de 2026, entrada de la Aduana de Keelung de la Administración de Aduanas del Ministerio de Finanzas. Lo que el informe de revisión de finales de octubre tiene que responder es quién debe sostener la función que hay detrás de esta puerta y quién debe pagarla. Photo: 丘崈, Wikimedia Commons, CC0 (fuente completa al final del artículo)._
+
+En la Comisión de Finanzas del 29 de julio, Peng Ying-wei se comprometió[^49] a presentar en tres meses un informe monográfico de revisión que evalúe si EZ WAY debe incorporarse a la infraestructura pública nacional y financiarse con presupuesto estatal[^27]. En la rueda de prensa del 3 de agosto lo reiteró, precisando al mismo tiempo que eso no equivale a reestatalizar el servicio sin más[^49]. Los tres meses cuentan desde finales de julio, así que el plazo vence a finales de octubre.
+
+La otra línea sigue abierta: la rebaja diferenciada del umbral de exención de 2.000 NT$ continúa en estudio y, hasta agosto de 2026, el Ministerio de Finanzas no ha anunciado formalmente ningún ajuste; siguen vigentes los 2.000 NT$ y las seis veces por semestre[^50]. En ese mismo periodo, la línea estadounidense ya se cerró el 29 de agosto de 2025 y la europea empezó a cobrar 3 euros por envío el 1 de julio de 2026.
+
+De las dos líneas, una tiene fecha límite y la otra no. EZ WAY tiene diputados que preguntan, un director general que se ha comprometido y un informe que entregar a finales de octubre. El umbral de exención sigue detenido en la palabra «estudio», sin plazo y sin nadie que lo persiga en comisión.
+
+La próxima vez que vibre el móvil, la notificación volverá a saltar y tú volverás a pulsar «declaración conforme». La diferencia es que esta vez ya sabes qué hay al otro lado de ese botón: el servidor de una empresa cotizada, una barrera de acreditación de 500 millones de NT$ y una comisión que acabará repartida en tu flete. Todo eso llevaba ocho años existiendo y solo cuando estalló una publicación se puso por primera vez sobre la mesa de una rueda de prensa. A finales de octubre, la respuesta volverá a esa misma mesa.
+
+**Lecturas relacionadas**:
+
+- [El ecosistema del comercio electrónico y el pago digital en Taiwán](/es/technology/e-commerce-and-digital-payment-ecosystem) — El contexto más amplio de plataformas de comercio transfronterizo de bajo precio como Shein o Temu en el mercado taiwanés
+- [La política de comercio internacional de Taiwán](/es/economy/taiwan-international-trade-policy) — El marco general en el que se inscribe la polémica del umbral de exención: cómo comercia Taiwán con el mundo
+- [Empresas de Taiwán: Chunghwa Telecom](/es/economy/taiwan-companies-chunghwa-telecom) — Otra empresa con participación pública y gestión privada, útil como contraste de modelos de gobernanza
+
+## Créditos de las imágenes
+
+Este artículo utiliza 5 imágenes de dominio público o con licencia CC, todas ellas cacheadas en `public/article-images/lifestyle/` para evitar el enlace directo a los servidores de origen:
+
+- [TW 台灣 Taiwan 台北 Taipei 臺灣桃園機場 Taoyuan Airport Terminal One 入境區 Customs counter March 2024](https://commons.wikimedia.org/wiki/File:TW_台灣_Taiwan_台北_Taipei_臺灣桃園機場_Taoyuan_Airport_Terminal_One_入境區_Customs_counter_March_2024_R12S.jpg) — Photo: Meutnake Ah ManHO, 2024-03-10, CC0 1.0 (imagen principal)
+- [Customs in Taipei Songshan Airport](https://commons.wikimedia.org/wiki/File:Customs_in_Taipei_Songshan_Airport.jpg) — Photo: Yuriy Kosygin, 2017-02-13, CC BY-SA 4.0 (imagen 1)
+- [海關博物館 磁帶機與磁帶櫃 20170818b](https://commons.wikimedia.org/wiki/File:海關博物館_磁帶機與磁帶櫃_20170818b.jpg) — Photo: 林高志, 2017-08-18, CC BY-SA 4.0 (imagen 2)
+- [財政部關務署海關大樓大門 20170818](https://commons.wikimedia.org/wiki/File:財政部關務署海關大樓大門_20170818.jpg) — Photo: 林高志, 2017-08-18, CC BY-SA 4.0 (imagen 3)
+- [財政部關務署基隆關入口](https://commons.wikimedia.org/wiki/File:財政部關務署基隆關入口.jpg) — Photo: 丘崈, 2026-03-22, CC0 (imagen 4)
+
+## Referencias
+
+
+[^1]: [Desde el 1 de marzo, mandato previo generalizado para la mensajería importada por particulares](https://money.udn.com/money/story/6710/9341541) — Economic Daily News, diciembre de 2025. Recoge literalmente la definición oficial de la Administración de Aduanas sobre el «mandato de confirmación previa»; es la frase clave para entender que pulsar «declaración conforme» equivale jurídicamente a un mandato en línea.
+
+
+[^2]: [Artículo 22 de la Ley de Aduanas](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=G0350001&flno=22) — Texto legal de la Base de Datos Nacional de Legislación, que establece que «los trámites de despacho y pago de tributos correspondientes a las mercancías podrán encomendarse a agentes de aduanas»; es la base legal de la relación de mandato.
+
+
+[^3]: [Artículo 7 del Reglamento de Despacho Aduanero de Envíos Postales](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=G0350072&flno=7) — Texto original en la Base de Datos Nacional de Legislación: exime de arancel, impuesto sobre consumos específicos e IVA a los envíos con valor en aduana de hasta 2.000 NT$, y excluye el tabaco, el alcohol y los productos agrícolas sujetos a contingente arancelario. Última modificación: 1 de abril de 2020.
+
+
+[^4]: [Artículo 29 de la Ley de Aduanas](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=G0350001&flno=29) — Base legal del valor en aduana; enumera los seis conceptos que deben añadirse al valor de transacción (comisiones y corretajes, envases, cánones, flete y gastos de carga y descarga, seguro, etc.). Los envíos personales de bajo valor suelen implicar solo el precio de la mercancía, el flete y el seguro, que es el escenario simplificado que adopta este artículo.
+
+
+[^5]: [Administración de Aduanas: seis usos por semestre para los envíos exentos de bajo valor](https://web.customs.gov.tw/singlehtml/2222?cntId=cus1_185635_2222) — Nota de prensa de la Administración de Aduanas de 25 de agosto de 2020; explica literalmente que el levante exento para envíos con valor en aduana de hasta 2.000 NT$ se limita a seis veces por semestre para un mismo sujeto pasivo, y anuncia la nueva consulta de «datos de importación frecuente» en la Ventanilla Única.
+
+
+[^6]: [126.000 personas agotaron en dos meses sus seis usos exentos del semestre](https://ec.ltn.com.tw/article/breakingnews/3272174) — Liberty Times Finance, 26 de agosto de 2020; registra que entre el 1 de julio y el 23 de agosto se acumularon 980.000 importaciones exentas de bajo valor y que 126.000 personas ya habían alcanzado el límite, lo que muestra que la regla afecta al comprador corriente y no solo a los intermediarios.
+
+
+[^7]: [Mobile01: descubro en EZ Way que el importe declarado por la agencia no coincide](https://www.mobile01.com/topicdetail.php?f=423&t=6771709) — Hilo de foro (experiencia personal, no estadística formal): un usuario descubre que la descripción y el importe declarados no coinciden con lo comprado, solo puede elegir entre «conforme» y «no conforme», y tras marcar «no conforme» el paquete llega igualmente.
+
+
+[^8]: [Ministerio de Finanzas: mandato de confirmación previa generalizado desde el 1 de marzo de 2026](https://www.mof.gov.tw/singlehtml/384fb3077bb349ea973e7fc6f13b6974?cntId=87e84e6a6cbc4af9a6608d03c333b06c) — Nota de prensa del Ministerio de Finanzas de 24 de febrero de 2026 que anuncia la implantación general del mandato de confirmación previa para la mensajería con declaración simplificada importada por particulares, con base en la reforma de los reglamentos de despacho de mensajería aérea y marítima.
+
+
+[^9]: [Llevaba años usándola y no sabía que la operaba una empresa privada](https://www.chinatimes.com/realtimenews/20260803000910-260405) — China Times, 3 de agosto de 2026; recopila la publicación original en Threads (más de 4.000 «me gusta») y los comentarios, incluido el «o sea que cuando compro en iHerb tengo que despachar en aduana con una empresa privada». El enlace a la publicación original no fue difundido por los medios, así que aquí se cita la versión referida en la información.
+
+
+[^10]: [Rueda de prensa del director general Peng Ying-wei: los tres grandes malentendidos sobre EZ Way](https://ec.ltn.com.tw/article/breakingnews/5526916) — Liberty Times Finance, 3 de agosto de 2026, sobre la rueda de prensa del mediodía; recoge la formulación completa de las tres aclaraciones del director general (uso no obligatorio, el mandato en línea protege los datos personales, solo se cobra a los agentes de aduanas).
+
+
+[^11]: [Aduana de Taipéi: historia de la automatización del despacho de mercancías](https://web.customs.gov.tw/taipei/singlehtml/101?cntId=cus2_99948_101) — Página oficial de la Aduana de Taipéi, que consigna literalmente la implantación oficial de la automatización el 9 de noviembre de 1992. La afirmación que circula por internet de que Taiwán fue «el tercero de Asia, tras Japón y Singapur» no aparece ni en esta página ni en las demás cronologías oficiales, por lo que este artículo no la utiliza.
+
+
+[^12]: [Sala de Archivo Histórico Fiscal del Ministerio de Finanzas: la automatización del despacho de mercancías](https://museum.mof.gov.tw/singlehtml/c54dcfe3b7cf439ebf6cf2536bf03f75) — Página oficial de archivo histórico del Ministerio de Finanzas: estudio en 1990, automatización aérea en noviembre de 1992 y marítima el 19 de junio de 1995, con la autoevaluación oficial de que «para los despachos por la vía C1, el tiempo se ha reducido de 4 horas a los 3 minutos actuales».
+
+
+[^13]: [Normas de despacho por declaración simplificada de mercancías de mensajería aérea](https://law-out.mof.gov.tw/LawContent.aspx?id=FL006333) — Texto del sistema normativo del Ministerio de Finanzas; define las cuatro categorías X1 (documentos), X2 (bajo valor exento, hasta 2.000 NT$), X3 (bajo valor gravado, de 2.001 a 50.000 NT$) y X4 (alto valor), y establece que la declaración simplificada solo admite el levante C1 y la inspección C3, sin examen documental C2.
+
+
+[^14]: [Análisis de los datos del comercio electrónico transfronterizo de Taiwán](https://www.mirai.com.tw/analysis-of-taiwans-cross-border-e-commerce-trade-data-2/) — Infografía de datos comerciales del Mirai Business Research Institute: entre 2014 y 2024 los paquetes pequeños importados pasaron de 15,82 a 58,47 millones de unidades y el importe medio por paquete bajó de 1.396 a 1.122 NT$. Como los criterios varían entre instituciones, este artículo usa la formulación de orden de magnitud «más de cincuenta y ocho millones».
+
+
+[^15]: [Directrices del programa piloto de verificación de identidad del destinatario de mensajería y mandato de despacho en línea](https://law-out.mof.gov.tw/LawContent.aspx?id=GL010451) — Orden n.º 1071013202 del Ministerio de Finanzas de 15 de junio de 2018; es la base legal de la apertura piloto del mandato en línea de EZ WAY y demuestra que el mandato en línea arranca en 2018 y no en 2020, como suele escribirse.
+
+
+[^16]: [Taiwan Customs: Real-Name Authorization APP (EZ Way)](https://web.customs.gov.tw/en/singlehtml/1865?cntId=1ddad168f44a42eba6cab1d4c8983687) — Página oficial en inglés de la Administración de Aduanas; consigna literalmente que desde el 16 de mayo de 2020 la Aduana dejó de admitir la declaración simplificada de quien no hubiera completado el registro con verificación de identidad o entregado un mandato en papel, lo que aclara la versión del 16 de abril que circula por ahí.
+
+
+[^17]: [Administración de Aduanas: mandato de confirmación previa](https://web.customs.gov.tw/singlehtml/3150?cntId=11c8861747b54153863dd6323122466a) — Página explicativa oficial que documenta la primera fase del mandato previo desde el 28 de diciembre de 2021 para listas específicas y la segunda fase (2.0) desde el 15 de septiembre de 2022, con adhesión voluntaria del público.
+
+
+[^18]: [Entra en servicio el mandato previo 3.0 para frenar las declaraciones con identidad suplantada](https://web.customs.gov.tw/singlehtml/2222?cntId=79c4e23b3329408397c0b8dd45f5a23b) — Nota de prensa de la Administración de Aduanas de agosto de 2023 que anuncia la puesta en marcha del mandato previo 3.0 y la ampliación del universo afectado. Cotejada palabra por palabra, esta nota no contiene ninguna estadística anual de casos de suplantación.
+
+
+[^19]: [Contra el despacho con identidad suplantada, la Aduana prevé implantar el año que viene el mandato de confirmación previa para todos](https://www.mof.gov.tw/singlehtml/384fb3077bb349ea973e7fc6f13b6974?cntId=5d4bf15583314cb2ba11f3a072e493f4) — Nota de prensa del Ministerio de Finanzas de 17 de diciembre de 2025; indica que la Administración impulsa el mandato previo por fases desde 2021 y que a 30 de noviembre de ese año ya superaba el 80 % de cobertura. Esta nota tampoco contiene las tres cifras «1.723 / 474 / 39» que tanto se citan.
+
+
+[^20]: [Trade-Van: del grupo de planificación del Ministerio de Finanzas a la empresa cotizada](https://finance.ettoday.net/news/3212529) — ETtoday Finance, 3 de agosto de 2026; documenta que Trade-Van nació como Grupo de Planificación y Promoción de la Automatización del Despacho de Mercancías del Ministerio de Finanzas y se privatizó en agosto de 1996, y cita al funcionario de la Administración de Aduanas sobre la no participación de Universal EC y el papel de Trade-Van como quien «puso recursos por delante para apagar el fuego».
+
+
+[^21]: [EZ Way, 7,59 millones de registros: ¿están seguros los datos? ¿Quién paga la comisión?](https://www.gvm.com.tw/article/132037) — Global Views Monthly, 3 de agosto de 2026; recoge que el Ministerio de Finanzas posee 54.162.436 acciones de Trade-Van (36,11 %), que EZ WAY acumula unos 7,59 millones de registros y más de cuatro millones de declaraciones simplificadas mensuales (cerca del 70 % de los expedientes), y el intervalo de tarifas de 0,8 a 3,5 NT$ por expediente.
+
+
+[^22]: [El Ministerio de Finanzas ocupa 6 de los 12 asientos del consejo de Trade-Van](https://www.mirrormedia.mg/story/20260803-177fin-182204) — Mirror Media, 3 de agosto de 2026; completa la estructura del consejo de administración de Trade-Van y su cuota de mercado, y consigna que Universal EC, que cumplía los requisitos, «no tenía intención de operarlo», de ahí que en la práctica quedara un único operador.
+
+
+[^23]: [Reglamento de Autorización y Gestión de las Redes de Despacho Aduanero](https://law.moj.gov.tw/LawClass/LawAll.aspx?pcode=G0350048) — Texto de la Base de Datos Nacional de Legislación, dictado al amparo del artículo 10.5 de la Ley de Aduanas: el artículo 4 exige un capital desembolsado de 500 millones de NT$ y el artículo 6 permite al Ministerio de Finanzas constituir una comisión evaluadora. Es un régimen de licencia por acreditación, no un procedimiento de licitación pública.
+
+
+[^24]: [Administración de Aduanas: cualquier operador acreditado puede desarrollar su app de mandato en línea](https://finance.ettoday.net/news/3212376) — ETtoday, 3 de agosto de 2026, sobre el contenido de la rueda de prensa; recoge literalmente la respuesta oficial a las acusaciones de monopolio con el marco de «acreditación y recertificación cada cinco años», y explica que el ciudadano puede otorgar el mandato en línea con el certificado digital de persona física en la Ventanilla Única, de modo que EZ WAY no es la única vía.
+
+
+[^25]: [Administración de Aduanas: explicación sobre la verificación de identidad del destinatario de mensajería](https://web.customs.gov.tw/singlehtml/3150?cntId=cus1_3150_3150_1149) — Página oficial de la Administración de 18 de marzo de 2020; consigna literalmente que el ciudadano puede seguir entregando un mandato en papel y fotocopias del anverso y el reverso de su documento de identidad al agente de aduanas de mensajería, es decir, que el mandato mantiene la doble vía de papel y en línea.
+
+
+[^26]: [Debate en el foro Gossiping de PTT: qué pasa si no usas Yilewei](https://disp.cc/b/Gossiping/iaY5) — Página de transcripción de un hilo de PTT (opinión en línea, sin fuente oficial ni identificada); recoge comparaciones del tipo «para irte de viaje nadie te obliga a tener pasaporte, simplemente no vas a poder pasar la aduana», que reflejan la sensación popular de una obligatoriedad «voluntaria de nombre, inevitable en la práctica».
+
+
+[^27]: [La Administración de Aduanas se compromete a presentar un informe monográfico en tres meses](https://news.pts.org.tw/article/820029) — PTS News, 30 de julio de 2026; registra el compromiso del director general Peng Ying-wei de presentar en tres meses un informe que evalúe la incorporación a la infraestructura pública nacional, y aporta otra versión de la estructura de tarifas (3,5 NT$ de tasa de confirmación más 0,8 NT$ de tasa de servicio).
+
+
+[^28]: [Velando por millones de compradores: Lin Tai-hua destapa la repercusión de tarifas de EZ WAY](https://tw.news.yahoo.com/%E6%9B%BF%E5%8D%83%E8%90%AC%E7%B6%B2%E8%B3%BC%E6%97%8F%E6%8A%8A%E9%97%9C-%E6%9E%97%E5%B2%B1%E6%A8%BA%E6%8F%AD-ez-way-%E8%BD%89%E5%AB%81%E6%94%B6%E8%B2%BB%E4%BA%82%E8%B1%A1-214343033.html) — Información reproducida en Yahoo Noticias; recoge la versión de tarifas aportada por el despacho de Lin Tai-hua («la conexión de datos por SFTP exige además una cuota mensual de 2.500 NT$ y 0,8 NT$ por expediente»), sin que la información original aclare si se trata de la misma partida que la escala de la tasa de confirmación.
+
+
+[^29]: [Lin Tai-hua interpela sobre la estructura de tarifas de EZ WAY](https://news.tvbs.com.tw/politics/4001130) — TVBS, julio de 2026, sobre la interpelación de la diputada Lin Tai-hua en la Comisión de Finanzas del Yuan Legislativo; recoge su estimación de costes «calculando sobre 60 millones de paquetes al año» y su tesis de que la tarifa escalonada perjudica a los agentes de aduanas pequeños y medianos del país.
+
+
+[^30]: [La diputada Lin Tai-hua: un sistema previsto por la ley, externalizado sin contrato](https://www.mirrormedia.mg/story/20260803edi001) — Mirror Media, 3 de agosto de 2026; resume los cuestionamientos de Lin Tai-hua sobre la externalización de EZ WAY y la repercusión de tarifas, así como las reacciones en redes. La transcripción íntegra de la interpelación no aparece en las informaciones de circulación pública, por lo que este artículo la trata al nivel de «según se informa».
+
+
+[^31]: [Lin Tai-hua](https://zh.wikipedia.org/wiki/%E6%9E%97%E5%B2%B1%E6%A8%BA) — Entrada de Wikipedia que consigna que el partido de la actual diputada Lin Tai-hua es el Partido Democrático Progresista.
+
+
+[^32]: [Si no das este paso al comprar en el extranjero, tu paquete puede ser devuelto](https://www.storm.mg/lifestyle/11088908) — Storm Media; es hasta ahora la única fuente rastreable de la serie «1.723 casos en 2023, 474 en 2024 y 39 entre enero y octubre de 2025» sobre despacho con identidad suplantada, y el propio artículo no indica de dónde procede el dato. Cotejadas palabra por palabra, ni la nota del Ministerio de Finanzas de 17 de diciembre de 2025 ni la de la Administración de Aduanas de agosto de 2023 contienen esas tres cifras.
+
+
+[^33]: [Red antifraude 165](https://165.npa.gov.tw/) — Portal oficial antifraude de la Agencia Nacional de Policía del Ministerio del Interior, donde pueden verificarse y denunciarse los SMS y llamadas que suplantan a organismos públicos, incluida la Aduana. La antigua página de aviso antifraude de la Administración de Aduanas (dominio customs.gov.tw) ha dejado de funcionar y redirige a la portada, por lo que se cita este recurso gubernamental de carácter general.
+
+
+[^34]: [El despacho de Taobao esconde mucho: consolidación encubierta y despacho con nombre ajeno](https://www.bnext.com.tw/article/81911/taobao-customs-clearance-scam) — Reportaje de Business Next que documenta casos reales de consumidores cuya mercancía fue agrupada sin aviso con paquetes de terceros para pasar la aduana y en cuyos envíos aparecían nombres de desconocidos, y que muestra que incluso con verificación de identidad queda margen de irregularidad en el eslabón intermediario.
+
+
+[^35]: [Propuesta ciudadana: en contra de reducir a 2.000 NT$ la franquicia de las compras en línea en el extranjero](https://join.gov.tw/idea/detail/f549a33d-644e-4016-831e-d375ae1eb83f) — Página oficial de la propuesta en la Plataforma de Participación Pública en Políticas, presentada el 4 de mayo de 2017 por la internauta «Duo-er» y respaldada por 5.226 personas; incluye la respuesta del organismo y la constancia de que la medida entró finalmente en vigor el 1 de enero de 2018.
+
+
+[^36]: [Base legal y calendario de la rebaja del umbral de exención a 2.000 NT$](https://finance.technews.tw/2017/05/24/online-shopping-tax-september/) — TechNews, 24 de mayo de 2017; explica que la reforma de la Ley de Aduanas aprobada en tercera lectura en 2016 dio base legal a la rebaja, y detalla el calendario inicial del Ministerio de Finanzas, que preveía la entrada en vigor el 1 de septiembre de 2017.
+
+
+[^37]: [Comparación de los umbrales de exención de 14 países y respuesta de la Administración de Aduanas](https://www.businesstoday.com.tw/article/category/183022/post/202210210036/) — Business Today, octubre de 2022; recoge la posición escrita de la Administración en aquel momento: un límite exento demasiado alto favorece la reimportación de mercancía nacional para eludir impuestos, pero entonces no había planes de modificar el techo y se seguirían observando las tendencias internacionales. Es el contexto de 2022, distinto de la posición reabierta a estudio a partir de 2025.
+
+
+[^38]: [Ministerio de Finanzas: el umbral de exención de 2.000 NT$ está en fase de análisis y reflexión](https://www.cna.com.tw/news/afe/202504100080.aspx) — CNA, 10 de abril de 2025, sobre la interpelación en la Comisión de Finanzas del Yuan Legislativo; registra las dudas del diputado Wu Ping-jui sobre el agravio a la industria manufacturera nacional, la respuesta de la ministra Chuang Tsui-yun y la creación por la Aduana de un «grupo de refuerzo de la inspección del transbordo irregular».
+
+
+[^39]: [La ministra: incorporaremos a las consideraciones rebajar el umbral para los países de origen con dumping](https://www.cna.com.tw/news/afe/202504160053.aspx) — CNA, 16 de abril de 2025; registra el estudio por el Ministerio de Finanzas de una rebaja diferenciada del umbral a 1.000 NT$ para determinados países de origen como China, y la respuesta de la ministra Chuang Tsui-yun. A agosto de 2026 seguía sin decidirse.
+
+
+[^40]: [La proporción de China en las declaraciones exentas de bajo valor sube del 50,4 % al 64,4 %](https://www.ctee.com.tw/news/20250417700134-439901) — Commercial Times, 17 de abril de 2025; es hasta ahora la única fuente rastreable de esta serie (no se ha encontrado una segunda fuente independiente para contrastarla) y añade que China y Hong Kong suman más del 88 %.
+
+
+[^41]: [Executive Order 14324: Suspending Duty-Free De Minimis Treatment for All Countries](https://www.whitehouse.gov/presidential-actions/2025/07/suspending-duty-free-de-minimis-treatment-for-all-countries/) — Texto original de la orden ejecutiva de la Casa Blanca, firmada el 30 de julio de 2025 y en vigor desde la madrugada del 29 de agosto, que suspende el trato exento del 19 U.S.C. 1321(a)(2)(C) con independencia del valor, el origen, el modo de transporte o el canal de despacho.
+
+
+[^42]: [El Consejo de la UE aprueba definitivamente las nuevas normas arancelarias para los paquetes pequeños](https://www.consilium.europa.eu/en/press/press-releases/2026/02/11/council-gives-final-green-light-to-new-customs-duty-rules-for-small-parcels/) — Nota de prensa oficial del Consejo de la Unión Europea de 11 de febrero de 2026, que confirma el arancel transitorio de 3 euros por subpartida arancelaria para los envíos de hasta 150 euros a partir del 1 de julio, vigente hasta la entrada en funcionamiento del Centro de Datos Aduaneros de la UE en 2028.
+
+
+[^43]: [WCO News: E-commerce at a turning point](https://mag.wcoomd.org/magazine/wco-news-108-issue-3-2025/e-commerce-at-a-turning-point/) — Artículo de la publicación de 2025 de la Organización Mundial de Aduanas; explica que la percepción internacional del de minimis ha pasado de instrumento de facilitación a agujero controvertido, y la presión que la fragmentación de los envíos de bajo valor ejerce sobre la gestión de riesgos y la recaudación de las aduanas.
+
+
+[^44]: [Oficina de Aduanas y Aranceles del Ministerio de Finanzas de Japón: exención para importaciones de escaso valor](https://www.customs.go.jp/tetsuzuki/c-answer/imtsukan/1006_jr.htm) — Página oficial de preguntas y respuestas de la aduana japonesa, que explica que, en principio, un valor imponible total de hasta 10.000 yenes queda exento de arancel e impuesto sobre el consumo; el texto oficial precisa que la exención efectiva depende del tipo de producto y de su uso, y este artículo adopta el caso general.
+
+
+[^45]: [Explicación del umbral de exención para compras directas en el extranjero en Corea del Sur](https://www.tossbank.com/articles/customs) — Guía de las reglas de despacho elaborada por un operador financiero surcoreano; consigna el umbral de despacho por lista de 150 dólares para mercancías generales y de 200 dólares para las importadas desde Estados Unidos mediante mensajería, con tributación íntegra por encima del umbral.
+
+
+[^46]: [Customs defends EZ Way app amid privacy concerns](https://www.taipeitimes.com/News/taiwan/archives/2026/08/03/2003861872) — Taipei Times, 3 de agosto de 2026; traduce frase a frase al inglés las tres aclaraciones del director general Peng Ying-wei, y es la única parte de esta polémica con un registro completo en dos lenguas.
+
+
+[^47]: [Administración de Aduanas: sistema de niveles del personal de interpretación de imágenes de rayos X](https://web.customs.gov.tw/singlehtml/2222?cntId=a742b46ee2954b9e96fca36859f1e9d9) — Nota de prensa oficial de la Administración de Aduanas que publica 368 personas en nivel inicial, 591 en intermedio y 184 en avanzado (a 2023), y el aumento de las incautaciones de drogas de 355 casos en 2018 a 558 en 2023; el documento no aborda la carga de interpretación por persona y hora.
+
+
+[^48]: [Página de EZ WAY 易利委 en la App Store y reseñas de usuarios](https://apps.apple.com/tw/app/ez-way-%E6%98%93%E5%88%A9%E5%A7%94/id1127781971) — Página de la tienda taiwanesa de Apple, con una gran acumulación de reseñas de una estrella centradas en los fallos del reconocimiento del documento de identidad, lo engorroso del registro, los errores de inicio de sesión, la respuesta del servicio de atención y la dificultad de uso para las personas mayores; es el registro público más concentrado de opinión del lado del consumidor.
+
+
+[^49]: [Administración de Aduanas: no hemos dicho que vayamos a reestatalizar EZ WAY sin más](https://www.chinatimes.com/realtimenews/20260803003905-260405) — China Times, 3 de agosto de 2026; registra las respuestas del director general Peng Ying-wei en la Comisión de Finanzas del Yuan Legislativo del 29 de julio de 2026 y la aclaración oficial expresa frente al marco de la «reestatalización».
+
+
+[^50]: [Ministerio de Finanzas: comprar en el extranjero es fácil, pero ojo con la importación frecuente](https://www.mof.gov.tw/singlehtml/384fb3077bb349ea973e7fc6f13b6974?cntId=afd982c0ea7e439a94e3e8df855ef4a2) — Nota de prensa del Ministerio de Finanzas de octubre de 2024 que reitera la exención para valores en aduana de hasta 2.000 NT$ y el criterio de las seis veces por semestre; sirve para constatar que el régimen vigente no se modificó durante el periodo de estudio de 2025-2026.


### PR DESCRIPTION
﻿Adds Spanish translation of `Lifestyle/台灣海關報關制度與EZWAY.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`. Note: `i18n/es/STYLE.md` does not exist in the repo yet (only `en` and `ja` are present), so this translation followed the shared TRANSLATE_PROMPT rules plus the conventions already in use across `knowledge/es/`.

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is a native Chinese speaker with some Spanish proficiency)

**Length ratio**: 2.871 (body chars 58,755 / 20,466) — inside the 2.0–4.0 healthy band for zh→es

**Structure alignment**: 9 `##` sections / 50 footnote definitions / 55 URLs (exact multiset, including the four Wikimedia URLs containing Chinese characters) / 5 inline images — 100% preserved. `scripts/tools/lang-sync/verify-translation.py` reports 17 PASS / 0 FAIL (the single WARN is the ratio sub-tool failing to run under a Windows shell, not a content issue; the ratio was computed manually and is shown above).

**Conventions followed**:

- `rationale`, `researchReport`, `relatedDiary`, `sporeLinks` and all passthrough fields kept verbatim
- `subcategory` left as `消費與生活制度`
- All custom blocks (`tw-stat` / `tw-timeline` / `tw-bars` / `tw-versus`), both curator notes, both "¿Lo sabías?" callouts and the `✦` pull-quote preserved
- "Related reading" links localised to `/es/...` slugs; all three targets already exist in `knowledge/es/`
- Chinese retained only inside image titles, file URLs and photographer credits

Uncertain terminology flagged for reviewer:

- 報關委任 → mandato de despacho aduanero · chose "mandato" over "poder"/"autorización" because the source stresses the civil-law mandate relationship
- 完稅價格 → valor en aduana · the standard Spanish customs term; note the article insists it includes freight and insurance, which is spelled out in the text
- 免稅門檻 → umbral de exención, with 免稅額 as franquicia · both terms are used, matching the two senses in the original
- 關貿網路 → Trade-Van Information Services · used the company's own English name rather than a Spanish calque
- 易利委 → Yilewei · kept in the tags as pinyin, since it is the app's Chinese nickname
- 報關業者 → agente de aduanas · in Taiwan these are firms; "agencia de aduanas" may read better for some reviewers
- 集運商 → agencia de consolidación de envíos · descriptive rendering, no settled Spanish term
- NT$ amounts left in NT$ throughout, with the international-comparison bar chart keeping the source's approximate USD equivalences

Please review. Happy to iterate.
