### PR TITLE
translate(en): 黃土水 → huang-tu-shui

### DIFF
--- a/knowledge/en/People/huang-tu-shui.md
+++ b/knowledge/en/People/huang-tu-shui.md
@@ -1,0 +1,170 @@
+---
+title: 'Huang Tu-shui: A Modern Taiwanese Sculpture That Returned from Disappearance'
+description: 'He learned Western sculpture in Tokyo, yet gradually found Taiwan through the gaze of a foreign land; a marble work missing for seven decades brought this chapter of art history back into view.'
+date: 2026-08-14
+category: 'People'
+tags:
+  [
+    'Huang Tu-shui',
+    'Ganlu Shui',
+    'Taiwanese Art History',
+    'Sculpture',
+    'Tokyo Fine Arts School',
+  ]
+subcategory: '雕塑'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-08-14
+lastHumanReview: false
+readingTime: 8
+viewpoint_formed: true
+curation: incubating
+translatedFrom: 'People/黃土水.md'
+sourceCommitSha: 'f89314e27'
+sourceContentHash: 'sha256:d22d7298dff5ac3a'
+translatedAt: '2026-08-27T11:21:11+08:00'
+---
+
+# Huang Tu-shui: A Modern Taiwanese Sculpture That Returned from Disappearance
+
+> **30-Second Overview:** Studying Western sculpture in Tokyo, Huang Tu-shui gradually found Taiwan through the gaze of his foreign surroundings; when _Ganlu Shui_ (Sweet Dew) reappeared after some seventy years missing, a severed chapter of Taiwan's modern art history was reconnected.
+
+In 1921, at the age of 26, Huang Tu-shui's marble sculpture _Ganlu Shui_ was selected for the Imperial Exhibition (Teiten) of the Imperial Art Academy of Japan. In 2021, after roughly seventy years missing, the work reappeared from the home of a private collector. In 2024, it went back to Tokyo University of the Arts — the very school Huang had once attended — for exhibition.[^1] [^2] [^3] [^4] [^9]
+
+This could easily be written as a story of "the genius artist finally being recognized." But the real question Huang Tu-shui left behind is not whether he succeeded. It is: **how did a Taiwanese man studying Western sculpture in Tokyo learn to be seen, be misunderstood, in a foreign land, and ultimately carve "the East" step by step into "Taiwan"?**
+
+## From Mengjia to Tokyo: First, Learning to Be Seen
+
+Huang Tu-shui was born in 1895 in Mengjia, today's Wanhua District, Taipei. In 1906, he first attended Mengjia Public School, and later transferred to Dadaocheng Public School for family reasons. In 1912, he entered the Engineering/Teacher Training Section, Division B of the Taiwan Governor-General's National Language School. After graduating in 1915, he briefly taught at Dadaocheng Public School; that same year, his work _Li Tieguai_ passed review, and he entered the Woodcarving Division of the Sculpture Department at Tokyo Fine Arts School without sitting an entrance examination.[^1]
+
+This path does not resemble the artist biography people later imagined: it was not a matter of growing up in a well-off household and then turning a hobby into a profession. Instead, he first entered modern education and then crossed the sea through his work, recommendations, and scholarships. Research by the Kaohsiung Museum of Fine Arts (KMFA) points out that Huang's family was not wealthy. Growing up in Taipei, where modern education had taken root, gave him the chance to connect his talent to the colonial education system.[^3]
+
+Once in Tokyo, he did not find a ready-made position of "Taiwanese artist" waiting for him. Tokyo Fine Arts School was the core institution of modern art training in Japan, and Huang was the first Taiwanese artist to study in Japan during the Japanese colonial period. He had to master the techniques of woodcarving, modeling, and stone carving, while also bearing the weight of the gaze that came with "where are you from."[^3] [^5]
+
+> "No matter how I sharpened the carving knife, it wouldn't cut. It was frustrating. Every day after everyone went home, I was still sharpening my knife until dark." — Huang Tu-shui[^3]
+
+The weight of those words is not only about diligence. They show a student who had never received complete sculpture training, using hours of knife sharpening to squeeze himself into an art world that had not originally reserved a place for him.
+
+> **Curator's Note:** Huang Tu-shui's first work was not a statue, but a path into the institution. He first had to prove that he "could learn" before he could speak of what he wanted to carve.
+
+## After _The Indigenous Child_, Taiwan Was No Longer Just Others' Imagination
+
+In 1920, Huang Tu-shui's _The Indigenous Child_ was selected for the Teiten for the first time. KMFA's research reminds us that this was his only work on an Indigenous Taiwanese subject. The following year, he challenged the Teiten with the life-size marble female figure _Ganlu Shui_.[^3]
+
+Placed side by side, the two works reveal a turn that is not immediately intuitive. _The Indigenous Child_ could easily be absorbed into the existing imperial imagination of how Japan saw Taiwan. _Ganlu Shui_, by contrast, no longer places "Taiwan" plainly on the figure. It is a woman born from a great clam shell, her body facing the viewer, legs crossed, shells scattered at her feet.[^2] [^3]
+
+Catalogue records at the National Taiwan Museum of Fine Arts (NTMoFA) note that _Ganlu Shui_ is made of marble, created in 1919, and measures 172 × 80 × 38 centimeters. The catalogue also notes that it is often associated with Botticelli's _The Birth of Venus_, but that the shell in the work is closer to the clams familiar to Taiwanese people. In Taiwanese folk parlance, it is therefore nicknamed "the clam spirit."[^2]
+
+It looks like a Western nude sculpture, yet it does not copy Western mythology. KMFA's essay reads the figure through two lines: one is Botticelli's Venus, the other is the East Asian legend of the Clam Guanyin and the Clam Beauty. The work's name, _Ganlu Shui_ ("sweet dew"), and the English rendering "Daughter of Nectar" in the Teiten catalogue, weave these two lines together.[^3]
+
+> **Curator's Note:** _Ganlu Shui_'s Taiwanese-ness is not carved into the pedestal as a place name; it hides inside a clam that Western art history had not pre-named for it.
+
+## A Female Figure Standing Between Three Gazes
+
+What gives _Ganlu Shui_ its power is not whether it "resembles Venus." Explained by imitation alone, it misses the real work Huang did: he put the Western nude, Eastern legend, and actually observed Eastern female bodies into the same block of stone, then let that body stand before the viewer in an almost frontal posture.[^2] [^3]
+
+KMFA's research describes her as a woman of corporeal strength, not a graceful ideal made only for viewing. The difference is subtle, but it decides the work's temperament: she is neither a goddess drifting in from the waves nor an exotic specimen arranged at a distance, but a person with weight who occupies space.
+
+_Extended viewing: [Huang Tu-shui's *Ganlu Shui* marble sculpture, collection of the National Taiwan Museum of Fine Arts](https://collections.culture.tw/files/12/JPG640/111009430000.JPG)_
+
+_Image: Huang Tu-shui's *Ganlu Shui*, official collection image. The frontal posture and clam shell form make the simple answer "like Venus" insufficient._
+
+The "Taiwan" Huang faced in Tokyo was likewise not a stable concept. KMFA's essay records that Japanese society's knowledge of Taiwan at the time was often stuck in one-sided images produced by colonial newspapers, magazines, and postcards. The questions Huang met abroad even included "Do you eat rice in Taiwan just as they do in the mainland (Japan)?"[^3]
+
+So _Ganlu Shui_ is not a completed national symbol. It is more like an experiment: when Western forms, Japanese schooling, and Taiwanese experience all inhabit one body at once, how does an artist produce a figure that is not merely "a Japanese student's work" or "exotic Eastern flavor"?
+
+## From Oriental Subjects Toward the Water Buffalo
+
+### Technique Is Not a Neutral Tool
+
+Calling Huang Tu-shui "the first sculptor to study in Japan" is accurate, yet still too fast. Because the study abroad was not a one-way ticket to modernity: every technique he learned carried with it the school's institutions, teachers' lineages, and the yardsticks of modern Japanese art. The Tokyo University of the Arts exhibition placed Huang back in the artistic environment of 1915–1930 and hung his work alongside that of Takamura Kōun, Takamura Kōtarō, Ogiwara Morie, Kitamura Seibō, and others. This juxtaposition does not dilute him into one among many; it lets us see how he found his own voice within a ready-made vocabulary.[^5] [^7]
+
+Marble is also more than a symbol of "prestige" or "the West." It demands long hours of chiseling, grinding, and waiting. Once struck, an error cannot be erased like a pencil line. KMFA's essay records that Huang had no stone-carving teacher in Tokyo, so he watched Italian sculptors working marble in their studios and went home to teach himself.[^3] _Ganlu Shui_ is therefore not merely the result of being selected for the Teiten in a certain year; it is also the process by which he brought knowledge from outside the institution into his body, and then into the stone.
+
+This process also frees "Taiwanese-ness" from being shrunk into a few symbols. It can be the shape of a clam, the bearing of an Eastern woman, the weight of water buffalo repeating themselves, or an artist's homesickness in his Tokyo dormitory. When these elements stand side by side, they do not automatically fuse into one pure answer. The friction between them is why the work is still alive.
+
+_Extended viewing: [Tokyo University of the Arts official exhibition poster, 2024 Huang Tu-shui works exhibited at his alma mater](https://museum.geidai.ac.jp/exhibit/file/Huang-Tu-Shui.jpg)_
+
+_Image: Poster as shown on the 2024 exhibition page of the Tokyo University of the Arts Museum. The exhibition places Huang alongside the modern Japanese art environment of his student years._
+
+In 1922, Huang returned to Taiwan. In 1924, his _Outskirts_ was selected for the fifth Teiten. NTMoFA's artist biography page also records that he began _Group of Water Buffalo_ in 1928 and completed it in 1930.[^1]
+
+During those years, the direction of Huang's subjects gradually shifted. KMFA's research points out that after 1923, the Taiwanese water buffalo became a theme he returned to repeatedly. Compared with the East–West hybrid female figure of _Ganlu Shui_, the water buffalo pulls the gaze back to Taiwan's land, labor, and rural experience.[^3]
+
+This does not mean Huang suddenly found a pure, contradiction-free "Taiwanese style." A water buffalo can also be looked at, beautified, and placed inside a national narrative. What matters is that Huang began to push the question of his work from "can I create with the language of modern sculpture" toward "with this language, where do I look?"
+
+> **Curator's Note:** Huang Tu-shui did not first hold a Taiwanese aesthetic and then fill it with technique; his Taiwan grew out of repeated choices of subject and medium.
+
+## The Vanished Work Did Not End the Story
+
+### Preservation Itself Is Also a Piece of Taiwanese History
+
+If you only look at the white marble in the gallery, _Ganlu Shui_ looks as though it never left art history. But its real history includes wooden crates, dirt, moves, private keeping, and a blank stretch that cannot be immediately verified. KMFA's research writes that when the work reappeared, the white marble surface had accumulated years of grime. Only after restoration could viewers again see the form left behind a century ago.[^3]
+
+This detail changes the reading of "the masterpiece reappears." Reappearance is not pulling the original untouched out of time; it is admitting that the work was affected by environment and institutions, then — through restoration, research, and public collecting — restoring it to a state that can be viewed together. The accession number, medium, and dimensions listed on NTMoFA's collection page look like administrative data, but they are also building a new public identity for the work.[^2]
+
+When introducing the album _Taiwan Soil, Water of Freedom: The Resurrection of Huang Tu-shui's Artistic Life_, the Ministry of Culture's Government Publication Information site specifically lists exhibition works, documents, exhibition records, curatorial essays, and a chronology. These materials that seem subordinate to the artwork actually show that an artistic life is not sustained by a single statue alone: exhibitions, catalogues, researchers, preservers, and viewers reconnect it to history.[^8]
+
+_Extended viewing: [Images of *Ganlu Shui* in restoration and exhibition, as published in the Kaohsiung Museum of Fine Arts research essay](https://www.kmfa.gov.tw/FileDownLoad/PageSections/20220711092128070318.jpg)_
+
+_Image: Images of *Ganlu Shui* as shown in the KMFA research essay. The preservation history of the work is as important as its formal history._
+
+Huang Tu-shui died in Tokyo in 1930 of peritonitis following appendicitis, at the age of 36. In 1931, his widow Liao Qiugui brought his posthumous works from Tokyo back to Taiwan. Yet even after the artist's death, his reputation and his works gradually slipped out of public view. The album preview on the government publication site notes that Huang's artistic achievements once fell like fragments into a historical fault line after the war, and were only reassembled through later research, exhibitions, and biographical writing.[^1] [^8]
+
+The fate of _Ganlu Shui_ was especially concrete. KMFA records that it was missing for about seventy years after the 1950s, and only reappeared from a collector's home in 2021. In 2022, the collector's family donated the work to the Ministry of Culture.[^3] KMFA later framed the matter as a "search notice," folding it into a larger question: why do artworks get dispersed and lost, and who keeps searching for them?[^4]
+
+There is a part of this that must not be romanticized: the work did not survive because it was "meant to be." It was able to return to public collection because someone kept it, someone researched it, someone identified it, and someone was willing to give a privately held work back to society. NTMoFA's records show that the marble sculpture later entered the museum's collection, and in 2024 traveled to Tokyo University of the Arts with other Huang Tu-shui works for exhibition.[^2] [^5] [^7]
+
+Art history is therefore not just a ranking of famous people and famous works; it is also a preservation system. When a sculpture goes missing for seventy years, what disappears is not a single object but one entrance through which readers could understand Taiwan's modern art.
+
+## What He Left Behind Is Not an Answer, but a Direction
+
+Huang Tu-shui once wrote:
+
+> "There is only one way to never die, and that is spiritual immortality. At least for us artists, as long as the works created with our blood and sweat have not been completely destroyed, we will not die."[^3]
+
+It is easy to read these words as prophecy. But the reason we can read them today is not that the work automatically preserved its own life; it is that later generations kept retrieving the work from private spaces, exhibition archives, research essays, and memory fault lines. The research postscript on Openbook therefore places Huang on a longer line: he was not only a genius who died young, but also a forerunner who allowed later Taiwanese sculptors to emerge in groups.[^6]
+
+In 2024, the Tokyo University of the Arts exhibition brought _Ganlu Shui_ back to Huang's alma mater. The exhibition did not merely display his works; it also presented the modern Japanese art environment he inhabited between entering the school in 1915 and his death in 1930.[^5] This arrangement matters because it refuses to seal Huang inside a glass case of lonely genius: his work must return to the intersection of school, institutions, peers, the colony, and Taiwanese society before one can see why it is so restless and so powerful.
+
+Huang Tu-shui did not leave behind a single correct form for Taiwan's modern art. He left a direction: one can start from foreign technique without remaining forever in imitation; one can be seen in a foreign land and bend that gaze back toward one's own soil; and one can let a vanished work reappear, reminding later generations that culture is not a heritage passively waiting to be preserved, but a relationship that each generation re-identifies and re-cares for.
+
+Seeing _Ganlu Shui_ today, neither should we elevate it into a seamless national allegory. It was once made visible through the institutions of the Japanese Imperial Exhibition, and it once vanished from postwar public memory. Its form borrows from both Western art history and East Asian legend, and turned, in Huang's hands, toward Taiwan's bodies and land. These competing sources are exactly why it is hard to conscript into a single label.[^3] [^5] [^9]
+
+For creators today, Huang's value may not lie in offering a replicable "Taiwanese style." What is genuinely inheritable is his working method: first admitting that one stands inside others' techniques and institutions, then using time to grind foreign vocabularies until they can carry one's own experience. When a work is no longer merely proving that "Taiwan can too," and begins asking "how is Taiwan to be seen," modern art changes from a qualification contest into its own question.
+
+This is also why the return of _Ganlu Shui_ is more than exhibition news. It connects several moments that are usually kept apart: in 1915, a young man from Mengjia entered Tokyo Fine Arts School; in 1921, he left his name at the Imperial Exhibition with a marble female figure; in 1930, he died in Tokyo; after the 1950s, the work lost its trace; in 2021, it was recognized again inside another family; in 2024, it returned to his alma mater.[^1] [^3] [^5] [^9]
+
+Each moment changes the meaning of the work. The Imperial Exhibition made it an artwork identifiable by institutions; the disappearance made it a memory that must be asked after; re-collection let it become public culture once more. Huang's life was short, but _Ganlu Shui_ reminds us that the time of art is not decided only by the creator's age, but also by whether later people are willing to keep searching, preserving, and viewing.
+
+If someone stands before this female figure today and only sees "Taiwan's first nude sculpture," they have not finished looking. What is more worth pausing on is the inconsistency she carries: Western posture and Eastern legend, Tokyo training and Taiwanese land, a short-lived creator and a long preservation history. Huang did not smooth these differences away; he let them stand together in the stone. That is why the sculpture still has something to say a century later. It does not turn Taiwan into a closed answer, but lets Taiwan keep generating through overseas movement, learning, misunderstanding, and preservation. What readers take away should not be only "who is Huang Tu-shui," but a harder and more art-like question: when we say a work represents Taiwan, are we describing its origin, or describing how it has been re-seen by generation after generation?
+
+More precisely, Huang Tu-shui's artistic legacy is not a tradition already paved; it is a site still being continued: someone writes his name into a chronology, someone removes grime from the stone, someone brings an exhibition back to his alma mater, and someone else sees that slightly upturned face for the first time today. The work therefore not only preserves the past, but also demands that people of the present answer: which memories are we willing to make room for? That is the most important pause when reading Huang Tu-shui.
+
+## Image Sources
+
+This article embeds only hot-linked images provided by official institutions and does not download or store images separately. The image hot links are, in order: the National Taiwan Museum of Fine Arts collection image (https://collections.culture.tw/files/12/JPG640/111009430000.JPG), the Tokyo University of the Arts Museum exhibition poster (https://museum.geidai.ac.jp/exhibit/file/Huang-Tu-Shui.jpg), and the image carried in the Kaohsiung Museum of Fine Arts research essay (https://www.kmfa.gov.tw/FileDownLoad/PageSections/20220711092128070318.jpg). The works' information, exhibition context, and page sources follow the article pages cited in the footnotes above.
+
+## Further Reading
+
+To go deeper on Huang Tu-shui, cross-read NTMoFA's artist chronology, the work's collection page, the KMFA research essay, and the Tokyo University of the Arts exhibition page. For English readers, _The Reporter_'s English edition offers an in-depth feature on the preservation history and artistic significance of _Ganlu Shui_.
+
+## References
+
+[^1]: [NTMoFA Collection – Huang Tu-shui (1895–1930)](https://ntmofa-collections.ntmofa.gov.tw/AuthorData.aspx?AID=MIMLMW) — National Taiwan Museum of Fine Arts artist biography page, covering birth, education, Imperial Exhibition selections, creative chronology, and death.
+
+[^2]: [Huang Tu-shui – Ganlu Shui – NTMoFA Collection](https://ntmofa-collections.ntmofa.gov.tw/GalData.aspx?RNO=MXMDM6M8MAMSM8M2&FROM=KH5JKWK7M95M0G5D) — National Taiwan Museum of Fine Arts work collection page, providing medium, dimensions, date, accession number, and description.
+
+[^3]: [The Germination of Taiwanese Consciousness at the Intersection of East and West: The Birth and Rebirth of _Ganlu Shui_](https://www.kmfa.gov.tw/ArtAccrediting/ArtArticleDetail.aspx?Cond=7050093f-1721-42c8-9a25-e749a396d1c4) — Kaohsiung Museum of Fine Arts _Art Accreditation_ essay, analyzing _Ganlu Shui_ through the work, study-abroad experience, and Taiwan–Japan art history.
+
+[^4]: [Search Notice](https://www.kmfa.gov.tw/ArtAccrediting/ArtTopicDetail.aspx?Cond=ea7e8da4-a273-4f2f-b9f2-f434461cc28c) — Kaohsiung Museum of Fine Arts special-topic page, explaining the search, preservation, and art-history reconstruction of dispersed works.
+
+[^5]: [Huang Tu-Shui and His Time: Taiwan's First Western-style Sculptor and the Tokyo Fine Arts School in the Early 20th Century](https://museum.geidai.ac.jp/exhibit/2024/09/Huang-Tu-Shui.html) — Tokyo University of the Arts Museum official exhibition page, recording dates, organizers, loans, and institutional history.
+
+[^6]: [Topic: Taiwan's Pioneer of Modern Art: Postscript to _Huang Tu-shui and His Time_](https://www.openbook.org.tw/article/p-67673) — Openbook reading journal, publishing researcher Suzuki Keika's postscript on Huang's place in art history and later influence.
+
+[^7]: [Huang Tu-Shui and His Time: Taiwan's First Western-style Sculptor and the Tokyo Fine Arts School in the Early 20th Century (English)](https://museum.geidai.ac.jp/en/exhibit/2024/09/Huang-Tu-Shui.html) — Tokyo University of the Arts Museum English exhibition page, explaining Huang's alumni identity, exhibited works, and position in modern art history.
+
+[^8]: [Book Preview: Taiwan Soil, Water of Freedom: The Resurrection of Huang Tu-shui's Artistic Life](https://gpi.culture.tw/news/16500) — Ministry of Culture Government Publication Information site preview, introducing the exhibition album's contents, chronology, and the process by which Huang's works were re-researched and preserved.
+
+[^9]: [Sculpting Enlightenment: The Century-Long Legacy Of Huang Tu-Shui's 'Water Of Immortality'](https://www.twreporter.org/a/ng-thoo-sui-and-kam-loo-tsui-english) — _The Reporter_ English edition in-depth feature, discussing Huang's artistic legacy from the 1921 Imperial Exhibition, the work's form, and its preservation and reappearance.


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

資料型塑的英文翻譯：`知識庫 / People / 黃土水` 的 zh-TW SSOT 完整翻譯為英文（`knowledge/en/People/huang-tu-shui.md`）。

黃土水是日治時期第一位留日臺灣雕塑家，《甘露水》失蹤七十多年後於 2021 年重現、2024 年回到母校東京藝術大學展出。本譯文依照 TRANSLATION-PIPELINE v4（重寫式翻譯，非文字替換），保留核心矛盾、人物/地點/時間 anchor、引言 verbatim、腳註來源 URL，並把策展視角投影到英文讀者的 reference frame。

## 📁 變更類型

- [x] 🌐 翻譯（zh-TW → en）

## ✅ 自我檢查

- [x] frontmatter 完整；`translatedFrom: 'People/黃土水.md'` 指向存在的原文
- [x] `category: 'People'` 對齊路徑；`featured: false`（由維護者管理）
- [x] `date/lastVerified` 與原文一致；`curation: incubating` mirror 原文
- [x] 腳註用 canonical 格式 `[^N]: [標題](URL) — 描述`，9 條腳註全部指向可查證來源（國美館典藏、高美館《藝術認證》、東京藝術大學美術館、Openbook、文化部政府出版品、《報導者》英文版）
- [x] 無 COPYRIGHT 問題：三張圖沿用原文的官方機構熱連結（國美館 / 東藝大 / 高美館），不另行下載或改存圖片
- [x] 段落結構與原文 1:1（secs 9→9、footnotes 9→9、urls 15→15）

## 🔍 已通過的閘門

- 翻譯比率 `translation-ratio-check.sh`：**2.97**（zh→en 健全區間 2.20–3.50，PASS）
- `article-health.py --profile=release-pr`：**hard=0 / warn=0**（ai-residue、footnote-format、footnote-url、link-target、wikilink-target、image-health 全綠）
- `test-frontmatter.mjs`：本檔無錯誤
- Prettier：已格式化，通過 `prettier --check`

## 🔗 相關 Issue

無。
