### PR TITLE
fix(frontmatter): 五語六檔重複 YAML key／非字串 tag 清掉，frontmatter-gate 全綠

### DIFF
--- a/knowledge/ar/Society/lgbtq-in-taiwan.md
+++ b/knowledge/ar/Society/lgbtq-in-taiwan.md
@@ -22,8 +22,6 @@ featured: false
 lastVerified: 2026-04-30
 lastHumanReview: false
 readingTime: 12
-lastVerified: 2026-04-30
-lastHumanReview: false
 translatedFrom: 'Society/LGBTQ.md'
 sourceCommitSha: '4b6d28c54'
 sourceContentHash: 'sha256:2dceb8d4eac7775f'

--- a/knowledge/fr/History/228-incident.md
+++ b/knowledge/fr/History/228-incident.md
@@ -10,7 +10,7 @@ tags:
     terreur blanche,
     démocratisation,
     loi martiale,
-    228,
+    '228',
   ]
 subcategory: 'Histoire militaire'
 category: 'History'

--- a/knowledge/hi/Food/taiwanese-new-immigrant-culinary-fusion.md
+++ b/knowledge/hi/Food/taiwanese-new-immigrant-culinary-fusion.md
@@ -13,15 +13,11 @@ image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/5/5c/Pho%2C_popular
 imageAlt: 'वियतनामी फो'
 imageCredit: 'Wikimedia Commons, CC BY-SA'
 readingTime: 10
-lastVerified: 2026-03-20
-lastHumanReview: false
-featured: true
 translatedFrom: 'Food/台灣新住民美食融合.md'
 sourceCommitSha: '4b6d28c54'
 sourceContentHash: 'sha256:bd8e4eaaa3e395c7'
 sourceBodyHash: 'sha256:6806ae061b784232'
 translatedAt: '2026-07-25T05:00:12+08:00'
-readingTime: 10
 ---
 
 # ताइवान के नए आप्रवासियों का पाक कला संलयन

--- a/knowledge/hi/Music/deserts-chang-and-anpu.md
+++ b/knowledge/hi/Music/deserts-chang-and-anpu.md
@@ -16,7 +16,6 @@ tags:
      'सूर्य फूल छात्र आंदोलन',
    ]
 subcategory: 'स्वतंत्र और रॉक'
-author: 'Taiwan.md'
 featured: false
 lastVerified: '2026-04-13'
 lastHumanReview: 'true'

--- a/knowledge/vi/Society/cognitive-warfare-against-taiwan.md
+++ b/knowledge/vi/Society/cognitive-warfare-against-taiwan.md
@@ -17,7 +17,6 @@ tags:
     "Trách nhiệm nền tảng",
   ]
 subcategory: "Media và Phát ngôn"
-author: "Taiwan.md Contributors"
 featured: false
 lastVerified: 2026-04-23
 lastHumanReview: false

--- a/knowledge/vi/Society/pts-public-television-service.md
+++ b/knowledge/vi/Society/pts-public-television-service.md
@@ -24,11 +24,6 @@ rationale:
   whats_excluded: 'Chi tiết quy trình biên tập nội bộ TaiwanPlus (sự kiện báo cáo Trump của Louise Watt đã đề cập các case tượng trưng, không khai triển toàn bộ 6 tranh chấp); lịch sử phát triển độc lập của kênh Khách Gia / kênh Đài ngữ / kênh Dân tộc (subcategory khác, dành cho bài viết chuyên biệt); danh sách hoàn chỉnh các giải thưởng sản xuất-phát hành của Đài Loan Công cộng (chi tiết giải Chuông vàng có giá trị thấp với độc giả, chỉ tham chiếu 32 giải của lần thứ 60); toàn bộ luận điểm của Đảng Xanh «TaiwanPlus là miệng loa của Đảng Dân chủ Tiến bộ» (đã sử dụng ankh Trần Học Thánh + Trần Ngọc Châu, không lặp lại khai triển).'
   where_it_hedges: '«9 tỷ ngân sách nuôi phim ấn tượng» thực tế là 9 tỷ + trợ cấp dự án của Bộ Văn hoá + cộng tác quốc tế kết hợp (như «Mây xanh rực» Bộ Văn hoá trợ cấp 600 triệu, «Cô gái liên lạc ngoài cõi» cộng tác HBO Asia), trong bài dùng khái quát «ngân sách cơ bản 9 tỷ + lớp trợ cấp dự án tăng thêm từng lớp», không liệt kê chi tiết ngân sách mỗi phim. «2026 giấy thử độ trưởng thành dân chủ» là quan điểm, không phải bằng chứng thực nghiệm — dùng câu hỏi kết thúc để dành cho độc giả, không kết luận định đoạt.'
   whos_pushing_back: 'Cử nhân Quốc Dân Đảng Trần Ngọc Châu, La Trí Cường, Trần Học Thánh (nghi ngờ tăng ngân sách, TaiwanPlus lệch lạc chính trị); nhà kinh doanh truyền hình thương mại (lo lắng lâu dài về mở rộng của Đài Loan Công cộng); bình thường với quan điểm «Đài Loan Công cộng không ai xem» (tỷ suất xem dài ngày thấp). Ba phía đều có chú thích chú dẫn.'
-translatedFrom: 'Society/公視.md'
-sourceCommitSha: '81f10131f'
-sourceContentHash: 'sha256:5d55767b0e73ce88'
-sourceBodyHash: 'sha256:55150dbbe846399a'
-translatedAt: '2026-08-09T09:26:48+08:00'
 ---
 
 > **Tóm tắt 30 giây:**


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

清理 6 個翻譯檔的 frontmatter YAML 結構錯誤（都是 babel 批次落地時留下的機械性重複 key / 非字串 tag，會讓該檔無法被 gray-matter 正確解析）：

- `vi/Society/cognitive-warfare-against-taiwan.md` — 移除重複的 `author`
- `vi/Society/pts-public-television-service.md` — 移除 `rationale:` 之後整組重複的 provenance 欄位（translatedFrom/sourceCommitSha/sourceContentHash/sourceBodyHash/translatedAt）
- `hi/Food/taiwanese-new-immigrant-culinary-fusion.md` — 移除重複的 `lastVerified` / `lastHumanReview` / `featured` 與結尾多餘的 `readingTime`
- `hi/Music/deserts-chang-and-anpu.md` — 移除重複的 `author`
- `ar/Society/lgbtq-in-taiwan.md` — 移除重複的 `lastVerified` / `lastHumanReview`
- `fr/History/228-incident.md` — tags 裡裸的數字 `228` 改成字串 `'228'`（YAML 會把 `228` parse 成整數，陣列型別檢查失敗）

只刪重複 / 修正型別語法，不動任何內容、不重整格式，逐位數清除。

## 📁 變更類型

- [x] 🐛 修復錯誤（frontmatter YAML 結構）

## ✅ 自我檢查

- [x] 六檔逐檔跑 `node scripts/core/test-frontmatter.mjs --strict`（TWMD_VALIDATE_FILES=<file>）全數通過
- [x] diff 只有刪除（1 insertion / 14 deletions），無內容改動

## ⚠️ 一個已知殘留（不在本 PR 範圍）

full-tree strict scan 仍會列出的既有問題（main 上早就存在、與本 PR 無關）：若干 en 檔缺 `translatedFrom`（`taiwan-energy-transition-and-green-industry` 找不到對應 zh SSOT、`taiwan-people-knowledge-base-roadmap` 是規劃文件不是翻譯）、幾個 en/ja 檔有英文 slug 大寫檔名或缺 `tags`。這些需要維護者判斷（建 zh SSOT／搬檔案／改 slug）而非機械修補，留待獨立處理。

## 🔗 相關 Issue

無。
