### PR TITLE
translate(id): 日治時期 → japanese-colonial-era

### DIFF
--- a/knowledge/id/History/japanese-colonial-era.md
+++ b/knowledge/id/History/japanese-colonial-era.md
@@ -1,0 +1,79 @@
+---
+title: 'Masa Pemerintahan Jepang'
+description: 'Selama 50 tahun antara 1895 dan 1945 Jepang memerintah Taiwan, membawa modernisasi menyeluruh dan tata kelola yang terlembaga, sekaligus menjalankan politik asimilasi yang membekas dalam pada perkembangan masyarakat Taiwan'
+date: 2026-03-17
+category: 'History'
+tags: ['History', 'Pemerintahan Jepang', 'Modernisasi', 'Gerakan Kominka']
+subcategory: '殖民與帝國'
+author: 'Taiwan.md Contributors'
+featured: true
+lastVerified: 2026-03-19
+lastHumanReview: false
+translatedFrom: 'History/日治時期.md'
+---
+
+# Masa Pemerintahan Jepang
+
+> **Ringkasan 30 detik:** Setelah Perjanjian Shimonoseki 1895, Jepang memerintah Taiwan selama 50 tahun. Lewat sistem Kantor Gubernur Jenderal, Jepang menjalankan modernisasi menyeluruh: infrastruktur, sistem pendidikan, dan pengembangan industri. Bersamaan dengan itu Gerakan Kominka didorong untuk mengasimilasi orang Taiwan, sementara orang Taiwan berkali-kali melancarkan perlawanan, sampai Jepang menyerah dan Perang Dunia II berakhir pada 1945.
+
+Dari 1895 sampai 1945, Jepang memerintah Taiwan selama lima puluh tahun. Babak ini membawa modernisasi yang cepat, tetapi juga penindasan kolonial dan politik asimilasi budaya. Jalinan keduanya menjadi lapisan dasar penting bagi masyarakat dan budaya Taiwan hari ini.[^1]
+
+## Sistem Pemerintahan Kolonial
+
+Kantor Gubernur Jenderal Taiwan (台灣總督府) di Taipei adalah lembaga pemerintahan tertinggi Jepang di Taiwan. Gubernur jenderal diangkat Kaisar dan memegang kewenangan administratif, legislatif, sekaligus militer. "Undang-Undang Nomor 63" (六三法) memberinya wewenang menetapkan peraturan berkekuatan hukum, sementara organisasi *baojia* (保甲) di bawah sistem kepolisian memasukkan tiap rumah tangga ke jaringan saling mengawasi dan tanggung renteng, sehingga kontrol kolonial menembus lapisan terbawah.
+
+Saat mengambil alih Taiwan pada 1895, Jepang berhadapan dengan perlawanan bersenjata Republik Demokratik Taiwan. Perlawanan bersenjata lokal terus meletus sesudahnya, dan baru pada dasarnya berhenti setelah Peristiwa Xilaian (西來庵事件) 1915. Pemerintahan kolonial lalu memasuki fase pembangunan modernisasi yang relatif stabil.
+
+Secara administratif, Taiwan dibagi menjadi prefektur Taipei, Hsinchu, Taichung, Tainan, dan Kaohsiung. Pembagian itu berjalan seiring survei tanah yang memastikan kepemilikan di seluruh pulau, dan menjadi landasan kelembagaan bagi industri modern serta sistem perpajakan.
+
+## Pembangunan Modernisasi
+
+Di bidang transportasi, Jalur Kereta Lintas Utara-Selatan (縱貫鐵路) beroperasi penuh pada 1908, menghubungkan Keelung sampai Takao (打狗, kini Kaohsiung) — salah satu sistem kereta kolonial terbesar di Asia Timur saat itu. Pada periode yang sama Pelabuhan Keelung dan Kaohsiung dibangun ulang menjadi pelabuhan dagang modern, dan kemampuan perdagangan luar negeri Taiwan melonjak.
+
+Di bidang pengairan, Kanal Chianan (嘉南大圳) yang dirancang insinyur Jepang Hatta Yoichi (八田與一) dan dibangun selama sepuluh tahun (1920-1930) mengubah 150.000 hektare lahan Dataran Chianan menjadi kawasan irigasi yang stabil; Hatta Yoichi sampai kini masih sangat dihormati di Taiwan.[^2] Pembangkit listrik tenaga air Sun Moon Lake (日月潭) memasok kebutuhan listrik seluruh pulau.
+
+Di bidang pendidikan, sistem sekolah umum (公學校) menaikkan **angka partisipasi sekolah** anak usia sekolah dari kurang dari 5% pada awal masa pemerintahan menjadi sekitar 71% pada akhir masa pemerintahan Jepang (statistik 1944). "Angka melek huruf" dan "angka partisipasi sekolah" adalah indikator yang berbeda: statistik keaksaraan pemerintah kolonial berpatokan pada kemampuan baca-tulis bahasa Jepang dan berjalan berdampingan dengan keaksaraan tradisional beraksara Han, sehingga kedua standar itu tidak layak dicampur. Universitas Kekaisaran Taihoku (台北帝國大學, 1928) — kini Universitas Nasional Taiwan — adalah cikal bakal pendidikan tinggi Taiwan, tetapi kesempatan studi dan kerja bagi mahasiswa Taiwan selalu dibatasi perlakuan diskriminatif berbasis etnis.
+
+Salah satu penggerak modernisasi adalah **Goto Shinpei** (後藤新平, Kepala Administrasi Sipil 1898-1906). Berpijak pada "teori pemerintahan kolonial berbasis biologi", ia mendahulukan survei ilmiah lalu memindahkan sistem Jepang secara bertahap, dan meletakkan kerangka bagi perkeretaapian, survei tanah, serta kesehatan masyarakat di Taiwan.
+
+## Gerakan Sosial dan Perlawanan Budaya
+
+Perlawanan politik memasuki bentuk baru pada 1920-an. Gerakan Petisi Pendirian Parlemen Taiwan (1921-1934) pimpinan Lin Hsien-tang (林獻堂) menuntut partisipasi politik dari dalam kerangka kolonial, dengan lima belas kali petisi kepada Parlemen Kekaisaran. Chiang Wei-shui (蔣渭水) bersama Lin Hsien-tang mendirikan Asosiasi Kebudayaan Taiwan pada 1921, mendorong kesadaran kebangsaan lewat pencerahan budaya, lalu membentuk Partai Rakyat Taiwan pada 1927 untuk mendorong pengorganisasian politik.[^3]
+
+**Peristiwa Chihching 1923** (治警事件) adalah penindasan besar penguasa kolonial atas gerakan politik: dengan dalih pelanggaran *Undang-Undang Kepolisian Keamanan Umum*, pihak Jepang menangkap anggota inti gerakan petisi — termasuk Chiang Wei-shui — menggelar perdebatan yang menghebohkan di ruang sidang, dan akhirnya menjatuhkan vonis bersalah. Peristiwa itu justru melambungkan popularitas gerakan petisi sekaligus mempercepat pembelahan kesadaran politik orang Taiwan. **Partai Komunis Taiwan 1928** didirikan Hsieh Hsueh-hung (謝雪紅) dan kawan-kawan di Shanghai sebagai organisasi lingkar luar Partai Komunis Jepang, dengan tuntutan kemerdekaan bangsa Taiwan; partai itu segera ditumpas habis penguasa kolonial dan bubar pada 1931.[^4]
+
+Sarjana Jepang **Yanaihara Tadao** (矢內原忠雄) menulis *Taiwan di Bawah Imperialisme* (帝國主義下の台湾) pada 1929, membedah struktur eksploitasi kolonial Jepang atas Taiwan lewat ekonomi politik kapitalisme; sampai kini karya itu termasuk literatur sejarah kolonial kritis yang paling banyak dikutip.
+
+Peristiwa Musha (霧社事件) 1930 adalah perlawanan bersenjata masyarakat adat terbesar sepanjang masa pemerintahan Jepang. Kepala suku Seediq, Mona Rudao (莫那魯道), memimpin sekitar tiga ratus warganya bangkit melawan; penumpasan Jepang dan kebijakan susulannya memicu kontroversi luas.
+
+Di bidang sastra, Lai Ho (賴和), Yang Kui (楊逵), dan Lu Ho-jo (呂赫若) menulis dalam bahasa Han vernakular maupun bahasa Jepang. Dari dalam sistem kolonial mereka menyuarakan kritik atas penindasan dan penegasan identitas terhadap tanah sendiri, dan meletakkan nada dasar kelokalan bagi sastra baru Taiwan.
+
+## Masa Kominka dan Sesudah Perang
+
+Setelah Perang Tiongkok-Jepang pecah pada 1937, koloni masuk ke sistem mobilisasi masa perang dan Gerakan Kominka (皇民化運動) digelar besar-besaran.
+
+Kebijakan "pembiasaan bahasa nasional" membatasi pemakaian bahasa Taiwan, program "penggantian nama marga" mendorong pemakaian nama Jepang, pemujaan di kuil Shinto diwajibkan, dan laki-laki Taiwan dikerahkan sebagai pekerja militer atau tentara Jepang — diperkirakan lebih dari 200.000 orang bertugas atau bekerja untuk militer dalam Perang Dunia II.
+
+Pada 1945 Jepang kalah perang dan Taiwan beralih ke pemerintahan Republik Tiongkok. Infrastruktur modern, tenaga terdidik, gagasan negara hukum, dan efisiensi administrasi warisan masa pemerintahan Jepang menjadi titik berangkat penting bagi perkembangan Taiwan pascaperang; sementara rumitnya identitas etnis — jurang budaya antara generasi berbahasa Jepang dan pendatang dari daratan — menjadi salah satu akar sebagian konflik politik Taiwan sesudah perang.
+
+## Perspektif Historiografis: Modernisasi Kolonial vs. Eksploitasi Kolonial
+
+Penafsiran sejarah masa pemerintahan Jepang masih terus diperdebatkan di dunia akademik. "Tesis modernisasi kolonial" menekankan warisan positif berupa infrastruktur, pendidikan, dan sistem kesehatan, serta menilai pemerintahan Jepang meletakkan dasar material bagi industrialisasi Taiwan; "tesis eksploitasi kolonial" menunjuk bahwa survei tanah merampas hak tanah tradisional masyarakat adat dan petani kecil, bahwa struktur ekspor gula dan beras melayani kebutuhan Kekaisaran Jepang alih-alih perkembangan Taiwan, dan bahwa politik Kominka secara sistematis menghancurkan pewarisan budaya beraksara Han. Historiografi lokal Taiwan — misalnya Wu Mi-cha (吳密察) dan Wakabayashi Masahiro (若林正丈) — cenderung memadukan kedua perspektif dan menghindari penegasan atau penyangkalan yang menyederhanakan.
+
+**Catatan istilah**: "Riji" (日治, pemerintahan Jepang) dan "Riju" (日據, pendudukan Jepang) mencerminkan posisi sejarah yang berbeda di kalangan sejarawan Taiwan; yang pertama lebih netral dan akademis, yang kedua menekankan sifat pendudukan kolonial. Tulisan ini memakai "Riji", tanpa mengandaikan posisi politik tertentu.
+
+## Referensi
+
+[^1]: [臺灣日治時期 — Wikipedia](https://zh.wikipedia.org/wiki/%E8%87%BA%E7%81%A3%E6%97%A5%E6%B2%BB%E6%99%82%E6%9C%9F) — Ikhtisar masa pemerintahan Jepang di Taiwan: sistem pemerintahan, kronologi peristiwa utama, dan kebijakan tiap tahap.
+
+[^2]: [嘉南大圳 — Wikipedia](https://zh.wikipedia.org/wiki/%E5%98%89%E5%8D%97%E5%A4%A7%E5%9C%B3) — Proses pembangunan Kanal Chianan dan latar keinsinyuran Hatta Yoichi.
+
+[^3]: [台灣文化協會 — Wikipedia](https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E6%96%87%E5%8C%96%E5%8D%94%E6%9C%83) — Latar pendirian Asosiasi Kebudayaan Taiwan, peran Chiang Wei-shui dan Lin Hsien-tang, perpecahan berikutnya, dan kaitannya dengan Partai Rakyat Taiwan.
+
+[^4]: [治警事件 — Wikipedia](https://zh.wikipedia.org/wiki/%E6%B2%BB%E8%AD%A6%E4%BA%8B%E4%BB%B6) — Seluk-beluk penangkapan anggota Gerakan Petisi Parlemen Taiwan oleh penguasa kolonial Jepang berdasarkan Undang-Undang Kepolisian Keamanan Umum pada 1923.
+
+[^5]: [後藤新平 — Wikipedia](https://zh.wikipedia.org/wiki/%E5%BE%8C%E8%97%A4%E6%96%B0%E5%B9%B3) — "Teori pemerintahan kolonial berbasis biologi" Goto Shinpei, Kepala Administrasi Sipil Kantor Gubernur Jenderal Taiwan, dan kebijakan infrastrukturnya.
+
+## Bacaan Lanjutan
+
+- [乙未之役 (Perang Tahun Acar)](/id/history/1895-taiwan-resistance-war) — Titik awal masa pemerintahan Jepang: pendaratan tentara Jepang pada 1895 dan perlawanan Republik Demokratik Taiwan


### PR DESCRIPTION
Adds Indonesian translation of `History/日治時期.md`.

**Translation method**: Rewrite-style (not literal) per docs/prompts/TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.29 (body chars, zh 2884 → id 9481). Existing shipped `knowledge/id/` corpus: n=589, median 2.78, p10 2.29, p90 3.34 - this sits inside the established band.

**Structure alignment**: 7 headings / 4 footnote refs + 5 definitions / 5 external URLs - 100% preserved. Paragraph count 33 vs 35: the two dropped items are Further Reading links to `qing-dynasty-rule` and `mona-rudao`, which do not exist under `knowledge/id/` yet (kept only `1895-taiwan-resistance-war`, which does). Same policy the `en` version uses.

**Note**: `i18n/id/STYLE.md` does not exist yet - followed TRANSLATE_PROMPT.md plus the conventions already established in the existing Indonesian corpus (Chinese proper nouns kept in parentheses, `subcategory` left in Chinese, `author: 'Taiwan.md Contributors'`).

Uncertain terminology flagged for reviewer:

- 日治時期 → "Masa Pemerintahan Jepang" - chose "pemerintahan" (rule/administration) over "pendudukan" (occupation) to match the source's own note that it deliberately uses the more neutral term.
- 保甲 → kept romanised as *baojia* with the Chinese in parentheses; there is no settled Indonesian rendering and existing corpus favours romanisation.
- 皇民化運動 → "Gerakan Kominka" - Kominka is used untransliterated in Indonesian-language scholarship on Taiwan; happy to switch to a fuller gloss if preferred.
- 公學校 → "sistem sekolah umum" - literal "sekolah publik" risks reading as modern public schooling rather than the colonial-era track for Taiwanese children.

Please review. Happy to iterate.