### PR TITLE
translate(en): 林獻堂 → lin-hsien-tang

### DIFF
--- a/knowledge/en/People/lin-hsien-tang.md
+++ b/knowledge/en/People/lin-hsien-tang.md
@@ -1,0 +1,168 @@
+---
+title: 'Lin Hsien-tang: Turning a Family Study into a Public Doorway for the Taiwanese People'
+description: 'Born in 1881 into the Wufeng Lin family, Lin Hsien-tang chose non-armed resistance and led the Taiwan Parliament Petition Movement (1921–1934). His 378-day world tour became a lesson in self-governance. What he left behind was not only a family name, but a method connecting education, culture, and autonomy.'
+date: 2026-08-15
+category: 'People'
+tags:
+  [
+    'Lin Hsien-tang',
+    'Wufeng Lin Family',
+    'Taiwan Parliament Petition Movement',
+    'Taiwan Cultural Association',
+    'Non-armed Resistance',
+  ]
+subcategory: '政治與民主'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-08-28
+lastHumanReview: false
+readingTime: 10
+curation: incubating
+translatedFrom: 'People/林獻堂.md'
+sourceCommitSha: '7fa2d9630'
+sourceContentHash: 'sha256:b3b7816f9ed81e72'
+sourceBodyHash: 'sha256:fd90a845acbf3ca4'
+translatedAt: '2026-08-28T10:05:00+08:00'
+---
+
+# Lin Hsien-tang: Turning a Family Study into a Public Doorway for the Taiwanese People
+
+> **30-Second Overview:** Born in 1881 into the Wufeng Lin family, Lin Hsien-tang did not keep his family’s resources inside the family. After meeting Liang Qichao in 1907, he threw himself into cultural, educational, and political movements; beginning in 1921 he led the Taiwan Parliament Petition Movement, submitting fifteen petitions over fourteen years. In 1927, he spent 378 days traveling through sixteen countries and sixty cities. What he wanted to see was never merely foreign scenery, but the possibility of Taiwanese winning self-governance.[^1] [^2] [^3]
+
+![Portrait of Lin Hsien-tang](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9b/%E8%87%BA%E7%81%A3%E6%96%87%E5%8C%96%E8%88%87%E6%B0%91%E4%B8%BB%E9%81%8B%E5%8B%95%E9%A0%98%E8%A2%96%E6%9E%97%E7%8D%BB%E5%A0%82_Lin_Hsien-tang%2C_Leader_of_Taiwanese_Culture_and_Democracy_Movement.jpg/500px-%E8%87%BA%E7%81%A3%E6%96%87%E5%8C%96%E8%88%87%E6%B0%91%E4%B8%BB%E9%81%8B%E5%8B%95%E9%A0%98%E8%A2%96%E6%9E%97%E7%8D%BB%E5%A0%82_Lin_Hsien-tang%2C_Leader_of_Taiwanese_Culture_and_Democracy_Movement.jpg)
+
+_Image: Portrait of Lin Hsien-tang; public domain. The original file and license information are on [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:%E8%87%BA%E7%81%A3%E6%96%87%E5%8C%96%E8%88%87%E6%B0%91%E4%B8%BB%E9%81%8B%E5%8B%95%E9%A0%98%E8%A2%96%E6%9E%97%E7%8D%BB%E5%A0%82_Lin_Hsien-tang,_Leader_of_Taiwanese_Culture_and_Democracy_Movement.jpg).[^11]_
+
+## 1907: A Brush-Talk in Nara
+
+In 1907, Lin Hsien-tang met Liang Qichao in Nara, Japan. The two could not speak each other’s language, so they talked with brushes and ink. This scene has been recorded again and again since then, not because it reads like an anecdote about famous men, but because Lin Hsien-tang asked a very practical question there: how were Taiwanese to win their freedom? Materials assembled by the Office of the President note that Liang Qichao later came to Wufeng in 1911, where he advised Lin not to read only literature, but to study politics, economics, society, and thought.[^4]
+
+Lin Hsien-tang was not a man who began on the street. He was born on October 22, 1881, styled Chao-chen, self-named Kuan-yuan, the son of Lin Wen-chin of the Dingcuo branch of Wufeng’s Lin family. Exhibition materials from the National Taiwan Library describe him as receiving a traditional tutorial education in childhood and managing the family estate from a young age.[^2] The estate gave him resources, and it also gave him a question he had to answer: a man who owned land, a family name, and local prestige — what was he going to do with these things? This question is also why Lin Hsien-tang cannot be filed away under “local gentry family”: his whole life was the process of gradually converting private resources into public facilities and a public language.
+
+The Wufeng Lin family residence was not an apolitical backdrop. It was the space where the family received guests, read, collected books, and socialized; it was also the physical scene in which Lin Hsien-tang met local figures, cultural people, and political activists. The Lin family buildings still visible today cannot be equated wholesale with Lin Hsien-tang’s life, but they remind the reader that modern Taiwan’s public movements often first took shape inside family houses, studies, schools, and local networks, and only then moved toward newspapers and the street.[^2] [^14]
+
+![The Wufeng Lin Family House](https://upload.wikimedia.org/wikipedia/commons/thumb/e/ee/%E9%9C%A7%E5%B3%B0%E6%9E%97%E5%AE%B6_The_Lin_Family_House_at_Wufeng_-_panoramio.jpg/960px-%E9%9C%A7%E5%B3%B0%E6%9E%97%E5%AE%B6_The_Lin_Family_House_at_Wufeng_-_panoramio.jpg)
+
+_Image: The Wufeng Lin family house, photographed by lienyuan lee, CC BY 3.0; [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:%E9%9C%A7%E5%B3%B0%E6%9E%97%E5%AE%B6_The_Lin_Family_House_at_Wufeng_-_panoramio.jpg).[^14]_
+
+> **Curator’s Note:** The key to Lin Hsien-tang is not the familiar turn of “a rich man’s son who later entered politics,” but the fact that he did not treat the family’s security as the destination. He converted the family estate into schools, newspapers, associations, and a public capacity that others could take over.
+
+## From Armed Resistance to a Route That Could Be Sustained
+
+After Taiwan came under the Japanese Empire in 1895, resistance on the island never had only one form. Office of the President materials place Lin Hsien-tang inside a clear turn: after meeting Liang Qichao in 1907 and meeting again at Wufeng in 1911, he gradually moved away from the imagination of armed resistance, toward a non-armed route that used education, culture, and political organization to win equality.[^4]
+
+This route was not capitulation, and it was not swapping politics for safer cultural activity. Exhibition materials from the National Taiwan Library record that Lin Hsien-tang led Taiwanese in seeking equality under Japanese colonial rule, while also taking part in cultural enlightenment, educational culture, and social charity.[^2] He understood that if a movement relied only on the courage of a few people, it would vanish along with its fallen leaders. If more people could read, run newspapers, organize, and discuss, resistance would become a daily capacity of society.
+
+The Taiwan Cultural Association, founded in 1921, was the concentrated expression of this idea. Office of the President materials record that Lin Hsien-tang was pushed into the position of president, and the association gathered Lin Yu-chun, Lai Ho, Hsieh Wen-ta, and others, with more than 1,000 members. Lin Hsien-tang once said: “One man can count as a thousand, and so more than a thousand members can be looked upon as more than a million people.” [^1]
+
+That sentence is not simple bravado. It reinterprets “too few people” as “every person must take on more public work,” and it imagines the Cultural Association not as a club of famous men but as a device that could amplify the strength of society.
+
+## One Petition, Fourteen Years of Political Endurance
+
+At the end of 1920, the Shinminkai (New People’s Society) in Tokyo was discussing which road to take: abolishing the special powers the Governor-General had obtained through Law 63, or demanding the establishment of a Taiwan Parliament. Materials from the Taipei City Taiwan New Culture Movement Memorial Museum point out that Lin Hsien-tang ultimately chose to use the right of petition recognized by the Japanese Imperial Constitution, and to petition the Imperial Diet for the establishment of a Taiwan Parliament.[^3]
+
+In January 1921, the petition movement began. It did not have a single uprising or a decisive battle as its dramatic climax; instead it sent documents again and again, waiting for responses of “not adopted” or “deliberation not concluded” again and again. Materials from the Legislative Yuan’s Democracy & Governance Park describe this history as a movement of 1921–1934. After the Taiwan People’s Party was forced to dissolve in 1931, the petition movement gradually declined.[^10]
+
+After the third petition, the 1923 Police Affair broke out at the end of that year, and Chiang Wei-shui, Tsai Pei-huo, and others were arrested and put on trial, yet the petitions did not immediately stop because of it.[^3] This is a passage easily written as “a failed movement”; the more accurate reading is that it stretched politics from a single success or failure into an organizational habit capable of absorbing setbacks.
+
+> **Curator’s Note:** What Lin Hsien-tang left behind is not an inspirational story of “finally succeeding in the end.” The petition movement did not win a Taiwan Parliament under colonial rule. What it left behind was a political technique: writing the demand for equality into documents, carrying it into institutions, and bringing it back into society’s discussion.
+
+In 1934, the fifteenth petition failed again. The memorial museum records that Lin Hsien-tang and more than twenty others met on September 2 at the Greater East Trust Company in Taichung, and after three hours decided to stop the movement. The campaign that began in 1921, lasted fourteen years, and submitted fifteen petitions was formally reported to the governor-general as terminated on September 4.[^3]
+
+Stopping was not the same as admitting that the original demands were without reason. It was more like a judgment about the political environment: Japanese militarism was rising, the Governor-General was linking parliamentary demands with “plotting Taiwan independence,” and the space for legal petition had already been compressed until it could no longer continue.[^3] What Lin Hsien-tang showed here was not invincibility, but knowing when a road had to be folded up, to keep it from dragging everyone into deeper danger together.
+
+## 1927: He Brought the World Back to Taiwan
+
+On May 15, 1927, Lin Hsien-tang set out from Keelung, taking his second son on a round-the-world journey. The English-language _Taipei Times_, drawing on his diaries and related research, notes that the journey lasted 378 days and passed through more than sixteen countries and sixty cities. He went first to Xiamen, Hong Kong, Malaysia, and Sri Lanka, then to Europe, crossed from Paris to the United States, and finally returned to Asia.[^5]
+
+The most interesting thing about this trip is not the curiosity piece of “a Taiwanese circled the globe a hundred years ago,” but the way he looked at the world. In her research summary at National Taiwan Normal University, Lin Shu-hui points out that Lin Hsien-tang’s 1927 diaries and his _Record of a Journey Around the World_ simultaneously carried the meanings of self-narration, the re-presentation of world-historical memory, and cultural enlightenment; he was not merely recording where he went, but thinking, while traveling, about how Taiwanese understood the world.[^7]
+
+The _Taipei Times_ quotes from Lin Hsien-tang’s travel writing: he observed how American society treated women, and criticized the public racial lynchings that then openly existed; in Hyde Park, London, he noticed that speakers were applauded by the crowd while police did not intervene.[^5] The value of these records is not that his imagination of the West was entirely correct, but that he turned overseas observations into a measuring stick, held up against Taiwan’s colonized situation.
+
+He even wrote down in Monaco something close to a direct political inference: a place whose land and population are both small, if it could govern itself, need not necessarily remain a colony.[^5] Here Lin Hsien-tang was not treating the West as a perfect answer; rather, after comparing different systems, he was proposing a more concrete question for Taiwan: are the people capable of governing their own lives?
+
+The photograph he and his second son left in London turned this journey from an abstract “record of a trip around the world” into an experience with family relations and intergenerational transmission. Lin Hsien-tang did not bring the world back to Taiwan alone. His son, his secretary, the readers of his newspapers, and the people who later organized his manuscripts together formed the route of this movement of knowledge.
+
+![Lin Panlong, Lin Hsien-tang, and Lin Youlong in London](https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Lin_Panlong%2C_Lin_Hsien-tang%2C_and_Lin_Youlong%2C_at_London.jpg/960px-Lin_Panlong%2C_Lin_Hsien-tang%2C_and_Lin_Youlong%2C_at_London.jpg)
+
+_Image: Lin Panlong, Lin Hsien-tang, and Lin Youlong photographed together in London, 1927; public domain. The original file and license information are on [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Lin_Panlong,_Lin_Hsien-tang,_and_Lin_Youlong,_at_London.jpg).[^13]_
+
+> **Curator’s Note:** Lin Hsien-tang’s journey was not a departure from Taiwan, but a change of distance through which to look at Taiwan. What he brought back was not the empty phrase “foreign countries are more advanced,” but concrete observations about self-governance, equality, the condition of women, and public discussion.
+
+## Beyond the Study: Schools and Daily Life
+
+### The Diary Was Not a Private Anecdote but the Draft of Public Work
+
+The diaries Lin Hsien-tang left behind let researchers see the friction of the political movement before it had yet become a historical noun: who visited whom, who passed on messages, which meetings were postponed, which newspapers were worth reading, and how a resourceful local leader allocated his time among family, career, and public activity. A diary does not automatically equal “the truth”; it is still the text Lin Hsien-tang chose to write down. But it keeps a figure from being reduced to monument-style accomplishments.
+
+A diary image dated July 28, 1933, currently collected on Wikimedia Commons lets the reader see this trace of work directly. Its importance lies not in whether every character is legible to webpage readers, but in that it restores “Lin Hsien-tang kept a diary” to paper, handwriting, and dates: political history here is not only institutions, but also how one person recorded the world each day.[^7] [^12]
+
+![Mr. Kuan-yuan’s Diary, July 28, 1933](https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Diary_of_Lin_Hsien-tang_1933-07-28.jpg/960px-Diary_of_Lin_Hsien-tang_1933-07-28.jpg)
+
+_Image: Mr. Kuan-yuan’s Diary, July 28, 1933; public domain. The original file and license information are on [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Diary_of_Lin_Hsien-tang_1933-07-28.jpg).[^12]_
+
+If Lin Hsien-tang is written only as the leader of the petition movement, his most enduring influence is still missed. The National Taiwan Library exhibition divides his activities into political participation, business management, literary activity, social charity, educational culture, women, and the diary, showing that his public practice was not a single political résumé.[^2]
+
+Office of the President materials mention that he called for fundraising to establish Taichung Middle School — today’s Taichung First Senior High School. After the war he served as the first chairman of Yanping College’s board, and in 1949 he opened Laiyuan High School.[^4] These schools are not only educational institutions; they are also his concrete answer to the belief that “Taiwanese must cultivate their own public talent.”
+
+He also supported newspapers and cultural organizations. The political line that split from the Taiwan Cultural Association in 1927, the founding of the Taiwan People’s Party, and his service as adviser to the Taiwan Local Self-Government League in 1930 all show that he was always looking for the connecting points among culture, political parties, and local self-governance.[^4] He was not the sole leader of every line, and not every movement was uncontroversial. His role was more like someone who could supply resources, prestige, and intermediation, letting people of different generations and different political languages sit temporarily at the same table.
+
+This intermediary role also had its limits. Lin Hsien-tang’s family background, wealth, and social standing let him bear the cost of long-term political activity and overseas travel; the same conditions could not be replicated by every Taiwanese. His road therefore cannot be treated as the only “model of Taiwanese awakening.” What deserves more attention is how he used the resources obtained inside an unequal society to support schools, newspapers, and organizations, and to keep public participation from depending entirely on him.
+
+## The Wufeng Yixin Association: Making Self-Governance as Small as One Village
+
+On March 29, 1932, the Wufeng Yixin Association was founded. A special-topic article in the Academia Sinica digital archives points out that the Yixin Association was led by Lin Hsien-tang, with Lin family members and the people of Wufeng and surrounding villages as its main members; its goal was to raise rural culture and cultivate the “spirit of self-governance” from the village of Wufeng outward. It did not keep self-governance inside the Tokyo petitions or the ordinances of the Governor-General; it shrank the question into activities that local residents could take part in every day: reading, lectures, hygiene, sports, industry, and mutual aid in society.[^15]
+
+The Yixin Association had departments for survey, hygiene, society, scholarship, sports, and industry, and held Sunday lectures, debates, reading circles, and courses in classical Chinese and Japanese; it also organized comfort gatherings for the elderly, affection meetings for children, forums for young people, and tea gatherings for women.[^15] These names do not look like “big events,” but they precisely show Lin Hsien-tang’s public imagination: self-governance was not a slogan that appeared only on election day, but the gradual growth of knowledge, division of labor, and responsibility about local affairs among the people.
+
+The Yixin Association also let women be more than passive recipients of education. Digital archives materials record that the 1935 roster already included women cadres; some female members were responsible for handicraft teaching, lectures, and social-department work, and others lectured locally on midwifery and hygiene knowledge.[^15] In this way “education” stopped being merely an extension of men’s reading circles, and became a passage through which women could transmit knowledge, take professional positions, and enter public life. Related research also treats the Wufeng Yixin Association as an important case for understanding Lin Hsien-tang’s view of women’s education and local civil society.[^16]
+
+The Yixin Association finally ceased operations after the Marco Polo Bridge Incident in 1937. It did not finish a blueprint of institutions for a self-governing state, but it completed another kind of work that is harder to see: it let local residents, outside the colonial government and the authority of family elders, practice how to learn together, discuss, and take care of one another. This is the layer most worth adding to Lin Hsien-tang’s political career, because it turns “Taiwanese should have self-governance” into “how Taiwanese learn self-governance in local life.”
+
+## After 1947, Even the Family Name Became a Risk
+
+After Japan’s defeat in 1945, Lin Hsien-tang attended the surrender ceremony at Taipei Public Hall. In 1946, he joined Chiu Nien-tai and others in forming the Taiwan Retrocession Tribute Mission to China.[^4] These actions cannot be simplified into a single answer of ethnic identity. They reflect the expectations Taiwanese faced simultaneously after the war: the end of colonial rule, Taiwan’s return to a familiar cultural imagination, and whether the new regime would truly treat Taiwanese equally.
+
+After the 228 Incident broke out in 1947, Office of the President materials record that Lin Hsien-tang worked to stabilize order and let Yen Chia-kan, then head of the Taiwan Provincial Department of Finance, take refuge at the Wugui Pavilion; he was later also invited to take part in the aftermath discussions.[^4] This material must keep its source position and political context; a local elite’s act of rescue cannot be written as a single proof that “228 was not an ethnic conflict.” The victims, responsibility, and memory of the incident must remain in the hands of the more complete historiography of 228.
+
+Lin Hsien-tang moved to Japan in his later years and died in 1956. A doctoral dissertation abstract made public by the University of Tasmania in Australia summarizes him as a Taiwanese elite who crossed the Qing dynasty, Japanese colonial rule, and Nationalist government rule; the thesis observes how Taiwan changed under different regimes through the political, social, and cultural experience of his life.[^6]
+
+This ending is important because it keeps Lin Hsien-tang from being only “the father of the Taiwan Parliament” or a representative figure of the Wufeng Lin family. His life contained ideals and also misjudgments; resources, and also the class distance that resources brought; resistance, and also the search for a space in which to keep living between different regimes. Understanding him is not canonizing him. It is understanding that Taiwan’s public life was usually built, bit by bit, by contradictory people in imperfect times.
+
+## Further Reading
+
+[Special Exhibition on Lin Hsien-tang and the Wufeng Lin Family](https://wwwacc.ntl.edu.tw/fp.asp?fpage=cp&xItem=56548&ctNode=1540&mp=5); [Timeline of the Taiwan New Culture Movement Memorial Museum](https://tncmmm.gov.taipei/Content_List.aspx?n=2A7801BEF42FD19F); [Lin Hsien-tang’s 1927 Round-the-World Journey](https://www.taipeitimes.com/News/feat/archives/2018/12/09/2003705767).
+
+## References
+
+[^1]: [President Attends the Commemorative Concert Banquet for the 60th Anniversary of Lin Hsien-tang’s Passing](https://www.president.gov.tw/NEWS/19865) — Office of the President 2015 event news release, laying out the official account of Lin Hsien-tang and Liang Qichao, the Taiwan Cultural Association, his educational work, the Taiwan Parliament Petition Movement, and his postwar activities.
+
+[^2]: [Special Exhibition on Lin Hsien-tang and the Wufeng Lin Family](https://wwwacc.ntl.edu.tw/fp.asp?fpage=cp&xItem=56548&ctNode=1540&mp=5) — National Taiwan Library exhibition page, providing curatorial summaries of Lin Hsien-tang’s family background, tutorial education, estate management, and political, cultural, educational, and social-charity activities.
+
+[^3]: [September 2, 1934: The End of the Taiwan Parliament Petition Movement](https://tncmmm.gov.taipei/Content_List.aspx?n=2A7801BEF42FD19F) — Taipei City Taiwan New Culture Movement Memorial Museum timeline, detailing the route choice, political pressure, rounds, and termination meeting of the 1921–1934 petition movement.
+
+[^4]: [President Attends the Commemorative Concert Banquet for the 60th Anniversary of Lin Hsien-tang’s Passing](https://www.president.gov.tw/NEWS/19865) — Full official speech, recording Liang Qichao’s twice-repeated influence on Lin Hsien-tang, the scale of the Cultural Association, the founding of schools, the postwar tribute mission, and activity during the 228 period.
+
+[^5]: [Taiwan in Time: A political activist’s journey to the West](https://www.taipeitimes.com/News/feat/archives/2018/12/09/2003705767) — _Taipei Times_ English historical feature, reconstructing from diaries, travel writing, and research Lin Hsien-tang’s 378-day round-the-world journey of 1927–1928 and his political observations.
+
+[^6]: [Lin Hsien-tang and resistance and adaptation in 20th century Taiwan](https://figshare.utas.edu.au/articles/thesis/Lin_Hsien-tang_and_resistance_and_adaptation_in_20th_century_Taiwan/23252669) — Public doctoral thesis abstract from the University of Tasmania, Australia, analyzing Taiwan’s historical transformation through Lin Hsien-tang’s life experience across Qing, Japanese, and Nationalist rule.
+
+[^7]: [Narrative, Representation, Enlightenment — The Cultural Significance of Lin Hsien-tang’s 1927 Diary and Record of a Journey Around the World](https://scholar.lib.ntnu.edu.tw/zh/publications/%E6%95%98%E4%BA%8B%E5%86%8D%E7%8F%BE%E5%95%9F%E8%92%99%E6%9E%97%E7%8D%BB%E5%A0%82%E4%B8%80%E4%B9%9D%E4%BA%8C%E4%B8%83%E5%B9%B4%E6%97%A5%E8%A8%98%E5%8F%8A%E7%92%B0%E7%90%83%E9%81%8A%E8%A8%98%E7%9A%84%E6%96%87%E5%8C%96%E6%84%8F%E7%BE%A9/) — National Taiwan Normal University academic output page, providing research summaries of the diary and travel record in self-narration, world memory, and cultural enlightenment.
+
+[^8]: [Narrative, Representation, Enlightenment — The Cultural Significance of Lin Hsien-tang’s 1927 Diary and Record of a Journey Around the World](https://www.airitilibrary.com/Article/Detail/16081692-200812-201206060006-201206060006-65-91) — Article detail page for issue 13 of the _Journal of Taiwan Literature_, providing the study title, author, journal pagination, and academic context of Lin Hsien-tang’s travel writing.
+
+[^9]: [Lin Hsien-Tang’s Taiwanese Home Rule Movement as Inspired by the Irish Model](https://eprints.lse.ac.uk/124781/2/14816169_Taiwan_Culture_Research_Programme_Taiwan_in_Comparative_Perspective_vol_4.pdf) — London School of Economics research publication, comparing Lin Hsien-tang’s Taiwanese self-rule movement with the Irish home-rule experience, adding an English-language scholarly view and political-thought background.
+
+[^10]: [Taiwan Parliament Petition Movement 1921–1934](https://daap.ly.gov.tw/tw/daap/125-3993.html) — Historical brief from the Legislative Yuan’s Democracy & Governance Park, laying out the institutional history of the movement’s main leaders, the dissolution of the Taiwan People’s Party, and the 1934 termination.
+
+[^11]: [File: Leader of the Taiwan Culture and Democracy Movement, Lin Hsien-tang](https://commons.wikimedia.org/wiki/File:%E8%87%BA%E7%81%A3%E6%96%87%E5%8C%96%E8%88%87%E6%B0%91%E4%B8%BB%E9%81%8B%E5%8B%95%E9%A0%98%E8%A2%96%E6%9E%97%E7%8D%BB%E5%A0%82_Lin_Hsien-tang,_Leader_of_Taiwanese_Culture_and_Democracy_Movement.jpg) — Wikimedia Commons file page; marked public domain on the page, with the image credited to the Lin Hsien-tang Cultural Relics Museum.
+
+[^12]: [File: Diary of Lin Hsien-tang 1933-07-28](https://commons.wikimedia.org/wiki/File:Diary_of_Lin_Hsien-tang_1933-07-28.jpg) — Wikimedia Commons file page; Mr. Kuan-yuan’s Diary for July 28, 1933, marked public domain on the page.
+
+[^13]: [File: Lin Panlong, Lin Hsien-tang, and Lin Youlong, at London](https://commons.wikimedia.org/wiki/File:Lin_Panlong,_Lin_Hsien-tang,_and_Lin_Youlong,_at_London.jpg) — Wikimedia Commons file page; London group photograph of 1927, marked public domain on the page.
+
+[^14]: [File: Wufeng Lin Family House](https://commons.wikimedia.org/wiki/File:%E9%9C%A7%E5%B3%B0%E6%9E%97%E5%AE%B6_The_Lin_Family_House_at_Wufeng_-_panoramio.jpg) — Wikimedia Commons file page; photographed by lienyuan lee, marked Creative Commons Attribution 3.0 Unported (CC BY 3.0).
+
+[^15]: [Coming into View — Taiwanese Women’s Social Participation in the Wufeng Yixin Association](https://ascdc.digitalarchives.tw/subject_1679.html) — Academia Sinica digital archives special-topic article, recording the Yixin Association’s founding purpose, organizational departments, local cultural activities, women cadres, and social-hygiene work.
+
+[^16]: [Lin Hsien-tang and Women’s Education — The Case of the Wufeng Yixin Association](https://www.ntl.edu.tw/public/Attachment/281415581732.pdf) — Research article collected by the National Taiwan Library, discussing Lin Hsien-tang’s view of women and his public cultural practice through women’s education and the Wufeng Yixin Association.


### PR DESCRIPTION
## 這個 PR 做了什麼？

新增林獻堂（Lin Hsien-tang）英文翻譯 — 霧峰林家出身的臺灣議會設置請願運動領袖。遵循 TRANSLATION-PIPELINE v4.0：從中文 SSOT 完整投影，保留全部 16 條腳註與 4 張圖片，ratio 2.59 落在 en 健康帶（2.20–3.50）。

## 變更類型

- [x] 🌐 翻譯（zh-TW → 目標語言）

## 自我檢查

- [x] 完整 frontmatter（title, description, date, tags, category, subcategory；含 translatedFrom / sourceCommitSha / sourceContentHash / translatedAt）
- [x] `category` 用英文且對齊路徑（People）
- [x] `translatedFrom: 'People/林獻堂.md'` 指向存在的 zh-TW 原文
- [x] `author: 'Taiwan.md Contributors'`
- [x] `featured: false`
- [x] 腳註用 canonical 格式 `[^N]: [標題](URL) — 描述`
- [x] 每個引用都有可查證來源（總統府、國立臺灣圖書館、新文化運動紀念館、Taipei Times、LSE、UTAS 論文等）
- [x] 已跑驗證：ratio-check OK (PASS 1/1)、frontmatter --strict PASS、article-health --profile=pre-commit (hard=0 warn=0)、banned-phrases 掃描 CLEAN

翻譯指南遵循 TRANSLATION-en.md：`Lin Hsien-tang` Wade-Giles、`Taiwan Parliament Petition Movement`、`Taiwan Cultural Association`、`Wufeng`、`Keelung` 等既有慣例沿用全站已建立拼法；無 sovereignty leak。