### PR TITLE
translate(en): 蔡瑞月 → tsai-jui-yueh

### DIFF
--- a/knowledge/en/People/tsai-jui-yueh.md
+++ b/knowledge/en/People/tsai-jui-yueh.md
@@ -1,0 +1,189 @@
+---
+title: 'Tsai Jui-yueh: From a Green Island Cell to a Dance Studio That Could Not Be Burned Away'
+description: 'Born in Tainan in 1921, Tsai Jui-yueh left for Japan at sixteen to study dance, was imprisoned in 1949 after her husband Lei Shih-yu fell to political persecution, and kept teaching dance on Zhongshan North Road after her release. What she left behind was more than a set of steps: a studio that was rescued, burned, and still rehearses today, and the standing question of how Taiwan preserves the memory of the wounded.'
+date: 2026-08-19
+category: 'People'
+tags:
+  [
+    'Tsai Jui-yueh',
+    'Modern Dance',
+    'White Terror',
+    'Women',
+    'Rose Historic Site',
+  ]
+subcategory: '藝術與設計'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-08-28
+lastHumanReview: false
+rationale:
+  why_this_hook: 'Frames the artistic and political life of Tsai Jui-yueh through the contrast between the studio, the cell, and the fire.'
+  whats_excluded: 'Does not treat responsibility for the 1999 fire as settled, and does not lay out a full chronicle of Taiwanese modern dance.'
+  where_it_hedges: 'For the 1999 fire, states only verified events and the surviving disputes, keeping the foundation’s claims distinct from established fact.'
+  whos_pushing_back: 'Preservation groups, the official heritage narrative, and the political-victim archives hold different memories of the same site.'
+readingTime: 9
+curation: incubating
+translatedFrom: 'People/蔡瑞月.md'
+sourceCommitSha: 'c462122e6'
+sourceContentHash: 'sha256:f91b55938ef411f1'
+sourceBodyHash: 'sha256:6b90253634145c2e'
+translatedAt: '2026-08-28T19:45:00+08:00'
+---
+
+# Tsai Jui-yueh: From a Green Island Cell to a Dance Studio That Could Not Be Burned Away
+
+> **30-Second Overview:** Tsai Jui-yueh left Tainan for Japan to study dance, was imprisoned during the White Terror after returning to Taiwan, and went on teaching dance on Zhongshan North Road after her release. Her dance studio survived a demolition crisis and a fire; today it is both a venue for modern dance and a living site where Taiwan keeps the memory of political persecution.
+
+In 1946, twenty-five-year-old Tsai Jui-yueh sailed back to Taiwan from Japan and choreographed _Song of India_ on board. In 1949, her husband Lei Shih-yu was arrested by the government and deported; a few months later she too became a political prisoner and was sent to Green Island. After her release in 1953, she opened a dance school again, and finally settled her classroom in a Japanese-era wooden dormitory on Zhongshan North Road in Taipei.[^1] [^2] [^3]
+
+![The entrance of the Tsai Jui-yueh Dance Institute, photographed in 2013](https://upload.wikimedia.org/wikipedia/commons/3/36/Tsai_Jui-yueh_Dance_Institute_20130925.jpg)[^12]
+
+_Image 1: The entrance of the Tsai Jui-yueh Dance Institute. Photo: lienyuan lee, licensed CC BY 3.0. Original hotlinked file: [Wikimedia Commons original](https://upload.wikimedia.org/wikipedia/commons/3/36/Tsai_Jui-yueh_Dance_Institute_20130925.jpg). License and file description: [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:Tsai_Jui-yueh_Dance_Institute_20130925.jpg). Unmodified._
+
+This is not the résumé one expects of a dancer. It never separated the stage, the prison cell, the surveillance, and the fire; it let them settle, again and again, onto the same body. The core question Tsai Jui-yueh left behind is therefore not “was she the mother of Taiwanese modern dance,” but this: **when the state can restrict a person’s movement, work, and family, can the body still keep a rhythm of its own?**
+
+📝 Curator’s Note: The story of Tsai Jui-yueh is not one of suffering crowning art, but of art finding, inside suffering, a way of breathing that borrowed nothing from power.
+
+## A Letter with No Address
+
+Tsai Jui-yueh was born in Tainan in 1921. In high school, she saw the Japanese dancer Baku Ishii perform at Tainan’s Miyako-za theater, and began to imagine dancing as something one could do for a lifetime. She later wrote to Japan in search of a teacher. The letter carried no address at all, yet it made its way — passed along on the strength of Ishii Baku’s fame — to the man himself. At sixteen she left Tainan and entered Ishii Baku’s dance school, and afterwards went on to study under Ishii Midori.[^9]
+
+This was a small beginning. A girl in a colonized city sees one performance, writes a letter, waits for a reply, and then persuades her family to let her leave the country. Taiwanese dance history later often summed her up as a “pioneer,” but the word pioneer sands down the adventure she actually undertook. She was not standing at the head of a road that had already been paved; in a place where no road existed, she put her own foot down first.
+
+Touring Japan and the South Seas, Tsai Jui-yueh accumulated extensive stage experience. After the war she refused to stay and build her career in Japan, and chose to sail home to Taiwan. The profile of Tsai Jui-yueh reprinted by _Min Bao Culture Magazine_ placed _Song of India_, created on the voyage back, within the early development of Taiwanese modern dance.[^2]
+
+What she said to herself on that ship later became one of the keys to reading her:
+
+> “I didn’t care if other passengers thought I was crazy.”[^3]
+
+She was not unaware of how others would see her. She had simply decided, first, to dance. Another line is even more direct:
+
+> “I couldn’t wait to get home to perform, to choreograph, to teach.”[^3]
+
+The “home” in that sentence was not a quiet destination. It was a place with no stage yet — one that would have to be built by hand.
+
+## The Land She Returned to Was Not Blank
+
+In 1946, not long after returning to Tainan, Tsai Jui-yueh performed at Taipingjing Church (太平境教會) and began teaching dance in the city. In 1947 she married the poet Lei Shih-yu, and the two later moved to Taipei, living and working in NTU faculty housing. The Japanese-style building at Lane 48, Section 2 of Zhongshan North Road gradually became a dance classroom, a family residence, and a gathering place for friends in the arts.[^4] [^9]
+
+The value of this building does not come only from who once lived in it. Archives and site documentation note that the structure was originally a Japanese-era civil-servant dormitory, built around 1925 and later extended or remodeled for the needs of dance teaching. These not-quite-consistent traces of different periods are exactly what show that the studio was never a sealed display piece, but a working space continuously adjusted by the people who used it.[^8] [^9]
+
+![The building of the Tsai Jui-yueh Dance Institute](https://upload.wikimedia.org/wikipedia/commons/f/f3/%E8%94%A1%E7%91%9E%E6%9C%88%28%E8%88%9E%E8%B9%88%E7%A0%94%E7%A9%B6%E7%A4%BE%29_0432.jpg)[^13]
+
+_Image 2: The building of the Tsai Jui-yueh Dance Institute. Photo: Lin Kao-chih, licensed CC BY-SA 4.0. Original hotlinked file: [Wikimedia Commons original](https://upload.wikimedia.org/wikipedia/commons/f/f3/%E8%94%A1%E7%91%9E%E6%9C%88%28%E8%88%9E%E8%B9%88%E7%A0%94%E7%A9%B6%E7%A4%BE%29_0432.jpg). License and file description: [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:%E8%94%A1%E7%91%9E%E6%9C%88%28%E8%88%9E%E8%B9%88%E7%A0%94%E7%A9%B6%E7%A4%BE%29_0432.jpg). Unmodified._
+
+The materials preserved by the National Archives Administration keep this classroom from being remembered as merely a warm literary salon. Writers and artists — Huang Jung-tsan, Chin Tzu-hao, and Lan Yin-ting among them — came and went here, talking about how literature, language, and dance might grow in Taiwan.[^4] But the same archival context shows that artistic activity never left the sight of the police authorities. In 1949, the Tsai Jui-yueh Song and Dance Troupe was listed as a “suspicious person under control and surveillance” because of its performance content. Police department documents even read passages from the stage as potentially producing “homesickness and war-weariness” and as “suspected propaganda for the Communist bandits.”[^5]
+
+This is not later generations draping the White Terror over art history; the archives genuinely preserve the way the state looked at dance. A dancer’s body was seen not only as art but as a possible carrier of thought. To power, dance did not need an explicit slogan to be dangerous. The movement of a body was itself something that could be read as disobedience.
+
+## Prisoner No. 15 and the Rhythm of the Floor
+
+In 1949, Lei Shih-yu was arrested for political reasons and subsequently deported. Tsai Jui-yueh was arrested through her connection to her husband, imprisoned for three years, and sent to Green Island. The National Archives Administration’s feature materials record that Lei Shih-yu and Tsai Jui-yueh were separated for years, reuniting only in 1990, in Hebei, China.[^4]
+
+In another piece of transcribed oral history, Tsai Jui-yueh recalled that during her years on Green Island, while carrying loads on a shoulder pole, she would pick up seashells along the way — keeping the sea wind and the fine sand as one of the few memories of prison life she could hold herself. When she was released she asked “why did you arrest me,” and the answer she received was “shaken in thought.” These two sentences are not the same kind of voice. The first is a detainee demanding to understand; the second is the state’s verdict used to close understanding down.[^9] This experience should not be written as the inspirational fable of “she used art to triumph over suffering.” The cell did not thereby become a stage, and the political persecution did not thereby become acceptable. The more accurate statement is: in a place where freedom had been taken away, she still worked to keep her feeling for the body and for memory alive.
+
+After her release in 1953, Tsai Jui-yueh went back to teaching. She first opened classes on Nong’an Street in Taipei, later moving to the studio’s current site on Section 2 of Zhongshan North Road. At its height the studio had three to four hundred students, and from morning until night someone was always stepping across the floor.[^9]
+
+In 1959, so that the studio could be formally registered, and to cope with agent surveillance and interference with performances, Tsai Jui-yueh renamed it the “China Dance Society” (中華舞蹈社). The renaming was an administrative necessity — and it also left the mark of the authoritarian era on the place: a space for teaching dance first had to learn how to explain itself clearly inside the system before it could go on dancing.[^2] [^9]
+
+She almost never refused an outside performance invitation. In her oral history she said:
+
+> “I never turned down a show after I got back because I was determined to spread the seeds of dance all over Taiwan.”[^3]
+
+Read only as a declaration of passion, the sentence loses its background. She was choosing to increase the number of times she appeared in public while under surveillance, while performances could be canceled, and while opportunities to leave the country were restricted.
+
+## Puppets on the March Is Not Abstract Freedom
+
+Tsai Jui-yueh’s work is often discussed as “the beginning of Taiwanese modern dance.” That is not wrong, but it is not enough. Her dances were also working on a concrete question: whose hands move the body, and can it win back its own direction?
+
+_Song of India_ took shape on the ship returning to Taiwan. It carries the speed of going home, and the decision of a dancer bringing what she had learned back to the island. _The Chase_ (追), created in 1949, drew its imagery from Taiwan’s Indigenous peoples and its mountain forests, and later became one of her signature works.[^2] [^9]
+
+What faced political oppression even more directly was _Puppets on the March_ (傀儡上陣). A Taipei Cultural Express feature describes it as a work from after Tsai Jui-yueh’s release: the dancer moves like a puppet governed by unseen strings, yet still leaves a voice of resistance to authoritarian power on the stage.[^7] That reading stands, but the piece does not need to be inflated into “a dance that toppled authoritarianism.” It is closer to a bodily testimony left by one person: I know the strings are still there, I know I am being pulled, and I still want the audience to see the strings.
+
+In 1983, Tsai Jui-yueh moved to Australia. She left Taiwan, but she never cut the studio out of her life. In the oral-history reporting of the _Taipei Times_ she said:
+
+> “It was difficult to leave behind my beloved country and dance studio.”[^3]
+
+The second half of that sentence is often skipped. What was hard to leave was not a country in the abstract, but “country and dance studio” — the land, and one concrete classroom. For Tsai Jui-yueh, the studio was not a backdrop. It was the organ through which she reattached herself to Taiwan.
+
+## How a House Became Public Memory
+
+In 1994, the studio faced demolition for the Taipei MRT project. The cultural community launched a rescue campaign: three dancers once stayed aloft for twenty-four hours, while on the ground dance, music, and lectures ran in relay. The studio was saved.[^9]
+
+What made that preservation campaign matter was not only that a wooden house did not disappear. It was the first large-scale demonstration by Taiwan’s arts community that cultural preservation is not something experts decide on society’s behalf, and that a building does not stay alive merely by being named a historic site. What actually kept the space standing was people willing to put their bodies into the risk, making an address into a public question again.
+
+In 1999, the studio was designated a Taipei municipal historic site. Days later, the building was burned out by fire. Responsibility for the fire remains contested to this day. In 2026, the Central News Agency reported that the Tsai Jui-yueh Culture Foundation and allied groups petitioned the Control Yuan, demanding a re-examination of the cause of the fire, the preservation of the scene, and the responsibility of the overseeing agencies.[^11]
+
+Here “arson” and “who set it” must be kept apart. The CNA report covered the claims of the foundation and its supporting groups, including the surveillance-camera and on-site forensics arguments they raised — but that is not the same as proving that a specific person or agency ordered the fire. The article can say the fire’s unanswered questions remain; it should not write unconfirmed responsibility into a verdict.
+
+Tsai Jui-yueh stood before the charred studio and said:
+
+> “It was as if I had lost a daughter.”[^10]
+
+That line comes from a 2015 _Min Bao Culture Magazine_ article on the Tsai Jui-yueh Dance Institute. It is not a court verdict, nor a fire-investigation report; it is a memory of the moment preserved by an interviewee. It is quoted here so the reader knows this fire was not an abstract heritage incident: a person watched the wooden floor, the walls, and the traces of a life she knew get burned away.
+
+## After the Fire, Do Not Stop at Rebirth
+
+In 2006, the Tsai Jui-yueh Dance Institute reopened. The Office of the President’s press release at the time called it Taiwan’s first municipal historic site themed on dance, positioning it as an entry point for Taiwanese dance and international exchange.[^6] The current introduction by the Taipei City Department of Cultural Affairs states that the site presents dance history materials and images and promotes research, education, and international exchange.[^8]
+
+This positioning keeps the Rose Historic Site (玫瑰古蹟) from being merely “a house Tsai Jui-yueh once lived in.” It is at once an archival gateway for dance history, an educational space where ordinary people encounter the training of the body, and a cultural outpost placing Taiwanese dance in international conversation. The three uses are not always naturally compatible. Preservation demands controlling the environment and its traces; teaching needs the floor used again and again; international exchange needs a local story translated into a language outside audiences can understand. The studio’s long-term difficulty is precisely to make these three uses support one another rather than wear each other down.[^6] [^8]
+
+“Reborn from the ashes” is a convenient phrase — and one that can cover up what came after. The restoration meeting records from November 1999 preserved by the foundation show that after the fire, the foundation, scholars, and the relevant Taipei City government agencies met to discuss restoration.[^10] But restoration does not end when the walls are rebuilt. Which materials may be replaced, which traces should be kept, who has the authority to decide how a place created by a cultural community operates — these, too, are part of preservation work.
+
+The value of the Rose Historic Site therefore lies not only in a wooden building still standing. Its value also lies in putting a chapter of dance history, a chapter of women’s suffering, a chapter of urban development, and a cultural-heritage dispute that has never been fully clarified into the same address. The Taipei City government’s cultural affairs department calls this place “the cradle of Taiwanese dance.” For that name to avoid becoming a tourist slogan, it has to be remembered together with the surveillance, the demolition crisis, the fire, and the restoration dispute.[^8]
+
+The interpretive plaques on site also remind visitors that “restoring the original appearance” here does not mean copying back a 1920s facade; it is a set of choices among the layers of the fire, of teaching, of additions, and of everyday use. Seeing a plaque is not the same as finishing this history, but it lets a visitor know: heritage preservation is also a kind of historiography, and who gets written in, which traces get kept, will shape how later generations understand Tsai Jui-yueh.[^13] [^14]
+
+![The interpretive plaque of the Tsai Jui-yueh Dance Institute](https://upload.wikimedia.org/wikipedia/commons/8/8f/Tsai_Jui-yueh_Dance_Institute_plaque_20190706.jpg)[^14]
+
+_Image 3: The interpretive plaque of the Tsai Jui-yueh Dance Institute. Photo: Solomon203, licensed CC BY-SA 4.0. Original hotlinked file: [Wikimedia Commons original](https://upload.wikimedia.org/wikipedia/commons/8/8f/Tsai_Jui-yueh_Dance_Institute_plaque_20190706.jpg). License and file description: [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:Tsai_Jui-yueh_Dance_Institute_plaque_20190706.jpg). Unmodified._
+
+## The Floor Is Still Waiting for the Next Movement
+
+Tsai Jui-yueh died in 2005. She did not live to see the dance institute reopen in 2006, but the classroom she left behind later became a base for dance festivals, cultural forums, and international exchange.[^2] [^6]
+
+What she finally left Taiwan was not a bronze-statue answer called “the mother of modern dance,” but a question that can still be used: how does dance keep the body free in a place marked by political wounds?
+
+The answer does not lie in writing Tsai Jui-yueh as someone who could not be hurt. She was hurt; she left; she watched her own studio swallowed by fire. The answer is closer to another kind of patience: reconnecting the movements that were forcibly interrupted, handing a house over from private memory to public discussion, and letting the next generation of dancers find their own rhythm on the same floor.
+
+Tsai Jui-yueh said she wanted to spread the seeds of dance all over Taiwan. Seeds are not souvenirs. They must go into the soil, meet wind and rain, surveillance, demolition plans, and fire — and there must be people willing to water them. Walk into 10, Lane 48, Zhongshan North Road today, and what is truly worth seeing is not how closely a monument has been restored to its former look, but whether this place still allows bodies to raise new questions.
+
+📝 Curator’s Note: The real proof that a dance studio was never burned away is not that the walls are still standing. It is that people are still rehearsing inside — and that they know what this floor has carried.
+
+## Further Reading
+
+The [Taipei City Department of Cultural Affairs page on the Tsai Jui-yueh Dance Institute](https://culture.gov.taipei/cp.aspx?n=772B4E67566296F7) provides information on the site, the building, and visitor services.
+
+The [National Archives Administration feature on Tsai Jui-yueh and Tsui Hsiao-ping in the arts world](https://art.archives.gov.tw/tw/art/906.html) extends the archival context of arts workers under authoritarian rule.
+
+## Image Licenses
+
+[^12]: [Wikimedia Commons: Tsai Jui-yueh Dance Institute 20130925.jpg](https://commons.wikimedia.org/wiki/File:Tsai_Jui-yueh_Dance_Institute_20130925.jpg) — Photo by lienyuan lee, licensed CC BY 3.0. The article uses the original photograph, unmodified.
+
+[^13]: [Wikimedia Commons: 蔡瑞月（舞蹈研究社）0432.jpg](https://commons.wikimedia.org/wiki/File:%E8%94%A1%E7%91%9E%E6%9C%88%28%E8%88%9E%E8%B9%88%E7%A0%94%E7%A9%B6%E7%A4%BE%29_0432.jpg) — Photo by Lin Kao-chih, licensed CC BY-SA 4.0. The article uses the original photograph, unmodified.
+
+[^14]: [Wikimedia Commons: Tsai Jui-yueh Dance Institute plaque 20190706.jpg](https://commons.wikimedia.org/wiki/File:Tsai_Jui-yueh_Dance_Institute_plaque_20190706.jpg) — Photo by Solomon203, licensed CC BY-SA 4.0. The article uses the original photograph, unmodified.
+
+## References
+
+[^1]: [Office of the President Gazette: Presidential commendation](https://www.president.gov.tw/Page/294/36913) — The commendation order published in 2005, summarizing Tsai Jui-yueh’s founding of the dance institute on her return, her choreography, her overseas performances, and her awards.
+
+[^2]: [Min Bao Culture Magazine reprint: Born for dance — Tsai Jui-yueh, mother of Taiwanese modern dance](http://www.laijohn.com/archives/pc/Chhoa/Chhoa,Sgoeh/brief/Ng,Sbin.htm) — A profile of Tsai Jui-yueh reprinted from _Min Bao Culture Magazine_, covering her studies in Japan, her return and choreography, her political persecution, and the history of the studio.
+
+[^3]: [Taipei Times: Born to groove](https://www.taipeitimes.com/News/feat/archives/2017/05/28/2003671430) — An English-language feature built on oral history, carrying Tsai Jui-yueh’s verbatim quotes on her return, her performances, the political persecution, and leaving the studio.
+
+[^4]: [National Archives Administration: Tsai Jui-yueh and Tsui Hsiao-ping in the arts world](https://art.archives.gov.tw/tw/art/906.html) — An archives feature on arts figures of the authoritarian period, laying out the family story of Tsai Jui-yueh and Lei Shih-yu, the studio, and the context of their political persecution.
+
+[^5]: [National Archives Administration: “Suspicious persons under control” — the Tsai Jui-yueh Song and Dance Troupe case](https://art.archives.gov.tw/tw/art/906-12793.html) — The specific case name and description page, showing how police agencies recorded and interrogated the Tsai Jui-yueh Song and Dance Troupe in 1949–1950.
+
+[^6]: [Office of the President news: President attends the reopening ceremony of the Tsai Jui-yueh Dance Institute](https://www.president.gov.tw/NEWS/11292) — The 2007 reopening press release, recording the preservation campaign, the studio’s history, its designation as a historic site, and Tsai Jui-yueh’s cultural influence.
+
+[^7]: [Taipei Cultural Express: A century-long pursuit — the spirit of Tsai Jui-yueh’s era](https://cultureexpress.taipei/PastTopic/C000004?ID=ae782329-f44a-4948-a1ce-c8fae6964292&PageType=1) — A Taipei City cultural feature placing _Puppets on the March_, _Song of India_, and other works back into the context of the White Terror, freedom, and transitional justice.
+
+[^8]: [Taipei City Department of Cultural Affairs: Tsai Jui-yueh Dance Institute](https://culture.gov.taipei/cp.aspx?n=772B4E67566296F7) — The city government’s institution page, providing the address, the background of the Japanese-era civil-servant dormitory building, and the site’s positioning for dance history display, research, and education.
+
+[^9]: [Tsai Jui-yueh Culture Foundation: The life course of the Rose Historic Site](https://www.dance.org.tw/%E9%97%9C%E6%96%BC%E6%88%91%E5%80%91about-us/%E7%8E%AB%E7%91%B0%E5%8F%A4%E8%B9%9F%E7%9A%84%E7%94%9F%E5%91%BD%E6%AD%B7%E7%A8%8B) — The foundation’s history and site chronology article, with material on her studies in Japan, her persecution, her teaching, the 1994 preservation campaign, and the handing-down of the dance festival.
+
+[^10]: [Tsai Jui-yueh Culture Foundation: Minutes of the post-fire restoration meeting, November 1999](https://www.dance.org.tw/1999%E5%B9%B411%E6%9C%88%E5%8F%A4%E8%B9%9F%E7%81%AB%E7%81%BD%E5%BE%8C%E5%8F%AC%E9%96%8B%E4%BF%AE%E5%BE%A9%E6%9C%83%E5%8B%98%E6%9C%83%E8%AD%B0%E7%B4%80%E9%8C%84) — The foundation’s public page for the post-fire restoration survey meeting, listing the foundation, scholars, and government units present in November 1999.
+
+[^11]: [Central News Agency: The Tsai Jui-yueh Dance Institute was set on fire 27 years ago; foundation seeks a renewed investigation](https://www.cna.com.tw/news/aipl/202607230250.aspx) — A 2026 news report recording the foundation’s petition to the Control Yuan and the unresolved dispute over responsibility for the fire.


### PR DESCRIPTION
## translate(en): 蔡瑞月（Tsai Jui-yueh）→ knowledge/en/People/tsai-jui-yueh.md

將 `knowledge/People/蔡瑞月.md` 完整翻譯為英文，接續 #1604（黃土水）、#1615（林獻堂）、#1616（唐鳳）的 EN People 翻譯系列。白色恐怖受難者／臺灣現代舞奠基者，sovereignty-sensitive 題材。

### 完整性檢查
- ✅ 章節 10:10（含 30 秒概覽、2 個 📝 策展人筆記、Further Reading、Image Licenses、References 全數保留）
- ✅ 腳註 14/14（inline 引用位置與原文一致；[^12]–[^14] 圖片授權腳註保留）
- ✅ zh→en body 字元比 **2.94**（健康區間 2.2–3.5）
- ✅ Taipei Times 口述史英文引語逐字保留；中文引語譯為自然英文（「我好像失去了一個女兒」等）
- ✅ 三張 Wikimedia Commons 圖片熱網址與授權頁連結原樣保留
- ✅ frontmatter provenance：`translatedFrom: 'People/蔡瑞月.md'`、`sourceCommitSha: 'c462122e6'`、`sourceContentHash: 'sha256:f91b55938ef411f1'`、`sourceBodyHash: 'sha256:6b90253634145c2e'`（status.py canonical 算法）
- ✅ `rationale` 區塊依既有 EN 慣例（megaport-festival.md 等）譯為英文
- ✅ `test-frontmatter.mjs --ci` 通過；prettier 格式化

### 對原文的小修正（翻譯時處理，REFLEXES 慣例）
- 原文兩處腳註格式 typo：`[^2] [9]` → `[^2] [^9]`、`[^2] [6]` → `[^2] [^6]`
- 移除圖 2 後一行殘留的重複裸連結

AI：Copilot (GLM) — 非英語母語者，逐段核對原文、腳註與引語後產出