### PR TITLE
translate(en): 鄧雨賢 → teng-yu-hsien

### DIFF
--- a/knowledge/en/People/teng-yu-hsien.md
+++ b/knowledge/en/People/teng-yu-hsien.md
@@ -1,0 +1,103 @@
+---
+title: 'Teng Yu-hsien: Hakka 1906, April Longing for Rain — Thirty-Nine Years of the Father of Taiwanese Songs'
+description: 'Born on July 21, 1906, to a Hakka family in Longtan, Taoyuan, under the birth name Teng Ping-yen, he graduated from a normal school and was recruited by Columbia Records in 1933. His four signature works, "April Longing for Rain" — "Four Seasons Red," "Moonlit Sorrow," "Longing for the Spring Breeze," and "Rainy Night Flower" — are still sung today. He taught at the public school in Qionglin, Hsinchu, from 1939 until his death at Zhudong Hospital on June 11, 1944, at the age of 39.'
+date: 2026-03-19
+category: 'People'
+tags:
+  [
+    'Music',
+    'Taiwanese (Hokkien) Songs',
+    'Composer',
+    'Japanese Colonial Era',
+    'Taoyuan',
+    'Hakka',
+  ]
+subcategory: '音樂'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-08-28
+lastHumanReview: false
+readingTime: 7
+curation: incubating
+translatedFrom: 'People/鄧雨賢.md'
+sourceCommitSha: '09ffe560f'
+sourceContentHash: 'sha256:03f4c1611aa95a6c'
+sourceBodyHash: 'sha256:0d86dfd69dceab10'
+translatedAt: '2026-08-28T19:55:00+08:00'
+---
+
+# Teng Yu-hsien: Hakka 1906, April Longing for Rain — Thirty-Nine Years of the Father of Taiwanese Songs
+
+> **30-Second Overview:** Teng Yu-hsien was born on July 21, 1906, to a Hakka family in Longtan, Taoyuan (桃園龍潭), birth name Teng Ping-yen.[^1] After graduating from a normal school (the predecessor of today's National Taiwan Normal University), he worked as an elementary school teacher. In 1933, Columbia Records (古倫美亞) recruited him as a staff composer,[^2] and that same year he composed "Longing for the Spring Breeze" (lyrics: Li Lin-chiu). His four signature works are known together as "April Longing for Rain": "Four Seasons Red," "Moonlit Sorrow," "Longing for the Spring Breeze," and "Rainy Night Flower."[^1] From 1939 he taught at the public school in Qionglin (芎林), Hsinchu.[^3] He died at Zhudong Hospital (竹東醫院) on June 11, 1944, at the age of 39.[^3]
+
+## 1906: Longtan, Taoyuan, and the Hakka
+
+Teng Yu-hsien was born on July 21, 1906, in Longtan, Taoyuan (桃園龍潭), with the birth name Teng Ping-yen. He came from a Hakka family with a scholarly tradition; his father, Teng Teng, was a xiucai (秀才), a holder of the imperial examination degree.[^1] He showed musical talent from childhood and entered the Taiwan Governor-General's Normal School (台灣總督府師範學校, the predecessor of today's National Taiwan Normal University), where he received a formal education in Western music, studying piano and violin.[^1]
+
+After graduating from the normal school in 1925, he worked as an elementary school teacher for a time before soon devoting himself to composing music.
+
+In Taiwan in the 1920s-30s, the Western music training the normal school offered was an extremely scarce resource. Few composers could learn piano, understand harmony, and read staff notation; Teng Yu-hsien was one of them. This technical background later let him combine the tonal character of Taiwanese (Hokkien) lyrics with Western musical forms, producing works with both academic foundations and a folk audience's listening intuition.
+
+## Columbia Records and the Birth of "Longing for the Spring Breeze"
+
+In 1933, Columbia Records (古倫美亞) recruited Teng Yu-hsien as a staff composer.[^2] That same year he composed the melody for "Longing for the Spring Breeze," with Taiwanese lyrics by Li Lin-chiu; by blending Western harmony into traditional Taiwanese melody, the song became an early signature work of Taiwanese pop songs.
+
+Columbia was one of the largest commercial record companies in Taiwan then. Being hired as a staff composer meant entering the core production machinery of Taiwanese popular music, giving his works commercial recording and distribution channels — an important condition for the rapid spread of "April Longing for Rain."
+
+The first recording of "Longing for the Spring Breeze" was sung by Chun-chun (Liu Ching-hsiang); the exact month of its first release still awaits primary-document confirmation. Its opening line, 「獨夜無伴守燈下，春風對面吹」("On a solitary night with no companion I stay under the lamp, the spring breeze blowing over my face"), makes it one of the earliest songs in the history of Taiwanese ballads to write an unmarried woman's inner world in a modern idiom. The melodic structure follows a Western harmonic framework, but the verbal feel is entirely the spoken language of the Taiwan countryside. Teng Yu-hsien used what he learned at the normal school to find the most fitting melodic shapes for the tones of the Taiwanese language.
+
+## "April Longing for Rain": Four Signature Works
+
+Teng Yu-hsien's four best-known works are together called "April Longing for Rain" (四月望雨), a name drawn from the first character of each of the four titles: 四 from "Four Seasons Red," 月 from "Moonlit Sorrow," 望 from "Longing for the Spring Breeze," and 雨 from "Rainy Night Flower."[^1] All four were composed between 1933 and 1934: "Four Seasons Red" (1933, lyrics by Chou Tien-wang, longing through the four seasons), "Moonlit Sorrow" (1933, lyrics by Chou Tien-wang, solitude on a moonlit night), "Longing for the Spring Breeze" (1933, lyrics by Li Lin-chiu, a young woman awaiting marriage's hopes), and "Rainy Night Flower" (1934, lyrics by Chou Tien-wang, the melancholy of fallen blossoms).
+
+"Rainy Night Flower" is said to have existed first as a Japanese-language melody (one account names the original "Spring Rain"), later set to Taiwanese lyrics by Chou Tien-wang (P0⚠️ this claim needs more historical evidence).[^1]
+
+The four songs share a common trait: an emotional structure that is simple yet profound — longing, solitude, waiting, and passing away are emotional registers that any era can resonate with. Teng Yu-hsien did not wrap them in elaborate musical language; he let the melodies cling closely to the meaning of the words. This closeness is why "April Longing for Rain" could still be reinterpreted by singers of different generations decades later without losing its power.
+
+## Under Wartime Control: From the Record Industry Back to Qionglin Public School
+
+After the Second Sino-Japanese War broke out in 1937, the Japanese authorities tightened cultural controls, shrinking the space for composing Taiwanese songs. In 1939, Teng Yu-hsien moved to Qionglin, Hsinchu (新竹芎林), teaching at the local public school until his death.[^3]
+
+From full-time composer at Columbia Records to elementary school teacher at Qionglin Public School, the turn was not merely a change of career but a matter of how the war ended his golden period of composition. His four most important songs all fall within a window of less than two years before the war. After leaving the record industry, he returned to the track his normal school had set him on: teaching, not composing.
+
+## Age 39 at Zhudong Hospital, and "April Longing for Rain" Afterward
+
+On June 11, 1944, Teng Yu-hsien died at Zhudong Hospital (竹東醫院) at the age of 39.[^3]
+
+(Note: some sources mistakenly record the place of death as "Taipei"; Zhudong Hospital is the authoritative account.)
+
+The works he left behind, including "April Longing for Rain," were later covered by singers of many generations, from Teresa Teng to Jody Chiang, and have continued to be sung. In 2006, the Taoyuan County Government established the Teng Yu-hsien Music and Culture Park to commemorate the centenary of his birth.[^4]
+
+In the decades after his death, Teng Yu-hsien's posthumous reputation gradually came into focus as Taiwanese cultural consciousness revived. The 1970s nativist literature debate and the re-evaluation of Taiwanese culture after the lifting of martial law (1987) both set "April Longing for Rain" back into the framework of discussions on Taiwanese cultural identity. His name slowly moved from the label of "old-fashioned songs (古早歌仔)" to a historical position as the founder of Taiwanese popular music.
+
+Teng Yu-hsien left behind no complete written interview record. His creative years belonged to the Japanese colonial era, and the primary materials that survive are mainly scores and record recordings. Later generations come to know him through those songs: the direction of the melodies and the logic of how lyrics and music fit together are his most direct language.
+
+In the decades that followed, the covers by Teresa Teng and Jody Chiang kept bringing new generations of listeners to "April Longing for Rain." Each cover recalibrates these songs to their contemporary context, but the melodies themselves have never needed to be revised. A melody that can be interpreted by different singers across decades without losing its power is Teng Yu-hsien's most silent statement about himself.
+
+**Common claim → a more precise reading:** Teng Yu-hsien is often called the "Father of Taiwanese Songs"; the essence is that he was the founder of Taiwanese popular ballads. His contribution was not being the first in music history to compose Taiwanese songs, but using the normal school's Western harmonic technique to give Taiwanese ballads, for the first time, a modern melodic structure open to endless reinterpretation. "Father" affirms a foundational contribution; it does not claim to have pioneered the entire genre.
+
+> 🎙️ **Curator's Note:** Teng Yu-hsien's 39 years are the most uneven allocation of time in the history of Taiwanese ballads: his creative peak was concentrated in 1933–1934, under two years, four songs; then came the silence of wartime control, and then death at 39.
+>
+> But the four songs of "April Longing for Rain" outlived him by eighty years. "Longing for the Spring Breeze" remains one of the old songs that the most people in Taiwan can hum today, not because it was included in textbooks, but because the melody still has room every time it is reinterpreted by a new generation.
+>
+> A Hakka person writing Taiwanese ballads, a normal school's Western training meeting the cultural controls of the Japanese colonial era — his creative conditions were themselves a convergence point of multiple cultural forces. What he left at that convergence point was some of the earliest coordinates of Taiwanese popular music.
+>
+> He died at 39, leaving no interview and no memoir. What he left behind was four melodies. How later generations judge him depends to a large extent on the context in which those four melodies are performed anew. Every cover is a reinterpretation of him.
+
+From a Hakka family with a scholarly tradition in Longtan, Taoyuan, to Columbia Records, to teaching in Qionglin, and then to age 39 at Zhudong Hospital — his life was short, but four melodies have outlived him by eighty years and still continue.
+
+That fact itself is one of the simplest, strongest arguments in the history of Taiwanese popular music: a good song can outlive its author — longer, wider, farther.
+
+**Further Reading**: [Teng Yu-hsien — Wikipedia](https://zh.wikipedia.org/zh-tw/鄧雨賢) ｜ [NTNU Library: Teng Yu-hsien Exhibition](http://archives.lib.ntnu.edu.tw/exhibitions/DengYuShian/master.jsp) ｜ [Taoyuan City Teng Yu-hsien Music and Culture Park](https://www.tyac.gov.tw/)
+
+## References
+
+[^1]: [Wikipedia: Teng Yu-hsien](https://zh.wikipedia.org/zh-tw/鄧雨賢) — Confirms he was born on July 21, 1906, in Longtan, Taoyuan, with the birth name Teng Ping-yen, attended a normal school, produced the four signature works "April Longing for Rain" ("Four Seasons Red"/"Moonlit Sorrow"/"Longing for the Spring Breeze"/"Rainy Night Flower"), and earned the title "Father of Taiwanese Songs."
+
+[^2]: [Storm.mg: Teng Yu-hsien and Columbia Records](https://www.storm.mg/lifestyle/237234) — Confirms that in 1933 he was recruited by Columbia (古倫美亞) Records as a staff composer.
+
+[^3]: [NTNU Library: Teng Yu-hsien Exhibition](http://archives.lib.ntnu.edu.tw/exhibitions/DengYuShian/master.jsp) — Confirms that in his later years, from 1939, he taught at the public school in Qionglin, Hsinchu, and died at Zhudong Hospital (not Taipei) on June 11, 1944, at the age of 39.
+
+[^4]: [Taoyuan City Teng Yu-hsien Music and Culture Park](https://www.tyac.gov.tw/home.jsp?id=10&parentpath=0,6,10) — Contains material on the centenary commemoration events and the establishment of the park.
+
+[^5]: [Nippon.com: Teng Yu-hsien's Taiwanese Ballads](https://www.nippon.com/hk/japan-topics/g02160/) — Reports on Teng Yu-hsien's creative background and the Taiwanese music environment during the Japanese colonial era.


### PR DESCRIPTION
## translate(en): 鄧雨賢（Teng Yu-hsien）→ knowledge/en/People/teng-yu-hsien.md

EN People 翻譯系列接續（#1604 黃土水 / #1615 林獻堂 / #1616 唐鳳 / #1617 蔡瑞月）。台灣歌謠之父，「四月望雨」四代表作，sovereignty-relevant 日治時期音樂人物。

### 產出方式
本篇由 **prime-agent-lite**（prime-agent → LiteLLM :4000 → cc-auto / ArliAI DeepSeek-V4-Flash）以單一 segment 產出，supervisor（Copilot）提供 worker prompt + 結構驗證閘門，並逐段人工核對後提交。

### 完整性檢查
- ✅ 章節 5:5、30 秒概覽 + 🎙️ 策展人筆記 blockquote 結構 1:1
- ✅ 腳註 5/5（URL byte-identical，描述譯為英文；[^5] 為原文即存在的 orphan def，原樣保留）
- ✅ zh→en narrative 字元比 **3.75**（區間 2.0–3.8）
- ✅ 兩處 P0⚠️ hedge 保留；「獨夜無伴守燈下」歌詞保留中文 + 英文 gloss
- ✅ 四月望雨 acronym 解釋（四/月/望/雨 各取一字）完整保留
- ✅ frontmatter provenance 依 status.py canonical 算法；`test-frontmatter.mjs --ci` 通過；prettier 格式化

AI worker：cc-auto (ArliAI DeepSeek-V4-Flash-0731) via prime-agent-lite；非母語產出，經 supervisor 逐段核對