### PR TITLE
translate(en): 黃春明 → huang-chun-ming

### DIFF
--- a/knowledge/en/People/huang-chun-ming.md
+++ b/knowledge/en/People/huang-chun-ming.md
@@ -1,0 +1,101 @@
+---
+title: 'Huang Chun-ming: Born in Luodong in 1935, Chronicler of the Little People from “A Day by the Sea” to “The Sandwich Man”'
+description: 'Born February 13, 1935, in Luodong, Yilan, he wrote “A Day by the Sea” (1967) and “The Sandwich Man” (1969), embodying nativist literature’s core concern for the little people, and stood at the center of the 1977 nativist literature debate. He won the Wu San-lian Literary and Arts Award and the National Award for Arts; his second son, the writer Huang Kuo-chun, died by suicide on June 20, 2003. Hou Hsiao-hsien brought his work to the screen in 1983, and he is still living as of 2026.'
+date: 2026-03-19
+category: 'People'
+tags:
+  [
+    'Literature',
+    'Nativist Literature',
+    'Yilan',
+    'Ordinary People',
+    'The Sandwich Man',
+    'A Day by the Sea',
+  ]
+subcategory: '文學'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-08-28
+lastHumanReview: false
+readingTime: 7
+curation: incubating
+translatedFrom: 'People/黃春明.md'
+sourceCommitSha: '09ffe560f'
+sourceContentHash: 'sha256:fa94afa39f837939'
+sourceBodyHash: 'sha256:59fc287ce8c0baeb'
+translatedAt: '2026-08-28T20:30:00+08:00'
+---
+
+# Huang Chun-ming: Born in Luodong in 1935, Chronicler of the Little People from “A Day by the Sea” to “The Sandwich Man”
+
+> **30-Second Overview:** Huang Chun-ming was born on February 13, 1935, in Luodong (羅東), Yilan (宜蘭), deeply rooted in Yilan, with the little people at the bottom of society at the heart of his writing.[^1] “A Day by the Sea” was published around 1967 (P0⚠️ further verification of the exact year is recommended), and “The Sandwich Man” in 1969.[^1] In 1977 the nativist literature debate erupted, and Huang Chun-ming was one of the writers chiefly discussed in it.[^2] He won the Wu San-lian Literary and Arts Award and the National Award for Arts.[^1] In 1983, Hou Hsiao-hsien directed the screen adaptation of the same title.[^3] His second son, the writer Huang Kuo-chun, died by suicide on June 20, 2003.[^4] As of 2026, Huang Chun-ming is still living.
+
+## Born in Luodong: An Elementary School Teacher's Observation Post
+
+Huang Chun-ming was born on February 13, 1935, in Luodong Township, Yilan, and grew up in Taiwan during the late Japanese colonial era and the turbulent postwar years.[^1] His father ran a small business, and the family was not well off.
+
+After graduating from the art department of Taipei Teachers College (now National Taipei University of Education), he returned to Yilan to serve as an elementary school teacher, spending years immersed in the daily lives of farmers and the people at the bottom of society. These observations of everyday life later became the raw material for all his fiction.
+
+The position of elementary school teacher gave Huang Chun-ming a unique observation post: he stood at the boundary between knowledge and ignorance, between city and countryside, facing the realities of rural children day after day. This vantage point gave his fiction both the structural sense of an intellectual and the authentic texture of life at the bottom of society.
+
+## “A Day by the Sea”: The Prostitute Pai-mei and the Non-Judgmental Gaze
+
+“A Day by the Sea” was published around 1967.[^1] It depicts the prostitute Pai-mei (白梅), who makes her living in the city to support her son far away in the countryside, presenting the inner world of a marginalized woman through sympathy rather than moral judgment. The exact year of publication should be further confirmed by consulting the original literary journal records.
+
+What makes “A Day by the Sea” distinctive is its humanitarian tone: Pai-mei is a prostitute, but Huang Chun-ming's narrative perspective holds no moral judgment—only deep sympathy. This attitude of “no judgment, only observation” is the most consistent spiritual foundation of his nativist literature; in that era, that attitude was itself a literary stance.
+
+## “The Sandwich Man”: Kun-shu's Clown Costume and Dignity
+
+In 1969, “The Sandwich Man” was published.[^1] It portrays Kun-shu (坤樹), a father who dresses as a clown to sell advertisements in order to feed his family; after the advertising company goes bankrupt, his son wails without stopping because he can no longer see the familiar clown. The survival plight and human dignity of the little people under the impact of modernization lie at the core of this story.
+
+In 1983, Hou Hsiao-hsien directed the adapted film _The Sandwich Man_, one of the important milestones of the Taiwan New Cinema movement.[^3] The success of Hou's adaptation owed much to the concreteness of Huang Chun-ming's original: Kun-shu is not a conceptual “little person at the bottom,” but a real person with a specific predicament and concrete actions. The translation of literary language into cinematic language did not lose anything because it was supported by that concreteness.
+
+The core question of “The Sandwich Man” concerns dignity, not just poverty: Kun-shu's clown act binds a man's means of livelihood to the image he presents in his son's eyes. When the advertising company collapses and the clown costume disappears, his son's crying voices the hardest-to-articulate loss in the process of modernization—the helplessness of being forced to choose which face to show the world.
+
+Huang Chun-ming's writing about the little people is never pitying from above; it speaks close against people. This “way of speaking” keeps his fiction effective decades later.
+
+## His Position in the 1977 Nativist Literature Debate
+
+In 1977, the “nativist literature debate” erupted, with critics questioning the political stance of nativist literature. Huang Chun-ming was one of the writers most discussed in this debate.[^2] He did not compromise or retreat, and continued to hold to a creative direction concerned with the lives of people at the bottom of society.
+
+The impact of the nativist literature debate on Huang Chun-ming lay in his work being forced into a political framework he had never intended to enter. He wrote about the little people because those people truly existed and needed to be seen; political statements were an interpretive framework imposed by others. After the debate his position did not change: he chose to keep using literature to do what he had always done—make those people seen.
+
+## Literary Awards
+
+Huang Chun-ming has received the Wu San-lian Literary and Arts Award and the National Award for Arts.[^1] Both awards are heavyweight recognitions from Taiwan's literary world for creators of long standing: the Wu San-lian Literary and Arts Award weighs the literary quality of the work itself, while the National Award for Arts is an overall assessment of one's whole career contribution. That Huang Chun-ming received both awards shows that, under the strict standards of literary juries, his writing of the little people has never been a mere display of “nativist sentiment.”
+
+## The Passing of the Second Son Huang Kuo-chun in 2003
+
+Huang Chun-ming's second son, Huang Kuo-chun, also a writer, died by suicide on June 20, 2003.[^4] Huang Kuo-chun left behind works such as _Shui Wen_ (《水問》), an important part of how Taiwan's literary world remembers the Huang family.
+
+Huang Kuo-chun's death was the heaviest moment of Huang Chun-ming's personal life and a common loss for Taiwan's literary world. He was an extension of his father's generation of nativist literary spirit, yet he moved toward a more introspective, more personal path of writing. That path was never walked to its end; the gap it left is the interruption of a possible literary direction, harder to fill than the disappearance of a writer.
+
+As of 2026, Huang Chun-ming is still living.
+
+Born in 1935 and still living in 2026, Huang Chun-ming is now past 90 and one of the most important living representatives of the nativist literature generation in Taiwan. In his later years he has kept his attention on children's culture; the work of the Huang Ta-yu Children's Theater (黃大魚兒童劇團) continues his guardianship of Yilan's local culture. From fiction to theater, his “concern for the vulnerable” has never stopped.
+
+**Common reading → A more precise reading:** Huang Chun-ming is often labeled “Yilan's nativist literature writer,” but this regional label obscures the universality of his work. The little people in his fiction—prostitutes, street vendors, migrant workers—are concrete figures from the period of Taiwan's accelerated modernization, yet their situations mirror the costs that appear in any rapidly modernizing society. He was not writing about “Yilan”; he was writing about “the people forgotten by development.”
+
+> 🎙️ **Curator's Note:** Huang Chun-ming is one of the writers of Taiwan's nativist literature who has most successfully crossed the two axes of “internal literary evaluation” and “general reader reception.” His stories could be adapted into film (the Hou Hsiao-hsien version), selected for textbooks, and recognized by literary award juries—this multi-layered recognition shows that his language has a rare breadth of penetration.
+>
+> The passing of his second son Huang Kuo-chun in 2003 was the heaviest moment in his personal life. The works Huang Kuo-chun left behind were equally valued by the literary world; what impact that tragedy left on Huang Chun-ming's later writing is the hardest chapter of his literary biography to articulate clearly, and the one that should least be skipped.
+>
+> Huang Chun-ming's 91 years span the entire course of Taiwan from the late Japanese colonial era, through the postwar turbulence and the nativist literature debate, to the cultural transformation of the 2000s. His fiction records the people forgotten by rapid modernization along the way, and he himself has become one of the most enduring witnesses of that history.
+
+From an elementary school teacher in Luodong to a representative figure of Taiwan's nativist literature, from fiction to children's theater, Huang Chun-ming's 91-year life is one person's sixty-year perseverance in “paying attention to the people around him.”
+
+That he is still living in 2026 is itself the quietest answer to everyone who ever questioned the nativist literature path: the path he chose has been walked for sixty years, and he is still walking it.
+
+**Further Reading**: [Huang Chun-ming — Wikipedia](https://zh.wikipedia.org/zh-tw/黃春明) ｜ [The Reporter: Nativist Literature and Huang Chun-ming](https://www.twreporter.org/a/1970s-taiwan-nativist-literature-huang-chunming) ｜ [National Museum of Taiwan Literature](https://www.nmtl.gov.tw/)
+
+## References
+
+[^1]: [Wikipedia: Huang Chun-ming](https://zh.wikipedia.org/zh-tw/黃春明) — Confirms birth on February 13, 1935, in Luodong, Yilan; “A Day by the Sea” (ca. 1967) and “The Sandwich Man” (1969); winner of the Wu San-lian Literary and Arts Award and the National Award for Arts.
+
+[^2]: [The Reporter: The 1970s Taiwan Nativist Literature Debate](https://www.twreporter.org/a/1970s-taiwan-nativist-literature-huang-chunming) — Covers the full story of the 1977 nativist literature debate and Huang Chun-ming's position in it.
+
+[^3]: [Wikipedia: The Sandwich Man (film)](<https://zh.wikipedia.org/zh-tw/兒子的大玩偶_(電影)>) — Confirms that Hou Hsiao-hsien directed _The Sandwich Man_ in 1983, an important representative work of Taiwan's New Wave cinema.
+
+[^4]: [Related report: Huang Kuo-chun's death in 2003](https://zh.wikipedia.org/zh-tw/黃國峻) — Confirms that Huang Kuo-chun died by suicide on June 20, 2003.
+
+[^5]: [National Museum of Taiwan Literature: Huang Chun-ming Digital Archive](https://www.nmtl.gov.tw/) — Archive of Huang Chun-ming's works and biographical materials.


### PR DESCRIPTION
## translate(en): 黃春明（Huang Chun-ming）→ knowledge/en/People/huang-chun-ming.md

EN People 翻譯系列接續（#1604 #1615 #1616 #1617 #1618）。台灣鄉土文學代表作家，sensitive 度低的文學人物。

### 產出方式
**prime-agent-lite segment 2**（prime-agent → LiteLLM :4000 → cc-auto / ArliAI DeepSeek-V4-Flash），同一套 supervisor 流程：worker prompt + 結構驗證閘門（sections/refs/defs/ratio），supervisor 逐段人工核對後提交。

### 完整性檢查
- ✅ 章節 6:6、30 秒概覽 + 🎙️ 策展人筆記（3 段 blockquote）+ **通行說法→更精確讀法** bold 段 1:1
- ✅ 腳註 5/5（URL byte-identical 含 angle-bracket 電影條目連結；[^5] orphan def 原樣保留）
- ✅ zh→en narrative 字元比 **3.56**（區間 2.0–3.8）
- ✅ 1967 年 P0⚠️ hedge 保留為括號註記
- ✅ frontmatter provenance 依 status.py canonical 算法；`test-frontmatter.mjs --ci` 通過；prettier 格式化

AI worker：cc-auto (ArliAI DeepSeek-V4-Flash-0731) via prime-agent-lite