### PR TITLE
translate(en): 龍應台 → lung-ying-tai

### DIFF
--- a/knowledge/en/People/lung-ying-tai.md
+++ b/knowledge/en/People/lung-ying-tai.md
@@ -1,96 +1,104 @@
 ---
-title: "Long Ying-tai: Daliao 1952, Public Intellectual from *Wild Fire* to Taiwan's First Minister of Culture"
-description: "Born 1952/2/13 in Daliao Township, Kaohsiung City. MA in English and American Literature, Kansas State University; doctoral degree has conflicting accounts (P0⚠️). *Wild Fire* first published 12/1985, reprinted 24 times in 21 days, surpassed 100,000 copies in 4 months. Taiwan's first Minister of Culture, 2012–2014 (appointed by Ma Ying-jeou). *Big River, Big Sea 1949* published 2009."
+title: "Lung Ying-tai: Born in Daliao in 1952, the Public Intellectual from The Wild Fire to Taiwan's First Minister of Culture"
+description: "Born on February 13, 1952, in Daliao Township, Kaohsiung County. She holds a master's degree in English and American literature from Kansas State University, though accounts of her doctoral degree differ (P0⚠️). The Wild Fire first appeared in December 1985, went through 24 reprints in 21 days, and surpassed 100,000 copies within four months. She served as Taiwan's first Minister of Culture from 2012 to 2014 (appointed by Ma Ying-jeou), and Big River, Big Sea — Untold Stories of 1949 was published in 2009."
 date: 2026-03-19
-author: 'Taiwan.md'
 category: 'People'
+tags:
+  [
+    'Literature',
+    'Essays',
+    'The Wild Fire',
+    '1949',
+    'Minister of Culture',
+    'Public Intellectual',
+    'Kaohsiung',
+  ]
 subcategory: '文學'
-tags: ['文學', '散文', '野火集', '大江大海', '文化部長', '公共知識分子', '高雄']
-readingTime: 7
-#   whats_excluded: "《親愛的安德烈》《目送》逐章分析；文化部政策清單；與余秋雨對話細節"
-#   where_it_hedges: "出生地大寮（P0確認）vs 現行文章說左營（已修正）；博士學歷：紐約大學德國文學vs堪薩斯州立大學英文系（待確認，兩說均見於資料）"'
-lastVerified: 2026-05-07
-lastHumanReview: true
+author: 'Taiwan.md'
 featured: false
-translatedFrom: People/龍應台.md
-sourceCommitSha: '0f8fae0a'
+lastVerified: 2026-08-28
+lastHumanReview: false
+readingTime: 7
+curation: incubating
+translatedFrom: 'People/龍應台.md'
+sourceCommitSha: '09ffe560f'
 sourceContentHash: 'sha256:32e758a1acf33e90'
 sourceBodyHash: 'sha256:fb31dbbb24515e69'
-translatedAt: '2026-05-25T21:06:51Z'
+translatedAt: '2026-08-28T21:00:00+08:00'
 ---
 
-# Long Ying-tai: Daliao 1952, Public Intellectual from _Wild Fire_ to Taiwan's First Minister of Culture
+# Lung Ying-tai: Born in Daliao in 1952, the Public Intellectual from The Wild Fire to Taiwan's First Minister of Culture
 
-> **30-second overview:** Long Ying-tai was born on February 13, 1952, in Daliao Township, Kaohsiung County (now Daliao District, Kaohsiung City), with family roots in Hengshan, Hunan. Her father, Long Huaisheng, was from Hunan; her mother, Ying Meijun, came from Chun'an, Zhejiang.[^1] She holds an MA in English and American Literature from Kansas State University; her doctoral degree has two coexisting accounts (PhD in English from Kansas State University, or PhD in German Literature from New York University) — P0⚠️ further verification recommended.[^1] _Wild Fire_ was first published as a book in December 1985, reprinted 24 times in 21 days, and surpassed 100,000 copies within 4 months.[^2] _Big River, Big Sea 1949_ was published in 2009.[^3] In 2012, she accepted President Ma Ying-jeou's appointment as Taiwan's first Minister of Culture, serving until her resignation in 2014.[^4]
+> **30-Second Overview:** Lung Ying-tai was born on February 13, 1952, in Daliao Township, Kaohsiung County (today's Daliao District, Kaohsiung City). Her ancestral home was Hengshan (衡山), Hunan; her father, Lung Huai-sheng, was from Hunan, and her mother, Ying Mei-chun, came from Chun'an (淳安), Zhejiang.[^1] She holds a master's degree in English and American literature from Kansas State University; two accounts of her doctorate coexist (a Ph.D. from Kansas State University's English department, or a doctorate in German literature from New York University), and P0⚠️ recommends further confirmation.[^1] In December 1985, The Wild Fire first appeared in book form, going through 24 reprints in 21 days and surpassing 100,000 copies within four months.[^2] In 2009 she published Big River, Big Sea — Untold Stories of 1949.[^3] In 2012 she accepted an appointment from President Ma Ying-jeou to become Taiwan's first Minister of Culture, a post she held until she resigned in 2014.[^4]
 
-## A Daliao Military Dependents' Village Childhood: Starting Point of Reflection Under Authoritarianism
+## The Military Dependents' Village in Daliao: Where Reflection Under an Authoritarian System Began
 
-Long Ying-tai was born on February 13, 1952, in Daliao Township, Kaohsiung County (now Daliao District, Kaohsiung City). Her father, Long Huaisheng, was from Hunan; her mother, Ying Meijun, came from Chun'an, Zhejiang. She grew up in the military dependents' village (_juancun_) in Zuoying.[^1]
+Lung Ying-tai was born on February 13, 1952, in Daliao Township, Kaohsiung County (today's Daliao District, Kaohsiung City). Her father, Lung Huai-sheng, was from Hunan, and her mother, Ying Mei-chun, came from Chun'an (淳安), Zhejiang. She grew up in the military dependents' village in Zuoying (左營).[^1]
 
-(Note: Some sources incorrectly list her birthplace as "Zuoying, Kaohsiung." P0 has confirmed the correct birthplace as "Daliao Township, Kaohsiung County (now Daliao District, Kaohsiung City).")
+(Note: some sources mistakenly record her birthplace as "Zuoying, Kaohsiung"; P0 confirms that the correct birthplace is "Daliao Township, Kaohsiung County (today's Daliao District, Kaohsiung City)".)
 
-She studied in the Department of Foreign Languages and Literature at National Cheng Kung University, then went to the United States for graduate study, earning an MA in English and American Literature from Kansas State University. There are two coexisting accounts of her doctoral degree: a PhD in English from Kansas State University, or a PhD in German Literature from New York University. P0⚠️ recommends consulting NCKU/Kansas State alumni records to confirm the definitive version.[^1]
+She studied in the Department of Foreign Languages and Literatures at National Cheng Kung University, then went to the United States for advanced study, earning a master's degree in English and American literature from Kansas State University. Two accounts of her doctorate coexist: a Ph.D. from Kansas State University's English department, or a doctorate in German literature from New York University. P0⚠️ recommends consulting alumni records at NCKU/KSU to confirm the exact version.[^1]
 
-In 1982, Long Ying-tai returned to Taiwan to teach in the Department of Foreign Languages and Literature at National Central University, beginning a dual career in academia and writing. She grew up in a military dependents' village in Taiwan, the daughter of a mainland Chinese soldier. This background gave her a complex relationship with the concept of the "Republic of China" that was at once intimate and distant. She was both a beneficiary of that system (education, identity) and later one of its most forthright critics.
+In 1982, Lung Ying-tai returned to Taiwan and taught in the Department of Foreign Languages and Literatures at National Central University, beginning a dual-track career in academia and writing. She grew up in a military dependents' village (眷村) in Taiwan, and her father was a mainlander (waishengren) soldier. This background gave her a complex relationship with the concept of the "Republic of China" — at once intimate and distant. She was both a beneficiary of that system (in education and identity) and, later, one of the people best able to criticize that system in the most direct terms.
 
-This position afforded her a particular vantage point: she had an insider's understanding of authoritarian rule, yet also the outsider's perspective of someone trained in Western liberalism. _Wild Fire_ was ignited precisely at this intersection.
+This position gave her a distinctive vantage point: she had an "insider's" understanding of the authoritarian system, yet also an "outsider's" eye, trained in Western liberalism. The Wild Fire was ignited precisely at this intersection.
 
-## 1984–1985: _Wild Fire_, 24 Reprints in 21 Days
+## 1984–1985: The Wild Fire, 24 Reprints in 21 Days
 
-In 1984, Long Ying-tai began publishing the "Wild Fire" series of opinion pieces in the _China Times_. The spark was a specific incident: she saw a legislator on television defending a soft-drink manufacturer, and the absurdity of a public figure shielding commercial interests so brazenly moved her to pick up her pen and write "Chinese People, Why Aren't You Angry?"[^6]
+In 1984, Lung Ying-tai began publishing her "Wild Fire" commentary series in the China Times. The trigger was a concrete event: watching on television a legislator defend the soda beverage industry, and seeing a public figure cover up for commercial interests, she found it absurd, picked up her pen in anger, and wrote "Chinese People, Why Aren't You Angry?"[^6]
 
-She later said it was never a planned endeavor: "**It wasn't intentional. It was really a case of an unplanned willow taking root.**"[^6] The "Wild Fire" series continued to take shape thereafter, each article igniting public debate.
+She later said it was not something planned: "**It wasn't really deliberate. In fact, it was the result of unintentional serendipity.**"[^6] The "Wild Fire" series continued to take shape after that, with every essay igniting public debate.
 
-In December 1985, the essays were collected and published as _Wild Fire_.[^2] After the first edition appeared, the book was reprinted 24 times in 21 days and surpassed 100,000 copies within 4 months, a landmark record in Taiwan's publishing history.[^2] In an era when martial law was still in effect, she used uncompromising prose to criticize government bureaucracy, rigid education, media self-censorship, and to demand that citizens take up their moral responsibilities. This discursive framework made _Wild Fire_ one of the unofficial manuals of Taiwan's student movements in the 1980s.
+In December 1985, the essays were first collected and published as The Wild Fire.[^2] Within 21 days of the first printing, it went through 24 reprints, surpassing 100,000 copies within four months — a major record in Taiwan's publishing history.[^2] In an era when the martial law system was still in place, she used uncompromising prose to criticize government bureaucracy, rigid education, and media self-censorship, and called on citizens to take moral responsibility. This discursive framework made The Wild Fire one of the unofficial handbooks of Taiwan's student movement in the 1980s.
 
-> 📝 **Curator's note:** The conventional account holds that _Wild Fire_ was an enlightenment text for Taiwan's democratization. But more precisely: it provided a specific social condition (the period around the lifting of martial law, the rise of middle-class consciousness) with a form of "textually grounded anger." Her writing made readers feel that it was permissible to be angry, and to be angry with justification. This function was more penetrating than any slogan.
+> 📝 **Curator's Note:** The prevailing account is that The Wild Fire was the enlightenment reading of Taiwan's democratization. But more precisely: it offered "anger with a textual basis" under specific social conditions (around the lifting of martial law, with the rise of middle-class consciousness). Her essays made readers feel they were allowed to be angry — and to be angry with a basis. This function was more penetrating than any slogan.
 
-## Major Works: _Dear Andre_, _Watching You Go_, _Big River, Big Sea 1949_
+## Major Works: Dear Andre, Watching You Go, and Big River, Big Sea — Untold Stories of 1949
 
-_Dear Andre_ records the epistolary dialogue between her and her son across Taiwan and Germany. _Watching You Go_ collects her reflections on the passage of life and parent-child relationships. Both have circulated widely across Taiwan, mainland China, and Hong Kong. The most frequently cited passage from _Watching You Go_ is her definition of the parent-child bond:
+Dear Andre records the correspondence between her and her son across Taiwan and Germany, while Watching You Go (《目送》) collects her reflections on the passing of life and on parent–child relationships; both circulate widely across the Strait. The most quoted passage in Watching You Go is her definition of the parent–child relationship:
 
-"**Slowly, slowly, I came to understand that so-called father-daughter, mother-son — it only means that your bond with him is to keep watching his back as he walks farther and farther away, in this lifetime. You stand at one end of the path, watching him gradually disappear around the bend, and he tells you silently, with his back: don't follow.**"[^6]
+"**I slowly, slowly came to understand that what is called a father-daughter or mother-son relationship is nothing more than this: your fate with him is to spend this life and this world continuously watching his back as it recedes into the distance. You stand at this end of the path, watching him gradually disappear around the bend of the path, and with his back he silently tells you: there is no need to chase.**"[^6]
 
-In 2009, _Big River, Big Sea 1949_ was published by CommonWealth Magazine, retelling the stories of displacement around 1949 from the perspective of ordinary people.[^3] She spent ten years preparing and four hundred days writing, traveling to mainland China, Taiwan, Southeast Asia, and other places to interview the descendants of those displaced. Within a year and a half of publication, sales exceeded 400,000 copies, generating widespread response on both sides of the strait.[^3]
+In 2009, Big River, Big Sea — Untold Stories of 1949 was published by CommonWealth Magazine (天下雜誌), re-examining the stories of displacement around 1949 from the perspective of ordinary people.[^3] She spent ten years preparing and four hundred days writing, traveling through mainland China, Taiwan, and Southeast Asia to interview the descendants of those displaced. Within a year and a half of publication, sales surpassed 400,000 copies, drawing a broad response on both sides of the Strait.[^3]
 
-She wrote in the book: "**I am proud to be a descendant of the defeated!**"[^6] Those ordinary people called "defeated" by the currents of history are the true protagonists of this book.
+In the book she wrote: "**I am proud to be a child of the losers!**"[^6] The ordinary people called "losers" in the torrent of history are precisely the true protagonists of this book.
 
 ## 2012–2014: Taiwan's First Minister of Culture
 
-In 2012, Long Ying-tai accepted President Ma Ying-jeou's appointment as the first Minister of Culture of the Republic of China, serving until 2014.[^4] She had previously served as the first Director of the Taipei City Department of Cultural Affairs (a position established before the Ministry of Culture).[^4]
+In 2012, Lung Ying-tai accepted an appointment from President Ma Ying-jeou to serve as the first minister of Taiwan's Ministry of Culture (中華民國文化部), holding office until 2014.[^4] She also served as the first director of the Taipei City Government's Department of Cultural Affairs (a position established before the aforementioned Ministry of Culture).[^4]
 
-During her tenure, she championed cultural soft power policies, promoted the "Creative Taiwan" initiative, worked to advance Taiwan's international cultural outreach, and facilitated cross-strait cultural forums. Her 2013 speech at Peking University drew wide attention. Addressing 1,800 mainland Chinese students, she said: "**A thousand missiles aimed at my home — how could I still have a Chinese Dream?**"[^6] These words stated Taiwan's geopolitical reality in the most direct language, delivered to a mainland Chinese audience.
+While in office, she championed cultural soft power policies, promoted the "Creative Taiwan" plan, worked to promote Taiwanese culture internationally, and advanced cross-strait cultural forums. Her 2013 speech at Peking University drew widespread attention; she told the 1,800 mainland Chinese students present: "**A thousand missiles are aimed at my home — where would I still find a Chinese dream?**"[^6] This sentence conveyed Taiwan's geopolitical reality to a mainland Chinese audience in the most direct language.
 
-In 2014, Long Ying-tai resigned as Minister of Culture and subsequently took up a visiting professorship at the University of Hong Kong, continuing to develop her work in academia and writing. Her position in the Taiwanese political arena has always been that of an "intellectual" rather than a "politician." Her criticism was never directed at a single party, and her gaze was fixed on culture and the human spirit, not on votes.
+In 2014, Lung Ying-tai resigned from the post of Minister of Culture, then went on to serve as a chair professor at the University of Hong Kong, continuing her development between academia and writing. Her position in Taiwan's political arena was always that of an "intellectual," never a "politician." The targets of her criticism were never limited to a single party, and her gaze rested on culture and the human heart, not on votes.
 
-To some, her acceptance of the Minister of Culture post seemed like a compromise; in her own view, it was perhaps an attempt "to enter the system and try to advance culture from within the system." She ultimately chose to leave, returning to the position most familiar to her: writing, commentary, teaching. The image of "an independent pen" became, if anything, clearer after she left government.
+Some saw her appointment as Minister of Culture as a condescension; in her own view, it was perhaps an attempt to "enter the system and try to promote culture from within the system." She ultimately chose to leave, returning to the position she knew best: writing, commentary, and teaching. The image of "an independent pen" became only clearer after she left government.
 
-## The Role of Public Intellectual
+## The Role of the Public Intellectual
 
-Long Ying-tai's life trajectory is a microcosm of a particular form of intellectual in the second half of 20th-century Taiwan: born in a military dependents' village, raised in an authoritarian era, educated in the United States, returned to Taiwan to critique, left Taiwan and returned again, shuttling continuously between literature and politics.
+Lung Ying-tai's life trajectory is the microcosm of a particular form of intellectual in the second half of 20th-century Taiwan: born in a military dependents' village, raised in an authoritarian era, educated in the United States, returning to Taiwan to offer criticism, leaving Taiwan and coming back, shuttling ceaselessly between literature and politics.
 
-She is not a politician, not a social activist, not a pure academic. She is someone who continuously occupied public space through the written word. _Wild Fire_ made her a spiritual symbol for a generation; _Watching You Go_ made her an emotional touchstone for another generation; in _Big River, Big Sea 1949_ narratives of displacement found a new position in her writing. The readerships of these three books barely overlap, yet each came to know the same Long Ying-tai within their own context.
+She is not a political figure, not a social activist, not a pure scholar. She is someone who persistently occupies space in the public sphere with words. The Wild Fire made her a spiritual symbol for one generation; Watching You Go made her an emotional footnote for another; Big River, Big Sea — Untold Stories of 1949 gave the narratives of displacement a new place within her writing. The readerships of the three books barely overlap, yet each recognizes the same Lung Ying-tai in its own context.
 
-The conventional account is that she "spans politics and literature," a rare "writer with political influence" in Taiwan. Another reading is this: she has only ever had one identity, a person who writes. Politics was a field she entered; literature was the language she could not leave behind. Each time she entered the political arena (the _Wild Fire_ period, the Minister of Culture period), she brought with her words, not party logic.
+The prevailing account is that she "spans politics and literature," a rare "writer with political influence" in Taiwan. Another reading: she has never had more than one identity: a person who writes. Politics is a field she entered; literature is a language she cannot leave. Every time she entered the political arena (the Wild Fire era, the Minister of Culture era), what she carried with her was still words, not party logic.
 
-The 1985 "Chinese People, Why Aren't You Angry?" and the 2013 Peking University line "A thousand missiles aimed at my home" are saying the same thing: in the face of injustice, you cannot stay silent. Across forty years, this core has not shifted.
+The 1985 essay "Chinese People, Why Aren't You Angry?" and that 2013 line at Peking University — "A thousand missiles are aimed at my home" — say the same thing: in the face of injustice, you cannot stay silent. For forty years, this core has not moved.
 
-Her name has ultimately become a symbol larger than any book title: Taiwan's discovery of a civic language during its authoritarian years owes something to the woman who used her pen to say "you cannot stay silent." And the greatest question she left behind is the question itself: why aren't _you_ angry?
+Her name ultimately became a symbol larger than any book title: that Taiwan found a civic language in the authoritarian years owes something to the woman who said, with her pen, "you cannot stay silent." And the largest question she left behind remains that very question: And you — why aren't you angry?
 
-**Further reading:** [Long Ying-tai — Wikipedia](https://zh.wikipedia.org/zh-tw/龍應台) ｜ [Civic Taipei Foundation](https://www.civictaipei.org) ｜ [CommonWealth: Long Ying-tai's Works](https://www.bookzone.com.tw/)
+**Further Reading**: [Lung Ying-tai — Wikipedia](https://zh.wikipedia.org/zh-tw/龍應台) ｜ [Lung Ying-tai Cultural Foundation](https://www.civictaipei.org) ｜ [CommonWealth Publishing: Works by Lung Ying-tai](https://www.bookzone.com.tw/)
 
 ## References
 
-[^1]: [Wikipedia: Long Ying-tai](https://zh.wikipedia.org/zh-tw/龍應台) — Confirms birth on February 13, 1952, in Daliao Township, Kaohsiung County (now Daliao District, Kaohsiung City); family roots in Hengshan, Hunan; MA in English and American Literature from Kansas State University; two accounts of doctoral degree (Kansas State English vs. NYU German Literature) pending confirmation.
+[^1]: [Wikipedia: Lung Ying-tai](https://zh.wikipedia.org/zh-tw/龍應台) — Confirms she was born on February 13, 1952, in Daliao Township, Kaohsiung County (today's Daliao District, Kaohsiung City), with her ancestral home in Hengshan, Hunan, and a master's degree in English and American literature from Kansas State University; the two accounts of her doctorate (Kansas State English vs. New York University German literature) remain to be confirmed.
 
-[^2]: [Wikipedia: Wild Fire](https://zh.wikipedia.org/wiki/野火集) — Confirms first published as a book in December 1985, reprinted 24 times in 21 days, surpassed 100,000 copies in 4 months (a publishing miracle in Taiwan).
+[^2]: [Wikipedia: The Wild Fire](https://zh.wikipedia.org/wiki/野火集) — Confirms it first appeared in book form in December 1985, with 24 reprints in 21 days and 100,000+ copies within four months (a Taiwanese publishing miracle).
 
-[^3]: [Wikipedia: Big River, Big Sea 1949](https://zh.wikipedia.org/zh-hant/大江大海一九四九) — Confirms _Big River, Big Sea 1949_ published in 2009 (CommonWealth Magazine).
+[^3]: [Wikipedia: Big River, Big Sea — Untold Stories of 1949](https://zh.wikipedia.org/zh-hant/大江大海一九四九) — Confirms Big River, Big Sea — Untold Stories of 1949 was published in 2009 (by CommonWealth Magazine).
 
-[^4]: [Ministry of Culture: Former Ministers](https://www.moc.gov.tw/cp.aspx?n=101) — Confirms Long Ying-tai as Taiwan's first Minister of Culture (2012–2014, appointed by Ma Ying-jeou); also confirms her role as the first Director of the Taipei City Department of Cultural Affairs.
+[^4]: [Ministry of Culture: List of Former Ministers](https://www.moc.gov.tw/cp.aspx?n=101) — Confirms Lung Ying-tai was Taiwan's first Minister of Culture (2012–2014, appointed by Ma Ying-jeou); also confirms her role as the first director of the Taipei City Government's Department of Cultural Affairs.
 
-[^5]: [Civic Taipei Foundation](https://www.civictaipei.org) — Founded by Long Ying-tai; official foundation materials and lecture information.
+[^5]: [Lung Ying-tai Cultural Foundation](https://www.civictaipei.org) — Founded by Lung Ying-tai; official materials and speech information from the cultural foundation.
 
-[^6]: [CommonWealth Magazine: Long Ying-tai on _Wild Fire_ — Tearing Off the Masks (2014)](https://www.cw.com.tw/article/5103819) — Includes the "unplanned willow taking root" account of her writing motivation, the "don't follow" quote from _Watching You Go_, the "a thousand missiles" line from the Peking University speech, and the "proud to be a descendant of the defeated" quote from _Big River, Big Sea_.
+[^6]: [CommonWealth Magazine: Lung Ying-tai on "The Wild Fire" — Tearing the Mask Open to See (2014)](https://www.cw.com.tw/article/5103819) — Includes the account of the writing motivation behind "the result of unintentional serendipity," the "no need to chase" quote from Watching You Go, the "thousand missiles" line from the Peking University speech, and direct quotes such as "proud to be a child of the losers" from Big River, Big Sea.
 
-[^7]: [CommonWealth Magazine: Long Ying-tai's _Big River, Big Sea_ Is a Gentle Key](https://www.cw.com.tw/article/5012220) — Covers the genesis of _Big River, Big Sea 1949_, the research process (10 years of preparation / 400 days of writing), and the report of sales exceeding 400,000 copies after publication.
+[^7]: [CommonWealth Magazine: Lung Ying-tai's Big River, Big Sea Is a Gentle Key](https://www.cw.com.tw/article/5012220) — A report on the creative origins of Big River, Big Sea — Untold Stories of 1949, the interview process (10 years of preparation / 400 days of writing), and sales surpassing 400,000 copies after publication.


### PR DESCRIPTION
## translate(en): 龍應台（Lung Ying-tai）→ knowledge/en/People/lung-ying-tai.md

EN People 翻譯系列接續（#1604 #1615 #1616 #1617 #1618 #1619）。《野火集》作者、台灣首任文化部長。

### 產出方式
**prime-agent-lite segment 3**（prime-agent → LiteLLM :4000 → cc-auto / ArliAI DeepSeek-V4-Flash）。本篇為 sovereignty-lens 壓力測試段：含北大演講「一千枚飛彈對準我家」等政治敏感引語，worker prompt 明列「verbatim、不得軟化」規則。

### 完整性檢查
- ✅ 章節 5:5、腳註 7/7（URL byte-identical；[^5]/[^7] orphan def 原樣保留）
- ✅ zh→en narrative 字元比 **3.64**（區間 2.0–3.8）
- ✅ 政治引語 verbatim 保留：「一千枚飛彈對準我家，我哪裡還有中國夢啊？」→ "A thousand missiles are aimed at my home — where would I still find a Chinese dream?"（含 missiles 一詞，未軟化）；「我，以失敗者的下一代為榮！」；〈中國人，你為什麼不生氣？〉
- ✅ P0⚠️ 博士學歷兩說 hedge + 出生地左營→大寮更正注記保留
- ✅ frontmatter provenance 依 status.py canonical 算法；`test-frontmatter.mjs --ci` 通過；prettier 格式化

AI worker：cc-auto (ArliAI DeepSeek-V4-Flash-0731) via prime-agent-lite；敏感引語經 supervisor 逐句核對未見 reframe