### PR TITLE
translate(id): 台灣攝影 → taiwanese-photography

### DIFF
--- a/knowledge/id/Art/taiwanese-photography.md
+++ b/knowledge/id/Art/taiwanese-photography.md
@@ -1,0 +1,120 @@
+---
+title: 'Fotografi Taiwan'
+description: 'Dari revolusi fotografi modern yang dipelopori Chang Chao-tang pada 1965, hingga "Manusia dan Tanah" karya Juan I-jong yang mendefinisikan estetika dokumenter — fotografi Taiwan merekam kisah pulau ini dalam permainan cahaya dan bayangan.'
+date: 2026-03-20
+category: 'Art'
+tags:
+  [
+    'Fotografi',
+    'Seni visual',
+    'Chang Chao-tang',
+    'Juan I-jong',
+    'Dokumenter',
+  ]
+subcategory: '視覺藝術'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-03-21
+lastHumanReview: false
+difficulty: 'beginner'
+readingTime: 10
+translatedFrom: 'Art/台灣攝影.md'
+---
+
+# Fotografi Taiwan
+
+> **Ringkasan 30 detik:** Fotografi Taiwan bertunas pada masa pendudukan Jepang. Pada 1965 Chang Chao-tang (張照堂) bersama Cheng Sang-hsi (鄭桑溪) menggelar "Pameran Duo Fotografi Modern"
+> yang membuka jalan bagi estetika avant-garde, dan pada 1987 karya Juan I-jong (阮義忠) "Manusia dan Tanah" (人與土地) menjadi klasik fotografi dokumenter.
+> Pada April 2021 Pusat Kebudayaan Fotografi Nasional resmi berdiri, menandai babak baru dalam perkembangan fotografi Taiwan.
+> Dari eksperimen hingga dokumenter, para fotografer Taiwan merekam perubahan pulau ini dan semangat kemanusiaannya lewat lensa mereka.
+
+Perkembangan fotografi Taiwan telah melampaui seratus tahun — dari masuknya teknologi pada masa pendudukan Jepang hingga penciptaan kontemporer yang beragam, melewati beberapa pergeseran estetika yang menentukan. Dua tokoh inti, Chang Chao-tang dan Juan I-jong, masing-masing melalui eksperimen avant-garde dan dokumenter humanis, menegakkan gaya klasik fotografi Taiwan yang pengaruhnya terasa sampai hari ini. Dari pendirian lembaga khusus oleh pemerintah hingga inovasi di era digital, fotografi Taiwan terus mencari cara berekspresinya sendiri di antara tradisi dan modernitas.
+
+## Masa Pendudukan Jepang: Masuknya Teknologi Fotografi
+
+Kemunculan seni fotografi di Taiwan berkaitan erat dengan pemerintahan kolonial Jepang. Setelah Perang Tiongkok–Jepang Pertama pada 1895, para fotografer yang menyertai pasukan Jepang merekam proses penaklukan Taiwan, membuka lembar pertama sejarah fotografi Taiwan. Setelah teknik pelat kering (乾版) menyebar luas, pemerintah kolonial memakainya secara sistematis untuk pengukuran geografis dan survei etnografis.
+
+Sarjana Jepang seperti Torii Ryūzō (鳥居龍藏) dan Mori Ushinosuke (森丑之助) membawa kamera masuk jauh ke pegunungan tinggi Taiwan, melakukan pengukuran dan pencatatan terhadap masyarakat Adat, dan meninggalkan sejumlah besar citra awal. Meskipun foto-foto itu bermuatan warna kolonial, ia sekaligus merupakan arsip visual sistematis paling awal yang dimiliki Taiwan.
+
+Sejak dekade 1920-an, pemuda-pemuda lokal Taiwan mulai mempelajari teknik fotografi, baik dengan menempuh studi di Jepang maupun lewat magang di studio foto. Menurut catatan literatur, studio foto pertama yang dibuka oleh orang Taiwan adalah "Studio Foto Er-Wo" (二我寫真館), didirikan pada 1901 oleh Shih Chiang (施強) dari Lukang. Keluarga Chiang (姜) di Beipu juga merupakan keluarga fotografer turun-temurun, dan hingga kini masih menyimpan negatif pelat kaca dari dekade 1890-an.
+
+Para fotografer Taiwan mula-mula dipengaruhi oleh "geijutsu shashin" (藝術寫真, fotografi seni) Jepang yang mengejar keindahan bak lukisan. Seiring masuknya "shinkō shashin-jutsu" (新興寫真術, teknik fotografi baru), penekanan bergeser ke "pengamatan realis atas jalanan" — pandangan bahwa fotografi harus berhadapan langsung dengan kenyataan. Ini memengaruhi arah fotografi dokumenter Taiwan selama beberapa dekade sesudahnya.
+
+**Peng Jui-lin** (彭瑞麟, 1904–1984) adalah salah satu perintis yang menerima pelatihan fotografi secara sistematis pada masa pendudukan Jepang. Ia berangkat ke Jepang untuk belajar di Sekolah Fotografi Oriental Tokyo, dan setelah kembali ke Taiwan pada 1935 membuka Studio Foto Apollo (阿波羅寫真館) di Taipei, dengan keunggulan pada potret. Generasi kemudian kadang menyebutnya "Doktor Fotografi", tetapi itu sebutan akrab di kalangan masyarakat, bukan gelar akademik resmi; sumbangan Peng Jui-lin terletak pada membawa pulang pengajaran fotografi modern Jepang ke Taiwan, dan meletakkan fondasi bagi pembinaan bakat fotografi lokal.[^1]
+
+Pada dekade 1940-an, fotografer lokal Taiwan bermunculan, dan yang paling representatif adalah Deng Nan-guang (鄧南光), Chang Tsai (張才), dan Lee Ming-tiao (李鳴鵰) — bersama-sama dijuluki "Tiga Pendekar Fotografi Taiwan". Deng Nan-guang piawai memotret kehidupan pasar dan jalanan secara candid; Chang Tsai pernah tinggal di Beijing dan Shanghai lalu membawa pulang cakrawala yang lebih luas; sedangkan Lee Ming-tiao unggul dalam fotografi ekologi dan alam. Ketiganya punya kekuatan masing-masing, dan bersama-sama menetapkan wajah awal fotografi humanis Taiwan.[^1]
+
+## Chang Chao-tang: Perintis Fotografi Modern
+
+Chang Chao-tang (張照堂, 1943–2024) adalah salah satu perintis fotografi modern Taiwan. Pada 1958, saat bersekolah di SMA Chenggong Taipei, ia bergabung dengan klub fotografi dan mulai berkarya di bawah bimbingan gurunya, Cheng Sang-hsi. Meski memperoleh jalur masuk langsung ke Jurusan Teknik Sipil Universitas Nasional Taiwan, ia menyerap dalam-dalam sastra modern, filsafat eksistensialisme, dan arus pemikiran surealisme — nutrisi yang kelak sangat memengaruhi karyanya.[^2]
+
+Pada 1965, Chang Chao-tang yang berusia 22 tahun menggelar "Pameran Duo Fotografi Modern" (現代攝影雙人展) bersama Cheng Sang-hsi. Tema, bentuk ungkapan, maupun isi pameran itu sangat berbeda dari gaya fotografi salon yang saat itu arus utama, sehingga memicu perdebatan sengit sekaligus perhatian luas di kalangan fotografi, dan menjadi peristiwa yang menandai zaman dalam sejarah fotografi Taiwan.[^3]
+
+Karya-karya awal Chang Chao-tang sangat dipengaruhi eksistensialisme dan surealisme; fotonya sarat aura kebingungan, muram, dan absurd. Yang paling terkenal adalah seri "lelaki tanpa kepala" dari dekade 1960-an: kepala sosok dalam foto sengaja ditutupi atau dipotong, menciptakan benturan visual yang kuat sekaligus mengungkapkan renungan filosofis atas kondisi manusia.
+
+Seiring bertambahnya usia, karya Chang Chao-tang bergerak dari eksperimen murni ke gaya dokumenter yang berpihak pada kepedulian humanis, dan ia mulai merekam perubahan masyarakat Taiwan. Ia juga terlibat dalam produksi acara televisi, membuat program seperti "Perjalanan Citra" (映象之旅) bersama Lei Hsiang (雷驤), Juan I-jong, dan Christopher Doyle (杜可風).
+
+Sumbangan Chang Chao-tang terletak pada membuka kemungkinan baru bagi fotografi Taiwan: fotografi bukan hanya bisa merekam kenyataan, tetapi juga mampu memikul renungan filosofis dan puisi — menyuntikkan kedalaman muatan budaya ke dalam fotografi Taiwan.
+
+## Juan I-jong: Penyair Kampung Halaman dan Kemanusiaan
+
+Juan I-jong (阮義忠, 1950–) lahir di Toucheng, Yilan, dan merupakan tokoh representatif fotografi dokumenter Taiwan. Pada masa awal ia bekerja sebagai editor di majalah sastra "Youshi Wenyi" (幼獅文藝) dan menggeluti dunia tulis-menulis; setelah pindah ke majalah berbahasa Inggris "Echo" (漢聲) terbitan Hansheng, ia mulai bersentuhan dengan fotografi. Ia benar-benar terjun ke penciptaan fotografi ketika menjabat editor foto di "Majalah Bulanan Keluarga" (家庭月刊), saat ia masuk jauh ke berbagai kota kecil dan desa di seluruh Taiwan untuk membuat reportase foto.
+
+Pada 1987, Juan I-jong menerbitkan "Manusia dan Tanah" (人與土地). Album foto ini, dengan sudut pandang yang hangat dan penuh kepedulian humanis, meninggalkan rekaman visual yang berharga bagi masyarakat Taiwan, dan diakui sebagai karya klasik dalam sejarah fotografi Taiwan.[^4]
+
+Arti penting "Manusia dan Tanah" terletak pada kemampuannya menangkap wajah sejati Taiwan pada masa transformasi sosial dekade 1970–80-an. Di zaman ketika ekonomi melaju cepat dan masyarakat berubah drastis, Juan I-jong mengarahkan lensanya ke cara hidup tradisional yang segera lenyap, merekam keadaan hidup orang Taiwan dalam kesahajaannya yang paling murni.
+
+Foto-foto itu merekam pemandangan pedesaan dan sawah, wajah khusyuk para perajin tradisional, senyum penuh kasih para orang tua, dan anak-anak yang bermain tanpa beban. Dengan daya amat dan kepekaan humanisnya, Juan I-jong mengubah momen-momen kehidupan yang biasa menjadi karya seni.
+
+Karya Juan I-jong bermuatan warna nostalgia dan kerinduan kampung halaman yang kuat. Ia berpendapat bahwa kebajikan orang Taiwan — kesahajaan dan sikap saling menolong — sedang menghilang. Melalui pertentangan antara yang tradisional dan yang modern, ia mengingatkan orang untuk merenungkan: dalam mengejar kemajuan material, apakah ada sesuatu yang justru hilang?
+
+Selain fotografi diam, Juan I-jong juga terlibat dalam produksi film dokumenter televisi. Sejak 1981 ia bersama Chang Chao-tang dan lainnya memproduksi program "Perjalanan Citra" (映象之旅), yang memaparkan proses berkarya para seniman Taiwan, perkembangan seni kampung halaman, kehidupan masyarakat Adat, serta pergeseran kota dan desa — sebuah program penanda dalam sejarah televisi Taiwan.
+
+## Pusat Kebudayaan Fotografi Nasional: Tonggak Pelembagaan
+
+Pada 2015, Kementerian Kebudayaan mendorong "Rencana Penyelamatan Aset Fotografi Nasional dan Pendirian Pusat Kebudayaan Fotografi". Pada April 2021, Pusat Kebudayaan Fotografi Nasional (國家攝影文化中心) resmi berdiri — sebuah tonggak pelembagaan dalam sejarah perkembangan fotografi Taiwan.[^5]
+
+Pusat ini menjadikan bekas Kantor Cabang Taipei Perusahaan Kapal Dagang Osaka (大阪商船株式會社台北支店) sebagai gedung Taipei-nya, dan lewat kuratorial profesional memperkenalkan tren perkembangan fotografi dan seni citra. Selain mengoleksi dan memamerkan karya fotografi Taiwan, ia juga mendorong penelitian kebudayaan fotografi dan memberi sokongan bagi riset akademis.[^6]
+
+Berdirinya Pusat Kebudayaan Fotografi Nasional menandai perpindahan fotografi Taiwan dari penciptaan perorangan menuju pelestarian dan pemajuan yang sistematis. Berbagai pameran fotografi yang digelar secara berkala memperkenalkan alur perkembangan sejarah fotografi Taiwan, mempromosikan hasil karya fotografer kontemporer, dan meningkatkan pemahaman masyarakat terhadap seni fotografi.
+
+## Perkembangan Beragam Fotografi Kontemporer
+
+Memasuki abad ke-21, fotografi Taiwan tampil dalam perkembangan yang beragam. Fotografer generasi baru menjelajahi berbagai kemungkinan di atas fondasi tradisi: Shen Chao-liang (沈昭良) menelusuri identitas Taiwan di bawah globalisasi lewat seri "Terapung" (漂流), sementara Ho Ching-tai (何經泰) merekam peristiwa-peristiwa sosial di ranah fotografi reportase — memperlihatkan kekuatan fotografi sebagai pencatat masyarakat.
+
+Fotografer keturunan Taiwan Chien-Chi Chang (張乾琦) dikenal karena investigasi mendalam yang berlangsung bertahun-tahun; karyanya mencakup isu buruh migran tanpa izin, terpidana mati, hingga rumah sakit jiwa. Ia adalah satu-satunya fotografer kelahiran Taiwan yang sampai saat ini memperoleh keanggotaan resmi di Magnum Photos.[^7]
+
+Menyebarnya teknologi fotografi digital membawa peluang sekaligus tantangan baru bagi fotografi Taiwan. Di satu sisi, ia menurunkan ambang masuk penciptaan sehingga lebih banyak orang bisa ikut berkarya; di sisi lain, bagaimana mempertahankan nilai seni dan kedalaman budaya fotografi di zaman banjir citra menjadi soal yang harus dihadapi fotografer masa kini.
+
+Bangkitnya media sosial mengubah cara fotografi disebarkan. Para fotografer muda membagikan karya lewat platform seperti Instagram dan Facebook, dan membangun merek pribadi. Hubungan langsung semacam ini membuka kemungkinan bertahan hidup bagi fotografer independen, sekaligus mendorong demokratisasi penciptaan fotografi.
+
+Perkembangan teknologi kecerdasan buatan membawa kemungkinan baru bagi fotografi. Pengolahan citra berbantuan AI, teknik pemotretan otomatis, dan analisis citra cerdas semuanya sedang mengubah pola penciptaan fotografi tradisional. Namun kemajuan teknologi tidak dapat menggantikan daya cipta dan kepedulian humanis seorang fotografer; justru di zaman ketika teknologi berganti tiap hari, sudut pandang dan bekal budaya seorang fotografer makin sulit ditiru.
+
+## Fungsi Sosial Fotografi
+
+Fotografi Taiwan memainkan peran sebagai saksi dalam proses demokratisasi masyarakat. Dari perlawanan politik pada masa darurat militer sampai gerakan sosial setelah pencabutannya, para fotografer merekam momen-momen kunci transformasi masyarakat Taiwan lewat lensa mereka, dan menjadi saksi sejarah. Karya-karya fotografi reportase ini memiliki nilai ganda: sebagai berita sekaligus sebagai bahan sejarah.
+
+Gempa bumi 921 pada 1999 adalah bencana besar dalam sejarah Taiwan modern, dan para fotografer menjalankan fungsi kesaksian mereka dengan merekam kedahsyatan bencana sekaligus cahaya kemanusiaan. Setelah gempa itu Juan I-jong kembali mengangkat kameranya dan mengarahkan lensanya kepada para relawan penyelamat, merekam semangat saling menolong dan kegigihan orang Taiwan di hadapan bencana.
+
+Seiring meningkatnya kesadaran lingkungan, makin banyak fotografer menaruh perhatian pada isu lingkungan: merekam kerusakan lingkungan akibat pencemaran industri, dampak perubahan iklim terhadap ekologi, dan pergeseran hubungan manusia dengan alam. Fotografi lingkungan semacam ini, lewat benturan visualnya, membangkitkan perhatian publik terhadap persoalan lingkungan.
+
+## Globalisasi dan Identitas Lokal
+
+Di tengah gelombang globalisasi, bagaimana mempertahankan ciri khas lokal fotografi Taiwan adalah persoalan yang dihadapi para fotografer masa kini. Di satu sisi perlu ada dialog dengan dunia fotografi internasional, mempelajari gagasan dan teknik penciptaan mutakhir; di sisi lain perlu berakar dalam pada budaya lokal, mengungkapkan muatan budaya dan pengalaman hidup Taiwan.
+
+Fotografer Taiwan yang berhasil biasanya menemukan keseimbangan antara globalisasi dan lokalisasi: karyanya memiliki cakrawala internasional sekaligus berakar di tanah budaya Taiwan. Dari jepretan jalanan Tiga Pendekar pada masa pendudukan Jepang, ke eksperimen eksistensialis Chang Chao-tang, ke dokumenter humanis Juan I-jong, sampai reportase investigatif Chien-Chi Chang di panggung Magnum — fotografi Taiwan, dengan bahasa yang berbeda-beda, merekam pulau yang sama pada zamannya masing-masing.
+
+## Referensi
+
+[^1]: [鄧南光 — Wikipedia](https://zh.wikipedia.org/wiki/%E9%84%A7%E5%8D%97%E5%85%89) — Latar belakang dan masa aktif Tiga Pendekar Fotografi Taiwan (Deng Nan-guang, Chang Tsai, Lee Ming-tiao).
+[^2]: [張照堂 — Wikipedia](https://zh.wikipedia.org/wiki/%E5%BC%B5%E7%85%A7%E5%A0%82) — Konfirmasi tahun lahir dan wafat Chang Chao-tang (1943–2024) serta latar pendidikannya.
+[^3]: [Fotografer Chang Chao-tang wafat pada usia 81 — UDN](https://udn.com/news/story/6898/7874899) — Konfirmasi "Pameran Duo Fotografi Modern" 1965 dan berita wafatnya Chang Chao-tang.
+[^4]: [人與土地: album foto klasik Juan I-jong — Books.com.tw](https://www.books.com.tw/products/0010712291) — Album fotografi dokumenter Juan I-jong (terbitan pertama 1987; ini edisi cetak ulang 2016).
+[^5]: [國家攝影文化中心 — Wikipedia](https://zh.wikipedia.org/zh-tw/%E5%9C%8B%E5%AE%B6%E6%94%9D%E5%BD%B1%E6%96%87%E5%8C%96%E4%B8%AD%E5%BF%83) — Konfirmasi tanggal pendirian resmi pada April 2021.
+[^6]: [Pusat Kebudayaan Fotografi Nasional](https://ncpi.ntmofa.gov.tw/) — Fungsi lembaga, kebijakan koleksi, dan rencana pameran.
+[^7]: [Chien-Chi Chang — Magnum Photos](https://www.magnumphotos.com/photographer/chien-chi-chang/) — Konfirmasi status Chien-Chi Chang sebagai anggota resmi Magnum Photos dan cakupan karyanya.
+
+**Bacaan Lanjutan**
+
+- [Wawancara khusus dengan fotografer Taiwan Chang Chao-tang — Initium Media](https://theinitium.com/project/20181020-photo-changchaotang)
+- [Koleksi dan riset Pusat Kebudayaan Fotografi Nasional](https://ncpi.ntmofa.gov.tw/)


### PR DESCRIPTION
Adds Indonesian translation of `Art/台灣攝影.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.68 — inside the `id` healthy band 2.00–4.30 (`scripts/tools/lang-sync/ratio-bands.json`, calibrated 2026-07-18)

**Structure alignment**: `##` 8→8 · footnote refs 8→8 · footnote defs 7→7 · URLs 9→9 (all identical, none dropped or substituted) · intro blockquote 4 lines → 4 lines — 100% preserved

**Note**: `i18n/id/STYLE.md` does not exist yet — followed `TRANSLATE_PROMPT.md` plus the established conventions of the existing `knowledge/id/` corpus (Chinese proper nouns kept alongside the Indonesian rendering, `subcategory` left in Chinese, `author: 'Taiwan.md'`).

Uncertain terminology flagged for reviewer:

- 藝術寫真 → `"geijutsu shashin" (藝術寫真, fotografi seni)` · kept the Japanese term because it names a specific Japanese photographic movement, with a short Indonesian gloss
- 新興寫真術 → `"shinkō shashin-jutsu" (新興寫真術, teknik fotografi baru)` · same reasoning as above
- 乾版攝影 → `teknik pelat kering (乾版)` · "pelat kering" is the standard Indonesian rendering of dry-plate photography
- 台灣攝影三劍客 → `"Tiga Pendekar Fotografi Taiwan"` · "pendekar" carries the martial/heroic connotation of 劍客 better than a literal "tiga pemain anggar"
- 人與土地 → `"Manusia dan Tanah" (人與土地)` · the photobook has no established Indonesian title, so the Chinese is kept in parentheses
- 原住民 → `masyarakat Adat` · per TRANSLATE_PROMPT, never "aborigines"; capitalised Adat follows current Indonesian usage for Indigenous peoples
- 921大地震 → `Gempa bumi 921` · kept the Taiwanese date-based name rather than "Gempa Jiji"

Please review. Happy to iterate.
