### PR TITLE
translate(en): 鍾肇政 → chung-chao-cheng

### DIFF
--- a/knowledge/en/People/chung-chao-cheng.md
+++ b/knowledge/en/People/chung-chao-cheng.md
@@ -1,0 +1,176 @@
+---
+title: 'Chung Chao-cheng: A Man Who Never Finished a College Degree, Yet Wrote the Long River of the Taiwanese People'
+description: 'Born in Longtan, Taoyuan in 1925, Chung Chao-cheng had his studies in the Chinese Department of National Taiwan University interrupted by a Japanese-language education and illness, yet he went from elementary school teacher to novelist, editor, and Hakka activist. With _Lubinghua_ he wrote about rural Taiwan, and with two trilogies he preserved the historical memory of the Taiwanese people. His literature lives not only on the bookshelf but also in a life-and-literature park in Longtan.'
+date: 2026-08-18
+category: 'People'
+tags:
+  [
+    'Chung Chao-cheng',
+    'Taiwanese Literature',
+    'Hakka Literature',
+    'Longtan',
+    'River Novels',
+  ]
+subcategory: '文學'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-08-28
+lastHumanReview: false
+readingTime: 8
+curation: incubating
+translatedFrom: 'People/鍾肇政.md'
+sourceCommitSha: '82038b29f'
+sourceContentHash: 'sha256:e30095af8a74328f'
+sourceBodyHash: 'sha256:9240eda59faf09e3'
+translatedAt: '2026-08-29T04:40:00+08:00'
+---
+
+> **30-Second Overview:** Chung Chao-cheng was not someone who entered the literary world along a smooth academic path. He received a Japanese-language education during the Japanese colonial period and only re-learned Chinese after the war; he entered the Chinese Department of National Taiwan University in 1948, yet left mid-course because of the language gap and health problems, and he still went on to write _Lubinghua_ (《魯冰花》, "lupine flower"), The Turbid Flow Trilogy (濁流三部曲), and The Taiwanese Trilogy (臺灣人三部曲), putting Hakka villages, Indigenous communities, and Taiwan's modern history into his novels.[^1] [^2] [^3]
+
+## Preface: First Ask Who Can Keep Taiwan's Memory
+
+To read Chung Chao-cheng, one cannot begin with a writer's chronology alone. A better entrance is to first imagine a person who was educated in Japanese before the age of twenty and, after the war, had to re-learn Chinese. He was not simply changing textbooks; he had to rediscover a language capable of describing his family, his place, and his own life. This language shift later became an undercurrent in postwar Taiwanese literature that is hard to see yet has always been there.[^11] [^12]
+
+Chung Chao-cheng's work matters also because he did not write this language predicament as a merely personal wound. He pushed it toward a larger question: if mainstream publishing accepts only a certain language, a certain history, and a certain "respectable" kind of protagonist, can the people living in Longtan's tea gardens, Hakka villages, mountain communities, and postwar families still become the center of Taiwanese stories?
+
+This article therefore does not treat _Lubinghua_ as a single nostalgic masterpiece, nor does it treat "the mother of Taiwanese literature" as the destination. What it traces is an actual line of work: how Chung Chao-cheng went from teacher to novelist, how he used editing and correspondence to link writers together, how he carried the Hakka language and ethnic memory into public action, and how he let Longtan's buildings and streets become a literary landscape that can still be read.[^1] [^2] [^4]
+
+> **Curator's Note:** The preface is placed after the 30-second overview so that the method of reading is settled before the biography begins. Chung Chao-cheng's core is not the phrase "success in adversity" but how language, place, and the literary system jointly shaped one writer; once readers grasp this question, the works and public actions that follow will not be broken into an unrelated résumé.
+
+## The Child of Jiuzuoliao in Longtan
+
+On January 20, 1925, Chung Chao-cheng was born in Jiuzuoliao (九座寮), Longtan (龍潭), Taoyuan. At that time the place belonged to Longtan Village, Daxi District, Shinchiku Prefecture, during the Japanese colonial period. His father was a teacher and later served as a school principal. This family gave him early contact with writing and education, but it also cut his upbringing in two with a linguistic rupture: the school used Japanese, while the postwar system demanded that he re-learn Chinese.[^1] [^4] [^5]
+
+He studied successively at Tamsui Middle School (淡水中學) and Changhua Youth Normal School (彰化青年師範學校), and after graduation became a teacher at a national school. In 1948 he was admitted to the Chinese Department of National Taiwan University (臺大), hoping to make literary creation a more formal path. But the language gap left by his early Japanese-style education, together with malignant malaria contracted during military service and the damage it did to his hearing, made it hard to keep up with the courses, and he finally returned to Longtan to teach.[^2] [^3]
+
+This experience can easily be written up as an inspirational story of "struggling after setbacks." But the key to Chung Chao-cheng is not that he conquered one failure; it is that he turned the gap in language into a problem of writing: in what language, after all, should a Taiwanese person write about his own place, family, and history? A retrospective in the English-language _Taipei Times_ places him in "the cross-lingual generation": a generation that grew up under a Japanese-language education and, after 1945, was forced to turn to Mandarin, so that the writing itself carried the friction left by institutional transition.[^11] [^12]
+
+## Starting With a Rejected Story
+
+In 1951, Chung Chao-cheng made his formal entry into the literary world when "After Marriage" (〈婚後〉) appeared in _Free Talk_ (《自由談》). Records from National Taiwan University alumni note that he later went through many rejections yet called himself a "submission warrior." He did not treat his teaching job as a lull in which to wait for fame; outside of teaching hours he read world literature, translated, and wrote.[^3]
+
+In the early 1960s, his long novel _Lubinghua_ was published in the supplement of _United Daily News_ (《聯合報》). Different sources record its first-published year as 1960, 1961, or 1962; the safer way to put it is that it appeared in the early 1960s, with its story drawn from the rural education and village life he saw while teaching at Longtan Elementary School (龍潭國小).[^1] [^2] [^3] [^6]
+
+What is easiest to remember in the novel is the child who draws and a teacher who refuses to hand talent over to fate. The deeper problem is that rural children are not without ability; rather, school, family, and social resources assigned their places very early. The later film made _Lubinghua_ a name familiar to the public, but what the novel first left behind was a record of how Taiwan's countryside in the 1960s viewed education and talent.[^3] [^6]
+
+![Longtan Elementary School Japanese-style dormitory](https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/%E9%BE%8D%E6%BD%AD%E5%9C%8B%E5%B0%8F%E6%97%A5%E5%BC%8F%E5%AE%BF%E8%88%8D.jpg/1280px-%E9%BE%8D%E6%BD%AD%E5%9C%8B%E5%B0%8F%E6%97%A5%E5%BC%8F%E5%AE%BF%E8%88%8D.jpg)
+
+_Image: 寺人孟子, [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:%E9%BE%8D%E6%BD%AD%E5%9C%8B%E5%B0%8F%E6%97%A5%E5%BC%8F%E5%AE%BF%E8%88%8D.jpg), [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/). This school building links the educational setting of \_Lubinghua_ back to the actual landscape of Longtan.\_
+
+> **Curator's Note:** The most worth-reading part of Chung Chao-cheng is not how many novels he wrote, but that he always hid the question of "who deserves to be written into history" inside a child, a village, or a dialect. This photograph of the school building is placed after the _Lubinghua_ section so that the school of the novel does not remain only inside the plot.
+
+## Stretching One Man's Memory Into a Long River
+
+_Lubinghua_ lets readers see the schools and countryside of Longtan, while The Turbid Flow Trilogy pulls the gaze back to the era of his own upbringing. The Taiwanese Trilogy extends further, writing the lives of Taiwanese people under different regimes and at historical turning points. The Taoyuan Literature Museum (桃園文學館) regards these works as an important practice through which Chung Chao-cheng pioneered the "river novel" (大河小說) in the Taiwanese long novel.[^1]
+
+![Longtan Great Pond's Yu-hsien Hall and the Bang Chhun-hong stele inscribed by Chung Chao-cheng](https://upload.wikimedia.org/wikipedia/commons/d/de/Yu-hsien_Hall_and_Bang_Chhun-hong_Stele_20100414.jpg)
+
+_Image: Chia wei ku, [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:Yu-hsien_Hall_and_Bang_Chhun-hong_Stele_20100414.jpg), public domain. The "Bang Chhun-hong" inscription in the photograph joins the writer's words directly to Longtan's public space._
+
+> **Curator's Note:** This photograph of the inscription stele is placed in the "river novel" chapter rather than at the start of the biography, because what it shows is the state of the work after it leaves the page: the writing becomes part of the local landscape, and readers can see in Longtan how literature is preserved, quoted, and then returns to everyday life.
+
+A "river novel" does not line years up into a table; it lets characters live between institutions and the land. The people in Chung Chao-cheng's writing are not merely victims or witnesses of history; they have work, marriages, families, and language, and they hold on to a daily life that refuses to disappear inside a vast era. This makes his fiction approach both local chronicles and family stories without being equal to either.
+
+Materials from the National Museum of Taiwanese Literature note that his important works also include The High Mountain Suite (《高山組曲》) and Raging Waves (《怒濤》). The High Mountain Suite deals with the history of Indigenous peoples, while Raging Waves is set against the 228 Incident; Chung Chao-cheng spent three years completing it, and it was published in 1993. This creative line shows that he did not write about Hakka people by shutting himself inside a single ethnicity; starting from his own position, he instead asked how different ethnic groups went through Taiwan's history together.[^2]
+
+His scale of writing therefore cannot be represented by a single _Lubinghua_. Database statistics record that he left behind 22 full-length novels, 154 novellas and short stories, 7 collections of essays and criticism, more than 30 television scripts, 47 translated works, and 15 edited anthologies. The numbers are not meant to crown the writer, but to make readers understand: he was more like a literary worker running continuously than an isolated genius who occasionally produced a famous work.[^2]
+
+## A Man of Letters Who Was Also an Editor and a Connector
+
+Chung Chao-cheng's role in the literary world was not limited to his own works. Starting in 1964, he helped Wu Cho-liu (吳濁流) edit _Taiwan Wen-yi_ (《臺灣文藝》). In 1978 he served as chief editor of the literary supplement of _Min Chung Daily_ (《民眾日報》), and he also edited the Literary Friends Newsletter (《文友通訊》). From 1957 onward he exchanged letters with writers such as Chung Li-ho (鍾理和), Liao Ching-hsiu (廖清秀), Li Rong-chun (李容春), and Chen Huo-chuan (陳火泉), trading works, opinions, and publishing news through publications.[^2]
+
+In 1965 he edited the Anthology of Native Taiwanese Writers' Works (《本省籍作家作品選集》) in ten volumes, covering as many as 168 authors of fiction and poetry. The importance of this anthology is not only in its numbers: it brought the postwar works of native-born Taiwanese writers together before readers, so that "Taiwanese literature" did not have to wait to be named later, but first existed as a body of texts that could be read, compared, and passed on.[^2]
+
+He also translated Japanese literature and edited the Anthology of Hakka Taiwanese Literature (《客家台灣文學選》) in two volumes. Both the Taoyuan Literature Museum and the Dictionary of Taiwanese Literature list this editing, translating, and mentoring of younger writers among his contributions to literary history. Chung Chao-cheng did not only complete his own works in his study. He was also helping Taiwanese literature weave a net that others could walk across.[^1] [^2] [^3]
+
+## "Hakka" Was Not a Backdrop but a Public Responsibility
+
+Chung Chao-cheng's public identity in his later years was intertwined with his literary creation. On December 28, 1988, he took part in and led the "Return Our Hakka Language" march (還我客語). In 1990 he served as president of Taiwan PEN; in 1994 he became chair of the Taiwan Hakka Public Affairs Association, and he took part in advancing Hakka culture and media.[^2] [^3]
+
+These actions made "Hakka" not only the local color of a novel but also an issue of language rights, cultural memory, and public participation. For Chung Chao-cheng, preserving Hakka literature did not mean sealing the Hakka inside tradition. It was more like demanding that, in an era dominated by a single language and a single historical narrative, Taiwan acknowledge that it had always had many voices. The English author introduction of the Hakka Affairs Council calls him a pioneer in completing river novels in Taiwan, and also records that the Literary Friends Newsletter ceased publication in 1958 under the pressure of the White Terror. Here literature is at once a form of creation and a way for writers to keep in touch with one another.[^4] [^7] [^12]
+
+He once served as a senior adviser to the president (總統府資政) and received honors such as the National Award for Arts, the Wu San-lien Award, and the Presidential Cultural Award. But if these awards are merely listed as a résumé, they actually hide what he truly did over the long run: writing, editing, translating, corresponding, organizing, and pulling newcomers through the door of literature.[^1] [^3]
+
+![Official memorial photograph of Chung Chao-cheng](https://commons.wikimedia.org/wiki/Special:FilePath/06.01%E5%89%AF%E7%B8%BD%E7%B5%B1%E8%BF%BD%E6%80%9D%E9%8D%BE%E8%82%87%E6%94%BF%E5%85%88%E7%94%9F_%2849959114051%29.jpg?width=1280)
+
+_Image: Official memorial photograph of the Office of the President. [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:06.01%E5%89%AF%E7%B8%BD%E7%B5%B1%E8%BF%BD%E6%80%9D%E9%8D%BE%E8%82%87%E6%94%BF%E5%85%88%E7%94%9F_%2849959114051%29.jpg), [CC BY 2.0](https://creativecommons.org/licenses/by/2.0/).\_
+
+> **Curator's Note:** This official memorial photograph is placed after the public cultural actions to remind readers that Chung Chao-cheng was not only a writer who was read, but a person whom Taiwanese society answered with medals, commendations, and public memory.
+
+## What Longtan Left Behind Is Not a Memorial
+
+Chung Chao-cheng died on May 16, 2020. Today the Chung Chao-cheng Literature and Life Park in Longtan, made up of the former Longtan Elementary School Japanese-style dormitory cluster and spaces such as the Longtan Butokuden Hall (龍潭武德殿), is positioned not merely to preserve the writer's materials but also to promote his works and Taiwanese Hakka literature.[^1] [^8] [^9]
+
+![Longtan Butokuden Hall](https://upload.wikimedia.org/wikipedia/commons/thumb/5/57/%E9%BE%8D%E6%BD%AD%E6%AD%A6%E5%BE%B7%E6%AE%BF.jpg/1280px-%E9%BE%8D%E6%BD%AD%E6%AD%A6%E5%BE%B7%E6%AE%BF.jpg)
+
+_Image: Kumokumo0310, [Wikimedia Commons file page](https://commons.wikimedia.org/wiki/File:%E9%BE%8D%E6%BD%AD%E6%AD%A6%E5%BE%B7%E6%AE%BF.jpg), [CC BY-SA 4.0](https://creativecommons.org/licenses/by-sa/4.0/deed.en). The Butokuden Hall and the Japanese-style dormitory cluster together form the local context of the Literature and Life Park._
+
+> **Curator's Note:** The photograph of the Butokuden Hall is placed in the section on the park's history rather than beside a portrait of the writer, because what is presented here is "how literature enters architecture and the preservation of place": Chung Chao-cheng's name remains in a cultural space where people can walk, look, and re-understand Longtan.
+
+The National Museum of Taiwanese Literature designed this site as a literary route that can be walked into local life. Visitors see not only a writer's chronology; they also encounter Longtan's streets, schools, old buildings, and the birthplace of _Lubinghua_. The writer's hometown is therefore not a backdrop, but a site still mutually explaining and being explained by his works.[^6] [^8]
+
+The Taoyuan Chung Chao-cheng Literature Award, for its part, places his name inside a new system of creation, continuously soliciting novels, reportage literature, fairy tales, and works in other genres. The event page of the National Museum of Taiwanese Literature shows that the award still takes open submission and the nurturing of new writing as its main forms. This arrangement has a very concrete meaning: the best way to commemorate Chung Chao-cheng is not to seal him inside the title of "the mother of Taiwanese literature," but to let people who do not yet have a name be read one day as well.[^9] [^10]
+
+Chung Chao-cheng's life left behind two lines that seem opposed. One is that he was always filling gaps in language, in history, and in the literary map. The other is that he kept giving up his own position, leaving entrances for other writers, ethnic groups, and places. That teacher who never finished a college degree finally completed not a diploma, but a literary bridge on which Taiwanese people could read their own history anew.
+
+The materials of this bridge are miscellaneous: children in Longtan's tea gardens, teachers in postwar classrooms who had just learned Zhuyin, rejected manuscripts, mimeographed journals mailed to writer friends, Hakka spoken in lowered voices, and sets of novels that stretched local memory long. Chung Chao-cheng did not write Taiwan into an already finished answer. He let readers see that Taiwanese literature grew out, sentence by sentence, amid language shifts, historical speechlessness, and mutual support.
+
+To read Chung Chao-cheng again today, perhaps the most important thing is not to accept the title of "the mother of Taiwanese literature," but to return to the gesture he repeated: put a person easily overlooked at the center of the story, and leave room for his language, his land, and his choices. This is also why the park and the literature award in Longtan still matter — they turn commemoration from the past tense into the present tense, and keep asking who has not yet been written into Taiwan.
+
+## Starting by Translating One's Own Mind
+
+Chung Chao-cheng's Chinese was not a language that existed naturally from the start. He was first educated in Japanese, learned Chinese after the war, and at times had to pass his writing through translation in his mind first. He did not hide this lack of ease; instead it became a key to understanding postwar Taiwanese literature.[^11] [^12]
+
+What he faced was not the simple problem of "learning the national language well." When a person's childhood memories are kept in Japanese, family and local life happen in Hakka or Hokkien, and the publishing market demands works in Mandarin, every sentence a writer sets down decides which experiences can be brought into the public world.
+
+Here the Literary Friends Newsletter played a role that was small and also important. It was not a large publisher but a narrow gate through which writers mailed works to one another, discussed, and encouraged. A narrow gate is still a gate, letting people excluded from mainstream publishing hand their works to one another first.[^2] [^12]
+
+This kind of literary activity also explains why Chung Chao-cheng is always remembered as an editor. Editing is not a writer's subsidiary job; it is the cultural distribution that decides who can be seen and which kind of Taiwanese experience can be preserved.
+
+He preserved the works of writers such as Chung Li-ho, pushed for memorial halls, and introduced the works of younger authors. These actions may not be directly visible to readers, yet they changed the scope of what could be seen in Taiwanese literature.[^2] [^7]
+
+If one reads only _Lubinghua_, one assumes Chung Chao-cheng mainly wrote about rural education. Only after reading about his editing and translating does one discover that he was actually always dealing with "who can become the subject of Taiwanese literature."
+
+## Four Rivers, Four Kinds of Taiwanese Time
+
+The English-language materials of the Hakka Affairs Council regard Chung Chao-cheng as a writer who completed four sets of river novels in Taiwan. The point of this claim is not to create a record for him, but that his works hold different historical scales: personal memory, the history of the Taiwanese people, the experience of Indigenous peoples, and the political trauma that had not yet calmed after the 228 Incident.[^12]
+
+The Turbid Flow Trilogy begins with the turbid water of an individual and an era; The Taiwanese Trilogy places its characters inside a longer history. The High Mountain Suite turns toward the mountains and Indigenous peoples, while Raging Waves faces the 228 Incident directly. These works cannot replace one another, because each one is changing the boundary of "the Taiwanese story."[^2]
+
+The "grand" in river novels is not merely a large number of characters; it is that the form lets the daily life of small people bear the weight of history. Chung Chao-cheng writes about eating, going to school, working, falling in love, and moving house, but in these actions readers feel how regimes, war, and language policy enter the family.
+
+This also keeps his historical writing away from a route that looks only at leaders. Political figures can announce institutions; fictional characters, however, must go on living after the institutions are announced. Chung Chao-cheng's long novels often place the real pressure of history on the latter.
+
+_Lubinghua_ was later adapted into a film, letting more people remember the story of tea gardens, children, and education. But the fame of the adaptation cannot replace the historical position of the novel itself. The novel preserves the perspective in which the writer, starting from Longtan's local experience, first wrote educational inequality as a social problem.[^3] [^6] [^11]
+
+Longtan is therefore not a backdrop for readers to photograph, but a measuring stick for Chung Chao-cheng's work. When readers walk through the neighborhoods where he lived and then return to the novels, they see more clearly how he turned a familiar place into a memory that spans generations.
+
+This localness does not amount to closure either. Chung Chao-cheng set out from Hakka villages and went on to write about Indigenous peoples, the 228 Incident, the postwar community of writers, and the institutions of Taiwanese literature. His Taiwan is not the autobiography of a single ethnic group but a plural memory left behind when different experiences collide with one another.
+
+Chung Chao-cheng's works deserve to be re-read precisely because Taiwan today already has more languages and more publishing positions. New readers do not have to treat him as an unchallengeable idol; they can set out from his choices and keep asking which people, which dialects, and which places have not yet entered the story.
+
+## References
+
+[^1]: [鍾肇政（九龍、鍾正、趙震、路加、路家）](https://tylm.tycg.gov.tw/tylm/wSite/ct?xItem=92338&ctNode=38047&mp=1) — Profile of the author by the Taoyuan Literature Museum, used to verify his life, works, editorial work, and the positioning of his river novels.
+
+[^2]: [鍾肇政（1925.1.20~2020.5.16）](https://db.nmtl.gov.tw/site2/dictionary?id=Dictionary01187&searchkey=%E9%8D%BE%E8%82%87%E6%94%BF) — Entry in the National Museum of Taiwanese Literature's Dictionary of Taiwanese Literature, used to verify his chronology of works, the numbers of his works, his public participation, and his editing and anthology work.
+
+[^3]: [第10屆（2015年）人文藝術類：鍾肇政](https://www.alumni.ntu.edu.tw/OutstandingAlumni/WinnerDetail/WL00000136) — National Taiwan University Outstanding Alumni records, used to verify his studies, teaching, the start of his writing, translation, and honors.
+
+[^4]: [作者介紹：鍾肇政](https://cloud.hakka.gov.tw/content/images/04/C/02/04-C-02-0001-01.html) — Hakka Cloud author introduction, used to verify his background, his view of Hakka literature, and the context of his cultural promotion.
+
+[^5]: [大河浩蕩——鍾肇政文學展](https://tlvm.nmtl.gov.tw/zh/Theme/ExhibitionCont1?LLid=111) — Exhibition page of the National Museum of Taiwanese Literature's Taiwan Literature Travels, used to verify his Longtan upbringing and the positioning of the literature exhibition.
+
+[^6]: [拜訪鍾肇政經典小說《魯冰花》的誕生地](https://tlvm.nmtl.gov.tw/en/Travel/TravelBlogCont?Blogid=41) — Taiwan Literature Travels article of the National Museum of Taiwanese Literature, used to verify the connection between _Lubinghua_, Longtan Elementary School, and local scenes.
+
+[^7]: [「鍾肇政」小行星命名發表臺灣文學精神閃耀星空](https://www.hakka.gov.tw/chhakka/app/data/view?module=hotnews&id=25&serno=ca074d95-b045-4b4e-83a2-f759da8415f1) — News article of the Hakka Affairs Council, used to verify the public standing of his identity as a Hakka writer, his literary creation, and his cultural promotion.
+
+[^8]: [鍾肇政文學生活園區](https://tlvm.nmtl.gov.tw/zh/Travel/TravelFamilyCont?Familyid=5) — Taiwan Literature Travels article of the National Museum of Taiwanese Literature, used to verify the park's positioning of linking works and reading promotion with Longtan's local life.
+
+[^9]: [2024桃園鍾肇政文學獎](https://tlvm.nmtl.gov.tw/zh/Travel/TravelEventCont?Eid=239) — Event article of the National Museum of Taiwanese Literature, used to verify the continuing form of the literature award's open submissions and creative nurturing.
+
+[^10]: [桃園鍾肇政文學獎](https://culture.tycg.gov.tw/News_Photo_Content.aspx?n=23556&s=1566323) — Article by Taoyuan City Government's Department of Cultural Affairs, used to verify the award's function of continuing the writer's spirit and cultivating creators.
+
+[^11]: [A great loss for Taiwanese literature](https://u.osu.edu/mclc/2020/06/06/a-great-loss-for-taiwanese-literature/) — Article reprinted by the MCLC Resource Center from the _Taipei Times_, used to verify the cross-lingual generation, language transition, and the context of Hakka public action.
+
+[^12]: [Chung Chao-cheng: the author who launched Taiwan's river-novels](https://english.hakka.gov.tw/Content/Content?NodeID=670&PageID=39914&LanguageType=ENG) — English author introduction by the Hakka Affairs Council, used to verify river novels, the sequence of works, and the literary-historical context of the Literary Friends Newsletter.


### PR DESCRIPTION
## translate(en): 鍾肇政（Chung Chao-cheng）→ knowledge/en/People/chung-chao-cheng.md

EN People 翻譯系列接續（#1616–#1620）。台灣大河小說開拓者、客家運動者。

### 產出方式
**prime-agent-lite segment 4**（prime-agent → LiteLLM :4000 → cc-auto / ArliAI DeepSeek-V4-Flash），同套 supervisor 流程（worker prompt + 結構驗證 gate + 人工逐段核對）。

### 完整性檢查
- ✅ 章節 9:9（含 5 個 📝 策展人筆記 blockquote 1:1；body 無 H1，與 zh source 一致）
- ✅ 腳註 12/12（URL byte-identical；inline 位置逐段對齊）
- ✅ 圖片 4/4（含 `Special:FilePath/...?width=1280` 特殊 URL，位置與 caption 結構 1:1）
- ✅ zh→en narrative 字元比 **3.16**（區間 2.0–3.8）
- ✅ 術語：還我客語大遊行 → “Return Our Hakka Language” march、大河小說 → river novels、「台灣文學之母」按原文譯為 “the mother of Taiwanese literature”（未擅改為 father）、《魯冰花》首刊年份三說 hedge 保留
- ✅ frontmatter provenance 依 status.py canonical 算法；`test-frontmatter.mjs --ci` 通過；prettier 格式化

AI worker：cc-auto (ArliAI DeepSeek-V4-Flash-0731) via prime-agent-lite