### PR TITLE
translate(en): 李仙得 → charles-le-gendre

### DIFF
--- a/knowledge/en/People/charles-le-gendre.md
+++ b/knowledge/en/People/charles-le-gendre.md
@@ -1,170 +1,173 @@
 ---
 title: 'Charles Le Gendre: The Treaty-Maker and the Traitor Were the Same Man'
-description: 'In 1867, the American merchant ship Rover wrecked off the Hengchun Peninsula, and 14 crew members were killed by the Paiwan people. U.S. Consul Le Gendre made eight trips to Taiwan, negotiating a treaty with indigenous chief Tauketok without any involvement from the Qing government. He then took his encyclopedic knowledge of Formosa and defected to the Japanese government. Five years later, Japan used his intelligence to launch a military expedition against Taiwan.'
+description: 'In 1867, the American merchant ship Rover wrecked off the Hengchun Peninsula, and 14 crew members were killed by the Paiwan people. U.S. Consul Le Gendre made eight trips to Taiwan, signing an agreement with indigenous chief Tauketok without the participation of the Qing government. He then took his encyclopedic knowledge of Formosa and defected to the Japanese government. Five years later, Japan used his intelligence to launch a military expedition against Taiwan.'
 date: 2026-04-12
-category: People
-subcategory: 歷史人物
+category: 'People'
 tags:
-  - 'Rover Incident'
-  - 'Mudan Incident'
-  - 'Indigenous Diplomacy'
-  - 'Charles Le Gendre'
-  - 'Tauketok'
-  - '19th Century'
-  - 'U.S. Consul'
-  - 'SEQALU'
-image: ''
+  [
+    'Rover Incident',
+    'Mudan Incident 1874',
+    'Indigenous Diplomacy',
+    'Charles Le Gendre',
+    'Tauketok',
+    '19th Century',
+    'US Consul',
+    'Seqalu',
+  ]
+subcategory: '歷史人物'
+author: 'Taiwan.md'
 featured: true
-author: Taiwan.md
-lastVerified: 2026-04-12
+lastVerified: 2026-08-29
 lastHumanReview: false
-translatedFrom: People/李仙得.md
-sourceCommitSha: '4b6d28c5'
+image: ''
+curation: incubating
+translatedFrom: 'People/李仙得.md'
+sourceCommitSha: '09ffe560f'
 sourceContentHash: 'sha256:b35bf2bd112055a5'
 sourceBodyHash: 'sha256:bbb48d4bf913e4a0'
-translatedAt: '2026-05-01T01:46:13+08:00'
+translatedAt: '2026-08-29T05:30:00+08:00'
 ---
 
 # Charles Le Gendre: The Treaty-Maker and the Traitor Were the Same Man
 
-> **30-second overview:** Charles W. Le Gendre (1830–1899) — French-born American diplomat, Civil War veteran, lost his left eye at the Battle of the Wilderness. From 1866 to 1872, he served as U.S. Consul in Amoy, making eight visits to Formosa and negotiating the "Treaty of South Cape" with Paiwan chief Tauketok. After resigning from the American consulate, he defected to the Japanese government and used his intimate knowledge of Taiwan to help Japan plan the 1874 Mudan Incident expedition. He left behind a 1,600-page manuscript and nearly 200 images — but this _Notes of Travel in Formosa_ was never published during his lifetime, finally appearing in a fully annotated edition from the National Museum of Taiwan History 137 years later.
+> **30-Second Overview:** Charles W. Le Gendre (1830–1899), French-born American diplomat, Civil War veteran, lost his left eye at Gettysburg. From 1866 to 1872 he served as U.S. Consul in Amoy, visiting Formosa eight times and signing the South Cape Agreement (南岬之盟) with the Paiwan chief Tauketok (卓杞篤). After leaving his consular post he defected to the Japanese government, using his knowledge of Taiwan to help Japan plan the 1874 Mudan Incident expedition. He left behind a 1,600-page manuscript and 200 images, but this "Taiwan Travelogue" was never published in his lifetime; only 137 years later did the National Museum of Taiwan History publish the fully annotated edition.
 
 ---
 
 ## The Rover
 
-On March 12, 1867, the American merchant ship _Rover_ was sailing from Swatow to Newchwang when it ran aground off the southern tip of the Hengchun Peninsula, near the waters of Liangqiao.[^1] Captain Joseph W. Hunt and his wife Mercy led the surviving crew ashore — directly into the territory of the Paiwan Kulaljuc community.
+On March 12, 1867, the American merchant ship _Rover_ ran aground off the southern tip of the Hengchun Peninsula, in the waters of Langqiao (琅嶠), while sailing from Swatow to Niuzhuang.[^1] Captain Joseph W. Hunt and his wife Mercy led the crew ashore, straying into the territory of the Kulaljuc community (龜仔甪社) of the Paiwan.
 
-Fourteen people were killed. Only one Cantonese sailor escaped to carry the news to Takow.
+Fourteen people were killed. Only a Cantonese sailor escaped, carrying the news to Takao (打狗).
 
-Word reached Amoy. U.S. Consul Le Gendre immediately traveled north to Fuzhou to press the Governor-General of Fujian and Zhejiang for action. The [Qing dynasty](/en/history/qing-dynasty-rule/) court's position was unambiguous: that was "savage" territory, outside its jurisdiction.[^2] The U.S. Navy also attempted a military intervention: the USS Hartford landed 181 men, who were repulsed by the Paiwan, with commander Alexander MacKenzie killed in the fighting.[^3]
+The news reached Amoy. Le Gendre, the U.S. Consul in Amoy, immediately went north to Fuzhou to press the Governor-General of Fujian and Zhejiang. The attitude of the Qing court (清廷) was unambiguous: that was the land of "raw barbarians" (生番), not under its jurisdiction.[^2] The U.S. Navy also attempted military intervention: the USS Hartford sent 181 men ashore, who were repulsed by the Paiwan, and commander Alexander MacKenzie was killed by gunfire.[^3]
 
-Warships could not subdue them. The authorities refused to act. Le Gendre decided to go himself.
+The warships could not subdue them, and the government refused to act. Le Gendre decided to go himself.
 
-## The One-Eyed Consul
+## The One-Eyed Diplomat
 
-The man who decided to walk into the jungle had an unusual history. Born in 1830 near Lyon, France, in a town called Oullins, his father was a painter and sculptor. After graduating from the University of Paris, he emigrated to America, and when the Civil War broke out in 1861, he joined the Union Army.[^4]
+The man who decided to walk into the jungle himself had an unusual backstory. He was born in 1830 in Oullins, near Lyon, France. His father was a painter and sculptor. After graduating from the University of Paris, he emigrated to America and joined the Union Army when the Civil War broke out in 1861.[^4]
 
-On May 9, 1864, at the Battle of the Wilderness, a bullet passed through his nose and left eye. He lost half his face's contour and was promoted to colonel. After the war, he needed work far from the battlefield. On July 13, 1866, he was appointed U.S. Consul at Amoy.[^5]
+On May 9, 1864, at the Battle of the Wilderness, a bullet pierced his nose and left eye. He lost the contour of half his face and was promoted to colonel. After the war ended, he needed a job far from the battlefield. In 1866 he was appointed U.S. Consul at Amoy.[^5]
 
-He had no idea this appointment would bring him to an island that would define the second half of his life.
+He could not know that this job would take him to an island, and that the island would define the rest of his life.
 
-## The Treaty of South Cape
+## The South Cape Agreement
 
-In September 1867, Le Gendre set out from Amoy with interpreter William A. Pickering and James Horn, pressing deep into the Paiwan territory of the Hengchun Peninsula.[^6] It was a march through jungle without roads, into the "aboriginal territory" beyond Qing control.
+In September 1867, Le Gendre set out from Amoy with interpreter William A. Pickering (必麒麟) and James Horn (何恩), heading deep into the Paiwan territory of the Hengchun Peninsula.[^6] It was a march through trackless jungle, into the "savage land" (番地) beyond the reach of Qing control.
 
-On October 10, he met Tauketok, the paramount chief of the Paiwan confederation of eighteen communities.
+On October 10, he met Tauketok (卓杞篤), the paramount chief of the Paiwan confederation of eighteen communities.
 
-What did they agree to? A formal memorandum dated February 28, 1869 records three specific terms: foreign sailors who survive a shipwreck and come ashore must raise a red flag to identify themselves; landing is only permitted at designated locations; and no one may enter mountain aboriginal villages.[^7]
+What did the two men talk about? The formal memorandum of February 28, 1869 records three specific terms: foreign sailors who come ashore after a shipwreck must raise a red flag to identify themselves; landing is permitted only at designated locations; and no one may enter mountain tribal villages.[^7]
 
-> **📝 Curator's note**
-> What makes the Treaty of South Cape remarkable is not its terms but its signatories: on one side, a U.S. Consul; on the other, the paramount chief of the [Paiwan](/en/history/indigenous-peoples-history-and-naming-movement/) confederation of eighteen communities. The Qing government was entirely absent. This may be the first written memorandum in Taiwan's history negotiated directly between an indigenous leader and a foreign representative — signaling that at the empire's periphery, indigenous peoples were not passive objects but capable negotiating subjects.
+> **📝 Curator's Note**
+> What makes the South Cape Agreement (南岬之盟) special is not the terms themselves but the two sides that signed it: on one side, an American consul; on the other, the paramount chief of the Paiwan (排灣族) confederation of eighteen communities. The Qing government was entirely absent. This may be the first written memorandum in Taiwan's history concluded directly between a local indigenous leader and a foreign representative. It means that at the edge of the empire, indigenous people were not passive objects but subjects capable of negotiating.
 
-From May 1867 to May 1872, Le Gendre visited Taiwan at least eight times.[^8] On each visit he took notes, drew maps, and gathered intelligence. He positioned himself as the foremost Western expert on Formosa.
+From May 1867 to May 1872, Le Gendre visited Taiwan at least eight times.[^8] On every trip he took notes, drew maps, and gathered intelligence. He positioned himself as the "Taiwan expert" in Western diplomatic circles.
 
 ## The Defection
 
-In 1872, Le Gendre resigned from the American consulate and joined the Japanese Foreign Ministry as a second-class foreign adviser, at an annual salary of twelve thousand dollars — the first foreigner hired by the Meiji government.[^9]
+In 1872, Le Gendre resigned his post as U.S. Consul and became a second-class foreign adviser to Japan's Ministry of Foreign Affairs, at an annual salary of twelve thousand dollars — the first foreigner hired by the Meiji government.[^9]
 
-The context: in 1871, Ryukyuan fishermen were killed in southern Taiwan (the Baxiawan Incident). The Meiji government was looking for an opportunity to expand abroad, and Taiwan was the first target. They needed someone who knew Taiwan.
+The background: in 1871, Ryukyuan fishermen were killed in southern Taiwan (the Bayao Bay incident (八瑤灣事件)). The Meiji government was looking for an opportunity to expand abroad, and Taiwan was its first target. It needed someone who knew Taiwan.
 
-Le Gendre was the perfect candidate. He had eight expeditions' worth of firsthand experience, personal relationships with indigenous chiefs, and a trove of intelligence the American government had nowhere to lock away. He told the Japanese that the "aboriginal territory" of southern Taiwan was, under international law, _terra nullius_ — unclaimed land — and that the Qing themselves had admitted they had no jurisdiction there, giving Japan the right to "punish" the indigenous inhabitants.[^10]
+Le Gendre was the perfect choice. He had the experience of eight field expeditions, personal relationships with indigenous chiefs, and a body of detailed intelligence that the American government could not keep locked in a safe. He told the Japanese: the "savage land" (番地) of southern Taiwan was "unowned land" (terra nullius) under international law; the Qing court itself said it was not under their jurisdiction, so Japan had the right to "punish" the indigenous people there.[^10]
 
-> **✦** "The man who signed the Treaty of South Cape and the man who sold the intelligence to Japan were the same man. The same knowledge of Taiwan was used first to sign a peace agreement and later to plan an invasion."
+> **✦** "The man who concluded the South Cape Agreement and the man who sold the intelligence to Japan were the same man. The same knowledge of Taiwan was used first to sign a peace agreement, and later to plan an invasion."
 
-In 1874, Japan launched a military expedition to Taiwan. Some 3,600 soldiers attacked Paiwan communities on the Hengchun Peninsula. This was the Mudan Incident — Japan's first overseas military operation in the modern era. Le Gendre worked behind the scenes to craft the diplomatic strategy, help recruit foreign soldiers, charter ships, and procure military supplies.[^11]
+In 1874, Japan dispatched troops to Taiwan. 3,600 soldiers attacked the Paiwan communities of the Hengchun Peninsula. This was the Mudan Incident, Japan's first overseas military operation in the modern era. Behind the scenes, Le Gendre planned the diplomatic strategy, helped hire foreign soldiers, charter ships, and procure military supplies.[^11]
 
 ## 1,600 Pages, 137 Years
 
-Around 1875, Le Gendre completed a monumental manuscript: _Notes of Travel in Formosa_ — 1,600 pages of text accompanied by nearly 200 maps, photographs, sketches, and paintings.[^12]
+Around 1875, Le Gendre completed a monumental manuscript: _Notes of Travel in Formosa_ (Taiwan Travelogue). 1,600 pages of text, plus nearly 200 maps, photographs, sketches, and paintings.[^12]
 
-The manuscript covers five areas: natural history centered on geology, the history of Dutch colonialism, the foreign relations of the Qing dynasty with Western powers, the ethnology and linguistics of Austronesian peoples, and economic and commercial potential.[^13] Its probable purpose was to serve as a comprehensive intelligence compendium for Meiji government decision-makers preparing to annex Taiwan in 1873–1874.[^14] After completion, the manuscript was submitted to his superior Ōkubo Toshimichi.
+The manuscript covers five areas: natural history centered on geology, the history of the Dutch colonial era, the foreign relations of the Qing dynasty with Western powers, the ethnology and linguistics of the Austronesian peoples, and economic and trade potential.[^13] Its motive for being written was very likely to provide the Japanese Meiji government with a "compilation of intelligence for annexing Taiwan."[^14] After it was completed, the manuscript was submitted to his superior, Okubo Toshimichi.
 
-The manuscript was never published during his lifetime. The original is held at the Library of Congress; a copy resides in the Japan National Archives. The Le Gendre Papers at the Library of Congress comprise 1,760 items — the first five boxes have been digitized as 4,774 images, but four volumes of the core manuscript journals remain under restoration and have not yet been scanned.[^15]
+The manuscript was never published during his lifetime. The original is held in the U.S. Library of Congress; a copy is in the National Archives of Japan. The Le Gendre Papers at the Library of Congress comprise 1,760 items; the first five boxes have been digitized into 4,774 images, but the four volumes of core manuscript journals are still under restoration and have not yet been scanned.[^15]
 
-More than 130 years later, Douglas L. Fix, a history professor at Reed College in Oregon, discovered the manuscript at the Library of Congress during 1991–1992. In 1999, he began formal collaboration with John Shufelt, assistant professor of foreign languages at Tunghai University, supported by the Chi Mei Foundation, traveling to the United States, Japan, and Britain to cross-reference the American and Japanese versions of the manuscript.[^16]
+More than 130 years later, Douglas L. Fix (費德廉), a history professor at Reed College in the United States, discovered this manuscript at the Library of Congress in 1991–92. In 1999, he began formal collaboration with John Shufelt (蘇約翰), associate professor in the Department of Foreign Languages and Literature at Tunghai University; funded by the Chi Mei Foundation, they traveled to the United States, Japan, and Britain to cross-check the American and Japanese versions of the manuscript.[^16]
 
-Shufelt later told _The Reporter_: "I cannot simply say he was an imperialist or a humanitarian. He is far more complex than that."[^17]
+Shufelt later said in an interview with _The Reporter_: "I cannot simply call him an imperialist or a humanitarian. He is far more complex than that."[^17]
 
-Annotation was completed in 2005. The English edition appeared in 2012, the Chinese edition in 2013, both published by the National Museum of Taiwan History. From manuscript completion to formal publication: 137 years.
+The annotation was finished in 2005. The English edition was published in 2012 and the Chinese edition in 2013, both by the National Museum of Taiwan History. From the completion of the manuscript to its formal publication: 137 years.
 
-> **📝 Curator's note**
-> Le Gendre's manuscript is the most complete firsthand record of 19th-century Taiwan in existence. But it is simultaneously an imperial intelligence document. The tension between its scholarly value and its political motivation is precisely why Fix and Shufelt spent thirteen years on it: you cannot simply read what it says — you must read at the same time for whom it was written.
+> **📝 Curator's Note**
+> Le Gendre's manuscript is the most complete firsthand record of 19th-century Taiwan. But it is also an imperial intelligence document. The tension between its scholarly value and its political motive is precisely why Fix and Shufelt spent thirteen years on it: you cannot only read what it says; you must also read who it was written for.
 
 ## SEQALU
 
-On August 14, 2021, _SEQALU: Formosa 1867_, produced by Taiwan's Public Television Service at a cost exceeding NT$155 million, had its premiere.[^18] Adapted from the 2016 Taiwan Literature Golden Classics Award-winning novel _Puppet Flowers_ by physician and novelist Chen Yao-chang, the drama is set against the backdrop of the 1867 Rover Incident and the Treaty of South Cape.
+On August 14, 2021, PTS (Taiwan's Public Television Service) premiered the epic drama _SEQALU: Formosa 1867_, produced with an investment of more than NT$155 million.[^18] Adapted from the novel _Puppet Flower_ (《傀儡花》) (2016 Taiwan Literature Golden Classics Award) by physician-novelist Chen Yao-chang (陳耀昌), its story is set against the 1867 Rover Incident and the South Cape Agreement.
 
-The original title followed the novel as _Puppet Flowers_, but was later renamed because the word "puppet" carries discriminatory connotations toward indigenous peoples. The 12-episode series employed more than 6,000 extras.[^19] It won Golden Bell Awards in 2022. The Paiwan actor Chamatuk Palauwl, who played Tauketok, was diagnosed with lung adenocarcinoma after filming and passed away on December 19, 2021.[^20]
+The drama's title originally followed the novel as "Puppet Flower," but it was later renamed because the word "puppet" carries discriminatory connotations toward indigenous people. The series runs 12 episodes and used more than 6,000 extras.[^19] It won the Golden Bell Awards in 2022. The Paiwan actor Camake Valaule (查馬克·法拉屋樂), who played Tauketok (卓杞篤), was diagnosed with lung adenocarcinoma after filming and passed away on December 19, 2021.[^20]
 
-Director Tsao Jui-yuan said: "_SEQALU_ is not a conclusion — it is a starting point. Taiwanese people should begin from here to rediscover the stories that happened on this land."[^21]
+Director Tsao Jui-yuan (曹瑞原) said: "_SEQALU_ is not a conclusion; it is a starting point. Taiwanese people should begin here, rediscovering the stories that happened on this land of theirs."[^21]
 
-Le Gendre is one of the central characters in the drama. But more important is this: Tauketok finally moves from supporting role to protagonist. In Le Gendre's manuscript, Tauketok is "a chief who needs to be persuaded." In _SEQALU_, he is a leader protecting his people in the gap between empires. The same event — it depends who is writing.
+In the drama, Le Gendre is one of the core characters. But more important is this: Tauketok (卓杞篤) finally moves from supporting role to protagonist. In Le Gendre's manuscript, Tauketok is "a chief who needs to be persuaded." In _SEQALU_, he is a leader who protects his people in the gap between empires. The same event — it depends on who is writing.
 
 ## What Became of Him
 
-Le Gendre left Japan in 1875. In 1890 he went to Korea, serving as diplomatic adviser to Emperor Gojong. On September 1, 1899, he died of a stroke in Seoul, at age 69.[^22]
+Le Gendre left Japan in 1875. In 1890 he went to Korea, serving as diplomatic adviser to Emperor Gojong. On September 1, 1899, he died of a stroke in Seoul, at the age of 69.[^22]
 
-His life spanned the diplomatic stages of three empires: America, Japan, Korea. But his most important six years were on Formosa. He was a contemporary of Robert Swinhoe (史溫侯 — zh only), and both left indelible records in Taiwan during the 1860s, but with completely different motivations: one for science, one for power.
-
----
-
-Shufelt spent thirteen years editing that manuscript. He cannot give Le Gendre a clean verdict.
-
-The man who signed the Treaty of South Cape, and the man who sold intelligence on Taiwan to Japan, were the same man. He left the most complete firsthand record of 19th-century Taiwan in existence, but the knowledge was accumulated for the purpose of selling it to the highest-bidding empire. "Taiwan expert" — was that in Taiwan's service, or was it opening the door for colonizers? The answer remains elusive.
+His life spanned the diplomatic stages of three empires: the United States, Japan, and Korea. But his most important six years were on Formosa. He was a man of the same era as Robert Swinhoe (史溫侯); both left indelible records in Taiwan in the 1860s, but with completely different motives: one for science, one for power.
 
 ---
 
-**Further reading:**
+John Shufelt spent thirteen years sorting through that manuscript. He cannot give Le Gendre a clean verdict.
 
-- [The Rover Incident and Tauketok](/en/history/rover-incident-and-tauketok) — The companion piece to this article: the same history seen from Tauketok's perspective — how the Treaty of South Cape protected his people, and how the other half of the agreement betrayed them
-- [Indigenous Peoples' History and the Rectification of Names Movement](/en/history/indigenous-peoples-history-and-naming-movement/) — The long journey of the Paiwan in the Treaty of South Cape, from "aboriginal territory" to recognized name
-- [Qing Dynasty Rule in Taiwan](/en/history/qing-dynasty-rule/) — The Qing governing structure when Le Gendre came to Taiwan, providing institutional context for the "outside our jurisdiction" response
-- [Robert Swinhoe](/en/people/robert-swinhoe-naturalist) — Another foreigner who left a profound record in Taiwan at the same time, but motivated by science rather than power
-- [The Sino-French War](/en/history/sino-french-war-in-taiwan) — Eight years after Le Gendre left Taiwan, France attacked Taiwan using similar imperial logic
+The man who concluded the South Cape Agreement, and the man who sold Taiwan's intelligence to Japan, were the same man. He left the most complete firsthand record of 19th-century Taiwan, but the purpose of accumulating that knowledge was to sell it to the empire that bid the highest. "Taiwan expert" — these words: did they serve Taiwan, or clear the way for colonizers? To this day, there is no answer.
+
+---
+
+**Further Reading:**
+
+- [The Rover Incident and Tauketok](/en/history/rover-incident-and-tauketok) — The companion piece to this article: the same history seen from Tauketok's perspective — how the South Cape Agreement protected his people, and how it was betrayed by the other half of the agreement
+- [The History of Taiwan's Indigenous Peoples and the Rectification of Names Movement](/en/history/indigenous-peoples-history-and-naming-movement) — The Paiwan in the South Cape Agreement: the long journey from "savage land" (番地) to the rectification of names
+- [Qing Dynasty Rule](/en/history/qing-dynasty-rule) — The Qing governance structure when Le Gendre came to Taiwan; understand the institutional background of the "outside its jurisdiction" response
+- [Robert Swinhoe](/en/people/robert-swinhoe-naturalist) — Another foreigner of the same era who left a profound record in Taiwan, but driven by science rather than power
+- [The Sino-French War](/en/history/sino-french-war-in-taiwan) — Eight years after Le Gendre left Taiwan, France attacked Taiwan with similar imperial logic
 
 ## References
 
-[^1]: [Rover incident, Wikipedia](https://en.wikipedia.org/wiki/Rover_incident) — On March 12, 1867, the American merchant ship Rover ran aground; Captain Hunt, his wife, and 12 others were killed by the Kulaljuc Paiwan community. Only one Cantonese sailor escaped.
+[^1]: [Rover incident, Wikipedia](https://en.wikipedia.org/wiki/Rover_incident) — On March 12, 1867, the American merchant ship Rover ran aground; Captain Hunt, his wife, and 12 others were killed by the Kulaljuc community of the Paiwan. Only one Cantonese sailor escaped.
 
-[^2]: [ibid., Rover incident, Wikipedia](https://en.wikipedia.org/wiki/Rover_incident) — Le Gendre arrived in Fuzhou in April to demand the Governor-General of Fujian and Zhejiang intervene; the Qing refused on grounds that "the savage territories are outside our jurisdiction."
+[^2]: [Same as [^1], Rover incident, Wikipedia](https://en.wikipedia.org/wiki/Rover_incident) — Le Gendre arrived in Fuzhou in April to demand the Governor-General of Fujian and Zhejiang intervene; the Qing refused on the grounds that "the land of raw barbarians (生番) is not under our jurisdiction."
 
-[^3]: [ibid., Rover incident, Wikipedia](https://en.wikipedia.org/wiki/Rover_incident) — The USS Hartford landed 181 men, who were repulsed by the Paiwan; commander Alexander S. MacKenzie was killed. The American military attempt failed.
+[^3]: [Same as [^1], Rover incident, Wikipedia](https://en.wikipedia.org/wiki/Rover_incident) — The USS Hartford landed 181 men, who were repulsed by the Paiwan; commander Alexander S. MacKenzie was killed. The American military attempt failed.
 
 [^4]: [Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Born in 1830 in Oullins, France; father Jean-François Legendre-Héral was a painter and sculptor. Graduated from the University of Paris, emigrated to America, joined the Union Army in 1861.
 
-[^5]: [ibid., Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Lost his nose and left eye at the Battle of the Wilderness in 1864, promoted to colonel. Appointed U.S. Consul at Amoy on July 13, 1866.
+[^5]: [Same as [^4], Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Lost his nose and left eye at the Battle of the Wilderness in 1864, promoted to colonel. Appointed U.S. Consul at Amoy on July 13, 1866.
 
 [^6]: [Formosa Expedition, Wikipedia](https://en.wikipedia.org/wiki/Formosa_Expedition) — In September 1867, Le Gendre, Pickering, and Horn penetrated the indigenous territory of the Hengchun Peninsula. Pickering served as interpreter.
 
-[^7]: [The Reporter: A manuscript opens a tangled history](https://www.twreporter.org/a/taiwan-19-century-history-charles-le-gendre-manuscript) — Three specific terms of the Treaty of South Cape: raising a red flag to identify oneself; landing only at designated points; no entry into mountain aboriginal villages. Oral agreement in October 1867; written memorandum February 28, 1869.
+[^7]: [The Reporter: A manuscript opens a tangled history](https://www.twreporter.org/a/taiwan-19-century-history-charles-le-gendre-manuscript) — The three specific terms of the South Cape Agreement: raise a red flag to identify oneself, land only at designated points, and do not enter mountain tribal villages. Oral agreement in October 1867; written memorandum on February 28, 1869.
 
-[^8]: [National Museum of Taiwan History "Overseas Historical Materials on Taiwan": Le Gendre's Notes of Travel in Formosa](https://taiwanoverseas.nmth.gov.tw/archives/319a70f3-c868-43d7-a10d-169851e987e4) — From May 1867 to May 1872, Le Gendre visited Taiwan at least eight times. Includes manuscript overview and publication notes.
+[^8]: [National Museum of Taiwan History, "Overseas Historical Materials on Taiwan": Le Gendre's Travels in Taiwan](https://taiwanoverseas.nmth.gov.tw/archives/319a70f3-c868-43d7-a10d-169851e987e4) — From May 1867 to May 1872, Le Gendre visited Taiwan at least eight times. Includes a manuscript overview and publication notes.
 
-[^9]: [ibid., Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Resigned from the American consulate in 1872, joined the Japanese Foreign Ministry as a second-class foreign adviser. Annual salary $12,000; first foreigner hired by the Meiji government.
+[^9]: [Same as [^4], Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Resigned from his American consular post in 1872, became a second-class foreign adviser to the Japanese Foreign Ministry. Annual salary $12,000; the first foreigner hired by the Meiji government.
 
-[^10]: [Mudan Incident, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E7%89%A1%E4%B8%B9%E7%A4%BE%E4%BA%8B%E4%BB%B6) — Le Gendre argued to the Japanese government that the "aboriginal territory" of southern Taiwan was _terra nullius_ under international law, and that the Qing's own admission of no jurisdiction served as proof.
+[^10]: [Mudan Incident, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E7%89%A1%E4%B8%B9%E7%A4%BE%E4%BA%8B%E4%BB%B6) — Le Gendre argued to the Japanese government that the "savage land" (番地) of southern Taiwan was "unowned land" (terra nullius) under international law, and that the Qing's own admission that it had no jurisdiction served as evidence.
 
-[^11]: [ibid., Mudan Incident, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E7%89%A1%E4%B8%B9%E7%A4%BE%E4%BA%8B%E4%BB%B6) — Japan launched a military expedition to Taiwan in 1874: 3,600 soldiers attacked Paiwan communities on the Hengchun Peninsula. Le Gendre helped plan the diplomatic strategy, recruited foreign soldiers, chartered ships, and procured military supplies.
+[^11]: [Same as [^10], Mudan Incident, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E7%89%A1%E4%B8%B9%E7%A4%BE%E4%BA%8B%E4%BB%B6) — In 1874, Japan dispatched troops to Taiwan; 3,600 soldiers attacked the Paiwan communities of the Hengchun Peninsula. Le Gendre helped plan the diplomatic strategy, hired foreign soldiers, chartered ships, and procured military supplies.
 
-[^12]: [Library of Congress: Charles Le Gendre Papers](https://www.loc.gov/collections/charles-william-le-gendre-papers/about-this-collection/) — _Notes of Travel in Formosa_: 1,600 pages of text + nearly 200 maps, photographs, and sketches. Original held at the Library of Congress. Primary source.
+[^12]: [Library of Congress: Charles Le Gendre Papers](https://www.loc.gov/collections/charles-william-le-gendre-papers/about-this-collection/) — _Notes of Travel in Formosa_: 1,600 pages of text + nearly 200 maps, photographs, sketches, and paintings. Original held at the U.S. Library of Congress. Primary source.
 
-[^13]: [ibid., National Museum of Taiwan History publication notes](https://taiwanoverseas.nmth.gov.tw/archives/319a70f3-c868-43d7-a10d-169851e987e4) — The manuscript's five areas: natural history, Dutch colonial history, foreign relations, ethnology/linguistics, economic trade.
+[^13]: [Same as [^8], National Museum of Taiwan History, publication notes](https://taiwanoverseas.nmth.gov.tw/archives/319a70f3-c868-43d7-a10d-169851e987e4) — The five areas of the manuscript: natural history, Dutch colonial history, foreign relations, ethnology and linguistics, and economic trade.
 
-[^14]: [ibid., National Museum of Taiwan History publication notes](https://taiwanoverseas.nmth.gov.tw/archives/319a70f3-c868-43d7-a10d-169851e987e4) — "Likely compiled as a reference intelligence compendium for Meiji government decision-makers preparing to annex Taiwan during 1873–1874."
+[^14]: [Same as [^8], National Museum of Taiwan History, publication notes](https://taiwanoverseas.nmth.gov.tw/archives/319a70f3-c868-43d7-a10d-169851e987e4) — "Likely assembled as a reference for the compilation of necessary intelligence by the Meiji government's decision-makers preparing to annex Taiwan during 1873–1874."
 
-[^15]: [ibid., Library of Congress](https://www.loc.gov/collections/charles-william-le-gendre-papers/about-this-collection/) — Le Gendre Papers: 1,760 items total. First five boxes digitized as 4,774 images; four volumes of core manuscript journals still under restoration.
+[^15]: [Same as [^12], Library of Congress](https://www.loc.gov/collections/charles-william-le-gendre-papers/about-this-collection/) — The Le Gendre Papers comprise 1,760 items in total. The first five boxes have been digitized into 4,774 images; the four volumes of core manuscript journals are still under restoration.
 
-[^16]: [ibid., The Reporter](https://www.twreporter.org/a/taiwan-19-century-history-charles-le-gendre-manuscript) — Fix discovered the manuscript at the Library of Congress in 1991–92. Began formal collaboration with Shufelt in 1999, supported by the Chi Mei Foundation. Annotation completed 2005. English edition 2012, Chinese edition 2013, National Museum of Taiwan History.
+[^16]: [Same as [^7], The Reporter](https://www.twreporter.org/a/taiwan-19-century-history-charles-le-gendre-manuscript) — Douglas L. Fix (費德廉) discovered the manuscript at the Library of Congress in 1991–92. Formal collaboration with Shufelt began in 1999, funded by the Chi Mei Foundation. Annotation finished in 2005. English edition 2012, Chinese edition 2013, published by the National Museum of Taiwan History.
 
-[^17]: [ibid., The Reporter](https://www.twreporter.org/a/taiwan-19-century-history-charles-le-gendre-manuscript) — Interview quotation from Shufelt. Original source: The Reporter special feature.
+[^17]: [Same as [^7], The Reporter](https://www.twreporter.org/a/taiwan-19-century-history-charles-le-gendre-manuscript) — Interview quotation from John Shufelt. The quotation is originally from The Reporter's special feature.
 
-[^18]: [SEQALU (TV series), Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E6%96%AF%E5%8D%A1%E7%BE%85_%28%E9%9B%BB%E8%A6%96%E5%8A%87%29) — Premiered on Public Television Service on August 14, 2021. Adapted from Chen Yao-chang's novel _Puppet Flowers_ (2016 Taiwan Literature Golden Classics Award). Director Tsao Jui-yuan; production cost exceeding NT$155 million.
+[^18]: [SEQALU (TV series), Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E6%96%AF%E5%8D%A1%E7%BE%85_%28%E9%9B%BB%E8%A6%96%E5%8A%87%29) — Premiered on PTS (Taiwan's Public Television Service) on August 14, 2021. Adapted from Chen Yao-chang's novel _Puppet Flower_ (《傀儡花》) (2016 Taiwan Literature Golden Classics Award). Director Tsao Jui-yuan; production budget exceeded NT$155 million.
 
-[^19]: [ibid., SEQALU, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E6%96%AF%E5%8D%A1%E7%BE%85_%28%E9%9B%BB%E8%A6%96%E5%8A%87%29) — 12 episodes; 6,000+ extras. Original title "Puppet Flowers" changed due to discriminatory connotations. Won 2022 Golden Bell Awards.
+[^19]: [Same as [^18], SEQALU, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E6%96%AF%E5%8D%A1%E7%BE%85_%28%E9%9B%BB%E8%A6%96%E5%8A%87%29) — 12 episodes in total, using 6,000+ extras. The original title "Puppet Flower" was changed because of its discriminatory connotations. Won the Golden Bell Awards in 2022.
 
-[^20]: [Chamatuk Palauwl, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E6%9F%A5%E9%A6%AC%E5%85%8B%C2%B7%E6%B3%95%E6%8B%89%E5%B1%8B%E6%A8%82) — Paiwan actor who played Tauketok. Diagnosed with lung adenocarcinoma after filming; died December 19, 2021.
+[^20]: [Camake Valaule, Wikipedia (zh)](https://zh.wikipedia.org/wiki/%E6%9F%A5%E9%A6%AC%E5%85%8B%C2%B7%E6%B3%95%E6%8B%89%E5%B1%8B%E6%A8%82) — Paiwan actor who played Tauketok. Diagnosed with lung adenocarcinoma after filming; died on December 19, 2021.
 
-[^21]: [VERSE Magazine: Interview with Tsao Jui-yuan](https://www.verse.com.tw/) — Director Tsao Jui-yuan on the cultural significance of _SEQALU_.
+[^21]: [VERSE Magazine: Interview with Tsao Jui-yuan](https://www.verse.com.tw/) — Director Tsao Jui-yuan on the cultural significance of _SEQALU: Formosa 1867_.
 
-[^22]: [ibid., Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Served as diplomatic adviser to Korean Emperor Gojong from 1890. Died of a stroke in Seoul on September 1, 1899, at age 69.
+[^22]: [Same as [^4], Charles Le Gendre, Wikipedia](https://en.wikipedia.org/wiki/Charles_Le_Gendre) — Became diplomatic adviser to Emperor Gojong of Korea in 1890. Died of a stroke in Seoul on September 1, 1899, at the age of 69.


### PR DESCRIPTION
## translate(en): 李仙得（Charles W. Le Gendre）→ knowledge/en/People/charles-le-gendre.md

EN People 翻譯系列接續（#1616–#1624）。羅發號事件、南岬之盟、牡丹社事件背後的美國領事——「締約者與出賣者是同一個人」。

### 產出方式
**prime-agent-lite segment 5**（prime-agent → LiteLLM :4000 → cc-auto / ArliAI DeepSeek-V4-Flash），同套 supervisor 流程。

### 完整性檢查
- ✅ 章節 7:7、文章 ✦ 主題句 blockquote 全力保留（"the man who sold the intelligence to Japan were the same man"，未軟化）
- ✅ 腳註 22/22（重複來源腳註「同 ^1」→ "Same as [^1]" 樣式保留；URL byte-identical）
- ✅ zh→en narrative 字元比 **3.17**（區間 2.0–3.9）
- ✅ wikilink 3 處依規則轉純文字（清廷 / 排灣族 / 史溫侯）
- ✅ 延伸閱讀 5 條內部連結全部轉為既有 EN 頁面路徑（/en/history/... ×4 + /en/people/robert-swinhoe-naturalist）
- ✅ 2 個 📝 策展人筆記 two-line blockquote 結構 1:1
- ✅ frontmatter provenance 依 status.py canonical 算法；`test-frontmatter.mjs --ci` 通過；prettier 格式化

AI worker：cc-auto (ArliAI DeepSeek-V4-Flash-0731) via prime-agent-lite