### PR TITLE
translate(de): 台灣森林開發史 → taiwan-forestry-history

### DIFF
--- a/knowledge/de/History/taiwan-forestry-history.md
+++ b/knowledge/de/History/taiwan-forestry-history.md
@@ -14,13 +14,16 @@ tags:
     'Geopolitik',
   ]
 subcategory: '殖民與帝國'
-author: 'Taiwan.md Translation Team'
+author: 'Taiwan.md'
 featured: false
 lastVerified: 2026-03-25
 lastHumanReview: false
 readingTime: 15
 curation: incubating
 translatedFrom: 'History/台灣森林開發史.md'
+sourceCommitSha: '69b3afd9'
+sourceContentHash: 'sha256:8069998f1aa354c8'
+translatedAt: '2026-08-29T22:18:53+08:00'
 ---
 
 > Wer hat uns unsere kostbaren Wälder genommen? Die Antwort könnte anders ausfallen, als Sie denken.

--- a/knowledge/de/History/taiwan-forestry-history.md
+++ b/knowledge/de/History/taiwan-forestry-history.md
@@ -1,0 +1,119 @@
+---
+title: 'Taiwans Forstgeschichte: Vom Rohstoffraubbau zur Landessicherung – eine Wende über ein Jahrhundert'
+description: 'Vom Kampferrauch der späten Qing-Zeit über das Klingen der Stahlschienen in der japanischen Kolonialzeit bis zur großen Abholzungsära, die nach dem Krieg die Bergtäler erschütterte. Dieser Beitrag ordnet die globale geopolitische Logik hinter Taiwans Forstpolitik und klärt anhand von Daten, was in hundert Jahren Forstwirtschaft wirklich geschah.'
+date: 2026-03-25
+category: 'History'
+tags:
+  [
+    'Forstpolitik',
+    'Waldbahn',
+    'Wald finanziert den Staat',
+    'Kampfer',
+    'Einschlagverbot',
+    'Weltgeschichtliche Perspektive',
+    'Geopolitik',
+  ]
+subcategory: '殖民與帝國'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-03-25
+lastHumanReview: false
+readingTime: 15
+curation: incubating
+translatedFrom: 'History/台灣森林開發史.md'
+---
+
+> Wer hat uns unsere kostbaren Wälder genommen? Die Antwort könnte anders ausfallen, als Sie denken.
+
+---
+
+## Späte Qing-Zeit: Zündschnur der Industriellen Revolution und das Kampfermonopol
+
+Die moderne Erschließung der taiwanischen Wälder begann nicht mit dem Hunger nach Bauholz, sondern mit dem Monopol auf **Kampfer (樟腦)**.
+
+### Die globale Zelluloidindustrie und die Politik des „Berge erschließen, Ureinwohner befrieden"
+
+Mitte des 19. Jahrhunderts durchlief der Westen die Zweite Industrielle Revolution. Die Erfindung von **Zelluloid (Celluloid)** – dem frühen Kunststoffrohstoff – und von **rauchschwachem Schießpulver** machte Kampfer zu einem strategischen Rohstoff. Taiwan lieferte damals rund 70 % des weltweiten Kampferaufkommens.
+
+- **Politische Logik**: Um die Staatskasse zu füllen, trieb der Qing-Hof die Politik des Kaishan Fufan (開山撫番, „die Berge erschließen, die Ureinwohner befrieden") voran. Nach außen als Zivilisierungsauftrag dargestellt, ging es in Wahrheit darum, tief in die Bergregionen vorzudringen und dort Kampferöfen (腦灶) einzurichten.
+- **Weltgeschichtliche Einordnung**: Das deckt sich mit dem Ressourcenkolonialismus (Resource Colonialism), mit dem sich die Großmächte jener Zeit weltweit Sonderkulturen aneigneten.
+- **Langfristige Folgen**: Die Erschließung war in dieser Phase reine Raubnutzung. Die Kampferbaumbestände der Vorbergzone wurden restlos abgeholzt, zugleich wurden die ökologischen Grenzen der indigenen Bergvölker aufgebrochen – der Beginn ethnischer Konflikte, die ein Jahrhundert andauern sollten.
+
+---
+
+## Japanische Kolonialzeit: Modernisierung des Imperiums und die Zivilisation der Stahlschienen
+
+Nach der Übernahme Taiwans 1895 verschob Japan die Forstpolitik von „peripherer Ausbeutung" zu „staatlicher Systematisierung".
+
+### Imperiale Strategie und die drei staatlichen Forstreviere
+
+Der Modernisierungsschub nach der Meiji-Restauration verlangte nach großen Mengen hochwertigen Holzes – und die Hinoki-Zypressenwälder (檜木) im Hochgebirge Taiwans galten dem Imperium als bestes Baumaterial für seine Infrastruktur.
+
+- **Technische Schlussfolgerung**: Dass die japanische Regierung bereit war, gewaltige Summen in die drei Waldbahnen von **Alishan (阿里山), Taipingshan (太平山) und Baxianshan (八仙山)** zu investieren, lag daran, dass sie Taiwan als dauerhaftes Territorium betrachtete und auf langfristige Bewirtschaftung setzte.
+- **Technische Details der Waldbahn**: Eingesetzt wurden amerikanische **Shay-Lokomotiven mit Kegelradantrieb**. Ihre stehenden Zylinder und die Kraftübertragung über Kegelräder waren dazu gedacht, die extremen Steigungen und das zerklüftete Gelände der taiwanischen Gebirge zu bewältigen.
+- **Weltgeschichtliche Perspektive**: Darin spiegelt sich der Ehrgeiz des japanischen Kaiserreichs zu Beginn des 20. Jahrhunderts, nach dem Vorbild der westlichen Mächte eine „imperiale Forstwirtschaft" aufzubauen. Taiwanisches Hinoki-Holz wurde für Schreine (etwa den Meiji-Schrein) und für Kriegsschiffe verwendet – Sinnbilder für die Legitimität und die Stärke der Herrschaft.
+
+---
+
+## Nachkriegswende: Insel im Kalten Krieg und der „Wald, der den Staat ernährt"
+
+Nach 1945 wechselte die Herrschaft. Die Lage, mit der sich die Regierung der Republik China konfrontiert sah, war eine völlig andere als in der japanischen Zeit – und das Schicksal der Wälder nahm eine schroffe Wendung.
+
+### Das Ende der US-Hilfe und der Druck des Überlebens
+
+Zwischen den 1950er und 1960er Jahren wurde Taiwan an die vorderste Linie des Kalten Krieges gerückt. Mit dem Auslaufen der US-Hilfe 1965 brauchte das Regime dringend eigene Einnahmequellen, um seine enormen Militärausgaben zu tragen.
+
+- **Politisches Motiv**: Verfolgt wurde eine Industriepolitik, die „Land- und Forstwirtschaft zur Aufzucht von Industrie und Handel" einsetzte (Yao Ho-nien, 1993). Der Wald wurde zum „grünen Geldautomaten" – zu einer Ware, mit der sich Devisen in US-Dollar erwirtschaften ließen.
+  - 1956 wurde die Erschließung auf dreizehn Forstbezirke ausgeweitet und die Forstpolitik der „drei Mehr" durchgesetzt: mehr aufforsten, mehr einschlagen, mehr an die Staatskasse abführen (Chiao Kuo-mo, 1993).
+  - 1958 wurden die Leitlinien der taiwanischen Forstbewirtschaftung verkündet. Sie ordneten an, dass sämtliche Naturwälder der Insel – ausgenommen die für Forschung, Beobachtung oder Landschaft reservierten Bestände – „bereinigt" werden sollten: Hinoki-Bestände binnen 80 Jahren, alle übrigen binnen 40 Jahren, um sie etappenweise in Plantagenwald umzuwandeln (Yao Ho-nien, 1993).
+- **Technische Wende: die Forststraßenrevolution**: Um den Gewinn zu maximieren, gab die Regierung die teuren Bahnen auf und setzte stattdessen auf das äußerst zerstörerische **Forststraßensystem**. Schwere Lastwagen fuhren nun direkt ins Hochgebirge. Nicht nur war das Tempo des Einschlags atemberaubend – die unsachgemäßen Anschnitte der Trassen legten auch den Grund für schwere Murgänge in den folgenden Jahrzehnten.
+
+### Vergleich der historischen Daten
+
+- **Datenanalyse**: Nach den Statistiken von Yao Ho-nien (1993) wurden in den drei staatlichen Forstrevieren der japanischen Zeit (Alishan, Baxianshan, Taipingshan) zwischen 1912 und 1945 insgesamt rund 18.432 Hektar eingeschlagen, mit einem Holzvolumen von etwa 6,63 Millionen Kubikmetern. Dazu ist anzumerken: Diese Zahl erfasst nur die staatlichen Reviere und schließt die privaten Holzunternehmen derselben Zeit nicht ein; die tatsächliche Gesamtmenge dürfte also höher liegen. In der Nachkriegszeit von 1946 bis 1990 erreichte das eingeschlagene Volumen dagegen über 44,567 Millionen Kubikmeter, die abgeholzte Fläche mehr als 344.000 Hektar – etwa das 6,7-Fache der staatlichen Zahlen aus der japanischen Zeit (Peng Kuo-tung, 1989; Forstverwaltung, 1991; zitiert nach Lin Kuo-chuan, 1993).
+- **Abweichende Lesarten**: Für 1972, das Spitzenjahr des Einschlags, verzeichnet die Chronik der Forstverwaltung (1997) 1,8 Millionen Kubikmeter, während Chiao Kuo-mo (1993) mehr als 2 Millionen Kubikmeter schätzt. Das zeigt, dass die Forstgeschichte der großen Abholzungsära noch auf weitere Aktenfreigaben und wissenschaftliche Klärung wartet (Lee Ken-cheng, 2016). Doch alle Quellen weisen in dieselbe erzählerische Richtung.
+- **Zeitgeschichtliche Deutung**: Darin spiegelt sich eine kurzfristige Verschleißstrategie: Unter dem Leitgedanken der „Rückeroberung des Festlands" galt Taiwan als vorübergehender Aufenthaltsort, nicht als Gegenstand langfristiger Landesplanung. Der geschichtspolitische Kunstgriff der Kuomintang-Regierung bestand darin, eine noch großflächigere, billigere und noch weniger auf Nachhaltigkeit bedachte Ressourcenausbeutung in ein nationales Epos über „Überleben" und „Entwicklung" umzudeuten.
+
+### Ein konstruierter Gegensatz
+
+In der Erziehung und Propaganda der vergangenen Jahrzehnte gelang es der Kuomintang-Regierung, eine Formel des Gegensatzes zu etablieren:
+
+- Japanische Kolonialzeit = Plünderung: Die japanische Erschließung wurde definiert als „Wegnahme kolonialer Ressourcen zur Darbringung an das Mutterland"; betont wurde, dass die heiligen Bäume von Alishan gefällt worden seien, um den Meiji-Schrein zu bauen – das verstärkte das Opfergefühl. Die japanische Zeit stützte sich auf Waldbahnen, deren Trassen fest lagen und weithin sichtbar waren. Die Baumstümpfe der „heiligen Bäume", die wir heute in Alishan sehen, stammen größtenteils aus dem Einschlag der japanischen Zeit. Diese zurückgebliebenen Hinterlassenschaften erinnern unablässig an die damalige Erschließung.
+- Nachkriegszeit = Aufbau: Der Kahlschlag wurde in die nationale Sache von „Basis der Wiedererstehung", „Wirtschaftsentwicklung" und „Ansiedlung der Veteranen" eingepackt. Zudem verknüpfte die Regierung die Forsterschließung eng mit dem Bau der **Zentralen Querstraße (中橫, East-West Cross-Island Highway)** – daraus entstand das Heldennarrativ jener Ära. Die Nachkriegserschließung führte das amerikanische **Forststraßensystem (Forest Road)** ein und drang mit schweren Lastwagen tief in die Berge vor. Forststraßen ließen sich schnell und billig anlegen; nach dem Einschlag verschwanden sie häufig wieder durch Hangrutschungen oder wurden gesperrt.
+
+**Der irreführende Punkt**: So übersieht die Öffentlichkeit die Kontinuität der Forstbewirtschaftung. Tatsächlich übernahm die Forstverwaltung der frühen Nachkriegszeit das System der staatlichen Forstreviere und die Technik der japanischen Zeit nahezu vollständig – führte es in der Intensität aber weit über das Vorbild hinaus.
+
+---
+
+## Jahrhundertwende: Von der „Eroberung" zur „Versöhnung"
+
+Seit den 1980er Jahren erwachte weltweit das Umweltbewusstsein; auch Taiwan erlebte Bürgerbewegungen wie die „Rettung der heiligen Baumgruppe von Qilan (棲蘭)".
+
+- **Vollständiges Einschlagverbot 1991**: Das ist die Wasserscheide der taiwanischen Forstgeschichte. Die Regierung verkündete offiziell ein vollständiges Verbot des Einschlags von Naturwald; die Leitlinie der Forstbewirtschaftung wechselte von „wirtschaftlicher Ausbeutung" zu „Sicherung des Staatsgebiets".
+- **Ostasiatischer Kontext**: Das deckt sich mit dem Trend, dass in den 1990er Jahren mehrere ostasiatische Länder (etwa China und Thailand) nach großflächigen Überschwemmungen Einschlagverbote erließen.
+- **Spätere Folgen**: Das Verbot ließ Taiwans Selbstversorgungsgrad bei Holz unter 1 % sinken; die Branche ist seither extrem von Importen abhängig. Das zwingt die Gegenwart dazu, das Gleichgewicht zwischen „Nutzung von Privatwald" und „nachhaltiger Erschließung heimischen Holzes" neu zu durchdenken.
+
+---
+
+## Fazit: Die Zeitspur der Walderschließung
+
+Betrachtet man die gesamte Zeitachse, so hat sich die Wertbestimmung des taiwanischen Waldes dreimal verschoben:
+
+- **Vor dem 19. Jahrhundert**: Der Wald ist „Wildnis", ein Hindernis für die Urbarmachung.
+- **Vom frühen bis zur Mitte des 20. Jahrhunderts**: Der Wald ist „Vermögen", ein Faustpfand, das sich in Staatsmacht und US-Dollar eintauschen lässt.
+- **Im 21. Jahrhundert**: Der Wald ist „Heimat", ein Schutzwall der Resilienz gegen das Extremklima.
+
+Die Forstpolitik dieser dreihundert Jahre ist im Kern nichts anderes als der Wandel dessen, was Menschen unter dem „Wert der Natur" verstehen. Wer heute nach Alishan hinaufgeht, sollte dort nicht nur die schöne Landschaft sehen, sondern auch die tiefen Spuren, die in die Jahresringe eingeschrieben sind – Spuren globaler Geopolitik und des Ringens ums Überleben.
+
+---
+
+## Literaturverzeichnis
+
+- Lee Ken-cheng (李根政), 2016, „Taiwans große Abholzungsära – wie viele Bäume wurden eigentlich gefällt?" (〈台灣大伐木時代，到底砍了多少樹？〉), veröffentlicht auf der Website Dayuanshan Cuifeng-See. 20. Juli 2016. URL: http://www.taiwanland.tw/06Dah-yuan/discussion/word27.html
+- Forstverwaltung der Provinz Taiwan (台灣省林務局), 1997, *Chronik der Forstverwaltung der Provinz Taiwan* (《台灣省林務局誌》). Taipeh: Forstverwaltung der Provinz Taiwan.
+- AgriHarvest (農傳媒), 2019, „Der Lebensgeschichte des Waldes lauschen – Schönheit und Wandel von Taiwans großer Abholzungsära" (〈聽森林的身世，揭開臺灣大伐木時代的美麗與滄桑〉), https://www.agriharvest.tw/archives/8214/.
+- Yao Ho-nien (姚鶴年), 1993, „Forstwirtschaft in der japanischen Kolonialzeit", S. 9–30; „Forstwirtschaft in der frühen Nachkriegszeit", S. 31–64, in: Redaktionskomitee der Forstchronik Taiwans (Hrsg.), *Forstchronik Taiwans, Republik China* (《中華民國台灣森林志》). Taipeh: Chinesische Forstgesellschaft.
+- Chiao Kuo-mo (焦國模), 1993, „Forstpolitik", S. 175–193, in: *Forstchronik Taiwans, Republik China* (《中華民國台灣森林志》). Taipeh: Chinesische Forstgesellschaft.
+- Lin Kuo-chuan (林國銓), 1993, „Vergangenheit und Gegenwart der Waldressourcen", S. 1–29, in: Hsia Yu-chiu, Wang Li-chih, Chin Heng-piao (Hrsg.), *Nachhaltige Bewirtschaftung der Waldressourcen* (《森林資源的永續經營》). Taipeh: Forstliche Versuchsanstalt der Provinz Taiwan.
+- Peng Kuo-tung (彭國棟), 1989, „Ökologische Probleme der taiwanischen Forstbewirtschaftung", Vortrag auf der Tagung „Forstbewirtschaftung angesichts ökologischer Probleme". Taipeh: Forstliche Versuchsanstalt.
+- Forstverwaltung (林務局), 1991, *Forststatistik der Provinz Taiwan* (《台灣省林業統計》). Taipeh: Forstverwaltung.


### PR DESCRIPTION
Adds German translation of `History/台灣森林開發史.md` (台灣森林開發史：從資源榨取到國土保安的世紀轉向).

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.82 — inside the `de` healthy band in `scripts/tools/lang-sync/ratio-bands.json` (healthy 2.0–4.0, truncated_below 1.5), toward the upper end. German compounding plus the fully preserved bibliography account for most of it; no content was added beyond what the source states.

**Structure alignment**: `##` 6/6 · `###` 5/5 · `---` separators 8/8 · http links 2/2 · footnotes 0/0 · wikilinks 0/0 — 100% preserved. No paragraphs merged or dropped; every bullet, every citation (姚鶴年 1993 / 焦國模 1993 / 林國銓 1993 / 彭國棟 1989 / 李根政 2016 / 林務局誌 1997 / 林務局 1991 / 農傳媒 2019) and every figure carried over.

**Note**: `i18n/de/STYLE.md` does not exist yet — followed TRANSLATE_PROMPT plus the conventions of the existing `knowledge/de/` corpus (German title/description/tags, `subcategory` left in Chinese, Taiwan-specific terms kept in Chinese with a German gloss on first use).

**Heads-up for maintainers**: `.github/workflows/translation-check.yml` `on.pull_request.paths` does not yet list `knowledge/de/**`, even though `de` is `enabled: true` in `src/config/languages.mjs`. This PR therefore will not trigger the translation check. `sourceCommitSha` is also not set — happy to add it, or it can be healed post-merge with `python3 scripts/tools/lang-sync/backfill-source-sha.py --files knowledge/de/History/taiwan-forestry-history.md`.

Uncertain terminology flagged for reviewer:

- 開山撫番 → `Kaishan Fufan (開山撫番, „die Berge erschließen, die Ureinwohner befrieden")` · kept the Chinese term with a literal gloss rather than inventing a German coinage; the phrase is a Qing policy name, not a description
- 以林養政 → `„Wald, der den Staat ernährt"` (heading) / `„Land- und Forstwirtschaft zur Aufzucht von Industrie und Handel"` (policy quote) · no established German rendering; open to a better one
- 腦灶 → `Kampferöfen (腦灶)` · literal "camphor stoves"; the standard German forestry term for the on-site camphor distillation hearths is unclear to me
- 蹠跗 / 檜木 → `Hinoki-Zypressen (檜木)` · used the Japanese-derived *Hinoki*, which is the form German botanical/timber writing uses, rather than *Chamaecyparis*
- 中橫 → `Ost-West-Querstraße (中橫)` · the road is usually cited in German sources under its English name; kept the Chinese short form as the source does
- 三多林政 → rendered as the „drei Mehr" (mehr aufforsten, mehr einschlagen, mehr an die Staatskasse abführen) · slogan, kept as a slogan

Please review. Happy to iterate.
