### PR TITLE
translate(id): 台灣YouBike文化與城市微交通革命 → taiwan-youbike-and-micromobility-revolution

### DIFF
--- a/knowledge/id/Lifestyle/taiwan-youbike-and-micromobility-revolution.md
+++ b/knowledge/id/Lifestyle/taiwan-youbike-and-micromobility-revolution.md
@@ -1,0 +1,130 @@
+---
+title: 'Budaya YouBike Taiwan dan Revolusi Mikromobilitas Kota'
+description: 'Dari "mil terakhir" menjadi infrastruktur harian: bagaimana YouBike mengubah kebiasaan bergerak dan rasa waktu warga kota Taiwan lewat tarif receh, jaringan stasiun yang rapat, dan penjadwalan real-time.'
+date: 2026-04-14
+category: 'Lifestyle'
+tags: ['YouBike', 'Transportasi kota', 'Transportasi hijau', 'Mikromobilitas']
+subcategory: '交通與移動'
+author: 'Wilson Chen'
+featured: false
+lastVerified: 2026-04-14
+lastHumanReview: true
+readingTime: 8
+translatedFrom: 'Lifestyle/台灣YouBike文化與城市微交通革命.md'
+sourceCommitSha: '4b6d28c5'
+sourceContentHash: 'sha256:71377fcdfb99db3b'
+translatedAt: '2026-08-29T22:21:24+08:00'
+---
+
+> **Ringkasan 30 detik:**
+> Pada 2023 jumlah peminjaman YouBike di Taipei mencapai 46 juta kali setahun. Ini bukan lagi layanan rekreasi yang "sesekali dipakai", melainkan pilihan default banyak orang untuk berangkat kerja setiap hari.
+> Menariknya, di level sistem angka "tingkat ketersediaan sepeda" tercatat sekitar 90%, tetapi penggunanya tetap sering frustrasi karena "tidak kebagian sepeda".
+> Yang ingin dijawab artikel ini bukan "YouBike bagus atau tidak", melainkan: ketika sebuah kota menjadikan sepeda sebagai infrastruktur, sebenarnya apa yang sedang kita distribusikan ulang?
+
+Pada 22 Maret 2024, peminjaman YouBike Taipei dalam satu hari melonjak sampai 207.000 kali dan mencatat rekor baru.[^1]
+Di kota yang sama, indikator resmi menunjukkan tingkat ketersediaan sepeda se-kota bertahan di kisaran 90%.[^1]
+Tapi sebagian besar komuter paham betul rasanya: pukul 8.32 kamu berdiri di depan pintu keluar MRT, dan yang terpampang persis di depan mata adalah "0 sepeda tersedia".
+
+Ini bukan sekadar persoalan "ada sepeda atau tidak".
+Ini adalah soal kota: soal irisan waktu, kepadatan ruang, dan perilaku manusia.
+
+> **📝 Catatan Kurator**
+> Begitu sebuah sistem masuk ke rutinitas harian, standar penilaiannya naik kelas dari "bisa dipakai" menjadi "harus bisa dipakai tepat pada menit saya membutuhkannya".
+
+## Dari alat penyambung menjadi pilihan default harian
+
+Posisi awal YouBike dalam transportasi kota Taiwan sangat jelas: menambal mil pertama dan mil terakhir dari angkutan massal.[^2]
+Terdengar seperti peran figuran, tapi di kota berkepadatan tinggi, justru figuran yang sering menentukan apakah seluruh pertunjukan bisa berjalan.
+
+Riset akademik merumuskannya dengan lebih presisi.
+Studi yang mengambil Taipei sebagai kasus menunjukkan YouBike memang memberi layanan mil pertama dan mil terakhir yang nyata bagi MRT; sekaligus muncul zona ketidakcocokan berupa "pasokan tinggi permintaan rendah" yang berdampingan dengan "permintaan tinggi pasokan rendah".[^3]
+Dengan kata lain, sistem ini bukan cuma soal "ada atau tidak ada", melainkan "pas atau tidak pasnya penempatan".
+
+Ketidakcocokan semacam ini bisa dibayangkan sebagai "nomor sepatu" versi kota.
+Rak sepatu penuh sepatu tidak berarti setiap orang bisa memakai ukurannya sendiri pada saat itu juga.
+
+## NT$5, kenapa bisa mengubah ritme gerak satu kota?
+
+Kalau hanya melihat nominalnya, NT$5 adalah uang kembalian segelas minuman kocok di Taipei.
+Tapi kalau melihat perilakunya, NT$5 bisa menjadi garis pemisah antara "hari ini jalan kaki atau bersepeda".
+
+Sebuah studi empiris atas YouBike Taipei menunjukkan, setelah sistem menerapkan biaya awal sewa NT$5, peminjaman harian pada hari kerja turun 14% dan pada akhir pekan turun 43%; tingkat perputaran per sepeda per hari juga merosot dari 10,4 kali menjadi 8,0 kali.[^4]
+Yang lebih kunci: jam sibuk, durasi berkendara, dan distribusi jarak tidak berubah drastis.[^4]
+Artinya banyak orang bukan tidak membutuhkan sepeda, melainkan sangat sensitif terhadap ambang harga.
+
+> **📝 Catatan Kurator**
+> Ada kebijakan yang tampaknya sedang menyetel "tarif", padahal yang sesungguhnya disetel adalah "seberapa mudah sebuah kebiasaan dinyalakan".
+
+Logika yang sama muncul lagi setelah Taipei memulihkan gratis 30 menit pertama pada 2024.
+Pengamatan pemerintah maupun media sama-sama melihat pemakaian naik, dan dalam waktu singkat berulang kali muncul rekor harian yang mendekati atau menembus 190.000 kali.[^1]
+Diskusi soal YouBike pun bergeser dari "perlu dipromosikan atau tidak" menjadi "sanggup menampung atau tidak".
+
+## Stasiun makin rapat, kenapa masih sering merasa tidak kebagian?
+
+Ini bagian yang paling berlawanan dengan intuisi, sekaligus yang paling terasa "kota".
+"Rata-rata tingkat ketersediaan 90%" dan "komuter kerap merasa tidak kebagian" bisa benar bersamaan.[^1]
+
+Sebabnya, skala waktu yang diukur keduanya berbeda.
+Tingkat ketersediaan biasanya dihitung atas rentang waktu yang panjang, sedangkan komuter hidup di jendela yang sangat pendek: 5 sampai 10 menit.
+Kalau pukul 8.30 kamu tidak kebagian, bagimu itu 100% tidak kebagian; sekalipun stasiun tersebut punya sepeda selama 90% waktu sepanjang hari, angka itu tetap tidak menghapus satu pengalaman gagal tadi.
+
+Tambahkan lagi bahwa data real-time YouBike diperbarui setiap 1 menit.[^5]
+Pada jam sibuk, satu menit cukup untuk mengubah sederet tiang dari "ada sepeda" menjadi "kosong", dan juga mengubah "bisa dikembalikan" menjadi "tiang penuh".
+Dari sisi data, sistem ini dapat diamati secara kontinu, tetapi pengalaman penggunanya diskret dan emosional.
+
+> **📝 Catatan Kurator**
+> Kepuasan terhadap sebuah moda transportasi sering kali tidak ditentukan oleh nilai rata-rata, melainkan oleh "10 menit paling terburu-buru".
+
+## Kamu pikir sedang bersepeda, padahal sedang ikut dalam sebuah sistem algoritma real-time
+
+Banyak orang mengira YouBike adalah tiga langkah: pinjam sepeda, kayuh, kembalikan.
+Padahal di baliknya ada rekayasa sistem yang bekerja serentak: penempatan stasiun, kapasitas tiang, rute penjadwalan, arus data real-time, dan model prediksi.[^1][^5]
+
+Analisis *The Reporter* atas data terbuka Kota Taipei juga menunjukkan bahwa setelah kebijakan berjalan, tingkat ketersediaan pada sebagian jam dan sebagian stasiun memang berfluktuasi; pada saat yang sama pemerintah kota dan pihak operator terus menambah armada serta menyetel penjadwalan untuk merespons tekanan jam sibuk.[^1]
+Ini mengingatkan kita: sepeda publik bukan pembangunan perangkat keras yang "sekali dipasang lalu beres", melainkan layanan dinamis yang menuntut pemeliharaan setiap hari.
+
+Dari hasil operasi resmi Maret 2026 terlihat, stasiun populer sudah mencatat lebih dari 50.000 peminjaman dalam sebulan (misalnya stasiun-stasiun di sekitar MRT Gongguan).[^2]
+Kepadatan seperti ini sudah mendekati peran "pembuluh kapiler kota", bukan sekadar pelengkap transportasi di sekitar tempat wisata.
+
+## Ketika sepeda menjadi infrastruktur, ada pertanyaan baru yang harus dijawab kota
+
+Pertanyaan pertama soal efisiensi:
+Yang kita kejar itu angka rata-rata se-kota yang enak dipandang, atau turunnya tingkat kegagalan pada jam sibuk?
+
+Pertanyaan kedua soal keadilan:
+Sumber daya dipusatkan di zona panas berpermintaan tinggi, atau disisakan proporsi tertentu untuk kawasan berpermintaan rendah yang alternatif transportasinya lemah?
+
+Pertanyaan ketiga soal keselamatan dan ruang:
+Ketika makin banyak orang bergantung pada mikromobilitas, bagaimana jaringan jalur sepeda, ruang pejalan kaki, dan simpul perpindahan moda dirancang bersama supaya tidak saling berebut jalan?
+
+Menurut survei Kementerian Perhubungan tahun 113, moda non-bermotor menyumbang 12,8% dari jumlah perjalanan di Taiwan, dengan sepeda (termasuk sepeda berbagi) sebesar 9,9%; sementara transportasi hijau (angkutan umum ditambah non-bermotor) mencapai 28,0%.[^6]
+Angka-angka ini tidak terlihat seperti revolusi, tetapi bisa jadi inilah titik awal ketika cara sebuah kota bergerak ditulis ulang perlahan-lahan.
+
+> **📝 Catatan Kurator**
+> Revolusi transportasi yang sesungguhnya jarang berbentuk "upacara peresmian proyek raksasa"; ia lebih mirip momen ketika suatu hari kamu tiba-tiba sadar: rute ini sudah setengah tahun tidak pernah kutempuh dengan sepeda motor.
+
+Hal yang paling layak dipikirkan dari YouBike bukanlah apakah ia menggantikan moda tertentu.
+Melainkan bahwa ia membuat warga kota, untuk pertama kalinya dalam skala besar, memperlakukan "pergerakan jarak pendek" sebagai bagian keseharian yang bisa dirancang ulang.
+Begitu hal itu terjadi, soal perencanaan kota tidak lagi sekadar "jalannya cukup lebar atau tidak", melainkan "kita ingin pergerakan sehari-hari kita berbentuk seperti apa".
+
+---
+
+**Bacaan Lanjutan**:
+
+- [Sistem Transportasi Taiwan](/id/lifestyle/transportation-system) — YouBike adalah mil terakhir dari sistem ini, dan artikel tersebut melengkapi konteks di hulunya
+- [Sejarah Perkembangan MRT Taiwan](/lifestyle/台灣捷運發展史) — kenapa YouBike harus tersambung dengan MRT? Bagaimana penyambungan itu berubah menjadi infrastruktur harian
+- [Krisis Iklim Taiwan dan Transisi Nol Bersih](/id/nature/taiwan-climate-change-net-zero-transition) — posisi mikromobilitas di dalam porsi 28% transportasi hijau
+
+## Referensi
+
+[^1]: [The Reporter: Seberapa populer YouBike Kota Taipei? Apakah makin sulit dipinjam setelah 30 menit pertama kembali digratiskan?](https://www.twreporter.org/a/data-reporter-taipei-youbike-free-ride-for-the-first-30-minutes) — laporan berbasis data tahun 2024, memuat puncak peminjaman harian, tingkat ketersediaan sepeda, dan analisis penjadwalan.
+
+[^2]: [YouBike Smile Bike (Taipei) — hasil operasi](https://www.youbike.com.tw/region/taipei/operation/) — data resmi bulanan mengenai stasiun populer dan jumlah peminjaman.
+
+[^3]: [How public shared bike can assist first and last mile accessibility (Journal of Transport Geography)](https://scholar.nycu.edu.tw/en/publications/how-public-shared-bike-can-assist-first-and-last-mile-accessibili) — studi kasus Taipei, menganalisis kecocokan pasokan dan permintaan antara YouBike dan MRT.
+
+[^4]: [Impacts Of Imposing A Start Fee On The Bikesharing Program: Empirical Evidence Of Taipei YouBike](http://jase.tku.edu.tw/articles/jase-202311-26-11-0006) — meneliti dampak biaya awal sewa NT$5 terhadap volume berkendara dan tingkat perputaran.
+
+[^5]: [Platform Data Terbuka Pemerintah: informasi real-time sepeda publik YouBike2.0 Kota Taipei](https://data.gov.tw/dataset/137993) — sumber data real-time stasiun yang diperbarui setiap 1 menit.
+
+[^6]: [Kementerian Perhubungan: analisis ringkas survei penggunaan moda transportasi harian masyarakat tahun 113](https://www.motc.gov.tw/ch/app/data/doc?detailNo=1389089679046873088&id=56&module=survey&serno=202506190000&type=s) — statistik jumlah perjalanan, pangsa moda, dan transportasi hijau tingkat nasional.


### PR DESCRIPTION
Adds Indonesian translation of `Lifestyle/台灣YouBike文化與城市微交通革命.md` (台灣 YouBike 文化與城市微交通革命).

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 2.87 — squarely inside the `id` band in `scripts/tools/lang-sync/ratio-bands.json` (healthy 2.0–4.3, truncated_below 1.5)

**Structure alignment**: `##` 6/6 · footnote refs 20/20 · footnote definitions 6/6 · http URLs 6/6 (exact multiset) · 📝 curator-note panels 4/4 — 100% preserved. The 30-second overview callout, all four `📝 策展人筆記` panels and every figure (46M rentals in 2023, 207k on 2024-03-22, ~90% availability, NT$5 → −14%/−43%, 10.4 → 8.0 turns, 190k, 1-minute refresh, 50k monthly at Gongguan, 12.8% / 9.9% / 28.0%) carried over individually; no paragraphs merged.

**Verification**: `python scripts/tools/lang-sync/verify-translation.py` → 17 PASS / 0 FAIL. `sourceCommitSha`, `sourceContentHash` and `translatedAt` are filled in, and `author` is kept as the original contributor per the `heal-passthrough-fields.py` passthrough list (note: `TRANSLATE_PROMPT.md` still says to overwrite `author` with "Taiwan.md Translation Team", which contradicts the tooling — flagging in case that line should be updated).

**Note**: `i18n/id/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT plus the conventions of the existing `knowledge/id/` corpus (Indonesian title/description/tags, `subcategory` left in Chinese, `## Bacaan Lanjutan` for 延伸閱讀).

**Cross-links**: localized where an `id` article exists, left on the zh path where it does not — matching what `localize-cross-links.py` produces elsewhere in `knowledge/id/`:

- 台灣交通系統 → `/id/lifestyle/transportation-system` (exists)
- 台灣捷運發展史 → `/lifestyle/台灣捷運發展史` (no `id` version yet)
- 台灣氣候危機與淨零轉型 → `/id/nature/taiwan-climate-change-net-zero-transition` (exists)

Uncertain terminology flagged for reviewer:

- 見車率 → `tingkat ketersediaan sepeda` · no standard Indonesian bike-share term; chose "availability rate" over a literal "sighting rate"
- 微交通 → `mikromobilitas` · the loanword is what Indonesian urban-planning writing uses; `transportasi mikro` was the alternative
- 綠運輸 → `transportasi hijau` · matches MOTC's own English "green transportation"
- 車柱 → `tiang` · dock/stand; "tiang" reads naturally but may not be the term Indonesian bike-share users actually say
- 5 元 → `NT$5` · made the currency explicit since "5 dolar" would read as USD; the heading was adjusted accordingly
- 113 年 → left as `tahun 113` (ROC calendar, = 2024) since it is the survey's official designation; happy to add "(2024)" if preferred
- 手搖飲 → `minuman kocok` · lit. "shaken drink"; `minuman boba` would be more recognizable but narrows the category

Please review. Happy to iterate.
