### PR TITLE
translate(id): 台灣滷肉飯 -> braised-pork-rice

### DIFF
--- a/knowledge/id/Food/braised-pork-rice.md
+++ b/knowledge/id/Food/braised-pork-rice.md
@@ -1,0 +1,96 @@
+---
+title: 'Lu Rou Fan: Nasi Babi Kecap Taiwan'
+description: 'Dari dapur juancun sampai menjadi makanan nasional — perang utara-selatan dan identitas budaya di balik semangkuk lu rou fan Taiwan'
+date: 2026-03-19
+category: 'Food'
+tags: ['Lu rou fan', 'Rou zao fan', 'Masakan juancun', 'Makanan nasional', 'Perbedaan utara-selatan']
+subcategory: 'Kuliner Etnis'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-05-16
+lastHumanReview: false
+image: '/images/food/braised-pork-rice.jpg'
+imageAlt: 'Lu rou fan Taichung'
+imageCredit: 'Wikimedia Commons, CC BY-SA'
+readingTime: 8
+translatedFrom: 'Food/台灣滷肉飯.md'
+sourceCommitSha: '30569f74'
+sourceContentHash: 'sha256:6108c8dc00031909'
+translatedAt: '2026-08-30T22:10:00+08:00'
+---
+
+# Lu Rou Fan Taiwan
+
+> **Ringkasan 30 detik:** Lu rou fan (滷肉飯) adalah wadah inti memori kuliner rakyat Taiwan, berakar pada dapur juancun (眷村, permukiman keluarga tentara) setelah 1949. Utara menyebutnya "lu rou fan", selatan "rou zao fan" (肉燥飯) — cara masak, potongan daging, dan bumbunya berbeda: di balik perang nama utara-selatan tersembunyi percabangan teknik memasak. Pada 2011 edisi Inggris Panduan Michelin salah menerjemahkannya jadi "Shandong-style", memicu gerakan pelurusan nama nasional; sejak itu "lu rou fan adalah makanan rakyat asli Taiwan" menjadi kesimpulan yang diakui secara internasional.
+
+![Lu rou fan Taichung](/images/food/braised-pork-rice.jpg)
+_Sumber gambar: [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Braised_pork_rice_in_Taichung.jpg) | CC BY-SA | fotografer tidak diketahui_
+
+Semangkuk lu rou fan adalah wadah memori kolektif rakyat Taiwan. Hidangan yang sekilas biasa ini menorehkan satu bab tebal dalam sejarah kuliner Taiwan. Berawal dari rasa rindu kampung halaman di juancun setelah 1949, ia berkembang menjadi makanan nasional seluruh pulau, bahkan memicu perang utara-selatan tentang siapa yang "asli"[^1].
+
+## Perang Nama: Lu Rou Fan vs Rou Zao Fan
+
+Salah satu perdebatan kuliner paling menarik di Taiwan adalah soal nama semangkuk nasi ini. Orang utara bersikeras "lu rou fan" (滷肉飯), orang selatan "rou zao fan" (肉燥飯)[^2]. Di balik perbedaan istilah itu ada perbedaan mendasar cara memasak.
+
+Versi utara memakai san ceng rou (三層肉, samcan berkulit) dipotong bongkahan agak besar, direbus perlahan dengan api kecil bersama kecap asin, gula batu, dan arak beras. Daging selang-seling lemak itu, setelah dimasak lama, melepas kolagen melimpah sehingga kuahnya kental. Rou zao fan versi selatan memotong daging jauh lebih halus, kadang digiling jadi cacahan, bumbunya lebih ringan, dan lebih menonjolkan aroma bawang merah goreng.
+
+Perang ini tidak punya jawaban baku, dan justru jadi catatan kaki terbaik bagi keberagaman kuliner Taiwan. "Lomba Lu Rou Fan" Pemerintah Kota Taipei 2011 adalah wujud konkret kebanggaan kedaerahan itu.
+
+## Insiden Salah Kabar "Berasal dari Shandong" oleh Michelin 2011
+
+Episode paling terkenal dalam sejarah lu rou fan adalah kontroversi yang dipicu edisi bahasa Inggris *Panduan Michelin: Taiwan Green Guide* 2011. Michelin menerjemahkan lu rou fan menjadi "Lu (Shandong-style) Meat Rice" dan dalam keterangannya menyatakan hidangan ini berasal dari Shandong, Tiongkok.[^3]
+
+Kesalahan ini bermula dari tertukarnya aksara "滷" (lu, merebus dalam kuah berbumbu) dengan "魯" (lu, yang umum merujuk pada 魯菜 alias masakan Shandong). Karena "魯" adalah singkatan Provinsi Shandong, penyusunnya membuat asosiasi keliru. Peristiwa ini memicu reaksi keras masyarakat Taiwan; Wali Kota Taipei saat itu, Hau Lung-pin, secara terbuka meluruskan bahwa "lu rou fan adalah makanan rakyat asli Taiwan" dan menuntut koreksi dari Michelin. Kegaduhan itu menjadi tonggak penting Taiwan dalam meneguhkan identitas budaya kulinernya sendiri.
+
+## Asal-Usul Juancun dan Memori Rakyat Kecil
+
+Asal-usul lu rou fan bisa ditelusuri sampai budaya juancun setelah 1949. Keluarga tentara datang ke Taiwan dalam jumlah besar dan, dalam kesulitan ekonomi, harus membuat masakan paling mengenyangkan dari bahan paling murah. Daging babi relatif murah, ditambah nasi putih, sudah cukup mengenyangkan satu keluarga.
+
+Para ibu juancun menggabungkan teknik memasak kampung halaman dengan bahan pangan lokal Taiwan, lalu mengembangkan cara mengolah daging kecap yang khas. Mereka memakai kulit babi untuk menambah kolagen, gula batu untuk mengangkat rasa manis, dan api besar untuk menyusutkan kuah agar warnanya lebih pekat. Teknik yang tampak sederhana ini menyimpan kearifan memasak yang dalam.
+
+Seiring juancun satu per satu dibongkar, keterampilan ini tersebar ke seluruh penjuru Taiwan. Banyak kedai lu rou fan klasik yang jejaknya bisa dilacak sampai ke juancun. Contohnya, lu rou fan buatan pemilik perempuan kedai Liu Shandong Beef Noodle di Taipei masih mempertahankan cita rasa Shandong yang kuat.
+
+## Kontroversi "Nasi Nasional" 2011
+
+Pada 2011, diskusi tentang "nasi nasional Taiwan" menarik perhatian seluruh pulau. Sebuah media menggelar pemungutan suara, dan lu rou fan mengalahkan lawan berat seperti niu rou mian (牛肉麵, mi daging sapi) dan o a jian (蚵仔煎, telur dadar tiram) untuk merebut gelar itu. Hasilnya memicu perdebatan sengit: pendukungnya menganggap lu rou fan paling mewakili budaya rakyat Taiwan, penentangnya mempersoalkan asal-usul historisnya.
+
+Intinya adalah definisi "keterwakilan". Meski lu rou fan berasal dari pendatang waishengren (外省人, imigran dari Tiongkok pasca-1945), setelah puluhan tahun pelokalan ia melebur dalam-dalam ke keseharian orang Taiwan. Kaki lima, minimarket, restoran kelas atas, meja makan keluarga — di mana-mana ada sosoknya. Sifat merakyat dan mudah dijangkau seperti ini memang punya kualitas "makanan nasional".
+
+Pada akhirnya perdebatan ini tak menghasilkan jawaban baku, tetapi mendorong masyarakat Taiwan merenungkan identitas budaya kulinernya. Apa itu rasa Taiwan? Masakan masyarakat adat yang berdarah murni, atau masakan kreasi baru hasil peleburan dan evolusi? Contoh lu rou fan memberi tahu kita bahwa identitas budaya sering bukan pilihan hitam-putih.
+
+## Globalisasi dan Ekspor Budaya
+
+Beberapa tahun belakangan pemerintah Taiwan mendorong "Festival Lu Rou Fan Taiwan", berharap mempromosikan budaya kuliner Taiwan ke dunia lewat makanan nasional ini[^5]. Di restoran bergaya Taiwan di Los Angeles, Tokyo, Singapura, dan Melbourne, lu rou fan perlahan dikenal di kalangan diaspora Tionghoa.
+
+Restoran itu sering menjadikan lu rou fan menu andalan, dijual berbarengan dengan jajanan Taiwan lain. Menariknya, di luar negeri perdebatan "keaslian" justru tak sesengit itu; cita rasa utara dan selatan kerap hidup berdampingan sehingga pelanggan bebas memilih.[^4]
+
+Internasionalisasi lu rou fan juga menghadapi tantangan pelokalan. Di Jepang ada kedai yang menambahkan kulit yuzu; di Amerika Serikat ada restoran yang menyediakan versi vegetarian. Perubahan ini menyimpang dari yang "tradisional", tetapi mencerminkan daya rangkul dan adaptasi budaya kuliner Taiwan.
+
+## Perkembangan dan Inovasi Masa Kini
+
+Lu rou fan hari ini sudah lama tidak terbatas pada cara pembuatan tradisional. Ada restoran yang meluncurkan lu rou fan "versi naik kelas" dengan bahan premium seperti wagyu atau babi hitam; ada pula kedai yang mengambil jalur sehat dengan mengurangi lemak dan menambah porsi sayuran.
+
+Lu rou fan microwave di minimarket bahkan menjadi potret kehidupan modern. Meski rasanya tak sebanding dengan yang dibuat tangan, kepraktisannya adalah keunggulan yang tak tergantikan. Lu rou fan terindustrialisasi seperti ini, sampai taraf tertentu, justru memperluas pengaruh hidangan tersebut.
+
+Yang paling menarik adalah munculnya lu rou fan "versi wenqing" (文青, anak muda berselera seni). Sejumlah restoran baru mengemas ulang lu rou fan dengan penyajian rapi dan dekorasi bernuansa seni untuk menarik kelompok usia muda. Cara ini dikritik sebagian orang sebagai "sok gaya", tetapi juga membuat masakan tradisional menemukan generasi konsumen barunya.
+
+Dari rasa rindu kampung halaman milik nenek-nenek juancun, ke makan siang penyembuh bagi pekerja kantoran, sampai pengalaman pertama turis mengenal Taiwan — di balik setiap mangkuk lu rou fan ada versi memori yang berbeda. Masakan yang tampak sederhana ini sebenarnya adalah miniatur perubahan masyarakat Taiwan, sekaligus wadah konkret bagi identitas budaya.
+
+## Bacaan Lanjutan
+
+- [Panorama Kuliner Taiwan](/food/台灣美食總覽) — peta menyeluruh dari masyarakat adat sampai Michelin: kenapa lu rou fan adalah faktor persekutuan terbesar dari cara orang Taiwan makan
+- [Niu Rou Mian](/food/牛肉麵) — makanan nasional lain yang juga dibawa masuk ke Taiwan oleh imigran waishengren 1949, berbagi garis keturunan juancun dengan lu rou fan
+- [Budaya Sarapan Taiwan](/food/台灣早餐文化) — dari shaobing youtiao sampai burger dan onigiri, sisi lain dari peleburan kuliner Taiwan
+- [Kepindahan Pemerintah Nasionalis ke Taiwan dan Rekonstruksi Pascaperang](/history/國民政府遷台與戰後重建) — latar sejarah kelahiran lu rou fan, penataan ulang pola makan akibat 1,2 juta tentara dan warga sipil yang pindah ke selatan
+
+## Daftar Pustaka
+
+[^1]: [Wikipedia: 滷肉飯](https://zh.wikipedia.org/zh-tw/%E6%BB%B7%E8%82%89%E9%A3%AF) — merangkum latar belakang sejarah lu rou fan (termasuk perjumpaan antara masyarakat agraris awal dan budaya juancun).
+
+[^2]: [Wikipedia: 滷肉飯](https://zh.wikipedia.org/zh-tw/%E6%BB%B7%E8%82%89%E9%A3%AF) — mencatat perbedaan nama dan cara pembuatan antara "lu rou fan" di Taiwan utara dan "rou zao fan" di Taiwan selatan.
+
+[^3]: [Wikipedia: 滷肉飯](https://zh.wikipedia.org/zh-tw/%E6%BB%B7%E8%82%89%E9%A3%AF) — mencatat secara rinci insiden salah kabar "berasal dari Shandong" dalam *Panduan Michelin* 2011.
+
+[^4]: [CNN Travel: Taiwan's 40 best foods and drinks](https://edition.cnn.com/travel/article/40-taiwan-food/index.html) — CNN memilih 40 makanan Taiwan yang tak tergantikan, dengan lu rou fan di peringkat teratas, menegaskan posisi internasionalnya sebagai makanan nasional.
+
+[^5]: [Kementerian Ekonomi, Departemen Perdagangan: Festival Lu Rou Fan Taiwan 2019 (YouTube)](https://www.youtube.com/watch?v=zkvOChbvzAQ) — video promosi "Festival Lu Rou Fan Taiwan" yang diselenggarakan pemerintah, menjadi saksi proses pemerintah mempromosikan makanan nasional ini ke panggung internasional.


### PR DESCRIPTION
Adds Indonesian translation of `Food/台灣滷肉飯.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.03 (target median 2.78, p10-p90 2.29-3.34)

**Structure alignment**: 8 `##` headings / 5 footnote refs + 5 defs / 6 http links — 100% preserved

**Note**: `i18n/id/STYLE.md` does not exist yet — followed TRANSLATE_PROMPT.md plus established conventions from the existing `knowledge/id/` corpus.

Wikilink handling: source `[[牛肉麵]]` and `[[蚵仔煎]]` converted to plain text with gloss (`niu rou mian (牛肉麵, mi daging sapi)`, `o a jian (蚵仔煎, telur dadar tiram)`) because `knowledge/id/Food/beef-noodle-soup.md` does not exist and the id oyster-omelet article is not reachable under the Chinese wikilink target. Further-reading links kept on the zh routes since none of the four targets exist in `knowledge/id/` yet.

Uncertain terminology flagged for reviewer:

- 滷肉飯 -> `lu rou fan` (kept romanized Mandarin + 漢字 gloss, matching how the existing id corpus handles Taiwanese dish names rather than translating to "nasi babi kecap" in body text)
- 眷村 -> `juancun (permukiman keluarga tentara)` — no established Indonesian rendering; kept transliteration + explanatory gloss
- 三層肉 -> `san ceng rou (三層肉, samcan berkulit)` — "samcan" is the common Indonesian term for pork belly
- 外省人 -> `waishengren (外省人, imigran dari Tiongkok pasca-1945)`
- 文青 -> `wenqing (文青, anak muda berselera seni)`

Please review. Happy to iterate.