### PR TITLE
translate(de): 擲筊 → jiaobei-divination-blocks

### DIFF
--- a/knowledge/de/Culture/jiaobei-divination-blocks.md
+++ b/knowledge/de/Culture/jiaobei-divination-blocks.md
@@ -1,0 +1,71 @@
+---
+title: 'Jiaobei 擲筊: Hinter einer Chance von 50 Prozent die Stimme der Götter hören'
+description: 'Von der Beharrlichkeit des Handwerkers Huang Yi-hsun aus Chiayi, der Wurfblöcke aus Bambuswurzeln fertigt, bis zur Legende von 20 heiligen Würfen und 3 Millionen NT$ im Citian-Tempel in Pingtung — über die Wahrscheinlichkeit und die Wärme, mit der Menschen in Taiwan mit ihren Göttern sprechen.'
+date: 2026-03-27
+category: 'Culture'
+tags: ['Volksglaube', 'Traditionelles Handwerk', 'Jiaobei']
+subcategory: '宗教與民俗'
+author: 'Taiwan.md Translation Team'
+featured: false
+lastVerified: 2026-03-27
+lastHumanReview: false
+readingTime: 8
+curation: incubating
+translatedFrom: 'Culture/擲筊.md'
+sourceCommitSha: '69b3afd9'
+sourceContentHash: 'sha256:f8a1e86f13d5a657'
+sourceBodyHash: 'sha256:ef724755039c89a7'
+translatedAt: '2026-08-31T22:20:00+08:00'
+---
+
+> **In 30 Sekunden:**
+> Jiaobei 擲筊, das Werfen halbmondförmiger Holzblöcke, ist im taiwanischen Volksglauben das verbreitetste Ritual der Verständigung zwischen Mensch und Gottheit. Das Blockpaar trägt nicht nur einen wahrscheinlichkeitstheoretisch reizvollen Kern in sich, es ist zugleich ein bedrohtes Handwerk. Am Beispiel des Chiayi-Handwerkers Huang Yi-hsun 黃奕薰 und seiner Beharrlichkeit auf 竹頭筊 (zhutoujiao), Blöcke aus dem Wurzelstock des Dornbambus, wird sichtbar, wie Menschen in Taiwan hinter diesem Ritual über einen Gegenstand ihre Unruhe und ihre Hoffnung mit den Göttern tauschen.
+
+Im Juli 2024 stand in einer Werkstatt in Minxiong 民雄, Landkreis Chiayi, der 71-jährige Huang Yi-hsun gebeugt über einem Haufen erdverkrusteter Dornbambus-Wurzelstöcke. Er suchte kein gewöhnliches Holz, sondern Bambuswurzeln, die jahrelang unter der Erde lagen und extrem dichte Fasern haben. Dieses unscheinbare Paar halbmondförmiger Holzstücke ist im Leben vieler Taiwanerinnen und Taiwaner die letzte Instanz — bei einem Umzug, einem Berufswechsel, sogar bei der Heirat.
+
+### Die Kunst, Tugend zurückzulassen: ein jahrtausendealtes Versprechen in der Bambuswurzel
+
+Die meisten Menschen greifen im Tempel nach dem, was gerade dort liegt: industriell gefertigte Wurfblöcke aus Kunststoff oder billige Pressholzkopien. Für Huang Yi-hsun sind das nur „Waren", keine „Träger des Glaubens". Sein 竹頭 (zhutou) muss von der Übergangsstelle zwischen Rhizom und Wurzel des Dornbambus stammen — und symmetrisch gewachsen sein.
+
+„Was ich mache, ist keine Ware, sondern ein Sprachrohr des Glaubens." Im Interview mit FTV News seufzte Huang, ein gutes Paar 竹頭筊 brauche vom Ausgraben über Sonnen- und Schattentrocknung bis zum Zuschnitt oft mehrere Jahre. Im Taiwanischen klingt 竹 (zhu, „Bambus") wie 德 (de, „Tugend"); daher trägt das 竹頭筊 die Bedeutung von 留德, „Tugend zurücklassen", homophon zu 留竹, „Bambus zurücklassen". Das ist nicht nur Handwerk, sondern Ehrfurcht vor den Göttern.
+
+📝 Anmerkung der Kuratoren: Während wir um das Tempo der Antwort ringen, ringt der Handwerker um die Dichte des Materials — denn nur eine Bambuswurzel, die tausendfaches Hämmern übersteht, trägt die schwersten Bitten der Gläubigen.
+
+### Die Wissenschaft des heiligen Wurfs: Sind es wirklich nur 50 Prozent?
+
+Mathematisch wirkt Jiaobei wie ein simples Problem der Binomialverteilung. Eine flache und eine gewölbte Seite oben ergibt 聖筊 (shengjiao, Zustimmung), zweimal flach ergibt 笑筊 (xiaojiao, Unklarheit oder Erheiterung), zweimal gewölbt ergibt 陰筊 (yinjiao, Ablehnung). Theoretisch müsste ein heiliger Wurf bei 50 Prozent liegen.
+
+Nach Befunden des Wissenschaftsmagazins PanSci 泛科學 und mehrerer prämierter Jugend-Forschungsarbeiten sind die Blöcke jedoch keine perfekten geometrischen Körper: Ihr Schwerpunkt liegt zur gewölbten Seite hin. Beim Aufkommen ist die flache Seite oben deshalb etwas wahrscheinlicher als die gewölbte (rund 53 bis 56 Prozent). Mit Rückenwind der Physik fällt die Wahrscheinlichkeit für ein 聖筊 also großzügiger aus als gedacht — bei etwa 50 bis 52 Prozent.
+
+Im Extremfall wächst sich diese winzige Abweichung zu verblüffenden Legenden aus. Der Guilai-Citian-Tempel 歸來慈天宮 in Pingtung veranstaltet jedes Neujahrsfest einen „Jiaobei-Wettbewerb"; 2026 wurde der Hauptpreis auf drei Millionen NT$ in bar aufgestockt, Bedingung sind zwanzig heilige Würfe in Folge. Rechnerisch ein Wunder von eins zu einer Million (1/2^20). Der Tempelrekord steht bis heute bei 17 Würfen — ein Glücksgipfel, den auch Mathematiklehrer schwer erklären.
+
+### 立筊: wenn die Physik vorübergehend aussetzt
+
+Nichts sorgt in Taiwans Tempelnachrichten so verlässlich für Aufsehen wie das 立筊 (lijiao, „stehender Wurf") — der Block kommt auf und bleibt auf der Spitze oder der Schmalkante im Gleichgewicht aufrecht stehen.
+
+Volkskundler deuten das meist als „bedeutende Weisung" oder als Zeichen besonderer göttlicher Macht. Naturwissenschaftlich hat es mit der Reibung des Bodens, der Abnutzung der Blockkanten und dem Drehwinkel beim Werfen zu tun. Und doch: Wer in größter Anspannung ein Paar aufrecht stehender Blöcke sieht, dem verwandelt sich dieser „übernatürliche" Anblick sofort in starken seelischen Trost.
+
+„Ein 立筊 sieht man selten. Es heißt, die Gottheit schweigt — oder deine Bitte geht zu weit." So schilderte es ein erfahrener Tempelwärter in den sozialen Medien: Manchmal erinnere ein stehender Wurf daran, dass man die falsche Frage gestellt hat oder die Antwort längst kennt und gar nicht mehr fragen müsste.
+
+📝 Anmerkung der Kuratoren: Die Wissenschaft erklärt, warum der Block stehen bleibt. Der Glaube erklärt, warum wir wollen, dass er stehen bleibt.
+
+### Herausforderungen und Kontroversen: das Tauziehen zwischen Umweltschutz und Tradition
+
+Mit wachsendem Umweltbewusstsein steht auch Jiaobei vor Herausforderungen der Gegenwart. Traditionelle 竹頭筊 werden seltener, weil das Material schwer zu beschaffen ist und das Ausgraben der Wurzeln den Boden- und Wasserschutz beeinträchtigen kann. An ihre Stelle tritt Kunststoff: haltbar und billig, aber ohne die Wärme einer „Verbindung zur Erde".
+
+Zudem koppeln viele Tempel das Jiaobei inzwischen an hohe Geldpreise, was den Vorwurf einer „Kommerzialisierung des Glaubens" auslöst. Kritiker sehen darin eine als Ritual getarnte Wettform, die aus einer würdevollen Befragung der Gottheit etwas anderes macht. Befürworter halten es für ein „notwendiges Übel", das junge Menschen wieder in die Tempel bringt und ihnen die überlieferte Kultur nahebringt.
+
+### Schluss: das helle Geräusch beim Aufkommen
+
+Wenn das rote Blockpaar auf dem Terrazzoboden aufspringt, sich überschlägt und schließlich mit einem hellen „Klack" liegen bleibt, hält der ganze Tempel für einen Moment den Atem an.
+
+Ganz gleich, wie die Wissenschaft jene 50 Prozent erklärt oder wie eigensinnig ein Handwerker an der Maserung einer Bambuswurzel festhält: Für den Menschen, der dort auf dem Kissen kniet, ist dieses eine 聖筊 die wärmste Bestätigung der Welt. In einem modernen Leben voller Ungewissheit brauchen wir dieses Paar halbmondförmiger Holzstücke noch immer — damit es uns im hellen Geräusch des Aufkommens sagt: Keine Angst, versuch es einfach.
+
+## Referenzen
+
+- [筊 — Religiöse Ritualgegenstände, Nationales Informationsnetz für Religion](https://religion.moi.gov.tw/Knowledge/Content?ci=2&cid=345) (Primärquelle)
+- [竹頭筊-Meister Huang Yi-hsun erforscht seit über 30 Jahren Wurfblöcke aus Bambuswurzeln — FTV News](https://www.ftvnews.com.tw/news/detail/2024721W0065) (Primärquelle)
+- [Die Wahrscheinlichkeit für einen heiligen Wurf ist größer, als du denkst — PanSci 泛科學](https://pansci.asia/archives/93303)
+- [Jiaobei-Wettbewerb im Guilai-Citian-Tempel in Pingtung — Yahoo News](https://tw.news.yahoo.com/%E5%B1%8F%E6%9D%B1%E6%AD%B8%E4%BE%86%E6%85%88%E5%A4%A9%E5%AE%AE%E6%93%B2%E7%AD%8A%E5%A4%A7%E8%B3%BD-092443164.html)
+- [Vom Verschwinden bedroht: die 竹頭筊 und Huang Yi-hsuns Rettungsbemühungen — Chuanyi online](https://magazine.ncfta.gov.tw/News_Content2.aspx?n=3131&sms=12605&s=82594)
+- [Praxis und Wandel des Jiaobei im volkstümlichen Alltag — Chinesisches Kulturerbe-Netzwerk](https://www.chinesefolklore.org.cn/web/?NewsID=21245)


### PR DESCRIPTION
Adds German translation of `Culture/擲筊.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.07 (body chars, frontmatter excluded — 2,328 → 7,146). TRANSLATE_PROMPT gives zh→de a healthy range of 2.0–4.0 with a measured median of 3.2.

**Structure alignment**: 1 `##` / 5 `###` / 6 links / 2 curator callouts — 100% preserved, zero URL drift (no URL added or dropped). No H1 added, mirroring the zh source.

**Note**: `i18n/de/STYLE.md` does not exist yet — this follows TRANSLATE_PROMPT.md plus the conventions established in the existing `knowledge/de/` corpus (German typographic quotes „ ", `subcategory` left in the original Chinese, Taiwanese proper nouns kept in Chinese with a transliteration on first mention).

A first draft came out at ratio 3.50, above the healthy band, so it was compressed and rewritten before this PR — no content was dropped in that pass, only redundant phrasing.

Uncertain terminology flagged for reviewer:

- 聖筊 / 笑筊 / 陰筊 / 立筊 → kept in Chinese with pinyin plus a short gloss on first mention (`聖筊 (shengjiao, Zustimmung)`), then reused bare. German has no established equivalents, and inventing ones would obscure the ritual vocabulary.
- 擲筊 → `Jiaobei 擲筊, das Werfen halbmondförmiger Holzblöcke` · "Mondblöcke" is sometimes used in German ethnography, but is not well established; a descriptive gloss seemed safer.
- 竹頭筊 / 竹頭 → kept in Chinese with the explanation "Blöcke aus dem Wurzelstock des Dornbambus". 刺竹 rendered as "Dornbambus".
- 留德（留竹）→ the Hoklo homophone 竹/德 is explained inline rather than reproduced as a pun, since no German pun exists.
- 廟祝 → "Tempelwärter". Alternatives such as "Tempeldiener" carry an unwanted servile connotation.
- 3 Millionen NT$ → left in NT$ rather than converted to euros, since the figure is part of the reported event.

Please review. Happy to iterate.
