### PR TITLE
translate(id): 八部合音 → bunun-pasibutbut-eight-part-polyphony

### DIFF
--- a/knowledge/id/Music/bunun-pasibutbut-eight-part-polyphony.md
+++ b/knowledge/id/Music/bunun-pasibutbut-eight-part-polyphony.md
@@ -1,0 +1,87 @@
+---
+title: 'Pasibutbut: Fosil Hidup yang Menantang Pandangan Sejarah Musik Barat'
+description: 'Pada 1943, musikolog Jepang Kurosawa Takatomo merekam Pasibutbut suku Bunun di pegunungan Taitung. Sembilan tahun kemudian rekaman itu sampai ke UNESCO dan mengguncang dunia musikologi internasional—sebuah "bangsa tanpa aksara" menyanyikan paduan suara polifonik yang menurut Barat hanya bisa lahir dari peradaban tingkat tinggi.'
+date: 2026-04-01
+category: 'Music'
+tags: ['Suku Bunun', 'Musik Pribumi', 'Masyarakat Pribumi', 'Nada Harmonik', 'Warisan Budaya Takbenda', 'Budaya Taiwan']
+subcategory: '傳統與民族音樂'
+author: 'Taiwan.md Translation Team'
+featured: true
+lastVerified: 2026-04-01
+lastHumanReview: false
+image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Bunun_pasibutbut.jpg/1280px-Bunun_pasibutbut.jpg'
+imageAlt: 'Orang Bunun menyanyikan Pasibutbut'
+imageCredit: 'Wikimedia Commons, CC BY-SA'
+translatedFrom: 'Music/八部合音.md'
+sourceCommitSha: '4b6d28c5'
+sourceContentHash: 'sha256:3c2872e562b3f229'
+sourceBodyHash: 'sha256:43f231d59e183f8e'
+translatedAt: '2026-08-31T22:40:00+08:00'
+---
+
+> **Sekilas dalam 30 detik:** Pada 1943, musikolog Jepang Kurosawa Takatomo membawa peralatan rekaman masuk jauh ke perkampungan Kanding 崁頂 di Taitung dan merekam Pasibutbut, nyanyian suku Bunun untuk memohon panen millet yang melimpah. Sembilan tahun kemudian rekaman itu dikirim ke UNESCO, dan para musikolog yang hadir tercengang—teori Barat menganggap paduan suara polifonik sebagai produk peradaban tingkat tinggi, tetapi orang Bunun mencapainya di pegunungan terpencil, tanpa aksara dan tanpa alat musik, hanya dengan resonansi suara manusia. Suara surgawi yang dikenal sebagai "delapan suara harmoni" (八部合音) ini sampai hari ini tetap menjadi bunyi Taiwan yang paling mudah dikenali di dunia.
+
+Pada 1943, di penghujung Perang Dunia II, musikolog Jepang **Kurosawa Takatomo** (黑澤隆朝) mendapat penugasan dari Kantor Gubernur Jenderal Taiwan dan membawa perangkat rekaman yang berat masuk ke perkampungan Kanding di Kecamatan Haiduan, Kabupaten Taitung[^1]. Dibantu polisi setempat dan seorang pemuda Bunun bernama "Ado", ia mengatasi pasokan listrik yang tidak stabil dan akses jalan yang sulit, lalu merekam suara yang kelak mengubah sejarah musik.
+
+Belakangan Kurosawa menulis: "Ini adalah harmoni alami paling sempurna yang pernah saya dengar seumur hidup."[^2]
+
+Pada 1952, ia mengirimkan rekaman itu ke International Folk Music Council yang bernaung di bawah UNESCO. Pandangan arus utama teori musik Barat saat itu adalah bahwa musik manusia berkembang dari nada tunggal menuju polifoni, lalu menuju harmoni yang kompleks—sebuah jalur linear "evolusi peradaban". Kemunculan Pasibutbut meledakkan garis itu[^3]. Sebuah bangsa tanpa sistem aksara menyanyikan sesuatu yang menurut orang Eropa hanya bisa lahir dari peradaban tingkat tinggi.
+
+## Bukan delapan suara, tetapi lebih misterius daripada delapan
+
+Nama "delapan suara harmoni" sebenarnya adalah kesalahpahaman yang indah.
+
+Dari sudut analisis musik, Pasibutbut sebenarnya hanya memiliki empat bagian suara (kadang lima): suara rendah Mahalngal, suara tengah Manda, suara tinggi Bondada, serta suara tertinggi yang masuk di bagian penutup[^4]. Namun ketika orang Bunun menyanyikannya dengan teknik resonansi yang sangat presisi, bunyi itu memunculkan gejala fisika berupa "nada harmonik" (overtone) di antara tubuh manusia dan ruang sekitarnya—tangga nada berfrekuensi lebih tinggi bertumpuk di atas melodi utama, sehingga pendengar seolah mendengar delapan bagian suara atau bahkan lebih berbunyi bersamaan[^5].
+
+> **📝 Sudut pandang kurator:** Teknik menghasilkan nada harmonik secara kolektif ini punya kemiripan dengan khoomei (呼麥) dari Mongolia. Bedanya, khoomei adalah keterampilan seorang penyanyi tunggal, sedangkan orang Bunun mencapainya lewat nyanyian bersama—tingkat kesulitannya sama sekali berbeda.
+
+| Bagian suara | Nama dalam bahasa Bunun | Fungsi                                                      |
+| ------------ | ----------------------- | ----------------------------------------------------------- |
+| Suara rendah | Mahalngal               | Nada dasar, seperti getaran bumi, menyediakan alas resonansi |
+| Suara tengah | Manda                   | Mengisi ruang, membuat harmoni tebal dan penuh               |
+| Suara tinggi | Bondada                 | Melodi utama yang memanjat ke atas, melambangkan millet yang tumbuh |
+| Nada harmonik | (Overtone)             | Bagian suara semu yang lahir dari resonansi fisik            |
+
+Di hutan pegunungan yang terpencil dari dunia luar, orang Bunun mewariskan teknik ini dari generasi ke generasi selama ribuan tahun melalui peniruan bunyi air terjun, lebah, dan angin[^6].
+
+## Doa yang memanjat ke atas
+
+Bagi orang Bunun, Pasibutbut bukan pertunjukan, melainkan ritual. Nyanyian ini dibawakan setelah upacara Malahtangia (打耳祭, "upacara menembak telinga") dan sebelum upacara penaburan benih, dengan tujuan memohon kepada dewa langit Dehanin agar panen millet berlimpah[^7].
+
+Cara membawakannya diatur dengan ketat:
+
+Suara harus memanjat perlahan dari rendah ke tinggi, melambangkan millet yang tumbuh subur. **Jika nada jatuh atau melenceng di tengah jalan, itu dianggap pertanda buruk yang meramalkan kemungkinan bencana kelaparan pada tahun tersebut.** Orang Bunun percaya bahwa suara yang kurang selaras menandakan hati warga tidak murni atau ada perpecahan di dalam komunitas, sehingga dewa langit tidak akan memberikan panen yang berlimpah[^7].
+
+Saat menyanyi, warga berdiri membentuk lingkaran dengan tangan disandarkan ke punggung orang di sebelahnya, merasakan getaran rongga dada satu sama lain. Ini bukan pameran kemahiran pribadi, melainkan percakapan antara kehendak kolektif dan dewa langit. Secara tradisional hanya laki-laki yang boleh menyanyikannya, dan sebelum menyanyi harus dilakukan ritual penyucian[^7].
+
+> **📝 Sudut pandang kurator:** Mekanisme "kendali mutu" pada Pasibutbut sangat ketat—melenceng dari nada bukan sekadar salah menyanyi, melainkan penghinaan terhadap dewa langit dan pertanda buruk bagi seluruh suku. Pertunjukan sempurna di bawah tekanan seperti itu barangkali justru alasan teknik ini bisa terasah selama ribuan tahun.
+
+## Suaranya sedang mengecil
+
+Pada 2009, Kementerian Kebudayaan mencatatkan "delapan suara harmoni suku Bunun" sebagai seni tradisional penting tingkat nasional dan menetapkan sejumlah perkampungan sebagai kelompok pelestari[^8]. Namun kecepatan pencatatan dan perlindungan itu mungkin tidak mampu mengejar kecepatan kehilangannya.
+
+Generasi muda meninggalkan perkampungan, dan tingkat keterlibatan dalam ritual tradisional menurun. Demi memenuhi selera penonton, pertunjukan wisata kadang menyederhanakan alur nyanyian dan mengabaikan pantangan ritual. Persoalan yang lebih mendasar adalah bahasa—memudarnya bahasa Bunun membuat makna budaya yang dalam di balik liriknya sulit dipahami oleh generasi berikutnya.
+
+> "Kami bukan sedang belajar menyanyi, kami sedang belajar bagaimana bercakap-cakap dengan alam dan dengan roh leluhur."
+
+Di perkampungan Bunun di Nantou, Hualien, dan Taitung, masih ada tetua yang mengajari anak muda mengendalikan otot tenggorokan dan mendengar nada harmonik di udara. Yang mereka wariskan bukan hanya teknik, melainkan satu cara utuh memahami dunia—bunyi bukanlah buatan manusia, ia tumbuh dari bumi, dan manusia hanya membiarkannya lewat.
+
+Pada detik Kurosawa Takatomo menekan tombol rekam di tahun 1943, mungkin ia tidak menyangka bahwa delapan puluh tahun kemudian suara itu masih menjadi ekspor budaya Taiwan yang paling bertenaga. Bukan karena ia tua, melainkan karena dengan cara paling sederhana—beberapa tenggorokan manusia—ia membuktikan satu hal: kedalaman seni tidak pernah ditentukan oleh majunya teknologi.
+
+## Referensi
+
+[^1]: [Mendengar Tanah Jajahan: Kurosawa Takatomo dan Survei Musik Taiwan di Masa Perang (1943)](https://tci.ncl.edu.tw/cgi-bin/gs32/gsweb.cgi?o=dnclresource&s=id=%22SA10000019079%22.&searchmode=basic&tcihsspage=tcisearch_opt1_search) — keterangan lengkap lihat isi tautan aslinya; Perpustakaan Universitas Nasional Taiwan, 2008
+
+[^2]: [Musik Suku Takasago Taiwan](https://www.books.com.tw/products/0010430882) — Kurosawa Takatomo, Victor Records, 1974
+
+[^3]: [Survei Kurosawa Takatomo atas Musik Masyarakat Pribumi Taiwan](https://www.ntl.edu.tw/public/Attachment/9102615522190.pdf) — Cabang Taiwan Perpustakaan Pusat Nasional; Institut Musikologi Universitas Nasional Taiwan, 2008
+
+[^4]: [Pasibutbut Suku Bunun, Nyanyian Doa Panen Millet — Jaringan Warisan Budaya Nasional](https://nchdb.boch.gov.tw/assets/overview/traditionalPerformingart/20160317000001) — keterangan lengkap lihat isi tautan aslinya
+
+[^5]: [Biling Melihat Orang Bunun Menyanyikan Pasibutbut Menjadi Bisosilin](https://www.airitilibrary.com/Article/Detail/U0118-0807200916272865) — keterangan lengkap lihat isi tautan aslinya; tesis magister Asia University, 2008
+
+[^6]: [Studi Kasus Seni Musik Pribumi Taiwan "Delapan Suara Harmoni Suku Bunun"](https://cge.knu.edu.tw/var/file/22/1022/img/124/874464490.pdf) — keterangan lengkap lihat isi tautan aslinya; seminar akademik Chin-Yi University of Technology, 2003
+
+[^7]: [Beberapa Pemikiran tentang Pementasan Nyanyian Ritual Pasibutbut — Museum Prasejarah Nasional Taiwan](https://icloud.nmp.gov.tw/Library/EPaperContent?a=212&id=169&nid=638) — keterangan lengkap lihat isi tautan aslinya
+
+[^8]: [Data Pencatatan "Delapan Suara Harmoni Suku Bunun" — Biro Warisan Budaya, Kementerian Kebudayaan](https://twh.boch.gov.tw/non_material/intro.aspx?id=743) — keterangan lengkap lihat isi tautan aslinya


### PR DESCRIPTION
Adds Indonesian translation of `Music/八部合音.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 2.91 (body chars, frontmatter excluded — 2,915 → 8,482). Measured median for zh→id is 2.78, p10–p90 2.29–3.34.

**Structure alignment**: 4 `##` / 10 footnote refs / 8 footnote defs / 8 links / 4 callouts / 1 table (4 columns, 4 rows) — 100% preserved, zero URL drift (no URL added or dropped). No H1 added, mirroring the zh source.

**Note**: `i18n/id/STYLE.md` does not yet exist — this follows TRANSLATE_PROMPT.md plus the conventions established in the existing `knowledge/id/` corpus (tags translated, `subcategory` left in the original Chinese, Taiwanese and Indigenous proper nouns kept with Chinese/Bunun originals).

Small corrections carried over from the source, flagged per TRANSLATE_PROMPT §FAQ:

- `[^2]` in the zh source reads `黑澤隆朝，《》，勝利唱片，1974` — an empty title placeholder. Rendered as author + label + year without the empty brackets. Happy to restore verbatim if preferred.
- `lastHumanReview` set to `false` for this translation (the zh source has `true`, but this Indonesian text has not been reviewed by a human).

Uncertain terminology flagged for reviewer:

- Pasibutbut / Mahalngal / Manda / Bondada → left in Bunun, untranslated. They are the ritual's own vocabulary.
- 八部合音 → "delapan suara harmoni (八部合音)" on first mention. The article's whole point is that the name is a misnomer, so a literal-but-glossed rendering felt more faithful than an interpretive one.
- 打耳祭 → `upacara Malahtangia (打耳祭, "upacara menembak telinga")`. The Bunun name was added because the Chinese name alone is opaque to Indonesian readers; please confirm the Bunun spelling.
- 小米 → "millet". Indonesian has "jewawut", but "millet" is more widely recognised in writing about food and agriculture.
- 天神 Dehanin → "dewa langit Dehanin".
- 泛音 → "nada harmonik (overtone)" on first mention, then "nada harmonik".
- 高砂族 (in reference [^2]) → "Suku Takasago", kept as the historical Japanese-era term used in the 1974 record title rather than modernised to "masyarakat pribumi".

Please review. Happy to iterate.
