### PR TITLE
translate(id): 牛肉麵 → beef-noodle-soup

### DIFF
--- a/knowledge/id/Food/beef-noodle-soup.md
+++ b/knowledge/id/Food/beef-noodle-soup.md
@@ -1,0 +1,171 @@
+---
+title: 'Mi Sapi Taiwan'
+description: 'Dari kerinduan para migran waishengren hingga menjadi makanan nasional Taiwan: perpaduan budaya dan perjalanan global mi sapi Taiwan'
+date: 2026-03-17
+category: 'Food'
+tags:
+  [
+    'Makanan',
+    'Mi Sapi',
+    'Masakan Waishengren',
+    'Perpaduan Budaya',
+    'Festival Mi Sapi Internasional Taipei',
+    'Michelin',
+  ]
+subcategory: 'Jajanan Klasik'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-05-16
+lastHumanReview: true
+translatedFrom: 'Food/牛肉麵.md'
+sourceCommitSha: '37638e17'
+sourceContentHash: 'sha256:0f8567c72fce22ef'
+sourceBodyHash: 'sha256:31e72a4ea39ea451'
+translatedAt: '2026-09-01T17:09:55+08:00'
+image: '/images/wiki/5be514264de6.jpg'
+imageAlt: 'Niu rou mian Taiwan'
+imageCredit: 'Wikimedia Commons, CC BY-SA 2.0'
+---
+
+# Mi Sapi Taiwan
+
+> **Ringkasan 30 detik:** _Niu rou mian_ (牛肉麵, mi sapi Taiwan) lahir dari pengalaman _waishengren_ (外省人, migran daratan yang tiba bersama Kuomintang (KMT), terutama setelah 1949). Para veteran asal Sichuan, Shandong, dan Hunan membawa teknik memasak daging sapi dari berbagai provinsi, lalu memadukannya dengan selera lokal hingga melahirkan gaya _hongshao_ (紅燒, rebus kecap berempah), _qingdun_ (清燉, kuah bening), tomat, dan lainnya. Pada 2005, Festival Mi Sapi Internasional Taipei memulai upaya membangun citra kota; pada 2018, Panduan Michelin Taiwan yang pertama memasukkan Liu Shandong, Niu Ba Ba, dan Jian Hong ke dalam daftar rekomendasinya; nama "California Beef Noodle" pun merambah Amerika Utara. Semangkuk mi ini memuat 75 tahun perubahan tabu, percampuran latar provinsi, dan ingatan rasa.
+
+Semangkuk _niu rou mian_ yang mengepul, dengan kuah pekat, daging sapi empuk, dan mi kenyal, telah menjadi salah satu makanan nasional Taiwan yang paling representatif. Hidangan mi yang tampak sederhana ini membawa kenangan kampung halaman para _waishengren_, sekaligus menjadi saksi sejarah peleburan berbagai kelompok masyarakat Taiwan. Dari jajanan kaki lima, hidangan ini naik kelas menjadi bintang di panggung kuliner internasional: dalam semangkuk mi tersimpan keberagaman dan sikap terbuka budaya kuliner Taiwan.
+
+![Niu rou mian Taiwan](/images/wiki/5be514264de6.jpg)
+_Sumber gambar: [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Taiwanese_beef_noodles.jpg) | CC BY-SA 2.0 | fotografer tidak diketahui_
+
+## Asal-Usul Sejarah dan Latar Budaya
+
+### Dari Tabu Menjadi Santapan
+
+Pada masa Taiwan masih berupa masyarakat agraris, terdapat pandangan tradisional bahwa "sapi adalah penolong, bukan untuk dimakan". Sapi merupakan rekan penting dalam bercocok tanam, sehingga masyarakat memiliki kebiasaan "tidak makan daging sapi". Bahkan ada ungkapan dalam bahasa Taiwan, "M̄ chia̍h gû, khah iâⁿ chia̍h ka-tī bah" (毋食牛，較贏食自己肉), yang berarti lebih baik tidak makan sapi daripada seolah memakan daging sendiri, mencerminkan penghormatan terhadap hewan tersebut.[^1]
+
+Tabu pangan ini mengalami perubahan besar setelah 1949. Ketika pemerintah Nasionalis pindah ke Taiwan, banyak tentara beserta keluarganya bermigrasi dari berbagai provinsi di Tiongkok daratan ke Taiwan. Mereka membawa beragam budaya kuliner dan teknik memasak, termasuk kebiasaan menyantap daging sapi.
+
+### Kreasi dari Kerinduan Kaum _Waishengren_
+
+Kelahiran _niu rou mian_ merupakan proses peleburan sekaligus inovasi. Di lingkungan militer, daging sapi adalah sumber protein yang penting. Setelah pensiun, para veteran membawa teknik merebus dan mengungkep yang mereka pelajari di kesatuan ke tengah masyarakat, lalu mulai membuat hidangan daging sapi di Taiwan. _Juancun_ (眷村, permukiman keluarga militer) menjadi tempat tinggal para pendatang dari berbagai provinsi. Keluarga militer asal Sichuan, Shandong, Hunan, dan daerah lain saling bertukar bumbu serta teknik memasak dari kampung halaman, hingga perlahan mengembangkan versi berciri khas Taiwan. Dari sisi ekonomi, kondisi pada masa awal serba sulit dan banyak veteran bertahan hidup dengan berjualan di kaki lima. Biaya membuat _niu rou mian_ relatif rendah; satu mangkuk dapat sekaligus menyediakan karbohidrat, protein, dan sayuran, sehingga bergizi sekaligus mengenyangkan dan segera digemari masyarakat.
+
+### Perpaduan Cita Rasa Daerah
+
+_Niu rou mian_ Taiwan memadukan ciri berbagai masakan daerah. Gaya Sichuan memakai _doubanjiang_ (豆瓣醬, pasta kacang cabai fermentasi) dan aneka rempah, menghasilkan warna merah cerah dengan rasa _mala_ yang kebas, pedas, pekat, dan harum. Para veteran Sichuan di Gangshan, Kaohsiung, menjadi penggerak utama aliran ini.[^2] Orang Shandong mahir membuat mi dan menyumbangkan teknik pembuatan mi bermutu bagi _niu rou mian_ Taiwan; paduan roti pipih Shandong dengan daging sapi juga menjadi kombinasi klasik. Ciri Hunan tampak pada penggunaan cabai dan teknik mengungkep, yang menambah lapisan rasa masakan Hunan ke dalam _niu rou mian_. Tahap terakhir adalah penyesuaian lokal: mengikuti selera orang Taiwan dengan mengurangi rasa pedas berlebihan serta memperkuat keseimbangan rasa manis dan umami.
+
+## Aliran Utama dan Ciri Rasanya
+
+Setelah berkembang selama puluhan tahun, _niu rou mian_ Taiwan melahirkan beragam aliran dan gaya.
+
+**Mi sapi kuah _hongshao_** (紅燒; _hongshao_ berarti direbus lama dalam kuah kecap berempah) adalah hidangan klasik dari kawasan Jalan Taoyuan di Taipei. Kuahnya berwarna cokelat kemerahan gelap, dengan bumbu berupa kecap asin, _doubanjiang_, cabai, bunga lawang, kayu manis, dan lainnya; rasanya gurih, sedikit pedas, dan kuahnya kaya rasa. Dalam pembuatannya, daging sapi mula-mula ditumis dengan kecap asin dan _doubanjiang_ pedas hingga berwarna, kemudian ditambahkan kaldu dan direbus selama 2-3 jam agar aroma rempah meresap sepenuhnya dan kuah berubah menjadi warna ambar yang dalam.
+
+**Mi sapi kuah bening _qingdun_** (清燉) mengambil jalur kuah yang jernih. Hidangan ini hanya memakai jahe, daun bawang, arak beras, dan bahan sejenis untuk menghilangkan bau serta mengangkat rasa segar. Rasanya ringan, harum, dan meninggalkan sedikit rasa manis, dengan cita rasa asli daging sapi sebagai pusatnya; tradisi ini banyak diteruskan oleh kedai halal milik komunitas Muslim. Kaldu tulang sapi direbus lama dan semua kotorannya dibuang agar tetap jernih. Daging sapi dimasak hingga empuk, tetapi serat dagingnya tetap terasa.
+
+**Mi sapi tomat** adalah cabang inovasi yang relatif modern. Bahan bergaya Barat seperti tomat, bawang bombai, dan wortel ditambahkan untuk menghasilkan kuah merah cerah yang asam-manis dengan lapisan rasa yang kaya. Hidangan ini mewakili dialog budaya kuliner Taiwan dengan bahan-bahan Barat, sembari mempertahankan kerangka mi kuah Timur. **Mi sapi dengan kaldu sari daging asli** mengambil jalur minimalis dan hanya memakai daging sapi, tulang sapi, air, serta sedikit bumbu. Kuahnya putih pekat seperti susu, demi mengejar rasa daging sapi yang paling murni. **Mi sapi _mala_ gaya Sichuan** menggunakan _doubanjiang_ Sichuan autentik dan lada Sichuan (_huajiao_); rasanya pedas-kebas, gurih, dan harum dengan lapisan yang jelas, mempertahankan ciri memasak tradisional Sichuan.
+
+## Teknik Pembuatan dan Kunci Mutu
+
+Semangkuk _niu rou mian_ yang baik membutuhkan keseimbangan sempurna pada tiga unsur: kuah, mutu daging, dan mi.
+
+### Membuat Kuah
+
+**Kaldu tulang sapi:**
+Gunakan bagian kaya gelatin, seperti tulang kaki dan tulang iga sapi, lalu mulai rebus dari air dingin selama 6-8 jam. Buih yang muncul harus terus disingkirkan agar kuah tetap jernih.
+
+**Takaran rempah:**
+Lebih dari sepuluh macam rempah, termasuk bunga lawang, kayu manis, lada Sichuan (_huajiao_), cengkih, dan kapulaga hitam, harus ditakar dengan tepat. Setiap kedai memiliki racikan khasnya sendiri, sebuah rahasia dagang yang tidak dibagikan kepada orang luar.
+
+**Keseimbangan bumbu:**
+Keseimbangan asin, manis, asam, dan pedas adalah kuncinya. Selera Taiwan cenderung menyukai sedikit rasa manis, sehingga bumbu perlu mempertimbangkan kebutuhan cita rasa setempat.
+
+### Memilih dan Mengolah Daging Sapi
+
+Dalam memilih potongan, sengkel sapi memiliki banyak urat dan aroma daging yang kuat; setelah direbus lama, teksturnya kenyal dan menjadi pilihan paling umum. Daging sela iga memiliki perbandingan lemak dan daging yang seimbang, lalu menjadi empuk dan berair setelah dimasak. Potongan daging sapi tanpa lemak terasa lebih padat. Urat sapi yang kaya gelatin memerlukan waktu memasak lebih lama agar mencapai tekstur yang lumer di mulut. Dalam prosesnya, daging sapi harus lebih dahulu diblansir untuk membuang darah, kemudian direbus bersama rempah selama 2-3 jam sampai sumpit dapat menembusnya dengan mudah.
+
+### Memilih Mi
+
+Dalam menyesuaikan ketebalan, mi lebar cocok dengan kuah _hongshao_ yang pekat, sedangkan mi tipis cocok dengan kuah _qingdun_ yang ringan. Mi potong pisau yang kenyal juga merupakan gaya tersendiri dan sangat digemari. Dari sisi teknik pembuatan, mi yang baik harus kenyal tetapi tidak keras. Waktu memasaknya dijaga pada 2-3 menit agar teksturnya tetap optimal.
+
+## Festival Mi Sapi Taipei dan Internasionalisasi
+
+### Peluncuran Festival Mi Sapi
+
+Pada 2005, Pemerintah Kota Taipei meluncurkan "Festival Mi Sapi Internasional Taipei" untuk mempromosikan budaya _niu rou mian_ Taiwan dan meningkatkan pengakuannya di dunia internasional.[^3] Acara tahunan ini mencakup kompetisi _niu rou mian_ dalam kategori _hongshao_, _qingdun_, kreasi, dan lainnya; pameran kedai-kedai ternama dari seluruh Taiwan; kegiatan budaya seperti pameran sejarah _niu rou mian_ dan demonstrasi memasak; serta promosi internasional dengan mengundang media asing dan pencinta kuliner untuk mencicipinya. Dalam standar kompetisi, juri memberi nilai pada kuah, mutu daging, mi, dan performa keseluruhan, lalu memilih peraih medali emas, perak, dan perunggu setiap tahun.
+
+### Sorotan Media Internasional
+
+**Sorotan media internasional:**
+_Niu rou mian_ Taiwan telah memperoleh pengakuan dari berbagai media internasional dan panduan kuliner. Sebagai salah satu pintu masuk utama untuk mengenal Taiwan, popularitas internasionalnya terus meningkat.[^4]
+
+**Panduan Michelin:**
+Setelah Panduan Michelin Taiwan terbit pada 2018, sejumlah kedai _niu rou mian_ mendapat rekomendasi, antara lain:
+
+- Liu Shandong Beef Noodles: Bib Gourmand
+- Niu Ba Ba Beef Noodles: rekomendasi Michelin
+- Jian Hong Beef Noodles: rekomendasi berciri khas lokal
+
+**Perkembangan di luar negeri:**
+Kedai _niu rou mian_ Taiwan telah membuka cabang di Amerika Serikat, Kanada, Australia, dan berbagai tempat lain. Bahkan ada merek bernama "California Beef Noodle", yang sebenarnya merujuk pada _niu rou mian_ gaya Taiwan.
+
+### Kekuatan Lunak Diplomasi
+
+_Niu rou mian_ menempati posisi yang jelas dalam diplomasi budaya Taiwan:
+
+- Dewan Urusan Komunitas Perantauan mempromosikan _niu rou mian_ Taiwan di luar negeri
+- Kementerian Luar Negeri mengadakan festival kuliner Taiwan di negara lain
+- Biro Pariwisata mencantumkan _niu rou mian_ sebagai makanan yang wajib dicoba
+
+## Ciri Daerah dan Budaya Kedai Ternama
+
+**Wilayah Taipei** adalah medan persaingan utama _niu rou mian_ Taiwan. Pada 1950-an, Jalan Taoyuan menjadi tempat berkumpulnya kedai kaki lima mi sapi halal, lalu perlahan berkembang dengan gaya Sichuan. Kawasan komersial Jalan Yongkang terkenal dengan kedai-kedai lama seperti Yongkang Beef Noodles, Lao Zhang Beef Noodles, dan Pin Chuan Lan Beef Noodles. Sementara itu, kawasan Ximending berpusat pada kedai-kedai _niu rou mian_ di sekitar Lao Tian Lu, yang terkenal dengan hidangan _luwei_ atau rebusan kecap berbumbu, serta kreasi rasa untuk anak muda.
+
+**Wilayah Taipei Baru** memiliki Yonghe, yang mengembangkan model usaha unik berupa "kedai susu kedelai yang juga menjual _niu rou mian_", dengan layanan 24 jam untuk memenuhi kebutuhan pada berbagai waktu. Di sekitar Stasiun Fuzhong, Banqiao, berkumpul banyak kedai lama yang menawarkan harga terjangkau dan berpadu dengan budaya pasar malam.
+
+**Wilayah Taichung** lebih menyukai _niu rou mian_ bercita rasa segar. Kuahnya lebih ringan daripada gaya Taipei, tetapi tetap berlapis. Kedai yang mewakilinya antara lain jaringan Duan Chun Zhen Beef Noodles dan kedai lama setempat, Fuhong Beef Noodles. **Wilayah Tainan**, sesuai kegemaran kota tua ini terhadap rasa manis, juga cenderung memberi bumbu yang lebih manis pada _niu rou mian_. **Wilayah Kaohsiung** memiliki Gangshan, tempat lahirnya _niu rou mian_ gaya Sichuan. Para veteran asal Sichuan menciptakan gaya autentik di sini, dengan tingkat rasa kebas dan pedas yang lebih tinggi; hingga kini, ciri Sichuan yang lebih kuat masih dipertahankan.
+
+## Makna Budaya dan Dampak Sosial
+
+Perjalanan perkembangan _niu rou mian_ menampilkan secara utuh jejak peleburan budaya majemuk Taiwan. Hidangan ini mematahkan tabu masyarakat agraris untuk "tidak makan daging sapi", menjadi contoh konkret keterbukaan dan sikap inklusif masyarakat Taiwan. Teknik memasak para _waishengren_ berpadu dengan selera _benshengren_ (本省人, penduduk lokal keturunan migran yang tiba sebelum 1945), menciptakan cita rasa khas Taiwan. Generasi kedua dan ketiga para migran meneruskan usaha keluarga, sambil terus berinovasi di atas landasan tradisi untuk mengikuti perubahan zaman.
+
+Dari sisi ekonomi, industri _niu rou mian_ mendorong perkembangan usaha boga di banyak lapisan, dari kedai kaki lima hingga restoran kelas atas untuk memenuhi semua tingkat konsumsi. Industri ini juga turut menggerakkan rantai usaha lengkap yang mencakup peternakan sapi, pembuatan mi, dan industri bumbu di Taiwan. Bagi sektor pariwisata, _niu rou mian_ pun menjadi makanan wajib bagi wisatawan sekaligus salah satu daya tarik utama pariwisata Taiwan.
+
+Dalam budaya sehari-hari, _niu rou mian_ adalah pilihan andalan orang Taiwan untuk makan siang, makan malam, maupun makan larut malam. Ajakan "ayo makan _niu rou mian_" juga lazim digunakan untuk berkumpul bersama teman atau mengadakan pembicaraan bisnis. Bagi banyak orang Taiwan, semangkuk mi ini menyimpan nilai emosional berupa kenangan masa kecil dan kehangatan keluarga.
+
+## Inovasi dan Tren Masa Depan
+
+Dalam beberapa tahun terakhir, industri _niu rou mian_ berkembang ke berbagai arah. Dari sisi kesehatan, bermunculan "versi sehat" dengan garam dan minyak lebih sedikit, bahan organik, serta porsi sayuran lebih banyak. Diversifikasi rasa menghadirkan varian Jepang, Thailand, Italia, dan gaya internasional lain, juga versi vegetarian berbahan daging nabati atau jamur serta versi turunan yang mengganti daging sapi dengan makanan laut. Dari sisi layanan, pengembangan merek berjaringan, kemasan dan lingkungan bersantap yang lebih berkelas, serta meluasnya platform pesan antar telah memperluas cara dan konteks menikmati _niu rou mian_.
+
+Dalam penerapan teknologi, sebagian kedai memakai peralatan untuk mengendalikan suhu dan durasi memasak demi menjamin mutu yang konsisten. Teknologi kemasan beku memungkinkan _niu rou mian_ bermutu tinggi dikirim langsung ke rumah atau diekspor ke luar negeri. Media sosial dan aplikasi kuliner pun menjadi saluran pemasaran utama untuk menarik konsumen muda.
+
+### Tantangan Internasionalisasi
+
+_Niu rou mian_ yang merambah ke luar Taiwan menghadapi tiga lapis tantangan. Dalam adaptasi budaya, promosi di luar negeri perlu mempertimbangkan selera dan kebiasaan makan masyarakat setempat. Dalam pengadaan bahan, memperoleh bumbu dan bahan autentik di luar negeri selalu menjadi persoalan besar. Dalam perlindungan merek, nama "_niu rou mian_ Taiwan" kerap dipakai secara tidak semestinya, sehingga menjaga reputasi cita rasa Taiwan yang autentik menjadi perjuangan jangka panjang.
+
+## Budaya dan Etika Menikmati Hidangan
+
+Cara autentik menyantapnya memiliki urutan tertentu: cicipi kuah terlebih dahulu untuk merasakan lapisan rempah, lalu cicipi daging sapi untuk menilai kematangan daging, dan akhirnya makan bersama mi untuk menikmati keselarasan keseluruhannya. Sebagai pendamping, lauk kecil yang umum antara lain sayuran acar, telur kecap, dan tahu kering. Minumannya dapat berupa teh panas atau bir, dan sebagian kedai juga menyediakan nasi putih sebagai tambahan.
+
+Budaya kedai juga menjadi sisi yang tak terpisahkan dari _niu rou mian_ Taiwan. Para pemilik biasanya memiliki watak dan prinsip masing-masing, yang membentuk karakter unik setiap kedai. Kedai ternama sering kali mengharuskan pengunjung mengantre, dan antrean itu sendiri telah menjadi bagian dari budaya kuliner Taiwan. Pewarisan keterampilan tradisional dari guru kepada murid menopang rangkaian pengerjaan manual yang sulit ditiru secara industri.
+
+Di dalam semangkuk _niu rou mian_ yang mengepul: kuahnya adalah ingatan sejarah setelah 1949, mi menjadi jejak percampuran latar provinsi, dan minyak cabainya adalah kerinduan kampung halaman yang dibawa para veteran Sichuan di Gangshan, Kaohsiung.
+
+Dari kedai halal di Jalan Taoyuan, Taipei, kedai-kedai lama di Jalan Yongkang, dan _niu rou mian_ gaya Sichuan di Gangshan, hingga Panduan Michelin Taiwan pertama pada 2018 yang memasukkan Liu Shandong, Niu Ba Ba, dan Jian Hong ke daftar rekomendasi, lalu nama "California Beef Noodle" yang merambah Amerika Utara: semangkuk mi ini telah menempuh perjalanan 75 tahun, mengubah tabu menjadi keseharian dan kerinduan kampung halaman menjadi makanan nasional.
+
+## Bacaan Lanjutan
+
+- Ikhtisar Kuliner Taiwan — Peta menyeluruh dari masyarakat adat hingga Michelin: posisi _niu rou mian_ dalam empat abad percampuran cita rasa
+- Budaya Sarapan Taiwan — _Shaobing_, _youtiao_, dan susu kedelai, yang juga dibawa para migran _waishengren_ setelah 1949, berdiri bersama _niu rou mian_ sebagai simbol utama peleburan kuliner pascaperang
+- [Lu Rou Fan Taiwan](/id/food/braised-pork-rice) — Jalur lain dari dapur _juancun_ menuju makanan nasional, dengan garis keturunan ganda berupa kerinduan para migran dan pelokalan yang sama seperti _niu rou mian_
+- Perpindahan Pemerintah Nasionalis ke Taiwan dan Rekonstruksi Pascaperang — Perubahan budaya kuliner yang dibawa perpindahan 1,2 juta tentara dan warga sipil ke selatan menjadi latar sejarah kelahiran _niu rou mian_
+- [Budaya Pasar Malam Taiwan](/id/food/night-market-culture) — Ruang peredaran rakyat utama bagi _niu rou mian_ setelah keluar dari _juancun_
+
+---
+
+## Referensi
+
+[^1]: [Wikipedia: Sejarah _niu rou mian_ Taiwan](https://zh.wikipedia.org/zh-tw/%E7%89%9B%E8%82%89%E9%BA%B5) — Memuat kajian sejarawan Lu Yaodong: artikel Wikipedia
+
+[^2]: [The News Lens: Hubungan historis antara _doubanjiang_ Gangshan dan _niu rou mian_](https://www.thenewslens.com/article/117978) — Kajian asal-usul _niu rou mian hongshao_ di kalangan veteran Sichuan di Gangshan, Kaohsiung
+
+[^3]: [Situs resmi Festival Mi Sapi Internasional Taipei](https://tpebeefnoodle.com.tw/) — Materi resmi kegiatan pencitraan kota yang didorong Pemerintah Kota Taipei sejak 2005
+
+[^4]: [Panduan Michelin: Rekomendasi _niu rou mian_ Taiwan yang wajib dicoba](https://guide.michelin.com/tw/zh_TW/best-of/must-eat-beef-noodles-taiwan-recommendations) — Halaman resmi Panduan Michelin Taiwan merangkum daftar kedai _niu rou mian_ yang wajib dicoba, termasuk pilihan Bib Gourmand dan restoran berbintang, sekaligus mencatat posisi internasional _niu rou mian_ sebagai makanan yang mewakili Taiwan.


### PR DESCRIPTION
## Summary

- adds a complete Indonesian translation of `Food/牛肉麵.md`
- follows the canonical Indonesian editorial guide and its Kompas/Tempo-style formal register
- explains Taiwan-specific terms such as `niu rou mian`, `waishengren`, `juancun`, `hongshao`, and `qingdun` on first use
- localizes the two available Indonesian related-article links and converts three unavailable translations to plain text
- preserves the original image, citations, source URLs, facts, numbers, and Markdown structure

## Translation disclosure

- Language: Indonesian (`id`)
- AI assistance: Yes — OpenAI Codex
- Workflow: one `gpt-5.6-sol` high-reasoning translation agent, plus two `gpt-5.6-terra` high-reasoning agents for fidelity and Indonesian-language review
- Native-speaker review: No
- Human/native review recommended: Yes
- Note: `lastHumanReview` mirrors the Chinese source because the repository verifier treats it as a passthrough field; it does not mean this Indonesian translation received native-speaker review

## Validation

- Prettier: pass
- Strict frontmatter validation: pass
- Article health pre-commit profile: hard=0
- Translation verification: 18/18 pass
- Translation ratio: 3.85, pass
- CJK leakage and residue checks: pass
- Indonesian anti-framing terminology scan: pass
- Structure: 64→64 content blocks with exact type sequence
- Headings: H1 1→1, H2 10→10, H3 10→10
- Lists: 11→11 items
- Footnotes: 4→4 definitions
- External URLs: 5→5 exact multiset
- Images: 1→1
- Staged slug consistency and diff checks: pass

The article-health image-source warning is inherited from the source structure: the original and translation both include the same inline Wikimedia caption and frontmatter credit, without adding a separate image-source section.
