### PR TITLE
translate(vi): 八部合音 → bunun-pasibutbut-eight-part-polyphony

### DIFF
--- a/knowledge/vi/Music/bunun-pasibutbut-eight-part-polyphony.md
+++ b/knowledge/vi/Music/bunun-pasibutbut-eight-part-polyphony.md
@@ -1,0 +1,95 @@
+---
+title: 'Hợp xướng tám bè: hóa thạch sống thách thức lịch sử âm nhạc phương Tây'
+description: 'Năm 1943, nhà âm nhạc học Nhật Bản Kurosawa Takatomo ghi lại Pasibutbut của người Bunun giữa núi sâu Đài Đông. Chín năm sau, bản ghi đến UNESCO, gây chấn động giới âm nhạc học quốc tế: một dân tộc “không có chữ viết” đã tạo nên hợp xướng đa âm mà phương Tây tin rằng chỉ nền văn minh phát triển cao mới có thể sinh ra.'
+date: 2026-04-01
+category: 'Music'
+tags:
+  [
+    'Bunun',
+    'âm nhạc bản địa',
+    'các dân tộc bản địa',
+    'bồi âm',
+    'di sản văn hóa phi vật thể',
+    'văn hóa Đài Loan',
+  ]
+subcategory: 'Âm nhạc truyền thống và dân tộc'
+author: 'Taiwan.md Contributors'
+featured: true
+lastVerified: 2026-04-01
+lastHumanReview: true
+image: 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/Bunun_pasibutbut.jpg/1280px-Bunun_pasibutbut.jpg'
+imageAlt: 'Người Bunun trình diễn hợp xướng tám bè'
+imageCredit: 'Wikimedia Commons, CC BY-SA'
+translatedFrom: 'Music/八部合音.md'
+sourceCommitSha: '37638e173'
+sourceContentHash: 'sha256:3c2872e562b3f229'
+sourceBodyHash: 'sha256:43f231d59e183f8e'
+translatedAt: '2026-09-01T18:01:56+08:00'
+---
+
+> **Tổng quan 30 giây:** Năm 1943, nhà nghiên cứu âm nhạc Nhật Bản Kurosawa Takatomo mang thiết bị ghi âm vào tận cộng đồng Kanding giữa vùng núi Đài Đông và thu lại Pasibutbut, khúc hát cầu mùa kê bội thu của người Bunun. Chín năm sau, bản ghi được gửi đến UNESCO, khiến tất cả các nhà âm nhạc học có mặt đều sửng sốt — lý thuyết phương Tây cho rằng hợp xướng đa âm là sản phẩm của một nền văn minh phát triển cao, nhưng giữa núi sâu, không có chữ viết hay nhạc cụ, người Bunun vẫn làm được điều đó chỉ bằng sự cộng hưởng của giọng hát. Thanh âm được gọi là “hợp xướng tám bè” này đến nay vẫn có sức nhận diện quốc tế cao nhất trong các thanh âm của Đài Loan.
+
+Năm 1943, khi Thế chiến thứ hai bước vào giai đoạn cuối, nhà nghiên cứu âm nhạc Nhật Bản **Kurosawa Takatomo** nhận ủy thác của Phủ Tổng đốc Đài Loan, mang theo thiết bị ghi âm nặng nề vào cộng đồng Kanding, hương Hải Đoan, huyện Đài Đông.[^1] Với sự hỗ trợ của cảnh sát địa phương và một thanh niên Bunun tên “Adao”, ông vượt qua tình trạng điện chập chờn cùng những trở ngại giao thông để ghi lại một thanh âm làm thay đổi lịch sử âm nhạc.
+
+Sau này, Kurosawa Takatomo viết: “Đây là hòa âm tự nhiên hoàn hảo nhất mà tôi từng nghe trong đời.”[^2]
+
+Năm 1952, ông gửi bản ghi này đến Hội đồng Âm nhạc Dân gian Quốc tế trực thuộc UNESCO. Quan điểm chủ lưu của lý thuyết âm nhạc phương Tây lúc bấy giờ cho rằng âm nhạc loài người tiến hóa từ đơn âm sang đa âm, rồi đến hòa âm phức tạp — một con đường “tiến hóa văn minh” tuyến tính. Sự xuất hiện của Pasibutbut đã phá tung đường thẳng ấy.[^3] Một dân tộc không có hệ thống chữ viết đã cất lên thứ âm nhạc mà người châu Âu tin rằng chỉ nền văn minh phát triển cao mới có thể tạo nên.
+
+## Không phải tám bè, nhưng còn bí ẩn hơn tám bè
+
+Tên gọi “hợp xướng tám bè” thật ra là một sự hiểu lầm đẹp đẽ.
+
+Xét trên phương diện âm nhạc, Pasibutbut thực tế chỉ có bốn bè (đôi khi là năm): bè trầm Mahalngal, bè trung Manda, bè cao Bondada và giọng cao nhất được thêm vào ở phần kết.[^4] Nhưng khi người Bunun hát bằng kỹ thuật cộng hưởng cực kỳ chuẩn xác, âm thanh tạo ra hiện tượng “bồi âm” về mặt vật lý giữa cơ thể người và không gian — những âm ở tần số cao hơn chồng lên giai điệu chính, khiến người nghe có cảm giác như tám, thậm chí nhiều bè hơn, đang cùng lúc vang lên.[^5]
+
+> **📝 Góc nhìn giám tuyển:** Kỹ thuật tạo bồi âm tập thể này có nét tương đồng với lối hát họng khoomei của Mông Cổ. Tuy nhiên, khoomei là kỹ nghệ của một người hát đơn, còn người Bunun đạt được hiệu ứng ấy bằng hợp xướng tập thể — độ khó hoàn toàn khác biệt.
+
+| Bè       | Tên trong ngôn ngữ Bunun | Chức năng                                                  |
+| -------- | ------------------------ | ---------------------------------------------------------- |
+| Bè trầm  | Mahalngal                | Âm nền như mặt đất rung chuyển, tạo nền tảng cộng hưởng    |
+| Bè trung | Manda                    | Lấp đầy không gian âm thanh, khiến hòa âm dày và tròn đầy  |
+| Bè cao   | Bondada                  | Giai điệu chính đi lên, tượng trưng cho cây kê sinh trưởng |
+| Bồi âm   | (Overtones)              | Những bè ảo được tạo nên từ hiện tượng cộng hưởng vật lý   |
+
+Giữa núi rừng cách biệt với thế giới bên ngoài, người Bunun đã mô phỏng tiếng thác nước, ong và gió để truyền lại kỹ nghệ này từ đời này sang đời khác suốt hàng nghìn năm.[^6]
+
+## Lời cầu nguyện đi lên
+
+Với người Bunun, Pasibutbut không phải một tiết mục biểu diễn mà là nghi lễ. Khúc hát được cất lên sau lễ Bắn tai và trước lễ Gieo hạt, nhằm cầu xin thần trời Dehanin ban phước cho vụ kê bội thu.[^7]
+
+Việc hát tuân theo những quy tắc nghiêm ngặt:
+
+Giọng hát phải chậm rãi đi từ thấp lên cao, tượng trưng cho cây kê lớn lên khỏe mạnh. **Nếu cao độ hạ xuống giữa chừng hoặc bị chênh phô, đó được xem là điềm chẳng lành, báo trước năm ấy có thể gặp tai họa.** Người Bunun tin rằng tiếng hát thiếu hòa hợp cho thấy tâm hồn các thành viên chưa trong sạch hoặc cộng đồng chưa đoàn kết; thần trời sẽ không ban cho họ vụ mùa bội thu.[^7]
+
+Khi hát, mọi người đứng thành vòng tròn, hai tay đặt lên lưng người bên cạnh để cảm nhận lồng ngực của nhau rung lên. Đây không phải màn phô diễn kỹ thuật cá nhân, mà là cuộc đối thoại giữa ý chí tập thể với thần trời. Theo truyền thống, chỉ nam giới được hát và họ phải thực hiện nghi thức thanh tẩy trước khi cất giọng.[^7]
+
+> **📝 Góc nhìn giám tuyển:** Cơ chế “kiểm soát chất lượng” của Pasibutbut nghiêm ngặt đến cực độ — hát chênh phô không chỉ là sai nốt, mà còn là xúc phạm thần trời và là điềm dữ cho cả cộng đồng. Áp lực phải trình diễn hoàn hảo ấy có lẽ chính là lý do kỹ nghệ này được gọt giũa suốt hàng nghìn năm.
+
+## Thanh âm đang nhỏ dần
+
+Năm 2009, Bộ Văn hóa đưa “Hợp xướng tám bè của người Bunun” vào danh mục nghệ thuật truyền thống quan trọng cấp quốc gia, đồng thời chỉ định nhiều cộng đồng làm đơn vị bảo tồn.[^8] Nhưng nỗ lực bảo vệ bằng việc ghi danh có thể không theo kịp tốc độ mai một.
+
+Thế hệ trẻ rời cộng đồng và ngày càng ít tham gia các nghi lễ truyền thống. Để chiều lòng du khách, những buổi biểu diễn phục vụ du lịch đôi khi giản lược quy trình ca hát, bỏ qua các điều cấm kỵ trong nghi lễ. Vấn đề căn bản hơn nằm ở ngôn ngữ — khi tiếng Bunun mai một, thế hệ sau khó lòng hiểu được những tầng ý nghĩa văn hóa sâu xa phía sau lời ca.
+
+> “Không phải học hát, mà là học cách đối thoại với thiên nhiên và tổ tiên.”
+
+Trong các cộng đồng Bunun ở Nam Đầu, Hoa Liên và Đài Đông, các bậc cao niên vẫn dạy người trẻ kiểm soát các cơ ở cổ họng, lắng nghe bồi âm trong không khí. Điều họ truyền lại không chỉ là kỹ thuật, mà là cả một cách hiểu thế giới — âm thanh không phải do con người tạo ra, mà mọc lên từ đất; con người chỉ để nó đi qua mình.
+
+Khoảnh khắc Kurosawa Takatomo nhấn nút ghi âm vào năm 1943, có lẽ ông không ngờ rằng 80 năm sau, thanh âm ấy vẫn là dấu ấn văn hóa mạnh mẽ nhất mà Đài Loan đưa ra thế giới. Không phải vì nó cổ xưa, mà vì bằng cách đơn giản nhất — cổ họng của vài con người — nó chứng minh một điều: chiều sâu của nghệ thuật chưa bao giờ phụ thuộc vào mức độ phát triển của công nghệ.
+
+## Tài liệu tham khảo
+
+[^1]: [Lắng nghe thuộc địa: Kurosawa Takatomo và cuộc khảo sát âm nhạc Đài Loan thời chiến (1943)](https://tci.ncl.edu.tw/cgi-bin/gs32/gsweb.cgi?o=dnclresource&s=id=%22SA10000019079%22.&searchmode=basic&tcihsspage=tcisearch_opt1_search) — Xem phần bổ sung trong nội dung liên kết gốc〉, Thư viện Đại học Quốc gia Đài Loan, 2008
+
+[^2]: [Âm nhạc của các dân tộc Takasago ở Đài Loan](https://www.books.com.tw/products/0010430882) — Kurosawa Takatomo, 《》, Victor Records, 1974
+
+[^3]: [Khảo sát của Kurosawa Takatomo về âm nhạc bản địa Đài Loan](https://www.ntl.edu.tw/public/Attachment/9102615522190.pdf) — Phân quán Đài Loan thuộc Thư viện Trung ương Quốc gia〉, Viện Cao học Âm nhạc học, Đại học Quốc gia Đài Loan, 2008
+
+[^4]: [Pasibutbut của người Bunun — Cơ sở dữ liệu Di sản Văn hóa Quốc gia](https://nchdb.boch.gov.tw/assets/overview/traditionalPerformingart/20160317000001) — Xem phần bổ sung trong nội dung liên kết gốc
+
+[^5]: [Biling: nhìn người Bunun hát Pasibutbut và trở thành Bisosilin](https://www.airitilibrary.com/Article/Detail/U0118-0807200916272865) — Xem phần bổ sung trong nội dung liên kết gốc〉, luận văn thạc sĩ, Đại học Á Châu, 2008
+
+[^6]: [Lấy nghệ thuật âm nhạc bản địa Đài Loan “Hợp xướng tám bè của người Bunun” làm ví dụ](https://cge.knu.edu.tw/var/file/22/1022/img/124/874464490.pdf) — Xem phần bổ sung trong nội dung liên kết gốc〉, hội thảo học thuật Đại học Khoa học và Công nghệ Cần Ích, 2003
+
+[^7]: [Một số suy ngẫm về việc trình diễn khúc nghi lễ Pasibutbut — Bảo tàng Tiền sử Quốc gia Đài Loan](https://icloud.nmp.gov.tw/Library/EPaperContent?a=212&id=169&nid=638) — Xem phần bổ sung trong nội dung liên kết gốc
+
+[^8]: [Dữ liệu đăng ký “Hợp xướng tám bè của người Bunun” — Cục Di sản Văn hóa, Bộ Văn hóa](https://twh.boch.gov.tw/non_material/intro.aspx?id=743) — Xem phần bổ sung trong nội dung liên kết gốc


### PR DESCRIPTION
## Summary

- adds a complete Vietnamese translation of `Music/八部合音.md`
- follows the canonical Vietnamese editorial guide and its accessible cultural-journalism register
- preserves official Indigenous Latin spellings including `Bunun`, `Pasibutbut`, `Mahalngal`, `Manda`, `Bondada`, and `Dehanin`
- preserves every source section, table, quotation, factual claim, citation, footnote, image, and external URL
- follows the canonical English sibling slug `bunun-pasibutbut-eight-part-polyphony`

## Translation disclosure

- Language: Vietnamese (`vi`)
- AI assistance: Yes — OpenAI Codex
- Workflow: one `gpt-5.6-sol` high-reasoning translation agent, followed by independent Codex orchestrator review
- Native-speaker review: No
- Human/native review recommended: Yes
- Note: `lastHumanReview: true` mirrors the Chinese source because the repository verifier treats it as a passthrough field; it does not mean this Vietnamese translation received native-speaker review

## Validation

- Prettier: pass
- Strict frontmatter validation: pass
- Article health pre-commit profile: hard=0
- Translation verification: 18/18 pass
- Translation ratio: 2.70, pass
- CJK leakage, residue, and adjacency checks: pass
- Vietnamese anti-PRC-framing and respectful Indigenous terminology scan: pass
- Canonical translation status: fresh / same-commit
- Structure: exact semantic block-type sequence, 24→24
- Headings: H2 4→4
- Blockquotes: 4→4
- Table rows: 6→6
- Footnotes: 8→8 definitions, 10→10 references
- External URLs: 8→8 exact multiset
- Hero images: 1→1
- Staged slug consistency and diff checks: pass

The article-health image-source warning is inherited from the source structure: the Chinese source and this translation both retain the same Wikimedia hero image and `imageCredit` frontmatter but no separate image-source section. No new section was added because the translation workflow requires preserving the source structure.
