### PR TITLE
translate(id): 氣候 → climate

### DIFF
--- a/knowledge/id/Geography/climate.md
+++ b/knowledge/id/Geography/climate.md
@@ -1,0 +1,159 @@
+---
+title: 'Iklim Taiwan'
+description: 'Curah hujan tahunan 2,5 kali rata-rata global, tetapi termasuk 20 negara paling kekurangan air di dunia—iklim Taiwan tak pernah seperti yang dibayangkan'
+date: 2026-03-31
+category: 'Geography'
+tags: ['Geografi', 'Iklim', 'Topan', 'Hujan Mei-yu', 'Perubahan Iklim']
+subcategory: 'Iklim dan Mata Air Panas'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-03-31
+lastHumanReview: false
+translatedFrom: 'Geography/氣候.md'
+sourceCommitSha: '37638e173'
+sourceContentHash: 'sha256:0275e27f1a1e4e68'
+sourceBodyHash: 'sha256:c3a7643c439033af'
+translatedAt: '2026-09-01T18:02:09+08:00'
+---
+
+# Iklim Taiwan
+
+> **Ringkasan 30 Detik:** Taiwan menerima curah hujan 2.500 milimeter per tahun, 2,5 kali rata-rata global, tetapi pada saat yang sama termasuk salah satu dari 20 negara paling kekurangan air di dunia. Kontradiksi ini adalah kunci pertama untuk memahami iklim Taiwan. Hujan di Taiwan bukannya kurang banyak, melainkan terlalu terkonsentrasi, terlalu deras, dan terlalu cepat menghilang—seperti segala sesuatu di negara ini, semuanya ekstrem.
+
+| 2.500 mm                   | Rata-rata global 982 mm                   |
+| -------------------------- | ----------------------------------------- |
+| Curah hujan tahunan Taiwan | Taiwan menerima 2,54 kali rata-rata dunia |
+
+---
+
+## Terlalu Banyak Hujan, tetapi Terlalu Mudah Kekurangan Air
+
+Pada hari yang sama, suhu di dataran Taipei bisa mencapai 30 derajat, sementara dua jam berkendara menuju Pegunungan Tengah membawa kita ke Gunung Hehuan yang diselimuti salju setebal 9 sentimeter. Iklim Taiwan bukan sekadar rumit, melainkan terkompresi: sebagian besar zona iklim yang tersebar di berbagai garis lintang Bumi bertumpuk di negara yang panjangnya hanya 400 kilometer ini.
+
+Curah hujan tahunan rata-rata Taiwan mencapai 2.500 milimeter, tetapi 80% hujan itu terkonsentrasi selama enam bulan antara Mei dan Oktober.[^1] Keberadaan Pegunungan Tengah membuat hujan tercurah di pegunungan, lalu airnya bergegas menuju laut begitu cepat sehingga manusia tak sempat menahannya. Ditambah kepadatan penduduk dan tingginya konsumsi air untuk pertanian, jatah air tawar per kapita per tahun jauh di bawah rata-rata global. Akibatnya, Taiwan masuk dalam "daftar krisis kekurangan air" bersama negara-negara gurun.
+
+Paradoks ini—hujan banyak tetapi air tetap tak cukup—merupakan inti seluruh persoalan sumber daya air Taiwan, sekaligus alasan kekeringan terburuk dalam seabad pada 2021 begitu mengguncang seluruh negeri.
+
+---
+
+## Anomali di Garis Balik Utara
+
+Sebagian besar wilayah dunia yang dilintasi Garis Balik Utara berupa gurun atau kawasan semikering: Sahara, Semenanjung Arab, dan Meksiko utara. Taiwan justru tumbuh menghijau tepat di garis ini, dengan kepadatan spesies termasuk yang tertinggi di dunia. Ada tiga penyebabnya: persekutuan gunung, laut, dan monsun.
+
+Di tengah negara ini berdiri sebuah tulang punggung dengan lebih dari 100 puncak yang menjulang di atas 3.000 meter. Puncak tertingginya, Gunung Yushan (3.952 m), bahkan merupakan gunung tertinggi di dunia yang berada di dekat Garis Balik Utara.[^2] Pegunungan ini menahan uap air dari Samudra Pasifik, memaksanya naik, mendingin, lalu jatuh sebagai hujan. Pada musim dingin, monsun timur laut membawa udara dingin dari Siberia ke selatan. Ketika berhadapan dengan Pegunungan Xueshan dan Pegunungan Tengah, udara itu menumpahkan seluruh kandungan airnya di Yilan yang menghadap angin. Saat melewati puncak dan tiba di Hsinchu, kelembapannya telah habis; yang tersisa hanya angin kencang yang melaju melintasi Selat Taiwan. Dari sinilah ungkapan "angin Hsinchu, hujan Yilan" berasal—empat aksara dalam bahasa aslinya merangkum keajaiban pengaruh topografi terhadap iklim. Yilan mengalami lebih dari 200 hari hujan per tahun, sedangkan curah hujan tahunan di pegunungannya mencapai 5.500 milimeter. Sebaliknya, Hsinchu menjadi tempat paling berangin di Taiwan saat musim dingin, tetapi hampir tidak pernah turun hujan.[^3]
+
+Pada musim panas, polanya berbalik: monsun barat daya membawa udara panas dari Samudra Hindia dan Laut Tiongkok Selatan ke utara. Kali ini wilayah barat daya menghadap angin, sementara Taitung menjadi negeri angin foehn di sisi bawah angin. Setiap kali topan melintas, pesisir timur Taitung kerap mengalami angin foehn dengan suhu di atas 40 derajat Celsius: bukan karena terik matahari, melainkan karena udara panas dimampatkan kuat-kuat saat meluncur turun dari pegunungan di sebelah barat.
+
+> **✦** "Sebagian besar zona iklim yang tersebar di berbagai garis lintang Bumi bertumpuk di Taiwan, negara yang panjangnya hanya 400 kilometer ini."
+
+---
+
+## Empat Musim: Tidak Seperti yang Diajarkan Buku Pelajaran
+
+"Empat musim" di Taiwan adalah sebutan yang terdengar halus. Gambaran yang lebih mendekati kenyataan ialah: hujan Mei-yu, topan, monsun timur laut, dan musim dingin yang singkat—empat peristiwa iklim bergantian berkuasa, sesekali diselingi beberapa pekan yang disebut "musim semi" atau "musim gugur".
+
+Setiap tahun, dari pertengahan Mei hingga pertengahan Juni, front hujan Mei-yu tertahan di sekitar Taiwan. Hujan berkepanjangan mengisi waduk dengan persediaan air dalam jumlah besar. Curah hujan pada musim Mei-yu menyumbang 15% hingga 20% dari total tahunan, dan pertanian bergantung padanya untuk mengairi musim tanam padi pertama. Namun, hujan Mei-yu adalah pemasok yang sulit ditebak perangainya: terkadang turun selama tiga pekan berturut-turut, terkadang sama sekali tidak datang. Kondisi terakhir disebut "Mei-yu kosong", peringatan dini akan kekeringan yang menyusul.
+
+Juli hingga September merupakan puncak musim topan. Rata-rata tiga hingga empat topan menghantam Taiwan secara langsung setiap tahun, membawa 30% hingga 40% dari curah hujan tahunan. Di Taiwan, topan bukan hanya bencana; sampai taraf tertentu, ia juga menjadi "mekanisme pengisian paksa" bagi waduk. Pada tahun tanpa topan, ketinggian air waduk sering kali sudah memasuki kondisi genting sejak musim gugur.
+
+Selepas Oktober, monsun timur laut mulai berkuasa dan Taiwan memasuki pola "utara basah, selatan kering" hingga musim semi tahun berikutnya. Tainan nyaris tidak diguyur hujan pada Januari, sementara Taipei terus diselimuti mendung dan gerimis. Bagi penduduk Taiwan tengah, "begitu melewati Sungai Zhuoshui, cuacanya seperti berganti dunia" adalah pengalaman sehari-hari.
+
+Ketika musim dingin mencapai Gunung Hehuan, salju dapat menumpuk setebal 9 sentimeter atau lebih. Pada hari itu, dataran rendah mungkin masih menikmati musim dingin cerah bersuhu 15 derajat. Ketinggian Taiwan memampatkan zona-zona iklimnya, sehingga di negara yang sama dan pada sore yang sama, orang dapat melihat pantai tropis sekaligus pegunungan berselimut salju.
+
+---
+
+## Morakot, 8 Agustus 2009
+
+Pada 2009, sejumlah angka menjungkirbalikkan seluruh pemahaman tentang iklim Taiwan.
+
+Akumulasi curah hujan 24 jam di stasiun pengamatan Alishan: 1.403 milimeter. Curah hujan tahunan rata-rata Taiwan: 2.500 milimeter. Dengan kata lain, dalam sehari Alishan menerima hujan lebih dari jatah setengah tahun.[^4] Selama Topan Morakot berada di Taiwan (6 hingga 10 Agustus), total akumulasi curah hujan di Alishan melampaui 2.884 milimeter—lebih besar daripada curah hujan tahunan rata-rata Taiwan dan mendekati rekor dunia.[^5]
+
+Angka-angka itu hanyalah latar. Kisahnya berlangsung di Desa Xiaolin, Distrik Jiaxian, Kabupaten Kaohsiung.
+
+1. **2009/08/08 15.30** — Pusat Topan Morakot mendekati Taiwan, hujan deras terus turun
+2. **2009/08/09 05.00** — Di sisi timur laut Desa Xiaolin, Gunung Xiandu yang belum pernah dikembangkan manusia mengalami beberapa bidang retakan akibat hujan deras terus-menerus
+3. **2009/08/09 06.09** — Longsoran tanah dan batu dalam jumlah besar membendung Sungai Nanzihsien, membentuk danau bendungan yang segera jebol
+4. **110 detik kemudian** — Banjir menghancurkan jembatan nomor delapan dan sembilan; lebih dari 100 rumah tangga lenyap dari peta
+5. **Catatan akhir** — 491 orang hilang; lingkungan 9 hingga 18 di Desa Xiaolin terkubur lumpur dan batu[^6]
+
+Ini bukan semata-mata masalah kelalaian manusia atau kurangnya kesiapsiagaan bencana. Investigasi _The Reporter_ menunjukkan bahwa geologi lereng searah lapisan di Gunung Xiandu, ditambah giatnya pembentukan pegunungan Taiwan yang telah meremukkan massa batuan, membuat curah hujan ekstrem menjadi daya pemicu terakhir.[^7] Iklim, geologi, bentuk pegunungan: pada saat terburuk, kondisi geografis Taiwan berpadu sempurna dan menghasilkan bencana topan terparah sejak Banjir 7 Agustus 1959—681 orang tewas dan 18 orang hilang.
+
+> **📝 Catatan Kurator**
+> Bagian paling memilukan dari peristiwa Desa Xiaolin bukanlah bencana itu sendiri, melainkan kenyataan bahwa kondisi geologis Gunung Xiandu sudah lama ada: "longsor pernah terjadi pada masa lalu dan meninggalkan banyak lapisan endapan rombakan yang lepas". Gunung ini bukan "dirusak" oleh Morakot; ia hanya akhirnya mendapat hujan yang cukup banyak. Iklim yang semakin ekstrem berarti ambang "belum cukup, belum akan longsor" semakin mudah terlampaui.
+
+---
+
+## Kekeringan Terburuk dalam Seabad, 2021
+
+Pada musim panas 2020, tekanan tinggi subtropis mengalami anomali terkuat dan bertahan paling lama sejak 1949. Tekanan tinggi Pasifik menahan Taiwan, topan berbelok menghindarinya, hujan Mei-yu berakhir lebih awal, dan pengisian air pada musim panas gagal sepenuhnya.[^8]
+
+Pada musim dingin berikutnya, hujan musim semi juga tidak datang tepat waktu. Memasuki musim semi 2021, ketinggian air waduk-waduk utama Taiwan turun ke titik terendah sepanjang sejarah. Kapasitas Waduk Tsengwen tersisa kurang dari 5%. Waduk Paoshan dan Waduk Paoshan Kedua—sumber air bagi Taman Sains Hsinchu, kawasan teknologi terpenting di Taiwan—juga berada di ambang krisis. Tahun 2021 disebut sebagai "kekeringan terburuk dalam seabad", kekeringan paling parah sejak pencatatan lengkap dimulai pada 1947.[^9]
+
+Pertanian ikut terseret di dalamnya. Pohon teh di Gukeng, Yunlin, tidak mampu menumbuhkan tunas baru sehingga produksi teh musim semi merosot tajam; hasil panen plum hijau di Taoyuan, Kaohsiung, diperkirakan berkurang separuh; total kerugian pertanian di Nantou, Yunlin, dan Chiayi melampaui 200 juta dolar baru Taiwan.[^10] Ungkapan petani "menggantungkan hidup pada langit" menjadi kenyataan dalam bentuknya yang paling telanjang pada musim semi 2021.
+
+Situasi di Taman Sains Hsinchu bahkan lebih menegangkan. Pabrik semikonduktor seperti TSMC termasuk konsumen air terbesar di Taiwan, dan ketatnya persediaan air membuat seluruh industri teknologi berada dalam ketegangan. Pemerintah mengerahkan truk tangki untuk menambah pasokan air bagi pabrik. Pada saat bersamaan, lebih dari 50.000 hektare lahan pertanian dihentikan sementara dari kegiatan tanam agar air irigasi dapat dialihkan untuk industri dan kebutuhan rumah tangga.
+
+Pada akhirnya, jalan keluar dari kekeringan terburuk dalam seabad datang dari beberapa gelombang front hujan Mei-yu yang dimulai pada akhir Mei 2021, disusul topan pada Juli. Krisis terbesar tahun itu sekali lagi diakhiri oleh peristiwa iklim itu sendiri.
+
+> **⚠️ Sudut Pandang Kontroversial**
+> Kekeringan terburuk dalam seabad menyingkap kontradiksi mendalam dalam struktur pembagian sumber daya air Taiwan: pertanian mengonsumsi lebih dari 70% air di seluruh Taiwan, tetapi ketika krisis kekurangan air terjadi, pertanian sering menjadi pihak pertama yang dikorbankan. Petani berkata, "tidak ada air, tetapi kita juga harus makan"; industri berkata, "berikan air kepada kami, PDB yang kami ciptakan memberi imbal balik lebih besar". Kekeringan yang sama memperlihatkan ketidakadilan yang berbeda bagi orang yang berbeda.
+
+---
+
+## Tagihan Perubahan Iklim
+
+Selama 100 tahun terakhir, suhu rata-rata Taiwan telah meningkat sekitar 1,6°C, lebih tinggi daripada kenaikan suhu rata-rata global pada periode yang sama. Yang lebih merepotkan adalah permukaan laut: kenaikan permukaan laut Taiwan berlangsung dua kali lebih cepat daripada rata-rata global, yakni 3,4 milimeter per tahun selama 20 tahun terakhir.[^11] Jika pemanasan terus berlanjut, pada 2050 sekitar 900.000 orang di Taiwan mungkin terdampak kenaikan permukaan laut, sementara sekitar 1.131 kilometer persegi daratan menghadapi risiko terendam.
+
+Pada saat yang sama, NOAA Amerika Serikat mengeluarkan peringatan pada 2022 bahwa Taiwan menghadapi krisis pemutihan karang terbesar dalam 20 tahun. Ekosistem terumbu karang Taiwan terkenal kaya, tetapi suhu air laut yang terus meningkat membuat karang kehilangan alga simbiotiknya, lalu perlahan memutih dan mati.[^12]
+
+Hal yang paling mencemaskan para ahli meteorologi ialah kecenderungan menuju kondisi ekstrem: musim hujan semakin basah, musim kering semakin kering; jumlah topan mungkin berkurang, tetapi kekuatannya akan meningkat. Peristiwa seperti Morakot—"hujan lebih dari jatah setahun turun dalam dua hari"—mungkin akan lebih sering terjadi. Kekeringan terburuk dalam seabad pada 2021 mungkin menjadi keadaan normal, bukan lagi pengecualian.
+
+Sejarah pengamatan cuaca Taiwan bermula pada 1896, ketika orang Jepang meminjam sebuah kelenteng Fude di Hengchun sebagai stasiun cuaca sementara dan memasang peralatan untuk mulai melakukan pengukuran.[^13] Orang-orang saat itu tidak tahu, 130 tahun kemudian, angka-angka ini akan menjadi bukti tentang apa.
+
+---
+
+> **📝 Catatan Kurator**
+> Pada akhirnya, paradoks iklim Taiwan terbaca seperti sebuah peringatan: negara yang menerima hujan 2,5 kali rata-rata global berubah menjadi tempat yang kekurangan air karena topografinya terlalu curam, penduduknya terlalu padat, dan waduknya terlalu sedikit. Lalu topannya menurunkan hujan lebih banyak daripada rata-rata tahunan dalam dua hari. Lalu datang satu tahun penuh ketika semua topan berbelok menghindar dan waduk mengering hingga ke dasar. Iklim Taiwan bukanlah iklim yang jinak; sebagian besar waktu, ia hanya tampak demikian.
+
+---
+
+## Referensi
+
+- [Curah hujan tahunan Taiwan 2,54 kali rata-rata dunia—Ensiklopedia Iklim Administrasi Cuaca Pusat](https://climate.cwa.gov.tw/ClimatePedia/detail_page/7) (sumber primer)
+- [Karakteristik bencana kekeringan Taiwan—Platform Adaptasi Risiko Bencana Perubahan Iklim](https://dra.ncdr.nat.gov.tw/Frontend/Disaster/RiskDetail/BAL0000022) (sumber primer)
+- [Desa Xiaolin—Wikipedia (termasuk indeks sumber berita asli)](https://zh.wikipedia.org/zh-tw/%E5%B0%8F%E6%9E%97%E9%87%8C)
+- [Malam Itu, Tragedi Desa Xiaolin akibat Longsor Besar dan Bencana Majemuk—The Reporter](https://www.twreporter.org/a/bookreview-typhoon-morakot-xiaolin-village-disaster-causes)
+- [Peristiwa Bencana Iklim Ekstrem dalam Sejarah Taiwan—Platform Adaptasi Risiko Bencana Perubahan Iklim](https://dra.ncdr.nat.gov.tw/Frontend/Disaster/ClimateDetail/BAL0000004) (sumber primer)
+- [Krisis Kekeringan dan Kekurangan Air Taiwan 2021—Wikipedia](https://zh.wikipedia.org/zh-tw/2021%E5%B9%B4%E8%87%BA%E7%81%A3%E6%97%B1%E7%81%BD%E7%BC%BA%E6%B0%B4%E5%8D%B1%E6%A9%9F)
+- [Ketika Kekeringan Terburuk dalam Seabad Menjadi Kenormalan—Our Island (PTS)](https://ourisland.pts.org.tw/content/9997)
+- [Analisis Dampak Kenaikan Permukaan Laut Taiwan akibat Pemanasan Global—Greenpeace Taiwan](https://www.greenpeace.org/taiwan/press/9206/%E5%85%A8%E7%90%83%E6%9A%96%E5%8C%96%E4%B8%8B%E8%87%BA%E7%81%A3%E6%B5%B7%E5%B9%B3%E9%9D%A2%E4%B8%8A%E5%8D%87%E8%A1%9D%E6%93%8A%E5%88%86%E6%9E%90/)
+- [Sejarah Stasiun Cuaca Hengchun—Administrasi Cuaca Pusat](https://www.cwa.gov.tw/V8/C/A/organ/46759.html) (sumber primer)
+- [Kenaikan Permukaan Laut Taiwan Dua Kali Lebih Cepat daripada Rata-rata Global—Pusat Informasi Lingkungan](https://e-info.org.tw/node/226463)
+- [Analisis Penyebab Kekeringan Terburuk dalam Seabad di Taiwan pada 2020–2021—Basis Data Riset dan Aplikasi Ilmu Atmosfer](https://asrad.pccu.edu.tw/dbar/doc_journal/2020-2021%E8%87%BA%E7%81%A3%E7%99%BE%E5%B9%B4%E5%A4%A7%E6%97%B1%E5%8E%9F%E5%9B%A0%E5%88%86%E6%9E%90/) (akademis)
+- [Garis Balik Utara, gunung tertinggi Taiwan di garis tersebut—Wikipedia](https://en.wikipedia.org/wiki/Tropic_of_Cancer)
+
+[^1]: Ensiklopedia Iklim Administrasi Cuaca Pusat, data distribusi curah hujan Taiwan
+
+[^2]: Wikipedia, Garis Balik Utara: "Gunung tertinggi yang berada di atau berdekatan dengan Garis Balik Utara adalah Gunung Yushan di Taiwan"
+
+[^3]: Data Pemerintah Kabupaten Yilan dan sumber pengajaran geografi: curah hujan tahunan Dataran Lanyang 2.500–3.000 mm, wilayah pegunungan 5.500 mm, dengan lebih dari 200 hari hujan
+
+[^4]: Curah hujan 24 jam di stasiun Alishan sebesar 1.403 mm, bersumber dari data meteorologi yang dikutip banyak pihak; versi lain menyebut 1.165 mm (stasiun berbeda), dan angka yang digunakan di sini adalah angka yang dikutip secara luas
+
+[^5]: Platform Adaptasi Risiko Bencana Perubahan Iklim: "Di stasiun Alishan, total akumulasi curah hujan melampaui 2.884 mm, sudah melebihi curah hujan tahunan rata-rata Taiwan"
+
+[^6]: Wikipedia Desa Xiaolin: 491 orang hilang, danau bendungan jebol pada 2009/08/09 pukul 06.09
+
+[^7]: Kutipan buku di _The Reporter_: "Tanah dan batu yang lepas dan terpecah meluncur turun mengikuti lereng searah lapisan akibat gravitasi"
+
+[^8]: Basis Data Riset Ilmu Atmosfer: "Pada 2020, tekanan tinggi subtropis mencapai kekuatan terbesar dan bertahan paling lama sejak 1949"
+
+[^9]: Wikipedia tentang kekeringan Taiwan 2021: "Kekeringan paling parah sejak 1947"
+
+[^10]: PTS _Our Island_: pohon teh di Gukeng, Yunlin; plum hijau di Taoyuan, Kaohsiung; kerugian pertanian melampaui 200 juta dolar baru Taiwan
+
+[^11]: Pusat Informasi Lingkungan mengutip analisis: "Kenaikan permukaan laut Taiwan berlangsung dua kali lebih cepat daripada rata-rata global, dan selama 20 tahun terakhir terus meningkat 3,4 milimeter per tahun"
+
+[^12]: Greenpeace Hong Kong: "NOAA mengeluarkan peringatan bahwa Taiwan menghadapi krisis pemutihan karang terbesar dalam 20 tahun" (2022)
+
+[^13]: Administrasi Cuaca Pusat: "Pada 20 November 1896, orang Jepang mula-mula meminjam kelenteng Fude milik warga sebagai kantor sementara"


### PR DESCRIPTION
## Summary

- adds a complete Indonesian translation of `Geography/氣候.md`
- follows the canonical Indonesian editorial guide and its Kompas/Tempo-style formal register
- applies Indonesian number formatting and Taiwan/Tiongkok/Tionghoa terminology rules
- preserves every source section, table, list item, curatorial note, factual claim, citation, footnote, and external URL
- follows the canonical English sibling slug `climate`

## Translation disclosure

- Language: Indonesian (`id`)
- AI assistance: Yes — OpenAI Codex
- Workflow: one `gpt-5.6-sol` high-reasoning translation agent, followed by independent Codex orchestrator review
- Native-speaker review: No
- Human/native review recommended: Yes
- Note: `lastHumanReview: false` mirrors the Chinese source; this translation does not claim native-speaker review

## Validation

- Prettier: pass
- Strict frontmatter validation: pass
- Article health pre-commit profile: hard=0, warn=0
- Translation verification: 18/18 pass
- Translation ratio: 3.03, pass
- CJK leakage, residue, and adjacency checks: pass
- Indonesian anti-framing terminology scan: pass
- Canonical translation status: fresh / same-commit
- Structure: exact semantic block-type sequence, 49→49
- Headings: H1 1→1, H2 7→7
- Ordered list items: 5→5
- Table rows: 3→3
- Footnotes: 13→13 definitions and references
- External URLs: 12→12 exact multiset
- Images: 0→0
- Staged slug consistency and diff checks: pass
