### PR TITLE
translate(vi): 赤燭遊戲 → Red Candle Games

### DIFF
--- a/knowledge/vi/Technology/red-candle-games.md
+++ b/knowledge/vi/Technology/red-candle-games.md
@@ -1,0 +1,140 @@
+---
+title: 'Red Candle Games: câu chuyện Đài Loan mà một lá bùa không thể ngăn lại'
+description: 'Sáu người Đài Loan đưa Detention lên bảng bán chạy Steam, rồi Devotion biến mất sau tranh cãi về một lá bùa tại Trung Quốc. Năm 2024, Red Candle Games trở lại với Nine Sols, bán 800.000 bản và giành giải game độc lập của Sony.'
+date: 2026-04-25
+category: 'Technology'
+tags:
+  [
+    'Red Candle Games',
+    'Detention',
+    'Devotion',
+    'Nine Sols',
+    'trò chơi độc lập',
+    'Khủng bố Trắng',
+    'trò chơi Đài Loan',
+  ]
+subcategory: 'Cộng đồng và văn hóa số'
+author: 'zaious'
+featured: false
+lastVerified: 2026-04-25
+lastHumanReview: false
+readingTime: 10
+translatedFrom: 'Technology/赤燭遊戲.md'
+sourceCommitSha: '37638e173'
+sourceContentHash: 'sha256:33c90e10581f31c9'
+sourceBodyHash: 'sha256:1fba81d514ac33a3'
+translatedAt: '2026-09-01T20:25:00+08:00'
+---
+
+> Ngày 13 tháng 1 năm 2017, _Detention_, một trò chơi kinh dị lấy bối cảnh thời kỳ Khủng bố Trắng ở Đài Loan những năm 1960, ra mắt trên Steam. Hai năm sau, phần tiếp theo _Devotion_ bị loại khỏi thị trường Trung Quốc hoàn toàn vì một lá bùa có dòng chữ “Tập Cận Bình Gấu Pooh” và đến nay vẫn không thể mua trên Steam. Năm năm nữa trôi qua, cũng chính đội ngũ ấy bán được 800.000 bản _Nine Sols_ và giành giải game độc lập của Sony năm 2025. Mười năm của Red Candle Games tạo nên một trong những đường cong kịch tính nhất lịch sử game độc lập Đài Loan: kể chuyện bằng lịch sử của chính mình, bị thị trường lớn nhất quay lưng, rồi dùng tác phẩm tiếp theo để chứng minh họ vẫn còn ở đây.
+
+---
+
+## Sáu người và một phòng học
+
+Tiền thân của Red Candle Games là Prism Observer Studio, do sáu người đồng sáng lập vào tháng 9 năm 2015: Yao Shun-ting, hai anh em Wang Kuang-hao và Wang Han-yu, Chiang Tung-yu, Chen Ching-heng và Yang Shih-wei.[^1]
+
+Ý tưởng cốt lõi bắt nguồn từ một suy nghĩ của Yao Shun-ting vào năm 2013: biến bầu không khí ngột ngạt dưới thời thiết quân luật ở Đài Loan thành một trò chơi kinh dị. Bối cảnh là một trường trung học xa xôi trên vùng núi vào thập niên 1960; bùa chú và vàng mã trong tín ngưỡng dân gian Đạo giáo tạo nên ngôn ngữ hình ảnh, còn tố cáo và danh sách đen thời Khủng bố Trắng làm xương sống cho cốt truyện.[^2]
+
+Ngày 13 tháng 1 năm 2017, _Detention_ lên Steam.
+
+> **📝 Ghi chú của người tuyển chọn**
+> Trước _Detention_, game lấy lịch sử Đài Loan làm đề tài gần như là một khoảng trống. Nhật Bản có _Taikou Risshiden_, Âu Mỹ có _Assassin's Creed_, nhưng chưa có trò chơi nào dùng chính lịch sử Đài Loan làm chất liệu. Ngày nay, việc Red Candle thực hiện có thể được gọi là “phát triển IP văn hóa nguyên bản”, nhưng khi họ bắt đầu vào năm 2015, khái niệm ấy vẫn chưa phổ biến.
+
+---
+
+## Bằng chứng trị giá 260 triệu Đài tệ
+
+Thành tích của _Detention_ vượt xa mọi dự đoán.
+
+Sau khi phát hành, trò chơi nhanh chóng leo lên bảng bán chạy toàn cầu của Steam. Bản điện ảnh chuyển thể năm 2019 thu 260 triệu Đài tệ tại Đài Loan, đứng đầu phòng vé phim nội địa trong năm và cũng là bộ phim Đài Loan duy nhất năm ấy vượt mốc 100 triệu Đài tệ. Phim còn giành năm giải tại kỳ Kim Mã lần thứ 56.[^3]
+
+Năm 2020, Đài Truyền hình Công cộng Đài Loan và Netflix hợp tác ra mắt loạt phim _Detention_ gồm tám tập. Câu chuyện lấy bối cảnh cuối thập niên 1990, tạo thế đối chiếu với bối cảnh thập niên 1960 của bản điện ảnh.[^4]
+
+Một trò chơi → một bộ phim điện ảnh → một loạt phim truyền hình. _Detention_ đã đi trọn con đường chuyển thể đa phương tiện của một IP game Đài Loan, và thành công ở từng chặng.
+
+---
+
+## Sự cố lá bùa
+
+Ngày 19 tháng 2 năm 2019, Red Candle phát hành tác phẩm thứ hai, _Devotion_. Đây là trò chơi kinh dị giải đố góc nhìn thứ nhất, lấy bối cảnh một căn hộ Đài Loan trong thập niên 1980 và kể về bi kịch gia đình do người cha chìm đắm trong tín ngưỡng dân gian.
+
+Ngay ngày đầu ra mắt, lượng người xem đồng thời trên Twitch vượt 100.000. Chỉ trong vài ngày, trò chơi bán hơn một triệu bản.[^6]
+
+Rồi có người phát hiện một lá bùa trong khung cảnh trò chơi.
+
+Bốn góc lá bùa ghi “ne ma ba qi”, một lối chơi chữ theo âm đọc, còn chính giữa là dòng chữ triện màu đỏ “Tập Cận Bình Gấu Pooh”.[^7]
+
+Chỉ trong vài giờ, tranh cãi bùng nổ. Nhà phát hành Trung Quốc Indievent tuyên bố chấm dứt hợp tác. _Devotion_ bị gỡ khỏi Steam tại Trung Quốc, rồi biến mất hoàn toàn khỏi Steam trên toàn cầu. Ngay cả _Detention_ cũng hứng chịu làn sóng đánh giá tiêu cực trả đũa từ người chơi Trung Quốc, khiến mức xếp hạng từ “Cực kỳ tích cực” rơi xuống “Trái chiều”. Giấy phép của nhà phát hành Trung Quốc bị thu hồi, còn nhà đầu tư yêu cầu Red Candle bồi thường.[^8]
+
+Trong một cuộc phỏng vấn sau này, đồng sáng lập Yang Shih-wei kể lại rằng lá bùa chỉ là hình ảnh tạm do họa sĩ đặt vào trong quá trình phát triển. Khi nhóm thiết kế quá bận, họ nói “cứ đặt tạm thứ gì đó vào trước”, rồi quên thay thế. Ông nói: “Thật sự chỉ là chèn nhầm; chúng tôi tưởng những gì cần sửa đều đã sửa xong.”[^9]
+
+Dù sự thật là gì, _Devotion_ đến nay vẫn không có mặt trên Steam. Trò chơi từng xuất hiện trong thời gian ngắn trên GOG, nhưng cũng nhanh chóng bị gỡ dưới áp lực. Cuối cùng, Red Candle mở cửa hàng riêng trên trang web của mình để bán game, bỏ qua mọi nền tảng bên thứ ba.
+
+> **⚠️ Góc nhìn gây tranh cãi**
+> Tranh luận cốt lõi của sự cố lá bùa là: một hình ảnh tạm trong quá trình phát triển có được xem là tuyên bố chính trị hay không? Red Candle nói đó là lỗi chèn nhầm; phía Trung Quốc coi đó là hành động khiêu khích có chủ ý. Hậu quả của sự việc vượt xa số phận một trò chơi — nó khiến mọi nhà phát triển game Đài Loan muốn bước vào thị trường Trung Quốc nhận ra rằng ngưỡng rủi ro chính trị thấp hơn nhiều so với họ từng hình dung.
+
+---
+
+## Nine Sols: trở lại bằng tác phẩm
+
+Sau sự cố lá bùa, Red Candle im tiếng suốt năm năm.
+
+Ngày 31 tháng 5 năm 2024, _Nine Sols_ ra mắt trên Steam. Thể loại thay đổi hoàn toàn: một game phiêu lưu hành động màn hình ngang 2D, kết hợp khoa học viễn tưởng Đạo giáo, thế giới quan thần thoại cổ đại và những trận chiến khó với cơ chế đỡ đòn làm trọng tâm. Người chơi vào vai nhân vật báo thù Yi, tiêu diệt chín “Sol” trong một thế giới hòa trộn mỹ học phương Đông với cyberpunk.[^10]
+
+Ngay ngày đầu, trò chơi đứng thứ chín trên bảng bán chạy toàn cầu của Steam. Đến dịp kỷ niệm một năm phát hành vào tháng 5 năm 2025, doanh số đã vượt 800.000 bản. Tỷ lệ đánh giá tích cực trên Steam duy trì trên 95%, với hơn 16.000 bài đánh giá từ người chơi. Tháng 11 năm 2024, game có mặt trên PS5, Xbox và Switch, đồng thời gia nhập Xbox Game Pass ngay ngày đầu.[^11]
+
+Năm 2025, _Nine Sols_ nhận Giải Game độc lập của Sony tại PlayStation Partner Awards, vinh danh những tác phẩm game độc lập xuất sắc ở Nhật Bản và châu Á.[^12]
+
+Với _Nine Sols_, Red Candle chứng minh một điều: ngay cả khi mất thị trường Trung Quốc, một studio game độc lập Đài Loan vẫn có thể sống — và sống rất tốt.
+
+> **✦** Từ phòng học thời Khủng bố Trắng, đến căn hộ Đài Loan thập niên 1980, rồi thế giới thần thoại Đạo giáo-punk. Mỗi trò chơi của Red Candle kể một câu chuyện khác nhau, nhưng DNA bên dưới chưa từng đổi: đưa những yếu tố văn hóa Đài Loan vào các thể loại game mà người chơi khắp thế giới đều có thể hiểu.
+
+---
+
+## Cách họ được ghi nhớ
+
+Đường cong mười năm của Red Candle cô đọng mọi cơ hội và rủi ro mà game độc lập Đài Loan phải đối mặt.
+
+_Detention_ chứng minh lịch sử Đài Loan có thể trở thành đề tài trò chơi và được cả thế giới đón nhận. _Devotion_ cho thấy một lá bùa có thể khiến trò chơi bán triệu bản biến mất khỏi các cửa hàng toàn cầu. _Nine Sols_ chứng minh một đội ngũ bị cấm cửa vẫn có thể đứng dậy bằng tác phẩm tiếp theo.
+
+Đến năm 2026, Red Candle vẫn duy trì đội ngũ tinh gọn, không niêm yết cổ phiếu, không bị mua lại, cũng không chuyển hướng sang game di động. Họ vẫn là studio khởi đầu từ sáu con người ấy, chỉ khác là tác phẩm nay đã được giải Kim Mã công nhận và được Sony trao giải.
+
+_Devotion_ vẫn chưa trở lại Steam. Nhưng Red Candle vẫn còn ở đây.
+
+---
+
+## Đọc thêm
+
+- Toàn cảnh ngành trò chơi và giải trí số Đài Loan — từ phát hành hộ đến sáng tạo nguyên bản
+- [Hai thanh kiếm kinh điển của Softstar](/vi/technology/softstar-twin-classics) — ở thế hệ trước Red Candle, đây là khởi điểm để game Đài Loan kể chuyện bằng tiếng Hoa
+- [Những khoảnh khắc điên rồ của game thủ Đài Loan](/vi/technology/taiwan-gamers-wildest-moments) — một mặt khác trong hành vi tập thể của người chơi Đài Loan
+- [Rayark Games](/vi/technology/rayark-games) — một đội ngũ indie Đài Loan cùng thời; sau sự cố mã Morse ICE năm 2020, họ chọn con đường trái ngược Red Candle: cắt đứt quan hệ với nhân viên để giữ thị trường Trung Quốc
+
+---
+
+## Tài liệu tham khảo
+
+[^1]: [Wikipedia: Red Candle Games](https://zh.wikipedia.org/zh-tw/%E8%B5%A4%E7%87%AD%E9%81%8A%E6%88%B2) — thành lập năm 2015, sáu người đồng sáng lập
+
+[^2]: [Smile Taiwan: câu chuyện đằng sau danh tiếng của Detention](https://smiletaiwan.cw.com.tw/article/2346) — ý tưởng năm 2013 của Yao Shun-ting và bối cảnh thời thiết quân luật
+
+[^3]: [ETtoday: Detention thu 259 triệu Đài tệ, đứng đầu phim Đài Loan năm 2019](https://star.ettoday.net/news/1597165) — doanh thu 260 triệu Đài tệ, năm giải Kim Mã và phim Đài Loan duy nhất trong năm vượt mốc 100 triệu
+
+[^4]: [Wikipedia: Detention (loạt phim truyền hình)](https://zh.wikipedia.org/zh-tw/%E8%BF%94%E6%A0%A1_%28%E9%9B%BB%E8%A6%96%E5%8A%87%29) — loạt phim tám tập năm 2020 của PTS và Netflix, lấy bối cảnh thập niên 1990
+
+[^5]: [La Vie: từ Detention đến Devotion, Red Candle kể chuyện mang hương vị Đài Loan bằng game](https://www.wowlavie.com/article/ae1702163) — thông tin về việc Thư viện Harvard-Yenching đưa tác phẩm vào bộ sưu tập có trong bài gốc
+
+[^6]: [Cool3c: doanh số Devotion trên Steam nhanh chóng tiến tới một triệu bản](https://www.cool3c.com/article/141256) — 100.000 người xem đồng thời trên Twitch trong ngày đầu, doanh số vượt một triệu
+
+[^7]: [Cool3c: Red Candle chủ động gỡ Devotion khỏi Steam, nhìn lại các biến cố](https://www.cool3c.com/article/141357) — nội dung lá bùa và diễn biến gỡ game
+
+[^8]: [The News Lens: trở lại bản chất kinh doanh, Red Candle còn có thể tiếp tục sau sự cố Gấu Pooh?](https://www.thenewslens.com/article/114730) — nhà phát hành chấm dứt hợp tác, giấy phép bị thu hồi, nhà đầu tư đòi bồi thường và Detention bị đánh giá tiêu cực
+
+[^9]: [UDN Game: nhà sáng lập Red Candle kể lại sự cố lá bùa trong Devotion](https://game.udn.com/game/story/122089/8208614) — Yang Shih-wei nói “thật sự chỉ là chèn nhầm” và “tưởng những gì cần sửa đều đã sửa xong”
+
+[^10]: [Bahamut: tác phẩm mới Nine Sols của Red Candle ra mắt hôm nay](https://gnn.gamer.com.tw/detail.php?sn=268404) — phát hành ngày 31 tháng 5 năm 2024, phong cách Đạo giáo-punk và hành động 2D
+
+[^11]: [Ali213: Nine Sols vượt 800.000 bản sau một năm phát hành](https://www.ali213.net/news/html/2025-5/935135.html) — doanh số 800.000 bản, đánh giá tích cực 95% trên Steam, 16.000 bài đánh giá và phiên bản PS5, Xbox, Switch
+
+[^12]: [Liberty Times: Nine Sols của Red Candle giành giải game độc lập Sony năm 2025](https://news.ltn.com.tw/news/Taipei/breakingnews/5267415) — PlayStation Partner Awards


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

新增越南文翻譯：
- 來源：knowledge/Technology/赤燭遊戲.md
- 譯文：knowledge/vi/Technology/red-candle-games.md
- 依越南文規範使用 Đài Loan、Khủng bố Trắng 等詞形
- 中國市場與符咒事件的反應均保留明確的來源歸屬
- 僅連結已存在的越南文延伸閱讀頁面
- 保留原文段落、12 則腳註與所有 URL

## ✅ 驗證

- strict frontmatter：PASS
- article-health pre-commit：PASS（0 warnings）
- translation ratio：PASS（2.63）
- CJK leak / residue / adjacency：PASS
- anti-framing scan：PASS
- verify-translation：18/18 PASS
- 語意區塊序列：PASS（43 blocks）
- provenance：fresh / same-commit

## 🤖 AI 協作揭露

- 使用 OpenAI Codex 協助翻譯、術語一致性與自動檢查
- 本 PR 尚未經越南文母語者審閱
- lastHumanReview: false 沿用來源文章，不代表這份新譯文已完成人工審閱；建議合併前由越南文母語者複核語感