### PR TITLE
translate(id): 杜奕瑾 → ethan-tu

### DIFF
--- a/knowledge/id/People/ethan-tu.md
+++ b/knowledge/id/People/ethan-tu.md
@@ -1,0 +1,152 @@
+---
+title: 'Ethan Tu (杜奕瑾)'
+description: 'Mendirikan forum terbesar Taiwan dari sebuah komputer 486, memimpin lahirnya Cortana di Microsoft, lalu melepas gaji tinggi untuk pulang membangun AI nirlaba—tiga puluh tahun sejarah digital sang dewa pencipta PTT.'
+date: 2026-03-30
+category: 'People'
+tags: ['Ethan Tu', 'PTT', 'Taiwan AI Labs', 'Demokrasi Digital', 'Kecerdasan Buatan']
+subcategory: '科技與企業'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-03-30
+lastHumanReview: false
+readingTime: 9
+translatedFrom: 'People/杜奕瑾.md'
+sourceCommitSha: 'ab47ff39'
+sourceContentHash: 'sha256:61081ca7c646947e'
+sourceBodyHash: 'sha256:f186e67ce03f9679'
+translatedAt: '2026-09-01T22:35:00+08:00'
+---
+
+# Ethan Tu (杜奕瑾)
+
+> **Sekilas dalam 30 detik:** Ethan Tu (杜奕瑾), lahir pada 1976, mendirikan PTT tahun 1995 dari sebuah komputer 486 di asrama putra National Taiwan University. Forum berbasis teks murni itu bertahan melewati gelembung internet, kebangkitan Facebook, dan serbuan pasukan siber; tiga puluh tahun kemudian ia masih menjadi ruang inti wacana publik Taiwan. Ia pergi ke Amerika Serikat untuk meneliti genetika di NIH, lalu di Microsoft memimpin lahirnya Cortana, asisten AI lintas platform, dan pada Maret 2017 melepaskan gaji tinggi di Seattle untuk pulang mendirikan lembaga riset AI nirlaba pertama di Asia. Ini kisah tentang seseorang yang memilih untuk tidak menjadi Mark Zuckerberg versi Taiwan, melainkan mengerjakan sesuatu yang jauh lebih aneh: memakai teknologi paling mutakhir di tempat-tempat yang tidak menghasilkan uang.
+
+---
+
+Larut malam pada 14 September 1995, di Gedung 8 asrama putra National Taiwan University. Seorang mahasiswa tahun kedua menyambungkan sebuah komputer 486 bekas rakitan dari Guanghua Market ke jaringan, menjalankan serangkaian perintah Linux, lalu memakai ID-nya sendiri, "Ptt", sebagai nama situs — ia sering begadang sampai matanya menghitam, jadi teman sekamarnya memanggilnya "Panda"; digabung marganya "Tu (杜)", singkatannya menjadi PT, dan karena terlalu pendek ia menambahkan satu T lagi supaya lebih enak diucapkan.
+
+Tidak ada wartawan di sana, tidak ada konferensi pers, tidak ada investor. PTT begitu saja mengudara.
+
+---
+
+## Kebebasan berbicara adalah desain awal, bukan tambahan di kemudian hari
+
+Sebelum membangun PTT, Ethan Tu sudah menjadi administrator Yelin Fengqing (椰林風情), situs BBS resmi National Taiwan University. Masalahnya, pihak kampus mengatur terlalu ketat — ketika ada mahasiswa memakai nama samaran untuk mencari kencan satu malam di situs itu, kampus langsung memutuskan mematikan fitur nama samaran. Ethan Tu tidak sepakat dengan logika itu, lalu bersama beberapa teman membangun rumah sendiri, membuat PTT berdiri di luar jangkauan administrasi resmi.
+
+"PTT punya kebebasan berbicara dan kesetaraan suara; ia tidak memakai algoritma untuk mendorong iklan. Bisa berkembang selama 25 tahun dengan cara seperti itu sudah merupakan satu bentuk keberhasilan, dan di seluruh dunia sangat sulit menemukan kasus serupa." Begitu ia berkata dalam sebuah wawancara pada 2020.
+
+Sistem "push" (推文) dan "boo" (噓文) di PTT, mekanisme demokratis yang memilih moderator lewat pemungutan suara pengguna, serta struktur keuangan nonkomersial — semua rancangan itu ditulis ke dalam gen sistem sejak masa awal situs. Keputusan itu membuat PTT menempuh jalan yang sepenuhnya berbeda dari semua platform komunitas komersial.
+
+---
+
+## Sebuah forum yang berulang kali muncul di saat-saat genting
+
+Pada masa puncaknya, jumlah pengguna daring bersamaan di PTT melampaui 150.000 orang. Angka itu sendiri tidak menjelaskan mengapa ia penting, tetapi beberapa tanggal barangkali bisa:
+
+- **Kasus Hung Chung-chiu 2013**: kabar tentang seorang kopral Angkatan Darat yang tewas akibat penyiksaan mengendap dan membesar di PTT; para xiangmin (鄉民, sebutan bagi warga PTT) secara swadaya membentuk kelompok warga "Citizen 1985 Action Alliance" (公民 1985 行動聯盟) dan mendorong 250.000 orang turun ke jalan di seluruh Taiwan — salah satu demonstrasi swadaya warga terbesar di Taiwan sejak dekade 1990-an.
+- **Gerakan Bunga Matahari 2014**: mahasiswa yang menentang proses pengesahan tertutup perjanjian dagang jasa lintas selat menduduki Yuan Legislatif; PTT menjadi pusat komando mobilisasi sekaligus termometer bagi pihak luar untuk membaca arah opini publik.
+- **Awal wabah 2020**: peringatan yang dikirim dokter Li Wenliang lewat Weibo disalin ke PTT, sehingga Pusat Pengendalian Penyakit Taiwan sudah memegang informasi wabah pada akhir Januari dan bergerak lebih awal daripada mayoritas pemerintah lain.
+
+Ketiga peristiwa itu, bila disandingkan, menunjukkan PTT bukan sekadar tempat warganet mengobrol, melainkan infrastruktur dengan fungsi khas di dalam masyarakat sipil Taiwan.
+
+> 📝 **Struktur antikomersial PTT**
+> PTT tidak menjual iklan, tidak melantai di bursa, dan tidak menerima akuisisi korporasi. Servernya berjalan mengandalkan bandwidth jaringan akademik National Taiwan University, dikelola oleh klub swakelola mahasiswa "NTU Bulletin Board System Research Club", dan penasihat hukumnya adalah pengacara yang menjabat secara sukarela. Struktur ini membebaskannya dari tekanan monetisasi dan campur tangan algoritma iklan — tetapi dengan cara yang sama pula, ia selamanya kekurangan sumber daya.
+
+---
+
+## Pergi ke Amerika, lalu kembali lagi
+
+Pada 2003, Ethan Tu memutuskan "memilih dengan kaki" dan meninggalkan Taiwan.
+
+Alasannya lugas: waktu itu Taiwan sama sekali tidak menganggap penting industri perangkat lunak. Sejak awal ia ingin menjadikan pesan instan layanan lintas perangkat, tetapi diberi tahu bahwa yang bukan operator telekomunikasi tidak boleh melakukannya; ia membuat mata uang digital awal bernama "P幣" (P-coin), tetapi dihentikan dengan alasan melanggar regulasi keuangan. "Di dalam negeri sudah lama ada orang menggarap ekonomi digital, tetapi diremas mati begitu saja, dan industrinya sendiri memandangnya rendah. Waktu itu semua orang merasa mengobrol daring itu pekerjaan tanpa masa depan," katanya, dengan nada yang menyimpan kekecewaan lama.
+
+Belakangan sebuah perusahaan kecil Tiongkok bekerja sama dengan Yam.com (蕃薯藤) dan menghasilkan perangkat lunak pesan instan yang sangat mirip konsepnya dahulu. Perusahaan itu bernama Tencent, dan perangkat lunaknya bernama QQ.
+
+Setiba di Amerika Serikat, Ethan Tu mula-mula masuk National Human Genome Research Institute di bawah National Institutes of Health (NIH), menggarap riset sekuens gen dan deteksi kanker otomatis. Pada 2006 ia pindah ke Microsoft, mulai dari teknologi penyimpanan, lalu bergabung dengan tim pengembangan mesin pencari Bing yang dipimpin Dr. Harry Shum (沈向洋).
+
+Pada 2012 ia masuk ke divisi AI Microsoft dengan jabatan Principal Development Manager, dan produk yang ia tangani adalah Cortana. Pada 2015, tim Cortana yang ia pimpin merilis asisten suara AI lintas platform pertama di dunia — tidak hanya berjalan di Windows, melainkan juga di Android dan iOS. Pada 2016, saat Microsoft membentuk divisi proyek AI (AI.R.) beranggotakan 6.000 orang, ia menangani pengembangan Cortana lintas platform sekaligus kerja sama strategis Microsoft AI untuk kawasan Asia-Pasifik.
+
+---
+
+> 📝 **Arti penting Cortana: perang asisten bahasa pada 2016**
+> 2016 adalah tahun paling sengit di medan tempur asisten AI berbasis suara: Microsoft merilis Cortana lintas platform, Google mengumumkan Allo di konferensi I/O, dan Facebook meluncurkan Messenger Bot. Ketiga produk lahir di tahun yang sama, dan pada dasarnya adalah taruhan tiga perusahaan atas pertanyaan apakah asisten AI akan menjadi sistem operasi berikutnya. Ethan Tu berdiri di pihak Microsoft, memimpin puluhan insinyur, memperebutkan masa depan yang sama dengan perusahaan-perusahaan teknologi terbesar di dunia.
+
+---
+
+## Maret 2017: melepas Seattle, pulang membangun AI nirlaba
+
+Ibunya meninggal mendadak akibat sepsis pada 2013. Di Facebook ia menulis: "Saya menggenggam tangannya dari hangat menjadi bengkak, lalu menjadi dingin, melewati siksaan yang panjang. Sebelum detak jantungnya berhenti, saya mengusap kepalanya dan memanggil: 'Yi-jin datang menjenguk Ibu.'" Empat tahun kemudian, ia resmi pulang ke Taiwan.
+
+Pada Maret 2017, Ethan Tu mendirikan Taiwan AI Labs (台灣人工智慧實驗室) yang ditetapkan bersifat nonpemerintah dan nirlaba, sekaligus menjadi lembaga riset AI terbuka pertama di Asia. Titik berangkatnya: Taiwan punya basis data asuransi kesehatan paling lengkap di dunia dan talenta ilmu komputer kelas dunia, tetapi karena pasarnya kecil, ia selamanya di pinggiran percakapan yang menentukan arah AI.
+
+"Taiwan menumbuhkan profesor-profesor kelas internasional dan talenta perangkat lunak papan atas. Saya berencana mengumpulkan Taiwan AI Labs untuk secara nyata bekerja sama dengan perusahaan-perusahaan terdepan Taiwan dalam eksperimen AI," katanya dalam deklarasi pendirian, dengan nada yang lebih bertenaga daripada citranya yang biasanya kalem di media.
+
+Arah kerja Taiwan AI Labs terbagi ke dalam beberapa poros utama:
+
+**Pencitraan medis**: bekerja sama dengan pusat-pusat medis besar, melatih model AI memakai data asuransi kesehatan yang telah dianonimkan, dan mengembangkan platform bantuan pencitraan TaimedImg untuk mendeteksi kelainan pada rontgen paru serta menandai tumor otak secara otomatis, dipakai klinik maupun rumah sakit.
+
+**Interaksi manusia-mesin**: mengembangkan Yating (雅婷逐字稿), perkakas pengenalan suara yang disesuaikan dengan aksen Taiwan (mencakup bahasa Taiwan, bahasa Hakka, dan Mandarin Taiwan), yang luas dipakai untuk pencatatan cepat oleh wartawan media dan sebagai alat bantu bagi penyandang tunarungu. Pada 2021 mereka meluncurkan FedGPT yang digerakkan model bahasa besar, sehingga perusahaan dapat membangun basis pengetahuan kustom tanpa mengorbankan privasi data.
+
+**Penangkalan perang kognitif**: membentuk proyek Infodemic, memakai AI untuk menganalisis perilaku terkoordinasi yang janggal di media sosial, lalu membongkar strategi naratif dan jalur penyebaran disinformasi gugusan akun pasukan siber.
+
+---
+
+## COVID-19: satu aplikasi, satu perdebatan privasi
+
+Pada 2021, Taiwan AI Labs membantu pemerintah mengembangkan "Aplikasi Jaga Jarak Sosial Taiwan". Aplikasi ini mendeteksi kontak lewat Bluetooth, tidak mengumpulkan data identitas pribadi, dan tidak mengunggah lokasi — salah satu dari sedikit solusi pelacakan kontak di dunia yang berjalan tanpa basis data terpusat.
+
+Rancangan itu mencerminkan posisi lama Ethan Tu: teknologi harus melayani publik, dan tidak boleh dipakai memperluas pengawasan atas nama kesehatan masyarakat. Pengkritik juga mencatat efektivitasnya bergantung pada tingkat pemasangan — jika terlalu sedikit yang mengunduh, daya lacaknya terbatas; jika pemerintah mewajibkan, sifat sukarelanya justru dipertanyakan.
+
+---
+
+> 📝 **Pilihan politis di balik AI sumber terbuka**
+> Dalam perlombaan model bahasa besar (LLM), Taiwan AI Labs memilih mendorong model sumber terbuka berbahasa Mandarin tradisional alih-alih menempuh jalur lisensi komersial. Logikanya jelas: jika seluruh sistem AI Taiwan bergantung pada model OpenAI atau Google, Taiwan tak punya suara dalam menentukan konteks maupun nilai yang tertanam di dalam AI. Argumen Ethan Tu: hanya model sumber terbuka berperspektif Taiwan, dilatih dengan korpus Mandarin tradisional, yang bisa memastikan Taiwan tidak terpinggirkan. Namun ada pula yang mempertanyakan apakah daya saing komersial model sumber terbuka cukup untuk menopang dana riset secara berkelanjutan.
+
+---
+
+## Suara para pengkritik
+
+Citra publik Ethan Tu bukannya tanpa kontroversi, dan kontroversi itu layak dihadapi langsung.
+
+**Kecurigaan atas posisi politik**: pada 2021, penulis pro-Hijau Lin Wei-feng (林瑋豐) ketahuan melakukan trolling terbalik di PTT, dan sejumlah komentator menilai kasus itu menyingkap relasi jajaran pengelola PTT dengan partai berkuasa. Xie Han-bing (謝寒冰) di CTi News mengkritik Ethan Tu dengan kalimat "dari hulu ke hilir, industri satu rantai ini memang merekalah yang membuatnya"; Ethan Tu mengajukan gugatan, tetapi pada 2022 Pengadilan Distrik Shilin memutuskan ia kalah, dengan penilaian bahwa kritik Xie "tidak menyimpang secara nyata dari fakta pokoknya".
+
+**Ketergantungan pada tender pemerintah**: catatan di Wikipedia menyebutkan bahwa antara 2018 dan 2021, dari 8 perusahaan yang baru didirikan Ethan Tu, 5 di antaranya memenangkan total 22 tender pemerintah dengan nilai sekitar NT$198,12 juta. Bagi pendiri lembaga yang mengibarkan panji nonpemerintah dan nirlaba, angka itu membuat sebagian pengamat mengajukan pertanyaan soal "independensi".
+
+**Pernyataan soal pasukan siber**: pada Juli 2021, dalam wawancara khusus dengan United Daily News, Ethan Tu menyatakan, "Pasukan siber tidak pernah merupakan kejahatan; sekelompok orang di internet yang memiliki cita-cita bersama pun bisa disebut pasukan siber, yang penting adalah apakah mereka memperoleh apa yang mereka butuhkan dengan cara yang wajar." Kalimat itu memicu kontroversi luas; pengkritik menilai pendiri lembaga yang meneliti perang kognitif dan disinformasi tidak sepatutnya memberi nama baik kepada pasukan siber dengan cara demikian.
+
+**Undang-Undang Layanan Perantara Digital**: pada Agustus 2022, Ethan Tu secara terbuka membela "Undang-Undang Layanan Perantara Digital" (數位中介服務法) yang semula didorong NCC tetapi dikritik luas karena pasalnya terlalu longgar, dan sikap itu memicu perlawanan keras para xiangmin PTT. Sang dewa pencipta PTT dikritik oleh warganya sendiri karena berdiri di sisi "pengendalian kebebasan berbicara" — adegan itu sendiri barangkali merupakan catatan kaki paling rumit atas tiga puluh tahun perjalanannya.
+
+---
+
+## Ia bilang ia tidak peduli pada kesuksesan
+
+Dalam wawancara dengan Mirror Media pada 2020, wartawan bertanya kepadanya: "Anda pernah menjadi direktur riset dan pengembangan Asia-Pasifik untuk tim kecerdasan buatan asisten suara Cortana di Microsoft, sudah menikah dan punya dua anak perempuan. Pulang ke Taiwan lalu beralih ke industri AI itu bergerak naik atau turun?"
+
+Begitu mendengar dua kata "sukses", ia langsung tak tahan memprotes: "Apa yang disebut sukses? Sukses hanyalah sebuah definisi."
+
+Lalu ia mengucapkan satu kalimat yang seakan menjelaskan seluruh pilihannya selama tiga puluh tahun: "PTT tidak pernah ingin menjadi Facebook atau menjual iklan. Orang umumnya menganggap sukses itu dilihat dari kapitalisasi pasar dan pencatatan saham di bursa; saya tidak merasa begitu."
+
+---
+
+Kalau harus dicari satu garis utama dalam kisah Ethan Tu, mungkin begini: setiap kali ia mencapai puncak di sebuah posisi, ia memilih pergi mengerjakan sesuatu yang jauh lebih tidak pasti. Begitulah PTT, begitu pula saat ia meninggalkan Taiwan, dan begitu juga saat ia pulang.
+
+Kontroversi membuat citranya lebih rumit, tetapi juga lebih nyata. Orang yang selama tiga puluh tahun tidak pernah membiarkan PTT menjadi komoditas, dan pengusaha yang menerima tender pemerintah hampir NT$200 juta, adalah orang yang sama. Penjaga forum publik dan pembela regulasi digital juga orang yang sama.
+
+Kontradiksi bukanlah kelemahannya. Kontradiksi barangkali justru gambaran utuhnya.
+
+---
+
+## Referensi
+
+- [Mirror Media — 【One Shot】Tak Cinta Sukses, Cinta Kebebasan: Ethan Tu (2020)](https://www.mirrormedia.mg/story/20201120pol001/)（sekunder, wawancara tokoh berita）
+- [Wikipedia — Ethan Tu](https://zh.wikipedia.org/wiki/%E6%9D%9C%E5%A5%95%E7%91%BE)（kompilasi sekunder, disertai rujukan aslinya）
+- [Wikipedia — PTT Bulletin Board System](https://zh.wikipedia.org/wiki/%E6%89%B9%E8%B8%A2%E8%B8%A2%E5%AF%A6%E6%A5%AD%E5%9D%8A)（tanggal berdirinya PTT dan riwayat perkembangannya）
+- [Situs resmi Taiwan AI Labs](https://ailabs.tw/)（primer, profil lembaga dan arah risetnya）
+- [Taiwan AI Labs — Healthcare](https://ailabs.tw/healthcare/)（primer, platform pencitraan medis TaimedImg）
+- [Taiwan AI Labs — Human Interaction](https://ailabs.tw/human-interaction/)（primer, proyek Yating, FedGPT, dan Infodemic）
+
+---
+
+## Bacaan lanjutan
+
+Topik yang berkaitan dengan entri ini: [[唐鳳]]、[[太陽花學運]]、[[迷音Miin]]、sejarah internet Taiwan、[[半導體產業]]


### PR DESCRIPTION
Adds Indonesian translation of `People/杜奕瑾.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.22 (id corpus median 2.78, p10–p90 2.29–3.34) — inside band, toward the upper edge; one tightening pass was already applied (3.32 → 3.22) to trim connective padding without dropping content.

**Structure alignment**: 9 `##` headings / 0 footnotes / 6 URLs — 100% preserved. `scripts/tools/lang-sync/verify-translation.py` reports 17 PASS / 0 hard fail (the single WARN is the ratio shell script not running under Windows, not a content issue).

**Note**: `i18n/id/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT plus the established conventions of the existing `knowledge/id/` corpus (zh passthrough for `subcategory` and `author`, Chinese-title wikilinks kept intact, Taiwanese proper nouns kept in Chinese with a gloss).

Uncertain terminology flagged for reviewer:

- 鄉民 → `xiangmin (鄉民, sebutan bagi warga PTT)` · no Indonesian equivalent carries the PTT-specific connotation; kept romanized with an inline gloss on first use.
- 網軍 → `pasukan siber` · literal "cyber army"; `buzzer` is the closer Indonesian political-internet term but carries local Indonesian baggage, so the neutral rendering was chosen.
- 數位中介服務法 → `Undang-Undang Layanan Perantara Digital (數位中介服務法)` · no official Indonesian name exists; descriptive rendering with the Chinese kept.
- 推文／噓文 → `"push" (推文)` / `"boo" (噓文)` · kept the English PTT-community terms, which are what Indonesian-language writing about PTT tends to use.
- 用腳投票 → `"memilih dengan kaki"` · idiom rendered literally in quotes, matching how the zh source marks it.

Please review. Happy to iterate.
