### PR TITLE
translate(id): 台灣機械工具產業 → Industri Mesin Perkakas Taiwan

### DIFF
--- a/knowledge/id/Economy/taiwan-machine-tool-industry.md
+++ b/knowledge/id/Economy/taiwan-machine-tool-industry.md
@@ -1,0 +1,194 @@
+---
+title: 'Industri Mesin Perkakas Taiwan'
+description: 'Dari Koridor Emas Gunung Dadu hingga TMTS 2026: ketangguhan, keruntuhan, dan kebangkitan industri mesin perkakas Taiwan, serta kecemasan struktural setelah peringkat ekspornya turun dari posisi kelima ke ketujuh dunia pada 2024.'
+date: 2026-04-11
+category: 'Economy'
+tags:
+  [
+    'Mesin Perkakas',
+    'Mesin Presisi',
+    'Gunung Dadu',
+    'Taichung',
+    'Manufaktur',
+    'TMTS',
+    'Klaster Industri',
+    '2026',
+  ]
+subcategory: 'Industri Tradisional'
+author: 'Taiwan.md'
+difficulty: 'intermediate'
+readingTime: 13
+featured: true
+lastVerified: 2026-04-11
+lastHumanReview: false
+translatedFrom: 'Economy/台灣機械工具產業.md'
+sourceCommitSha: '37638e173'
+sourceContentHash: 'sha256:74fc634acab51c40'
+sourceBodyHash: 'sha256:f5ecba58cc661bc1'
+translatedAt: '2026-09-01T22:32:31+08:00'
+---
+
+# Industri Mesin Perkakas Taiwan
+
+## Tukang Kayu dari Hemei, Changhua, dan Bengkel Beratap Seng pada 1954
+
+Untuk memahami industri mesin perkakas Taiwan, mulailah dari seseorang bernama **Huang Chi-huang**.
+
+Huang lahir dalam keluarga tukang kayu di Hemei, Changhua. Ia pernah menjadi magang pada masa penjajahan Jepang. Seusai perang, ia dan mitranya, Lee Tao-tong, membuka sebuah pabrik kecil di bengkel beratap seng di Taichung. Produk pertama mereka adalah mesin pengupas sekam, yakni mesin pertanian untuk memisahkan kulit dari beras. Pada 1954, mereka secara resmi mendaftarkan pabrik itu sebagai **Victor Taichung Machinery Works Co., Ltd.**[^1]
+
+Jalan dari tukang kayu menuju mesin pengupas sekam, lalu mesin perkakas, bukan hasil sebuah rencana besar. **Permintaanlah yang memaksa mereka maju selangkah demi selangkah.** Setelah menguasai mesin pengupas sekam, para petani mulai bertanya apakah mereka dapat membuat alat yang lebih rumit. Mereka mempelajari pengecoran, pembubutan, dan penggerindaan, lalu mulai memproduksi mesin sekrap—salah satu mesin pengerjaan logam paling dasar. Ketika mesin sekrap laku, pabrik lain mulai memesan mesin bubut CNC dan pusat pemesinan vertikal.
+
+Pada 1990-an, Victor Taichung sudah disebut sebagai “merek mesin presisi nomor satu di dunia berbahasa Tionghoa”, dengan produk yang diekspor ke seluruh dunia.
+
+Kemudian krisis keuangan Asia datang pada 1998.
+
+Harga saham Victor Taichung **anjlok dari 120 dolar Taiwan** hingga menjadi saham “telur dan pangsit”—sebutan bagi saham berharga di bawah 10 dolar Taiwan. Utangnya mencapai **6,7 miliar dolar Taiwan** dan perusahaan memasuki restrukturisasi. Keluarga pendiri, ribuan pekerja, dan seluruh rantai pasok mesin presisi Taiwan tengah terseret ke masa gelap yang tak seorang pun tahu apakah dapat mereka lewati.[^2]
+
+Mereka membutuhkan 15 tahun.
+
+Pada 2013, Pengadilan Distrik Taichung menyatakan **restrukturisasi Victor Taichung berhasil**, lima tahun lebih cepat dari rencana semula. Pada 2019, perusahaan membangun kantor pusat operasional global senilai **3,5 miliar dolar Taiwan** di Taman Inovasi Teknologi Mesin Presisi Central Taiwan Science Park. Bangunan itu bergaya modern, memakai rancangan energi hijau, dan memiliki suasana artistik di dalamnya. Generasi kedua keluarga Huang bersama tim restrukturisasi lainnya menghabiskan 21 tahun untuk membawa perusahaan yang nyaris hilang itu kembali ke posisi yang lebih tinggi.
+
+Kisah ini bukan drama motivasi, melainkan miniatur industri mesin perkakas Taiwan: **tidak pernah benar-benar stabil, tetapi juga tidak pernah benar-benar mati**.
+
+> **Ringkasan 30 Detik:** Taiwan adalah negara pengekspor mesin perkakas terbesar ketujuh di dunia—turun dari peringkat kelima pada 2024. Industri ini terkonsentrasi di “Koridor Emas” sepanjang 60 kilometer di Gunung Dadu, Taichung, yang menampung 1.500 perusahaan mesin presisi dan puluhan ribu pemasok. Inilah klaster mesin presisi dengan nilai produksi per satuan luas tertinggi di dunia. Perusahaan utamanya mencakup Fair Friend Group atau FFG, produsen mesin perkakas terbesar ketiga dunia setelah DMG Mori dan Yamazaki Mazak; Victor Taichung, yang didirikan pada 1954, direstrukturisasi karena utang 6,7 miliar dolar Taiwan pada 1998, lalu keluar dari restrukturisasi pada 2013; serta Tongtai Machine Tool, penggerak M-Team Alliance pada 2011. Taiwan International Machine Tool Show atau TMTS 2026 digelar pada 25–28 Maret di Taichung International Convention Center dengan tema “Manufaktur Berkelanjutan yang Diberdayakan AI”, menghadirkan lebih dari 4.500 stan dan 750 peserta pameran. Tantangan struktural industri ini sekarang adalah depresiasi yen, strategi harga murah Tiongkok—pusat pemesinan seharga 40.000 dolar AS dibanding 110.000 dolar AS dari Taiwan—serta tekanan untuk beralih dari manufaktur kontrak menuju manufaktur cerdas.
+
+## Koridor Emas: Panjang 60 Kilometer, Kepadatan Tertinggi di Dunia
+
+Gunung Dadu membentang dari Qingshui, Shalu, Longjing, dan Wuri ke arah selatan hingga Changhua, kemudian berbelok ke timur menuju pusat Taichung, Fengyuan, Taiping, dan Dali, sebelum berakhir di kawasan industri Nantou. Jalur sempit sepanjang sekitar **60 kilometer** ini menjadi zona penyangga antara dataran Taiwan tengah dan pegunungan.
+
+Jika melihatnya dari udara, ada sesuatu yang ganjil: **di dalam bentang 60 kilometer itu berhimpun klaster mesin presisi dengan nilai produksi per satuan luas tertinggi di dunia**.[^3] Ini bukan kiasan. Sebanyak 1.500 perusahaan mesin presisi, puluhan ribu pemasok hulu dan hilir, serta kantor pusat atau pabrik utama dari 70 persen pelaku mesin presisi dan mesin perkakas Taiwan berada di jalur ini.
+
+Bagaimana klaster ini terbentuk?
+
+Jawabannya bukan perencanaan. Pada 1950–1970-an, pemerintah Taiwan tidak pernah mengumumkan, “Kami akan membangun pusat permesinan di Gunung Dadu.” Klaster ini tumbuh melalui **evolusi alami**. Pabrik generasi pertama, seperti Victor Taichung pada 1954, memilih Taichung karena saat itu kota tersebut merupakan kota terbesar di Taiwan tengah, sebuah simpul transportasi, dan pasar bagi mesin pertanian. Para teknisi yang dilatih di pabrik generasi pertama kemudian membuka bengkel kecil sendiri dan mengkhususkan diri pada satu komponen. Bengkel-bengkel itu melatih generasi berikutnya, yang lalu mendirikan pabrik dengan spesialisasi lebih tajam.
+
+Dalam tiga puluh tahun, koridor tersebut berubah menjadi sebuah **ekosistem**. Jika sebuah perusahaan membuat badan utama mesin perkakas, di dekatnya ada pembuat rel linear, kotak roda gigi, pengendali, jig dan fixture, cor presisi, jasa perlakuan panas, pelapisan permukaan, alat ukur, hingga oli khusus mesin perkakas. Semua kebutuhan dapat ditemukan dari pemasok dalam radius 30 kilometer—dan kemungkinan besar para pemasok itu saling mengenal.
+
+Dalam ilmu ekonomi, struktur seperti ini disebut **efek klaster industri**, tetapi logika kerjanya jauh lebih rumit daripada uraian buku teks. Ada beberapa ciri utama:
+
+**Pertama, pengetahuan menyebar dengan cepat.** Teknologi baru, metode baru, atau permintaan pelanggan baru di satu pabrik biasanya diketahui seluruh klaster dalam waktu kurang dari sebulan. Bukan karena semua orang membocorkan rahasia, melainkan karena teknisi mengambil pekerjaan tambahan di pabrik lain, karyawan berpindah tempat kerja, dan pemasok memperlihatkan spesifikasi milik perusahaan lain.
+
+**Kedua, persaingan harga sangat keras.** Untuk satu komponen yang sama, biasanya ada lima hingga sepuluh pemasok di dalam klaster. Mereka bersaing dalam harga, waktu pengiriman, dan mutu. Persaingan ini mendorong standar rata-rata klaster menjadi tinggi, tetapi juga menekan laba setiap perusahaan.
+
+**Ketiga, suksesi sulit dilakukan.** Pemilik generasi pertama umumnya adalah teknisi kelahiran 1950–1960-an yang kini sedang menyerahkan kendali. Banyak orang dari generasi kedua pulang setelah menempuh MBA di Amerika Serikat atau mempelajari CNC di Jerman. Mereka memahami manajemen dan pasar internasional, tetapi belum tentu memahami mesin. Ketika produk yang dijual menuntut presisi hingga hitungan seperseribu milimeter, memahami teori tidak sama dengan memiliki kepekaan tangan. Kemampuan dasar klaster sedang berpindah antargenerasi.
+
+**Keempat, terikat secara geografis.** Klaster ini tidak dapat begitu saja dipindahkan ke Vietnam atau India. Kenyataan bahwa “semua pemasok tersedia dalam radius 30 kilometer” merupakan endapan enam puluh tahun, bukan sesuatu yang dapat ditiru hanya dengan membangun kawasan industri. Ini adalah keunggulan sekaligus kerentanan: jika Gunung Dadu kehilangan daya saing, seluruh industri akan sulit berpindah ke tempat lain.
+
+## FFG: Bagaimana Satu Perusahaan Menjadi Nomor Tiga Dunia
+
+Salah satu kisah terbesar di dalam klaster ini adalah **Fair Friend Group (FFG)**.
+
+Ketika mendirikan usaha pada 1979, pendiri FFG, **Chu Chih-yang**, belum membuat mesin perkakas. Ia menjadi **agen baja dan mesin konstruksi Jepang**. Bisnis seperti ini memiliki hambatan masuk rendah dan kebutuhan modal menengah: menandatangani perjanjian distribusi dengan merek Jepang, mengimpor produknya ke Taiwan, lalu menjualnya kepada proyek konstruksi dan pabrik.
+
+Pada 1985, Chu memutuskan beralih dari distribusi ke manufaktur. FFG mendirikan divisi mesin perkakas dan mula-mula memproduksi **mesin gergaji pita dan mesin gerinda**, dua jenis produk yang relatif sederhana.[^4] Logikanya saat itu jelas: Taiwan sudah memiliki banyak pembuat mesin perkakas yang memproduksi bubut CNC dan pusat pemesinan, sehingga persaingannya sesak. Mesin gergaji pita dan gerinda berada satu tingkat di bawahnya, dengan hambatan masuk lebih rendah dan margin yang masih layak.
+
+Pada 1986, mereka membuat **pusat pemesinan vertikal berkolom bergerak tercanggih pertama di Taiwan**. Peralihan dari gergaji pita ke pusat pemesinan hanya memerlukan satu tahun. Menurut ukuran industri mesin Taiwan, kecepatannya tinggi tetapi bukan sesuatu yang luar biasa. Pada masa itu, teknologi memang menyebar secepat itu di Gunung Dadu.
+
+Kemudian Chu melakukan sesuatu yang kala itu jarang berani dilakukan produsen Taiwan: **ia membeli perusahaan lain**.
+
+Sejak 1990-an, FFG mengakuisisi produsen mesin perkakas di Taiwan, Jepang, Jerman, Amerika Serikat, dan Ceko. Strategi ini tidak lazim di Taiwan. Sebagian besar pemilik perusahaan mesin perkakas percaya pada jalur “produksi sendiri, jual sendiri”, sedangkan membeli perusahaan asing dianggap terlalu berisiko. Namun, logika Chu berbeda: **pasar mesin perkakas dunia terfragmentasi; satu produsen sulit unggul di semua segmen. Membeli merek lain lebih cepat daripada mengembangkan semuanya dari nol.**
+
+Strategi itu berhasil. Memasuki 2020-an, FFG menjadi **produsen mesin perkakas terbesar ketiga dunia** berdasarkan pendapatan, hanya di belakang DMG Mori yang berbasis di Jepang dan Jerman serta Yamazaki Mazak dari Jepang.[^5] Sebuah perusahaan Taiwan yang semula menjadi agen baja berubah menjadi kelompok mesin perkakas terbesar ketiga dunia dalam empat puluh tahun.
+
+Namun, struktur gelar “nomor tiga dunia” ini perlu diperhatikan. Sebagian besar pendapatan FFG **bukan berasal dari mereknya sendiri**, melainkan dari berbagai merek yang dipertahankan setelah akuisisi, termasuk Feeler, Fadal, MAG, Jobs, dan SMS. Dengan kata lain, peringkat global FFG “dibeli”, bukan “direbut” lewat satu merek. Ini bukan celaan, melainkan penjelasan bahwa Chu melihat jalan yang berbeda: **bukan membangun satu merek, melainkan menjadi kolektor merek**.
+
+Sebagian besar produsen mesin perkakas Taiwan lainnya masih mengikuti jalur lama: merek sendiri dan kanal penjualan sendiri. Ujung tertinggi jalur itu adalah menjadi “perusahaan multinasional menengah”, tetapi sulit menembus tiga besar dunia. FFG mengambil jalan yang dianggap tidak ortodoks oleh industrinya sendiri, dan justru menempuh jarak paling jauh.
+
+## Tongtai dan M-Team: Upaya Mendobrak Budaya Berjalan Sendiri
+
+Pada 2011, sesuatu yang bersifat struktural terjadi dalam industri mesin perkakas Gunung Dadu.
+
+**Tongtai Machine Tool**, perusahaan yang relatif muda dan didirikan pada 1999, memprakarsai sebuah organisasi bernama **M-Team Alliance**. Mereka mengundang Victor Taichung, Yeong Chin Machinery, Litz Hitech, dan Quaser Machine Tools untuk bergabung.[^6] M mewakili _Machine Tool_, sedangkan T mewakili _Team_. Tujuan aliansi ini bukan menjalankan usaha patungan, melainkan **berbagi rantai pasok, pengetahuan proses, dan pengalaman transformasi manufaktur cerdas**.
+
+Mengapa hal ini penting? Sebelum itu, budaya klaster Gunung Dadu menyimpan sebuah kontradiksi: **secara geografis merupakan klaster, tetapi secara operasional berupa pulau-pulau tersendiri**.
+
+Hubungan di antara pemilik pabrik adalah “saling mengenal, tetapi tidak bekerja sama”. Mereka tergabung dalam kamar dagang, asosiasi, dan pameran yang sama, tetapi merahasiakan struktur biaya, rencana pengembangan produk, dan daftar pelanggan luar negeri dari satu sama lain. Budaya “tidak berbagi” ini lahir dari tekanan persaingan. Jika satu pabrik memberikan spesifikasinya kepada tetangga, tahun depan tetangga itu dapat merebut pelanggan dengan harga lebih rendah.
+
+Namun, lingkungan industri berubah setelah 2010. Serangan harga murah Tiongkok—**40.000 dolar AS** untuk pusat pemesinan, dibanding **110.000–120.000 dolar AS** untuk produk Taiwan—membuat setiap perusahaan semakin sulit berjuang sendirian.[^7] Depresiasi yen meningkatkan daya saing harga Yamazaki Mazak dan DMG Mori dari Jepang. Di bawah tekanan ini, strategi “menutup pintu dan mengerjakan semuanya sendiri” mulai kehilangan daya guna.
+
+M-Team Alliance yang digerakkan Tongtai pada dasarnya adalah **upaya meningkatkan budaya klaster**. Pesannya kepada para anggota: **kita bersaing, tetapi juga bekerja sama. Daftar pelanggan tidak perlu dibagikan, tetapi mari belajar bersama cara menerapkan manufaktur cerdas. Margin laba tidak perlu dibuka, tetapi mari memakai standar sertifikasi yang sama untuk komponen penting.**
+
+Hasil nyata aliansi ini masih diperdebatkan. Ada yang menilai M-Team mendorong transformasi manufaktur cerdas industri mesin perkakas Taiwan; ada pula yang menganggap kegiatannya terutama berupa rapat, pembelian bersama, dan perebutan proyek pemerintah. Namun, keberadaannya sendiri adalah sebuah sinyal: **Gunung Dadu menyadari bahwa strategi berjalan sebagai pulau-pulau terpisah tidak lagi memadai**.
+
+## Tahun 2024: Turun dari Peringkat Kelima ke Ketujuh Dunia
+
+Pada Maret 2024, Kementerian Urusan Ekonomi Taiwan menerbitkan laporan statistik dengan satu kabar yang sulit diterima: **nilai ekspor mesin perkakas Taiwan turun dari peringkat kelima dunia pada 2023 ke peringkat ketujuh**. Negara yang melampaui Taiwan adalah **Amerika Serikat dan Korea Selatan**.[^8]
+
+Mengapa angka ini terasa menyakitkan? Industri Taiwan terbiasa menempatkan diri sebagai “lima besar dunia”. Peringkat itu bertahan selama sebagian besar 2010-an dan menjadi narasi utama untuk merekrut tenaga kerja, mencari pembiayaan, dan mendapatkan subsidi pemerintah. Turun dari urutan kelima ke ketujuh bukan sekadar bergeser dua posisi, melainkan **runtuhnya keseluruhan narasi**.
+
+Kementerian Urusan Ekonomi menyebut beberapa penyebab:
+
+1. **Depresiasi yen:** Nilai yen terhadap dolar AS turun tajam pada 2022–2024, sehingga dalam waktu singkat harga ekspor produsen Jepang menjadi 30 persen lebih murah. Mesin perkakas Taiwan dan Jepang bersaing dalam rentang harga yang sama; ketika yen melemah, Taiwan langsung kehilangan keunggulan.
+2. **Strategi harga murah Tiongkok:** Produsen Tiongkok memasuki pasar internasional dengan pusat pemesinan seharga 40.000 dolar AS, sementara produk Taiwan dengan tingkat setara ditawarkan pada 110.000–120.000 dolar AS. Tiongkok mengambil alih pasar kelas bawah dan menengah secara menyeluruh.
+3. **Perang Rusia–Ukraina dan konflik Timur Tengah:** Pesanan manufaktur global berkurang, dengan mesin perkakas berharga tinggi dari Jerman, Jepang, dan Taiwan menerima dampak terbesar.
+4. **Faktor struktural:** Mesin perkakas Taiwan terutama diekspor ke Eropa, Amerika Serikat, Tiongkok, dan Asia Tenggara. Permintaan Eropa dan Amerika melemah, kemampuan produksi dalam negeri Tiongkok meningkat, sedangkan permintaan kelas atas di Asia Tenggara belum tumbuh. Tiga pasar utama melambat pada saat yang sama.
+
+Namun, hal yang paling mencemaskan bagi industri bukan faktor eksternal tersebut, melainkan kenyataan bahwa **respons Taiwan terlalu lambat**.
+
+FFG menemukan jalan sendiri melalui akuisisi, tetapi perusahaan itu merupakan pengecualian. Sebagian besar produsen lain di Gunung Dadu masih mengikuti pola lama: membangun merek sendiri, menjual kepada pelanggan lama, mengikuti TMTS setiap tahun, menerima pesanan, lalu mengirim barang. Saat lingkungan industri berubah menyeluruh, irama ini terlalu lambat untuk mengejar keunggulan kurs Jepang dan perang harga Tiongkok.
+
+## TMTS 2026: Manufaktur Berkelanjutan yang Diberdayakan AI atau Pernyataan untuk Mengejar Ketertinggalan
+
+Pada 25–28 Maret 2026, **Taiwan International Machine Tool Show (TMTS)** berlangsung di Taichung International Convention Center. Ini adalah pameran besar pertama setelah gedung tersebut dibuka. Acara itu menghadirkan lebih dari **4.500 stan**, **750 peserta pameran**, dan area pameran seluas lebih dari **80.000 meter persegi**.[^9]
+
+Temanya adalah “**Manufaktur Berkelanjutan yang Diberdayakan AI**”.
+
+Pilihan tema itu cerdas. “AI” mengikuti arah gairah industri global, “berkelanjutan” menjawab tekanan pajak perbatasan karbon CBAM Uni Eropa, sedangkan “manufaktur” menegaskan bidang utama Taiwan. Ketiga kata itu mencoba meningkatkan narasi masa depan industri mesin perkakas Taiwan dari “manufaktur kontrak kelas menengah” menjadi “manufaktur cerdas + manufaktur hijau + komponen kelas atas”.
+
+Namun, di balik tema itu tersimpan kecemasan yang lebih dalam: **apakah industri mesin perkakas Taiwan benar-benar tahu cara menerapkan AI pada mesin perkakas?**
+
+Istilah “manufaktur cerdas” sudah digaungkan selama sepuluh tahun. Praktik sebagian besar produsen baru sebatas “memasang sensor + pemantauan awan + analisis statistik”. Itu bukan AI, melainkan digitalisasi. Penerapan AI yang sesungguhnya—misalnya pembelajaran mesin untuk memprediksi usia alat potong, visi komputer untuk mendeteksi cacat pemesinan secara otomatis, atau pembelajaran penguatan untuk mengoptimalkan parameter pemotongan—masih berada pada tahap uji konsep di segelintir perusahaan Gunung Dadu dan belum menjadi standar industri.
+
+Alih-alih sebuah deklarasi, tema TMTS 2026 lebih menyerupai **daftar harapan**: semoga AI menjadi keunggulan kompetitif berikutnya bagi mesin perkakas Taiwan, semoga keberlanjutan memberi alasan yang sah untuk peningkatan industri, dan semoga angka pameran empat tahun mendatang tidak kembali menurun.
+
+## Penutup: Bengkel Beratap Seng Huang Chi-huang, 72 Tahun Kemudian
+
+Dari Huang Chi-huang, tukang kayu asal Hemei, Changhua, pada 1954 hingga pusat pameran TMTS pada 2026, telah berlalu 72 tahun.
+
+Dalam 72 tahun itu, industri mesin perkakas Taiwan mengalami **tiga transformasi besar**:
+
+- **1970–1990-an:** dari mesin pertanian berupa pengupas sekam ke mesin pengerjaan logam berupa mesin sekrap, kemudian ke kendali komputer melalui bubut CNC dan pusat pemesinan. Ini adalah lompatan dari mekanika ke elektronika.
+- **1990–2010-an:** dari mesin tunggal ke integrasi sistem, dari pasar dalam negeri ke orientasi ekspor, dari substitusi impor ke partisipasi dalam rantai pasok global. Ini adalah lompatan dari pabrik menjadi industri.
+- **2010–2020-an:** dari mesin tradisional ke mesin cerdas, dari penjualan perangkat keras ke integrasi perangkat lunak dan keras, dari persaingan antarperusahaan ke kerja sama klaster. Ini adalah lompatan dari industri menjadi ekosistem.
+
+**Lompatan ketiga belum sungguh-sungguh selesai.** Dari 1.500 perusahaan di Gunung Dadu, mungkin kurang dari 100 yang benar-benar memasuki tahap baru “integrasi perangkat lunak dan keras + model berbasis layanan”. Sebanyak 1.400 lainnya masih memakai model bisnis 2010-an untuk menghadapi persaingan 2020-an. Inilah akar alasan industri mesin perkakas Taiwan turun dari peringkat kelima ke ketujuh dunia.
+
+Namun, jika sejarah 72 tahun mengajarkan satu hal, jawabannya adalah: **industri ini tidak pernah benar-benar stabil, tetapi juga tidak pernah benar-benar mati**. Utang Victor Taichung sebesar 6,7 miliar dolar Taiwan pada 1998, krisis keuangan global 2008, pandemi COVID-19 pada 2020, depresiasi yen dan perang harga Tiongkok pada 2024—setiap kali, pelaku industri berkata, “Kali ini benar-benar tamat.” Namun, setiap kali pula klaster ini bertahan dan kemudian menumbuhkan sesuatu yang baru.
+
+**Ketangguhan ini bukan soal padat modal, kecanggihan teknologi, ataupun subsidi kebijakan. Ia lahir dari keterampilan ragawi sekelompok orang yang selama enam puluh tahun mengumpulkan pengetahuan tentang “cara mengerjakan sepotong logam hingga presisi beberapa seperseribu milimeter”, ditambah disiplin bertahan hidup khas Gunung Dadu: “pelanggan menekan margin sampai tiga persen, tetapi barang tetap harus dikirim.”**
+
+Huang Chi-huang lahir dalam keluarga tukang kayu di Hemei, Changhua. Dengan dasar keterampilan dari masa magang, ia membuat mesin pengupas sekam di bengkel beratap seng pada 1954. Kisah pemilik bengkel kecil mana pun di Koridor Emas Gunung Dadu hari ini kemungkinan dimulai dengan cara yang serupa—atau itu adalah kisah ayah maupun kakek mereka.
+
+Ketika FFG mengakuisisi perusahaan Jerman, Victor Taichung membangun kantor pusat senilai 3,5 miliar dolar Taiwan, dan M-Team menggelar seminar manufaktur cerdas, ribuan bengkel kecil masih beroperasi di sepanjang 60 kilometer Gunung Dadu. Para pemiliknya masih berbau oli mesin, berbicara dengan logat Taichung, dan turun sendiri ke mesin bubut pada malam hari untuk mengasah alat potong. Merekalah penopang sejati industri mesin perkakas Taiwan.
+
+Mereka tidak menulis tema TMTS, tetapi merekalah yang memberi tema itu kesempatan untuk terwujud.
+
+---
+
+**Bacaan Lanjutan:**
+
+- [Industri Robotika Taiwan](/id/technology/taiwan-robotics-industry) — kemampuan mesin perkakas Gunung Dadu adalah fondasi hulu industri robotika, tetapi terdapat jurang dalam organisasi industri antara “membuat satu komponen dengan baik” dan “mengintegrasikan sebuah robot utuh”
+- [Industri Semikonduktor Taiwan](/id/technology/taiwan-semiconductor-industry) — contoh lain industri hulu rantai pasok global Taiwan, dengan banyak kesamaan struktural dengan mesin perkakas
+- [Transformasi Industri Taiwan: dari Manufaktur Menuju Inovasi](/id/economy/industrial-transformation-from-manufacturing-to-innovation) — dilema peningkatan dari manufaktur kontrak menuju merek, serta dari komponen menuju sistem; mesin perkakas merupakan kasus inti dalam perdebatan ini
+- [Perusahaan Taiwan: Foxconn Precision Industry](/id/economy/foxconn-precision-industry) — kisah manufaktur Taiwan lain yang dimulai dari teknisi bengkel; skalanya lebih besar, tetapi struktur dasarnya serupa
+- Perdagangan luar negeri Taiwan dan rantai pasok global — mesin perkakas adalah “juara tersembunyi” dalam struktur perdagangan Taiwan; skalanya lebih kecil daripada elektronik, tetapi menopang seluruh basis manufaktur
+
+## Referensi
+
+[^1]: [Victor Taichung — Wikipedia](https://zh.wikipedia.org/zh-tw/%E5%8F%B0%E4%B8%AD%E7%B2%BE%E6%A9%9F) — mencatat sejarah awal pendiri Huang Chi-huang membangun perusahaan di Taichung pada 1954, termasuk asalnya dari keluarga tukang kayu di Hemei, Changhua, kemitraannya dengan Lee Tao-tong, serta perkembangan produk dari mesin pengupas sekam hingga mesin sekrap.
+
+[^2]: [Menempuh Restrukturisasi Selama 15 Tahun: Victor Taichung Berubah Melalui Bisnis Intinya — Taiwan Industrial Revitalization Platform](https://www.tw-ren.com/renaissance/710) — laporan mendalam tentang krisis utang 6,7 miliar dolar Taiwan setelah krisis keuangan Asia 1998, anjloknya harga saham dari 120 dolar Taiwan, restrukturisasi selama 15 tahun, dan putusan pengadilan pada 2013 yang mengakhiri proses itu lima tahun lebih cepat dari rencana.
+
+[^3]: [Koridor Emas Mesin Presisi Taiwan, Nilai Produksi Tahunan Mendekati Satu Triliun — CNA](https://www.cna.com.tw/postwrite/Detail/102949.aspx) — data tentang 1.500 perusahaan mesin presisi dan puluhan ribu pemasok hulu-hilir di koridor Gunung Dadu sepanjang 60 kilometer, klaster mesin presisi dengan nilai produksi per satuan luas tertinggi di dunia dan tempat 70 persen produsen mesin presisi Taiwan berkantor pusat.
+
+[^4]: [Riwayat Perusahaan — Situs Resmi FFG](https://www.ffg-tw.com/category.php?c=132) — mencatat Chu Chih-yang memulai usaha pada 1979 sebagai agen baja dan mesin konstruksi Jepang, mendirikan divisi mesin perkakas pada 1985 untuk membuat gergaji pita dan gerinda, lalu menyelesaikan pusat pemesinan vertikal berkolom bergerak pertama di Taiwan pada 1986.
+
+[^5]: [Chu Chih-yang, Presiden FFG Group — ITRI](https://www.itri.org.tw/ListStyle.aspx?DisplayStyle=18_content&SiteID=1&MmmID=1036452026061075714&MGID=1001462030417350231) — profil yang merekam jalur FFG dari agen menjadi pengakuisisi produsen global hingga mencapai posisi kelompok mesin perkakas terbesar ketiga dunia setelah DMG Mori dan Yamazaki Mazak.
+
+[^6]: [Tongtai Machine Tool — Profil Perusahaan](https://www.tongtai.com.tw/tw/introduction.php) — mencatat pembentukan M-Team Alliance pada 2011 oleh Tongtai bersama Victor Taichung, Yeong Chin Machinery, Litz Hitech, dan Quaser Machine Tools, serta peran aliansi dalam transformasi manufaktur cerdas.
+
+[^7]: [Data 10 Negara Konsumen Mesin Perkakas Terbesar Dunia dan 10 Negara Tujuan Ekspor Terbesar Taiwan pada 2023 — TMBA](https://www.tmba.org.tw/zh-TW/news/traditionandbusiness/1566) — laporan pasar global dari Taiwan Machine Tool & Accessory Builders’ Association, termasuk perbandingan pusat pemesinan murah Tiongkok sekitar 40.000 dolar AS dengan produk Taiwan pada 110.000–120.000 dolar AS.
+
+[^8]: [Taiwan Naik Menjadi Pengekspor Mesin Perkakas Terbesar Kelima Dunia — Epoch Times](https://www.epochtimes.com/b5/24/3/27/n14212175.htm) — laporan Maret 2024 mengenai perubahan peringkat ekspor mesin perkakas Taiwan dari urutan kelima pada 2023 ke urutan ketujuh pada 2024, setelah dilampaui Amerika Serikat dan Korea Selatan, sementara Tiongkok naik ke posisi kedua dunia.
+
+[^9]: [TMTS 2026 Returns to Taichung — Digitimes](https://www.digitimes.com/news/a20260326PD219/taiwan-2026.html) — laporan mengenai TMTS 2026 pada 25–28 Maret 2026 di Taichung International Convention Center: lebih dari 4.500 stan, 750 peserta pameran, area lebih dari 80.000 meter persegi, dan tema “Manufaktur Berkelanjutan yang Diberdayakan AI”.


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

新增印尼文翻譯：
- 來源：knowledge/Economy/台灣機械工具產業.md
- 譯文：knowledge/id/Economy/taiwan-machine-tool-industry.md
- 完整保留 70 個語意區塊、9 則腳註與全部 URL
- 依印尼文規範使用 Taiwan、Tiongkok、Taichung、Changhua 等詞形
- 已用 Victor Taichung 官方英文資料交叉確認公司及創辦人拼法
- 僅連結已存在的印尼文延伸閱讀頁面

## ✅ 驗證

- strict frontmatter：PASS
- article-health pre-commit：PASS（0 warnings）
- translation ratio：PASS（3.06）
- CJK leak / residue / adjacency：PASS
- anti-framing scan：PASS
- verify-translation：18/18 PASS
- provenance：fresh / same-commit

## 🤖 AI 協作揭露

- 使用 OpenAI Codex 協助翻譯、術語一致性與自動檢查
- 本 PR 尚未經印尼文母語者審閱
- lastHumanReview: false 沿用來源文章；建議合併前由印尼文母語者複核語感