### PR TITLE
translate(vi): 台灣電子音樂與派對文化 → nhạc điện tử Đài Loan

### DIFF
--- a/knowledge/vi/Music/taiwan-electronic-music-and-party-culture.md
+++ b/knowledge/vi/Music/taiwan-electronic-music-and-party-culture.md
@@ -1,0 +1,104 @@
+---
+title: 'Nhạc điện tử và văn hóa tiệc tùng Đài Loan: từ rave ngầm đến sân khấu quốc tế'
+description: 'Từ văn hóa rave thập niên 1990 đến Road to Ultra, nhạc điện tử Đài Loan đã đi từ thế giới ngầm vào dòng chính, đồng thời nuôi dưỡng những DJ và nghệ sĩ thể nghiệm được quốc tế chú ý.'
+date: 2026-03-19
+category: 'Music'
+tags:
+  [
+    'nhạc điện tử',
+    'rave',
+    'văn hóa tiệc tùng',
+    'DJ',
+    'lễ hội nhạc điện tử',
+    'âm nhạc ngầm',
+  ]
+subcategory: 'Điện tử và thể nghiệm'
+author: 'Taiwan.md Contributors'
+featured: true
+lastVerified: 2026-03-19
+lastHumanReview: false
+translatedFrom: 'Music/台灣電子音樂與派對文化.md'
+sourceCommitSha: '37638e173'
+sourceContentHash: 'sha256:0beb5fc8433a2c70'
+sourceBodyHash: 'sha256:b7a689926177f96c'
+translatedAt: '2026-09-01T22:32:31+08:00'
+---
+
+# Nhạc điện tử và văn hóa tiệc tùng Đài Loan: từ rave ngầm đến sân khấu quốc tế
+
+> **Tóm tắt 30 giây:** Nhạc điện tử Đài Loan bắt đầu từ những bữa tiệc rave ngầm vào thập niên 1990. Sau hơn hai mươi năm, những cuộc vui trong nhà kho đã tiến vào dòng chính qua các lễ hội điện tử quy mô lớn. Sonia Calico, RayRay và nhiều nghệ sĩ khác đưa nhạc điện tử Đài Loan ra quốc tế, trong khi Meuko! Meuko! được chú ý trong giới nhạc điện tử thể nghiệm toàn cầu.
+
+Văn hóa nhạc điện tử Đài Loan phản ánh cách văn hóa thanh niên được bản địa hóa trong thời đại toàn cầu hóa. Từ chỗ tiếp nhận rave phương Tây, cộng đồng địa phương đã diễn giải lại nó bằng góc nhìn của mình và tạo dựng danh tiếng tại châu Á. Quá trình này để lại những cột mốc cụ thể, có thể lần theo trong lịch sử âm nhạc Đài Loan.
+
+## Khởi nguồn dưới lòng đất (1990–2000): thế hệ raver đầu tiên
+
+### Cuộc vui trong nhà kho
+
+Đầu thập niên 1990, nhạc điện tử Đài Loan lặng lẽ nảy mầm trong những không gian ngầm ở Đài Bắc. Chịu ảnh hưởng của acid house Anh và Detroit techno, thế hệ raver đầu tiên tổ chức các bữa tiệc trong nhà kho bỏ hoang và xưởng cũ. Cuộc vui thường kéo dài đến sáng, với nhịp độ 130–150 BPM tạo thành một cộng đồng văn hóa nhỏ.[^1]
+
+Thông tin được truyền qua máy fax, ấn phẩm ngầm hoặc lời rỉ tai. Vé vào cửa thường chỉ vài trăm Đài tệ, thiết bị cũng thua xa các câu lạc bộ chuyên nghiệp. Tinh thần cốt lõi đến từ PLUR của Anh — Peace, Love, Unity, Respect, tức hòa bình, tình yêu, đoàn kết và tôn trọng — rồi được diễn giải theo cách riêng tại Đài Loan.
+
+### Những địa điểm tiên phong và sự trỗi dậy của DJ
+
+Giữa thập niên 1990, một loạt địa điểm đã định hình bản đồ nhạc điện tử Đài Bắc. **ROXY 99** ở khu vực đường Trung Hiếu Đông là sàn nhảy đầu tiên của nhiều người. Các câu lạc bộ như **TeXound** và **Spark** mang đến không gian biểu diễn với hệ thống âm thanh tốt hơn; **@LIVE** và **Plush** thu hút cộng đồng nòng cốt bằng lịch diễn và cách chọn nhạc thiên về underground. Thông qua đĩa vinyl nhập khẩu, các DJ địa phương đưa những xu hướng mới nhất của nhạc điện tử quốc tế vào Đài Loan, đồng thời thử kết hợp chất liệu bản địa để tìm kiếm một âm thanh có căn cước riêng.
+
+### Lâm Cường: chiếc cầu then chốt của nhạc điện tử bản địa
+
+Năm 1990, **Lâm Cường (Lim Giong)** gây chấn động làng nhạc với album rock tiếng Đài _Tiến lên phía trước_. Sau đó, ông dần chuyển sang nhạc điện tử và hợp tác cùng các đạo diễn như Hầu Hiếu Hiền, viết nhạc cho nhiều bộ phim Đài Loan bằng cách hòa trộn âm thanh truyền thống với chất liệu điện tử. Con đường đi từ rock đại chúng đến thể nghiệm điện tử rồi nhạc phim của Lâm Cường là một trong những điểm nối sớm nhất, có sức ảnh hưởng rộng nhất giữa nhạc điện tử với bản địa Đài Loan. Ông cũng là một trong số ít nghệ sĩ giúp giới âm nhạc quốc tế hiểu nhạc điện tử qua chính bối cảnh Đài Loan.[^6]
+
+## Những bước đầu thương mại hóa (2000–2010): từ ngầm lên mặt đất
+
+### Văn hóa hộp đêm trỗi dậy và những đợt truy quét
+
+Đầu những năm 2000, đời sống về đêm tại Đài Loan mở rộng. Nhạc điện tử rời các nhà kho ngầm để đi vào những hộp đêm hợp pháp và tiếp cận đông đảo công chúng hơn. Khu Tín Nghĩa và khu Đông ở Đài Bắc trở thành các cứ điểm mới; house, trance, drum & bass và breakbeat đều tìm được người nghe riêng, còn nghề DJ dần chuyển từ thú vui nghiệp dư thành một con đường chuyên nghiệp.
+
+Tuy nhiên, **các đợt truy quét thuốc lắc MDMA giai đoạn 2003–2005** là bước ngoặt quan trọng. Cảnh sát đồng loạt kiểm tra những hộp đêm và không gian tiệc tùng quy mô lớn, khiến một số địa điểm phải đóng cửa và các bữa tiệc ngầm thu hẹp đáng kể. Cộng đồng buộc phải hoạt động phân tán và kín đáo hơn. Sự kiểm soát này đẩy nhanh quá trình phân hóa của nhạc điện tử Đài Loan: khoảng cách giữa các hộp đêm thương mại quy mô lớn và thế giới underground chuyên sâu từ đó ngày càng rộng.
+
+Cùng thời kỳ, **các bữa tiệc queer LGBT** cũng âm thầm phát triển. Lấy khu vực quảng trường Nhà Đỏ Ximending ở Đài Bắc làm trung tâm, những bữa tiệc này kết nối năng lượng của nhạc điện tử với giải phóng giới và tính dục. Chúng trở thành một trong những nhánh sôi động, gắn kết cộng đồng mạnh nhất của nhạc điện tử Đài Loan, với ảnh hưởng kéo dài đến bản đồ sự kiện ngày nay.
+
+### Trao đổi quốc tế sâu rộng hơn
+
+Internet phổ biến cùng sự tiến bộ của phần mềm sản xuất âm nhạc đã mở thêm cơ hội để nghệ sĩ điện tử Đài Loan kết nối với thế giới. Một số DJ bắt đầu được mời biểu diễn ở nước ngoài; đồng thời, ngày càng nhiều DJ quốc tế đến Đài Loan, làm tăng mật độ trao đổi trong cộng đồng địa phương.
+
+## Thời đại quốc tế hóa (2010 đến nay): dấu chân toàn cầu của nhạc điện tử Đài Loan
+
+### Cột mốc Road to Ultra
+
+Trên trục lễ hội, **Spring Scream** được tổ chức hằng năm tại Kenting từ năm 1995. Dù lấy rock làm chủ đạo, sự kiện vẫn dành sân khấu cho nhạc dance điện tử và là một trong những nơi đầu tiên ở Đài Loan đưa dòng nhạc này vào bối cảnh lễ hội quy mô lớn. Năm 2013, Ultra Music Festival lần đầu tổ chức “Road to Ultra Taiwan”, đánh dấu lúc nhạc điện tử Đài Loan bước vào tầm nhìn của dòng chính quốc tế. Sau đó, các lễ hội lớn do Đài Loan tổ chức như Looptopia lần lượt xuất hiện, thu hút người yêu nhạc điện tử từ khắp châu Á. Nhờ vậy, Đài Bắc xác lập vị trí trên bản đồ nhạc điện tử khu vực, còn nghệ sĩ trong nước có thêm cơ hội đứng chung sân khấu với DJ quốc tế.[^2]
+
+### DJ Đài Loan vươn ra quốc tế
+
+Hai DJ tiêu biểu của Đài Loan bước lên sân khấu quốc tế trong giai đoạn này. **Sonia Calico** được cộng đồng nữ DJ quốc tế công nhận nhờ gu âm nhạc tinh tế và kỹ thuật chuyên nghiệp. **RayRay** thường xuyên được mời tới các lễ hội quốc tế nhờ phong cách biểu diễn sáng tạo. Cả hai đều nhận được sự chú ý của những kênh truyền thông nhạc điện tử như Resident Advisor, trở thành các gương mặt Đài Loan có độ nhận diện cao ở nước ngoài và là điểm tham chiếu cụ thể cho thế hệ nghệ sĩ mới.[^3]
+
+### Tinh thần thể nghiệm của nghệ sĩ điện tử độc lập
+
+Song song với sự phát triển của các lễ hội dòng chính, Đài Loan cũng có những nghệ sĩ độc lập nổi tiếng vì tinh thần thể nghiệm. **Meuko! Meuko!** là dự án cá nhân được giới nhạc điện tử thể nghiệm quốc tế chú ý nhờ các thử nghiệm âm thanh tiên phong và hợp tác liên ngành. Tác phẩm của cô pha trộn noise, ambient và chất liệu âm nhạc truyền thống phương Đông, đồng thời được phát hành cùng nhiều nhãn đĩa quốc tế.[^4] Trong cộng đồng địa phương, những cửa hàng đĩa như Vacation Records cũng đóng vai trò điểm nối, liên kết văn hóa sưu tầm vinyl với giới sáng tác nhạc điện tử.
+
+## Phát triển và thách thức đương đại
+
+### Chuyển đổi trực tuyến trong đại dịch
+
+Sau khi đại dịch bùng phát năm 2020, các bữa tiệc và lễ hội âm nhạc truyền thống chịu ảnh hưởng nặng nề. Cộng đồng nhạc điện tử Đài Loan phát triển những hình thức mới như phát trực tiếp DJ set và lễ hội ảo để duy trì sự gắn kết.[^5]
+
+Sau COVID-19, nhiều địa điểm lâu năm đi vào lịch sử. **Korner**, nằm dưới tầng hầm ở quận Đại An, từng là điểm trung tâm của techno và house underground Đài Bắc trong thập niên 2010. Nơi đây nổi tiếng với tiêu chuẩn chọn nhạc khắt khe và những bữa tiệc marathon kéo dài từ đêm khuya đến sáng, được đánh giá cao trong cộng đồng nhạc điện tử châu Á, nhưng đã đóng cửa sau đại dịch. Cùng thời, **Pawnshop** và **Pipe** góp phần dựng nên hệ sinh thái underground Đài Bắc bằng những định hướng âm nhạc riêng; **Final** thiên về biểu diễn trực tiếp và tạo sân khấu cho nhạc điện tử thể nghiệm. Khi lớp địa điểm này lần lượt khép lại, những không gian thế hệ mới và các bữa tiệc pop-up không định kỳ tiếp quản vai trò cộng đồng của họ.
+
+Nhạc điện tử Đài Loan cũng đang tìm kiếm một phong cách địa phương rõ nét hơn. Một số nghệ sĩ phối lại ca khúc tiếng Đài và tiếng Khách Gia hoặc đưa mẫu âm thanh của nhạc cụ truyền thống vào sản phẩm điện tử, nhằm xây dựng một ngôn ngữ “nhạc điện tử kiểu Đài Loan” có gốc rễ tại chỗ.
+
+## Tài liệu tham khảo
+
+[^1]: [Resident Advisor — Taiwan](https://ra.co/promoters/tw) — cơ sở dữ liệu sự kiện nhạc điện tử Đài Loan của RA, gồm tư liệu về lịch sử tiệc ngầm và các địa điểm.
+
+[^2]: [Trang chính thức của Looptopia Festival](https://looptopia.com.tw/) — thông tin về lễ hội nhạc điện tử Đài Loan và danh sách nghệ sĩ qua các năm.
+
+[^3]: [Sonia Calico — hồ sơ trên Resident Advisor](https://ra.co/dj/soniacalico) — giới thiệu và lịch sử biểu diễn của DJ Sonia Calico trên truyền thông nhạc điện tử quốc tế.
+
+[^4]: [Meuko! Meuko! — Bandcamp](https://meukomeukomusicclub.bandcamp.com/) — các tác phẩm và thông tin hợp tác với hãng đĩa của Meuko! Meuko!.
+
+[^5]: [Thông tin chính thức Road to Ultra Taiwan](https://ultrataiwan.com/) — lịch sử các kỳ Ultra Music Festival tại Đài Loan.
+
+[^6]: [Lâm Cường — hồ sơ Giải Kim Khúc](https://www.gca.gov.tw/) — thành tích nhạc phim và các tác phẩm giao thoa điện tử của Lâm Cường.
+
+## Đọc thêm
+
+- [Resident Advisor — Taiwan](https://ra.co/promoters/tw) — cơ sở dữ liệu Đài Loan của truyền thông nhạc điện tử quốc tế
+- [Looptopia Festival](https://looptopia.com.tw/) — trang chính thức của lễ hội nhạc điện tử Đài Loan


### PR DESCRIPTION
## 📝 這個 PR 做了什麼？

新增越南文翻譯：
- 來源：knowledge/Music/台灣電子音樂與派對文化.md
- 譯文：knowledge/vi/Music/taiwan-electronic-music-and-party-culture.md
- 完整保留 34 個語意區塊、6 則腳註與全部 URL
- 依越南文規範使用 Đài Loan、Đài Bắc、Lâm Cường 等詞形
- 品牌、藝名、場館與音樂節名稱保留可搜尋的正式拼法

## ✅ 驗證

- strict frontmatter：PASS
- article-health pre-commit：PASS（0 warnings）
- translation ratio：PASS（2.60）
- CJK leak / residue / adjacency：PASS
- anti-framing scan：PASS
- verify-translation：18/18 PASS
- provenance：fresh / same-commit

## 🤖 AI 協作揭露

- 使用 OpenAI Codex 協助翻譯、術語一致性與自動檢查
- 本 PR 尚未經越南文母語者審閱
- lastHumanReview: false 沿用來源文章；建議合併前由越南文母語者複核語感