### PR TITLE
translate(pt): 牛肉麵 → beef-noodle-soup

### DIFF
--- a/knowledge/pt/Food/beef-noodle-soup.md
+++ b/knowledge/pt/Food/beef-noodle-soup.md
@@ -1,0 +1,159 @@
+---
+title: 'Sopa de Macarrão com Carne'
+description: 'Da saudade dos imigrantes continentais ao prato nacional de Taiwan — a fusão cultural e o alcance global do niúròumiàn'
+date: 2026-03-17
+category: 'Food'
+tags: ['gastronomia', 'sopa de macarrão com carne', 'cozinha continental', 'fusão cultural', 'Festival do Beef Noodle de Taipé', 'Michelin']
+subcategory: 'Petiscos clássicos'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-05-16
+lastHumanReview: true
+image: '/images/wiki/5be514264de6.jpg'
+imageAlt: 'Sopa de macarrão com carne taiwanesa'
+imageCredit: 'Wikimedia Commons, CC BY-SA 2.0'
+translatedFrom: 'Food/牛肉麵.md'
+---
+
+# Sopa de Macarrão com Carne (牛肉麵)
+
+> **Panorama em 30 segundos:** A linha do tempo da sopa de macarrão com carne (牛肉麵, niúròumiàn) de Taiwan começa depois de 1949, com os imigrantes continentais — veteranos de Sichuan, Shandong e Hunan que trouxeram as técnicas de cozimento de carne de cada província e as fundiram com o paladar local, dando origem às escolas do braseado (紅燒), do caldo claro (清燉) e do tomate. Em 2005, o Festival Internacional do Beef Noodle de Taipé inaugurou uma ação de branding urbano; em 2018, o primeiro Guia Michelin de Taiwan recomendou Liu Shandong (劉山東), Niu Baba (牛爸爸) e Jianhong (建宏); o nome "California Beef Noodle" chegou à América do Norte. Uma tigela carrega 75 anos de reviravoltas, mistura entre grupos provinciais e memória gustativa.
+
+Uma tigela fumegante de macarrão com carne — caldo denso, carne macia, macarrão de textura elástica — tornou-se o prato mais representativo da cozinha nacional taiwanesa. Este prato aparentemente simples carrega a nostalgia dos imigrantes continentais, testemunhou a fusão étnica da história de Taiwan e passou de comida de rua a estrela do palco gastronômico internacional: dentro de uma tigela reside toda a diversidade e a hospitalidade da cultura alimentar taiwanesa.
+
+![Sopa de macarrão com carne taiwanesa](/images/wiki/5be514264de6.jpg)
+_Fonte da imagem: [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Taiwanese_beef_noodles.jpg) | CC BY-SA 2.0 | fotógrafo desconhecido_
+
+## Origem histórica e contexto cultural
+
+### Da proibição ao prato favorito
+
+Na Taiwan agrária tradicional prevalecia a máxima "o boi é parceiro de trabalho e não se come". O animal era o companheiro essencial da lavoura, e o costume popular do "não comer carne bovina" era tão forte que um dito local afirmava "毋食牛，較贏食自己肉" (não comer boi é melhor do que comer a própria carne), evidenciando a reverência devotada ao bovino.[^1]
+
+Esse tabu alimentar sofreu uma mudança radical depois de 1949. Com a chegada do governo nacionalista a Taiwan, um grande contingente de militares e suas famílias migrou de várias províncias da China trazendo culturas culinárias e técnicas de preparo distintas — entre elas, o hábito de comer carne bovina.
+
+### Uma criação nascida da saudade dos imigrantes continentais
+
+A sopa de macarrão com carne nasce de um processo de fusão e invenção. Nas Forças Armadas, o boi era uma fonte importante de proteína; ao serem dispensados do serviço, muitos veteranos levaram para a vida civil as técnicas de estufado que haviam aprendido nos quartéis e passaram a preparar pratos de carne bovina em Taiwan. As "vilas de dependentes militares" (眷村) tornaram-se comunidades de imigrantes de várias províncias — as famílias vindas de Sichuan, Shandong, Hunan e outras regiões trocavam temperos e técnicas de casa, aos poucos desenvolvendo uma versão com sotaque taiwanês. No plano econômico, as condições iniciais eram duras e a maior parte dos veteranos sobrevivia com barracas de rua. O prato tinha custo relativamente baixo e uma única tigela fornecia carboidrato, proteína e vegetais em porção nutritiva e saciante, o que rapidamente conquistou o público.
+
+### Encontro entre sabores regionais
+
+A sopa de macarrão com carne de Taiwan reúne características de vários sistemas culinários regionais: o sabor de Sichuan aporta doubanjiang (豆瓣醬, pasta de feijão apimentada) e um leque de especiarias, produzindo o característico caldo avermelhado, picante e aromático — os veteranos de origem sichuanesa em Gangshan (岡山), Kaohsiung, foram os principais promotores dessa vertente.[^2] Os naturais de Shandong dominam a arte de fazer macarrão à mão e forneceram a Taiwan a técnica das massas de qualidade; a combinação do pão redondo de Shandong (山東大餅) com carne bovina virou um clássico. A contribuição de Hunan aparece no uso da pimenta e nos métodos de estufado, acrescentando ao prato camadas do repertório xiangnês. Por fim, houve a adaptação local: ajustou-se ao paladar taiwanês, reduzindo o excesso de picância e equilibrando notas doces e umami.
+
+## Principais escolas e perfis de sabor
+
+Após décadas de desenvolvimento, a sopa de macarrão com carne taiwanesa gerou várias escolas e estilos distintos.
+
+**A versão braseada (紅燒)** é o clássico da rua Taoyuan (桃源街) em Taipé: caldo castanho-avermelhado profundo, temperado com molho de soja, doubanjiang, pimenta, anis-estrelado, canela e outras especiarias — sabor salgado-aromático levemente picante e caldo encorpado. Na preparação, a carne é primeiro salteada com molho de soja e doubanjiang para ganhar cor, e depois estufada em caldo por 2-3 horas, tempo suficiente para as especiarias penetrarem completamente até o caldo assumir uma tonalidade âmbar profundo.
+
+**A versão em caldo claro (清燉)** segue o caminho da transparência: apenas gengibre, cebolinha e vinho de cozinha para retirar o cheiro forte e realçar o sabor, resultando num paladar limpo, com retrogosto adocicado, que ressalta o próprio sabor da carne. Essa vertente é frequentemente conduzida por casas muçulmanas halal. O caldo de ossos bovinos é fervido longamente e purificado de todas as impurezas para permanecer límpido. A carne cozinha até ficar macia, mas mantendo a fibra visível.
+
+**A sopa de tomate (番茄牛肉麵)** é um ramo relativamente moderno, no qual entram tomate, cebola, cenoura e outros ingredientes ocidentais, produzindo um caldo avermelhado, agridoce e de sabor estratificado. Representa o diálogo entre a estrutura oriental da sopa de macarrão e ingredientes ocidentais. **A versão "caldo puro" (原汁牛肉麵)** adota o minimalismo: só carne, ossos, água e um mínimo de tempero, num caldo denso e esbranquiçado como leite, em busca do sabor mais puro possível da carne. **A sopa apimentada estilo Sichuan (川味麻辣牛肉麵)** utiliza doubanjiang autêntico de Sichuan e pimenta-de-sichuan (花椒), oferecendo um perfil picante, amortecente e aromático, com camadas nítidas, preservando o traço tradicional da cozinha sichuanesa.
+
+## Técnicas de preparo e chaves da qualidade
+
+Uma boa tigela exige equilíbrio perfeito em três frentes: caldo, carne e macarrão.
+
+### Preparo do caldo
+
+**Caldo de ossos bovinos:**
+Utilizam-se ossos de perna e costela ricos em colágeno; entram na panela com água fria e cozinham por 6 a 8 horas. Durante o processo, a espuma precisa ser retirada continuamente para manter o caldo límpido.
+
+**Combinação de especiarias:**
+Anis-estrelado, canela, pimenta-de-sichuan, cravo, cardamomo-preto e mais de uma dezena de especiarias precisam ser dosados com precisão. Cada casa mantém a própria fórmula secreta, tratada como segredo comercial jamais divulgado.
+
+**Equilíbrio do tempero:**
+O balanço entre salgado, doce, ácido e picante é decisivo, e o paladar taiwanês tende a apreciar um toque de doçura — a dosagem precisa considerar essa adaptação local.
+
+### Escolha e preparo da carne
+
+Na escolha do corte: o músculo da coxa (牛腱), rico em tendão e sabor, fica firme e "Q" depois do estufado e é o mais usual; a costela em tiras (牛肋條) tem equilíbrio entre gordura e magro e resulta macia e suculenta; blocos de carne puramente magra oferecem textura mais firme; já o tendão bovino, cheio de colágeno, exige estufado prolongado até derreter na boca. Na sequência de trabalho, a carne é primeiro escaldada para retirar o sangue e em seguida cozinha junto com as especiarias por 2-3 horas, até que o pauzinho atravesse sem esforço.
+
+### Escolha do macarrão
+
+Quanto à espessura: massas largas casam com o caldo denso do braseado; massas finas combinam com o caldo leve do "qingdun"; o macarrão raspado à faca (刀削麵) tem uma textura elástica única que forma escola à parte, muito apreciada. Na técnica, a boa massa é mastigável mas não dura, e o tempo de cozimento fica entre 2 e 3 minutos para preservar a textura ideal.
+
+## O Festival do Beef Noodle de Taipé e a internacionalização
+
+### Criação do festival
+
+Em 2005, a Prefeitura de Taipé criou o "Festival Internacional do Beef Noodle de Taipé" (台北國際牛肉麵節) com o objetivo de promover a cultura da sopa taiwanesa e elevar sua projeção internacional.[^3] A cada ano o evento inclui competições (nas categorias braseado, caldo claro, criação, etc.), exposições das casas mais famosas de todo o país, atividades culturais como mostras históricas e demonstrações culinárias, e ações internacionais que reúnem meios de comunicação e gastrônomos estrangeiros para degustações. No quesito julgamento, os avaliadores pontuam quatro dimensões — caldo, carne, macarrão e apresentação geral — e definem, todos os anos, medalhas de ouro, prata e bronze.
+
+### Atenção da mídia internacional
+
+**Mídia internacional:**
+A sopa taiwanesa recebeu reconhecimento em diversos veículos e guias gastronômicos internacionais, sendo apontada como uma das portas de entrada essenciais para conhecer Taiwan, com projeção internacional em ascensão contínua.[^4]
+
+**Guia Michelin:**
+Depois da publicação do Guia Michelin de Taiwan em 2018, várias casas de macarrão com carne foram recomendadas, entre elas:
+
+- Liu Shandong Niúròumiàn (劉山東牛肉麵): Bib Gourmand
+- Niu Baba Niúròumiàn (牛爸爸牛肉麵): Recomendado Michelin
+- Jianhong Niúròumiàn (建宏牛肉麵): recomendação local
+
+**Expansão no exterior:**
+Casas taiwanesas de macarrão com carne abriram filiais nos Estados Unidos, no Canadá e na Austrália; existe até a marca "California Beef Noodle" (加州牛肉麵), que na prática é a versão taiwanesa.
+
+### Soft power diplomático
+
+O prato ocupa um lugar bem definido nas ações culturais externas de Taiwan:
+
+- O Overseas Community Affairs Council (僑委會) promove a sopa taiwanesa no exterior
+- O Ministério das Relações Exteriores organiza festivais gastronômicos taiwaneses em outros países
+- O Bureau de Turismo lista o niúròumiàn como comida imperdível
+
+## Perfil regional e cultura das casas famosas
+
+**A região de Taipé** é o principal palco do niúròumiàn taiwanês. A rua Taoyuan (桃源街) foi ponto de encontro das barracas halal de macarrão com carne nos anos 1950 e depois evoluiu para o estilo sichuanês. O quarteirão da rua Yongkang (永康街) ficou famoso por casas veteranas como Yongkang Niúròumiàn (永康牛肉麵), Lao Zhang Niúròumiàn (老張牛肉麵) e Pinchuanlan Niúròumiàn (品川蘭牛肉麵). Ximending (西門町) reúne barracas ao redor do Lao Tian Lu Wei (老天祿滷味) e propostas inovadoras dirigidas ao público jovem.
+
+**Em Nova Taipé**, Yonghe (永和) desenvolveu o modelo peculiar da "casa de leite de soja com macarrão com carne", com funcionamento 24 horas para atender a diferentes horários. Já Banqiao, no entorno da estação Fuzhong, concentra várias casas veteranas em rota popular ligada à cultura dos mercados noturnos.
+
+**Em Taichung**, a preferência é por um perfil mais leve — o caldo é mais suave que em Taipé, mas mantém as camadas de sabor; representantes locais incluem a rede Duan Chunzhen Niúròumiàn (段純貞牛肉麵) e a veterana Fuhong Niúròumiàn (富宏牛肉麵). **Em Tainan**, a preferência da "capital do prefeito" pelo doce se reflete também no niúròumiàn, mais adocicado. **Em Kaohsiung**, o distrito de Gangshan (岡山) é o berço do estilo sichuanês: veteranos de Sichuan fundaram ali a versão autêntica, com maior intensidade picante e amortecente, que até hoje conserva um sotaque mais forte de Sichuan.
+
+## Significado cultural e impacto social
+
+A trajetória do niúròumiàn desenha, por inteiro, o mapa da fusão multicultural de Taiwan. O prato quebrou o antigo tabu agrário do "não comer boi" e é um caso concreto da abertura e da hospitalidade da sociedade taiwanesa. A combinação entre as técnicas dos imigrantes continentais e o paladar dos taiwaneses nativos gerou um sabor tipicamente local. A segunda e a terceira gerações de imigrantes herdaram o ofício, mas seguem inovando sobre a base tradicional, adaptando-se às mudanças de época.
+
+Do ponto de vista econômico, o setor impulsionou o desenvolvimento em várias camadas da restauração, desde barracas de rua até restaurantes sofisticados, atendendo a todas as faixas de consumo. Também estimulou uma cadeia completa que vai da pecuária bovina em Taiwan à indústria de macarrão e à produção de temperos; do lado turístico, é comida obrigatória para visitantes e um dos principais argumentos de venda da experiência de viagem em Taiwan.
+
+No plano cotidiano, o niúròumiàn é opção capaz de sustentar almoço, jantar ou refeição de madrugada; "vamos comer niúròumiàn" tornou-se convite comum entre amigos e em reuniões de negócios; para muitos taiwaneses, essa tigela carrega memórias de infância, calor familiar e outros valores emocionais.
+
+## Inovação e tendências futuras
+
+Nos últimos anos, o setor tem se expandido em várias direções. No eixo da saúde surgem versões com menos sal e óleo, ingredientes orgânicos e maior proporção de vegetais; na diversificação de sabores aparecem variantes japonesa, tailandesa, italiana, versões vegetarianas com carne vegetal ou cogumelos, e desdobramentos que trocam o boi por frutos do mar. No serviço, o crescimento de redes, o refinamento das embalagens e do ambiente, e a popularização das plataformas de entrega ampliaram os cenários de consumo.
+
+Do lado tecnológico, algumas casas usam equipamentos para controlar temperatura e tempo de cozimento e assegurar consistência; técnicas de congelamento permitem entrega em domicílio ou exportação; redes sociais e aplicativos de gastronomia tornaram-se o principal canal de marketing para consumidores mais jovens.
+
+### Desafios da internacionalização
+
+Fora de Taiwan, o niúròumiàn enfrenta desafios em três frentes: adaptação cultural — a promoção externa precisa considerar o paladar e os hábitos locais; obtenção de ingredientes — conseguir temperos e insumos autênticos no exterior segue sendo problema difícil; proteção da marca — o nome "sopa de macarrão com carne de Taiwan" é frequentemente usurpado, e defender a reputação da versão autêntica é uma batalha de longo prazo.
+
+## Cultura de degustação e etiqueta
+
+A maneira "ortodoxa" de comer tem uma ordem: primeiro experimenta-se o caldo para captar as camadas de especiaria, depois a carne para julgar o ponto do estufado, e ao final o macarrão para avaliar a harmonia do conjunto. Nos acompanhamentos, os aperitivos costumam ser kimchi, ovo cozido em molho e tofu prensado; a bebida pode ser chá quente ou cerveja, e algumas casas também servem uma tigela extra de arroz branco.
+
+A cultura das casas também é parte inseparável da experiência taiwanesa: o dono costuma ter personalidade e teimosia próprias, formando uma atmosfera característica; nos estabelecimentos famosos, a fila é frequente e faz parte, ela mesma, da cultura gastronômica local; a transmissão do ofício pelo tradicional sistema de mestre-aprendiz sustenta a fabricação artesanal, difícil de replicar industrialmente.
+
+Numa tigela fumegante de macarrão com carne: o caldo é a memória histórica pós-1949, o macarrão é o rastro do encontro entre grupos provinciais, e o óleo de pimenta traz a saudade dos veteranos sichuaneses de Gangshan (岡山), em Kaohsiung.
+
+Das barracas halal da rua Taoyuan (桃源街) em Taipé, das casas veteranas da rua Yongkang (永康街) e do estilo sichuanês de Gangshan, até o primeiro Guia Michelin de Taiwan em 2018 recomendar Liu Shandong (劉山東), Niu Baba (牛爸爸) e Jianhong (建宏), passando pelo nome "California Beef Noodle" (加州牛肉麵) que chegou à América do Norte: em 75 anos de estrada, uma tigela transformou o tabu em rotina e a saudade em prato nacional.
+
+## Leituras complementares
+
+- [Panorama da Gastronomia Taiwanesa](/food/台灣美食總覽) — o mapa completo, dos indígenas ao Michelin: o lugar do niúròumiàn dentro de quatrocentos anos de paladar mestiço
+- [Cultura do Café da Manhã Taiwanês](/food/台灣早餐文化) — os pães fritos (燒餅), os "youtiao" (油條) e o leite de soja, também trazidos pelos imigrantes continentais de 1949, formam com o niúròumiàn a marca da fusão gastronômica do pós-guerra
+- [Arroz com Carne Estufada Taiwanês (滷肉飯)](/food/台灣滷肉飯) — outro caminho, também vindo das cozinhas dos "juancun", da vila de dependentes militares à mesa nacional, que compartilha com o niúròumiàn a dupla linhagem da saudade imigrante e da adaptação local
+- [Retirada do Governo Nacionalista para Taiwan e Reconstrução do Pós-Guerra](/history/國民政府遷台與戰後重建) — a virada gastronômica trazida pela migração de 1,2 milhão de pessoas é o pano de fundo histórico do surgimento do niúròumiàn
+- [Cultura dos Mercados Noturnos de Taiwan](/food/夜市文化) — o principal palco popular por onde o niúròumiàn circulou depois de sair das vilas de dependentes militares
+
+---
+
+## Referências
+
+[^1]: [Wikipedia: história do niúròumiàn taiwanês](https://zh.wikipedia.org/zh-tw/%E7%89%9B%E8%82%89%E9%BA%B5) — inclui a apuração histórica do historiador Lu Yaodong (逯耀東); verbete da Wikipédia
+
+[^2]: [The News Lens: elo histórico entre o doubanjiang de Gangshan e o niúròumiàn](https://www.thenewslens.com/article/117978) — investigação sobre a origem do braseado sichuanês criado pelos veteranos de Sichuan em Gangshan, Kaohsiung
+
+[^3]: [Site oficial do Festival Internacional do Beef Noodle de Taipé](https://tpebeefnoodle.com.tw/) — informações oficiais do evento de branding urbano promovido pela Prefeitura de Taipé desde 2005
+
+[^4]: [Guia Michelin: recomendações imperdíveis de niúròumiàn em Taiwan](https://guide.michelin.com/tw/zh_TW/best-of/must-eat-beef-noodles-taiwan-recommendations) — página oficial do Guia Michelin Taiwan reunindo a lista das melhores casas de niúròumiàn a experimentar, com o Bib Gourmand e a lista de estabelecimentos com estrela, documentando o niúròumiàn como uma das faces internacionais da gastronomia de Taiwan.


### PR DESCRIPTION
﻿Adds Portuguese translation of `Food/牛肉麵.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Portuguese proficiency)

**Length ratio**: 3.895 (pt band healthy 2.0-4.3)

**Structure alignment**: 10 `##` headings / 4 footnotes / 6 http links — 100% preserved

**Note**: i18n/pt/STYLE.md not yet exists — followed TRANSLATE_PROMPT + established translation conventions from existing pt corpus.

Uncertain terminology flagged for reviewer:

- 眷村 (juancun) → "vilas de dependentes militares" · usei termo descritivo; alternativa: manter chinês + parênteses
- 紅燒 → "braseado" (com nota do original 紅燒) · comum em cozinha pt
- 清燉 → "caldo claro" · alternativa: "cozido claro"
- 豆瓣醬 (doubanjiang) → mantido em pinyin + explicação · sem tradução consagrada em pt
- 老兵 → "veteranos" · mantido; alternativa "ex-militares"

Please review. Happy to iterate.
