### PR TITLE
translate(de): 日治時期 → japanese-colonial-era

### DIFF
--- a/knowledge/de/History/japanese-colonial-era.md
+++ b/knowledge/de/History/japanese-colonial-era.md
@@ -1,0 +1,81 @@
+---
+title: 'Japanische Kolonialzeit'
+description: '1895 bis 1945 herrschte Japan 50 Jahre über Taiwan. Diese Epoche brachte eine umfassende Modernisierung und institutionalisierte Verwaltung, zugleich aber auch die Assimilationspolitik der "Kōminka" — beides prägt die taiwanische Gesellschaft bis heute.'
+date: 2026-03-17
+category: 'History'
+tags: ['History', 'japanische Herrschaft', 'Modernisierung', 'Kōminka-Bewegung']
+subcategory: 'Kolonialismus und Imperium'
+author: 'Taiwan.md Contributors'
+featured: true
+lastVerified: 2026-03-19
+lastHumanReview: false
+translatedFrom: 'History/日治時期.md'
+---
+
+# Japanische Kolonialzeit (日治時期)
+
+> **Überblick in 30 Sekunden:** Nach dem Vertrag von Shimonoseki (馬關條約) im Jahr 1895 regierte Japan Taiwan 50 Jahre lang. Über das Generalgouvernement (總督府) wurden umfassende Modernisierungen durchgeführt — Infrastruktur, Bildungswesen und Industrieaufbau. Parallel dazu sollte die Kōminka-Bewegung (皇民化運動) die Taiwaner assimilieren. Die Kolonialzeit war zugleich von zahlreichen antijapanischen Bewegungen geprägt und endete 1945 mit der Kapitulation Japans am Ende des Zweiten Weltkriegs.
+
+Von 1895 bis 1945 herrschte Japan ein halbes Jahrhundert über Taiwan — eine Zeit, die zugleich rasche Modernisierung und koloniale Unterdrückung samt kultureller Assimilation brachte. Beide Kräfte verflechten sich zu einer Grundschicht der heutigen taiwanischen Gesellschaft.[^1]
+
+## Koloniales Herrschaftssystem
+
+Das Generalgouvernement Taiwan (台灣總督府) mit Sitz in Taipeh war die oberste Herrschaftsinstanz Japans auf der Insel; der Generalgouverneur wurde vom Tennō ernannt und vereinte Exekutive, Legislative und Militärgewalt. Das "Gesetz 63" (六三法) ermächtigte ihn, gesetzeskräftige Verordnungen zu erlassen. Unter dem Polizeisystem organisierte die Baojia-Struktur (保甲) jeden Haushalt in ein System gegenseitiger Überwachung und Kollektivhaftung, um die koloniale Kontrolle bis in die Basis zu tragen.
+
+Als Japan Taiwan 1895 übernahm, stieß es zuerst auf den bewaffneten Widerstand der Republik Taiwan (台灣民主國). Auch danach brachen immer wieder regionale Aufstände aus. Erst nach dem Xilai-An-Zwischenfall (西來庵事件) 1915 endete der bewaffnete Widerstand weitgehend, und die Kolonialherrschaft trat in eine relativ stabile Modernisierungsphase ein.
+
+Verwaltungstechnisch wurde die Insel in die Präfekturen Taipeh, Hsinchu, Taichung, Tainan, Kaohsiung u. a. unterteilt; eine flächendeckende Landerhebung klärte die Eigentumsverhältnisse und legte die institutionelle Grundlage für moderne Industrie und Steuersystem.
+
+## Modernisierung
+
+Im Verkehr wurde 1908 die durchgehende Nord-Süd-Bahnlinie (縱貫鐵路) eröffnet, die Keelung mit Takao (heute Kaohsiung) verband — eines der damals größten kolonialen Bahnsysteme Ostasiens. Zugleich wurden die Häfen von Keelung und Kaohsiung zu modernen Handelshäfen ausgebaut, was Taiwans Außenhandel erheblich stärkte.
+
+In der Wasser- und Landwirtschaft plante der japanische Ingenieur Hatta Yoichi (八田與一) den Kanan-Kanal (嘉南大圳), dessen Bau von 1920 bis 1930 zehn Jahre dauerte; er machte 150.000 Hektar Ackerland in der Chianan-Ebene (嘉南平原) zu einem stabil bewässerten Gebiet — Hatta wird in Taiwan bis heute geehrt.[^2] Das Wasserkraftwerk am Sonne-Mond-See (日月潭) deckte den Strombedarf der Insel.
+
+Im Bildungswesen hoben die öffentlichen Schulen (公學校, "Kōgakkō") die **Einschulungsquote** taiwanischer Kinder von unter 5 % zu Beginn der Kolonialzeit auf rund 71 % (1944). "Alphabetisierungsquote" (識字率) und "Einschulungsquote" (就學率) sind zu unterscheiden: erstere maß die Kolonialregierung an japanischer Lese- und Schreibfähigkeit parallel zum traditionellen chinesischsprachigen System — beide Maßstäbe sollten nicht vermischt werden. Die 1928 gegründete Kaiserliche Universität Taipeh (台北帝國大學, heute Taiwan University) war Vorläuferin der Hochschulen Taiwans; die Bildungs- und Berufschancen taiwanischer Studierender blieben durch ethnische Ungleichbehandlung beschränkt.
+
+Eine treibende Kraft der Modernisierung war **Gotō Shinpei** (後藤新平, Zivilverwaltungsleiter 1898-1906): auf Grundlage seiner "biologischen Doktrin der Kolonialverwaltung" ging er von wissenschaftlicher Erhebung aus und übertrug schrittweise japanische Institutionen — der Rahmen für Bahn, Landerhebung und öffentliche Hygiene entstand so.
+
+## Soziale Bewegungen und kultureller Widerstand
+
+In den 1920er Jahren nahm der politische Widerstand neue Formen an. Die von Lin Hsien-tang (林獻堂) geführte "Petitionsbewegung zur Einrichtung eines taiwanischen Parlaments" (台灣議會設置請願運動, 1921-1934) suchte politische Teilhabe im Kolonialsystem und reichte fünfzehn Petitionen beim japanischen Reichstag ein. Chiang Wei-shui (蔣渭水) gründete 1921 mit Lin Hsien-tang die Taiwanische Kulturgesellschaft (台灣文化協會), die kulturelle Aufklärung zur Stärkung des Nationalbewusstseins einsetzte; 1927 folgte die Taiwanische Volkspartei (台灣民眾黨) als politische Organisation.[^3]
+
+Der **Chih-ching-Zwischenfall 1923** (治警事件) war eine zentrale Repressionsaktion gegen die Bewegung: Unter Berufung auf das "Sicherheitspolizeigesetz" (治安警察法) verhaftete die Kolonialregierung Kernmitglieder der Petitionsbewegung — darunter Chiang Wei-shui — und leitete einen aufsehenerregenden Prozess ein, der mit Schuldsprüchen endete. Der Vorfall verschaffte der Petitionsbewegung große Öffentlichkeit und beschleunigte die politische Ausdifferenzierung. Die **Taiwanische Kommunistische Partei** (台灣共產黨) wurde 1928 von Hsieh Hsueh-hung (謝雪紅) und anderen in Schanghai als Außenorganisation der Kommunistischen Partei Japans gegründet, forderte die nationale Unabhängigkeit Taiwans, wurde umgehend zerschlagen und war 1931 faktisch aufgelöst.[^4]
+
+Der japanische Wissenschaftler **Yanaihara Tadao** (矢內原忠雄) veröffentlichte 1929 das Werk "Taiwan unter dem Imperialismus" (帝國主義下の台湾), in dem er die Ausbeutungsstruktur der japanischen Kolonialherrschaft mit den Werkzeugen der kapitalistischen Politischen Ökonomie analysierte. Es zählt bis heute zu den am häufigsten zitierten kritischen Werken der Kolonialgeschichtsschreibung.
+
+Der Wushe-Zwischenfall (霧社事件) von 1930 war der größte bewaffnete indigene Aufstand der japanischen Kolonialzeit. Der Häuptling der Seediq, Mona Rudao (莫那魯道), führte etwa dreihundert Angehörige seines Volkes in den Aufstand; die japanische Niederschlagung und die anschließende Politik lösten heftige Kontroversen aus.
+
+In der Literatur schrieben Autoren wie Lai He (賴和), Yang Kui (楊逵) und Lü Hê-jo (呂赫若) auf umgangssprachlichem Chinesisch und auf Japanisch — innerhalb des Kolonialsystems formulierten sie Kritik an der Unterdrückung, bekannten sich zum eigenen Boden und legten den bodenständigen Grundton der neuen taiwanischen Literatur.
+
+## Kōminka-Phase und Nachkriegszeit
+
+Mit dem Ausbruch des Japanisch-Chinesischen Krieges 1937 ging die Kolonie in ein System der Kriegsmobilisierung über, und die Kōminka-Bewegung (皇民化運動) entfaltete sich in großem Umfang.
+
+Die Politik der "Alltagssprache Japanisch" (國語常用) beschränkte das Taiwanische (台語), die "Namensänderung" (改姓名) förderte japanische Namen, Schreinbesuche wurden erzwungen, und taiwanische Männer wurden als japanische Militärangehörige oder Zivilbedienstete eingezogen — schätzungsweise über 200.000 leisteten im Zweiten Weltkrieg Wehr- oder Hilfsdienst.
+
+1945 wurde Japan besiegt, Taiwan kam unter die Verwaltung der Republik China. Moderne Infrastruktur, ausgebildetes Fachpersonal, Rechtsstaatsideen und Verwaltungseffizienz aus der japanischen Zeit waren wichtige Ausgangspunkte der Nachkriegsentwicklung. Die Komplexität der ethnischen Identitäten — die kulturelle Kluft zwischen der japanischsprachigen Generation und den vom Festland zugewanderten Gruppen — zählt zugleich zu den Ursprüngen späterer politischer Konflikte im Nachkriegs-Taiwan.
+
+## Geschichtsperspektive: koloniale Modernisierung vs. koloniale Ausbeutung
+
+Die historische Deutung dieser Zeit wird in der Wissenschaft weiter kontrovers diskutiert. Die "These der kolonialen Modernisierung" (殖民現代化論) betont das positive Erbe von Infrastruktur, Bildung und Gesundheitssystem als materielle Grundlage der Industrialisierung. Die "These der kolonialen Ausbeutung" (殖民剝削論) hebt hervor, dass die Landerhebung indigenen Völkern und Kleinbauern die traditionellen Landrechte entzog, dass die Exportstrukturen von Zucker- und Reisindustrie dem japanischen Imperium dienten statt Taiwans Entwicklung, und dass die Kōminka-Politik die chinesischsprachige Überlieferung systematisch zerstörte. Die einheimische Geschichtsschreibung — etwa Wu Micha (吳密察) oder Wakabayashi Masahiro (若林正丈) — integriert beide Perspektiven und meidet einseitige Bewertungen.
+
+**Anmerkung zur Wortwahl:** Die Begriffe 日治 (japanische Herrschaft) und 日據 (japanische Besetzung) spiegeln in der taiwanischen Geschichtswissenschaft unterschiedliche Standpunkte wider; ersterer gilt als neutral-akademisch, letzterer betont die koloniale Besetzung. Dieser Text verwendet 日治 ohne politische Vorannahme.
+
+## Referenzen
+
+[^1]: [Taiwan während der japanischen Herrschaft — Wikipedia](https://zh.wikipedia.org/wiki/%E8%87%BA%E7%81%A3%E6%97%A5%E6%B2%BB%E6%99%82%E6%9C%9F) — Gesamtübersicht der japanischen Kolonialzeit Taiwans mit Herrschaftsstruktur, wichtigen Ereignissen und Politik der einzelnen Phasen.
+
+[^2]: [Chianan-Kanal — Wikipedia](https://zh.wikipedia.org/wiki/%E5%98%89%E5%8D%97%E5%A4%A7%E5%9C%B3) — Baugeschichte des Chianan-Kanals und ingenieurtechnischer Hintergrund Hatta Yoichis.
+
+[^3]: [Taiwanische Kulturgesellschaft — Wikipedia](https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E6%96%87%E5%8C%96%E5%8D%94%E6%9C%83) — Entstehungshintergrund der Taiwanischen Kulturgesellschaft, die Rollen Chiang Wei-shuis und Lin Hsien-tangs sowie die spätere Spaltung und ihr Verhältnis zur Taiwanischen Volkspartei.
+
+[^4]: [Chih-ching-Zwischenfall — Wikipedia](https://zh.wikipedia.org/wiki/%E6%B2%BB%E8%AD%A6%E4%BA%8B%E4%BB%B6) — Ablauf der Verhaftungen von Mitgliedern der Petitionsbewegung durch die japanische Kolonialregierung nach dem Sicherheitspolizeigesetz 1923.
+
+[^5]: [Gotō Shinpei — Wikipedia](https://zh.wikipedia.org/wiki/%E5%BE%8C%E8%97%A4%E6%96%B0%E5%B9%B3) — Die "biologische Doktrin der Kolonialverwaltung" Gotō Shinpeis (Zivilverwaltungsleiter des Generalgouvernements Taiwan) und die Infrastrukturpolitik in Taiwan.
+
+## Weiterführende Lektüre
+
+- [Krieg von Yiwei](/history/乙未之役) — Der Beginn der japanischen Kolonialzeit: die Landung der japanischen Truppen 1895 und der Widerstand der Republik Taiwan
+- [Qing-Zeit](/history/清治時期) — Die Geschichte Taiwans vor der japanischen Herrschaft
+- [Mona Rudao](/people/莫那·魯道) — Der Wushe-Zwischenfall unter der "Reformpolitik gegenüber den Wilden" (理蕃政策): die Welt eines aufständischen Seediq-Häuptlings


### PR DESCRIPTION
﻿Adds German translation of `History/日治時期.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 4.001 (de band healthy 2.0-4.0 — hit the upper edge; already trimmed one round from an initial 4.485. German compound-word structure + preservation of Chinese proper nouns in parens make History articles trend toward the top of the band.)

**Structure alignment**: 5 `##` headings / 5 footnotes / 5 http links / all wikilinks preserved as internal routes — 100% preserved

**Note**: i18n/de/STYLE.md not yet exists — followed TRANSLATE_PROMPT + established translation conventions from existing de corpus.

Uncertain terminology flagged for reviewer:

- 日治 / 日據 → left as CJK characters in the `Wortwahl` note; alternative: transliterate as "Rìzhì / Rìjù" (removed to save length)
- 皇民化運動 → Kōminka-Bewegung (established Japanologisch)
- 保甲 → Baojia-Struktur (retained pinyin as untranslatable term)
- 治警事件 → Chih-ching-Zwischenfall · alternative: "Vorfall des Sicherheitspolizeigesetzes"
- 生物學殖民地統治論 → "biologische Doktrin der Kolonialverwaltung" · established sinologische Wortwahl variiert
- 台北帝國大學 → Kaiserliche Universität Taipeh · Standardübersetzung

Please review. Happy to iterate.
