### PR TITLE
Add German translation for People (Yeh Ping-cheng)

### DIFF
--- a/knowledge/de/People/yeh-ping-cheng-education-innovator.md
+++ b/knowledge/de/People/yeh-ping-cheng-education-innovator.md
@@ -1,0 +1,68 @@
+---
+title: 'Yeh Bing-cheng'
+description: 'Professor für Elektrotechnik an der National Taiwan University (NTU), der aus Unzufriedenheit mit dem Auswendiglernen die gamifizierte Lernplattform PaGamO schuf und 2014 einen globalen Preis für Bildungsinnovation gewann.'
+date: 2026-03-20
+category: 'People'
+tags:
+  [
+    'Bildung',
+    'Flipped Classroom',
+    'PaGamO',
+    'Gamifiziertes Lernen',
+    'NTU',
+    'Bildungsinnovation',
+  ]
+subcategory: '教育與社會'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-03-20
+lastHumanReview: false
+readingTime: 5
+curation: 'incubating'
+translatedFrom: 'People/葉丙成.md'
+sourceCommitSha: '69b3afd91'
+sourceContentHash: 'sha256:340bb6abbf6b93a5'
+sourceBodyHash: 'sha256:f85ae58b5cc5815d'
+translatedAt: '2026-09-03T00:00:00+08:00'
+---
+
+# Yeh Bing-cheng: Von der Wahrscheinlichkeitsvorlesung zur Revolution des spielerischen Lernens
+
+> **30-Sekunden-Überblick:** Yeh Bing-cheng, Professor für Elektrotechnik an der National Taiwan University, entwickelte 2013 gemeinsam mit seinen Studierenden PaGamO – ein Online-Spiel, in dem Lernende durch „Monster besiegen und Territorien erobern" ihr Fachwissen üben. 2014 setzte sich PaGamO unter 1.500 eingereichten Projekten durch und gewann den Wharton-QS Reimagine Education Award. Sein am häufigsten zitierter Satz lautet: „Schüler lieben Lernen durchaus – nur kein langweiliges Lernen."[^1]
+
+## Eine Rebellion in der Wahrscheinlichkeitsvorlesung
+
+2012 geschah in der Wahrscheinlichkeitsvorlesung der Elektrotechnik-Abteilung der NTU etwas, das Yeh Bing-cheng dazu brachte, einen anderen Weg einzuschlagen. Er beobachtete, wie die leistungsstärksten Studierenden im Hörsaal saßen, während ihre Blicke zum Fenster hin abschweiften – sie konnten Formeln auswendig, verstanden aber nicht wirklich, wozu man sie braucht. Die Paukschule („Auswendiglernen-Lernen") trainiert das „Richtig-Antworten" hervorragend, doch der Instinkt des „Wissen-Wollens" erlischt dabei nach und nach.
+
+Er entschied sich zunächst für das Konzept des Flipped Classroom: Studierende sehen sich zu Hause Unterrichtsvideos an, die Vorlesungszeit bleibt Diskussionen und dem Lösen von Aufgaben vorbehalten. Das galt damals in Taiwan als ungewöhnlicher Ansatz, veränderte aber die Atmosphäre in seinem Hörsaal spürbar. Doch er wollte mehr.
+
+## PaGamO: Lehrbücher als Spiel verpackt
+
+2013 baute Yeh Bing-cheng mit seinen Studierenden PaGamO (der Name leitet sich vom Taiwanesischen „phah game ooh" ab, „spielend lernen"). Die Gestaltungslogik ist unmittelbar einleuchtend: Jugendliche spielen gern Videospiele, weil Spiele sofortige Rückmeldung, Wettbewerb und Erfolgserlebnisse bieten. Warum diese Mechanismen nicht ins Lernen übertragen?
+
+In PaGamO „erobern" die Lernenden durch das Beantworten von Aufgaben Territorien auf einer virtuellen Landkarte und treten gegeneinander an. Richtige Antworten erweitern das eigene Gebiet, falsche Antworten laden zu Invasionen ein. Unter der spielerischen Hülle steckt echtes fachliches Üben. Wer seine Burg nicht verlieren will, schlägt selbst die Formeln nach.[^2]
+
+2014 gewann PaGamO den ersten Preis beim Wharton-QS Reimagine Education Award und setzte sich damit gegen mehr als 1.500 Bildungsinnovationsprojekte aus aller Welt durch. Dieser Preis lenkte zum ersten Mal internationale Aufmerksamkeit auf Taiwans Bildungsinnovation.[^3]
+
+Die Plattform wurde später an mehreren tausend Schulen in ganz Taiwan eingesetzt und erschloss Bildungsmärkte in Hongkong und Singapur; die Fächer reichen von Mathematik über Englisch bis hin zur Programmierung.
+
+## Vom Werkzeug zum Kampfplatz der Ideen
+
+Yeh Bing-cheng machte nicht an der Werkzeugebene halt. Er meldet sich seit Langem in öffentlichen Foren zu Themen wie Hochschulzugang, Kompetenzorientierung und digitalem Lernen zu Wort, hat mehrere Bildungsbücher veröffentlicht und eine große Anhängerschaft in den sozialen Medien aufgebaut.
+
+Seine Kernposition ist unverändert geblieben: Taiwans Bildungssystem trainiert Schüler darauf, „Aufgaben richtig zu beantworten", vermittelt aber nicht die Fähigkeit, „gute Fragen zu stellen" und „reale Probleme zu lösen". In einem Zeitalter, in dem KI zunehmend „Erinnern und Rechnen" übernimmt, so seine Überzeugung, prüfen Taiwans Schulen noch immer genau die Fähigkeiten, die am leichtesten zu ersetzen sind. Diese Kritik ist keine Anklage gegen Lehrkräfte, sondern stellt das Systemdesign als Ganzes infrage.
+
+**Weiterführendes**:
+
+- [Huang Kuo-chen](/people/黃國珍) — ein weiterer Bildungsinnovator, der Taiwans Lesekompetenz fördert
+- [Lu Guan-wei](/people/呂冠緯) — Vorstandsvorsitzender der Junyi-Bildungsplattform; gab die Medizin auf, um eine taiwanesische Variante der Khan Academy aufzubauen
+- [Yen Chang-shou](/people/嚴長壽) — Sozialunternehmer, der von der Tourismusbranche zur Bildung in ländlichen Regionen wechselte
+- [Audrey Tang](/people/唐鳳) — Schnittpunkt von digitaler Governance und Bildungsinnovation
+
+## Referenzen
+
+[^1]: Yeh Bing-cheng hat diesen Satz in zahlreichen öffentlichen Vorträgen und Medieninterviews wiederholt, darunter TEDx Taipei 2014 und der Bildungsschwerpunkt des Magazins „CommonWealth". Originaltexte finden sich in verschiedenen Medienberichten.
+
+[^2]: [Offizielle PaGamO-Website](https://www.pagamo.com/) — Erläuterung der Spielmechanik von PaGamO
+
+[^3]: [Wharton-QS Reimagine Education Awards 2014](https://www.reimagine-education.com/) — Globaler Preis für Bildungsinnovation, der jährlich die bahnbrechendsten Lehrinnovationen auszeichnet; PaGamO gewann 2014 den ersten Preis für „Best Gamified Learning".


### PR DESCRIPTION
## Summary

- 🇩🇪 New German translation: `knowledge/de/People/yeh-ping-cheng-education-innovator.md`
- Source: `People/葉丙成.md`（台大電機系教授、PaGamO 創辦人）
- Bilingual reference: English version already at `knowledge/en/People/yeh-ping-cheng-education-innovator.md`

## Checklist

- [x] Reads like a native German text (not translationese)
- [x] Taiwan proper nouns preserved (PaGamO, NTU, Wharton-QS Reimagine Education Award)
- [x] Key quote mirrored verbatim: „Schüler lieben Lernen durchaus – nur kein langweiliges Lernen."
- [x] Frontmatter: `translatedFrom` + `sourceCommitSha`/`sourceContentHash`/`sourceBodyHash`/`translatedAt` all set (byte-equal zh path)
- [x] `subcategory`/`date`/`featured` mirror zh SSOT
- [x] Footnote URLs preserved
- [x] Internal links use `/people/{zh}` routing (matching existing de People articles)
- [x] Verified: `translation-ratio-check.sh` ratio 3.24 (zh→de healthy range 2.0–4.0), secs/fns/urls aligned
- [x] File path follows `knowledge/de/People/yeh-ping-cheng-education-innovator.md` (same slug as EN)

🤖 Assisted by Dar's agent tooling
