### PR TITLE
Add German translation for People (He Feipeng)

### DIFF
--- a/knowledge/de/People/he-feipeng.md
+++ b/knowledge/de/People/he-feipeng.md
@@ -1,0 +1,71 @@
+---
+title: 'He Feipeng'
+description: 'Ein Medienprofi, der dem Markt acht Jahre voraus war, sieben Jahre in Folge Verluste machte und schließlich Taiwans größten Verlags- und Mediengruppenkonzern aufbaute.'
+date: 2026-03-26
+category: 'People'
+tags:
+  [
+    'Cite Publishing Group',
+    'Verlagswesen',
+    'Digitale Transformation',
+    'Selbstvervollkommnung',
+  ]
+subcategory: '數位與媒體'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-03-26
+lastHumanReview: false
+curation: 'incubating'
+translatedFrom: 'People/何飛鵬.md'
+sourceCommitSha: '69b3afd91'
+sourceContentHash: 'sha256:c6c5b08befa8584a'
+sourceBodyHash: 'sha256:65be42b8cac6c9ca'
+translatedAt: '2026-09-03T00:00:00+08:00'
+---
+
+# He Feipeng: Wie ein Verleger Taiwans Printmedien durch den digitalen Sturm steuerte
+
+> **30-Sekunden-Überblick:** 1987 gründete He Feipeng das *Business Weekly* (商業周刊) – in den ersten sieben Jahren verlor das Magazin jedes Jahr mehrere zehn Millionen NT-Dollar. Heute ist seine Cite Publishing Group (城邦媒體集團) nicht nur Taiwans größtes Verlagshaus, sondern auch eines der wenigen traditionellen Medien, die die Welle der digitalen Transformation überlebt haben. Seine Karriere ist zugleich eine Überlebensgeschichte der taiwanesischen Printmedien angesichts des digitalen Umbruchs.
+
+| 7 Jahre                                   | 100 Millionen NT-Dollar                   |
+| ----------------------------------------- | ----------------------------------------- |
+| Dauer der anfänglichen Verluste des *Business Weekly* | Investitionssumme für den Erwerb von PIXNET 2007 |
+
+1987 traf der 30-jährige He Feipeng eine mutige Entscheidung: Er gründete das *Business Weekly*, zu einer Zeit, als in Taiwan noch keine Gewohnheit bestand, Wirtschaftswochenmagazine zu lesen. Es war ein desaströser Auftakt – sieben oder acht Jahre lang verlor das Magazin jedes Jahr zehn bis zwanzig Millionen NT-Dollar.
+
+„Bei der Gründung des *Business Weekly* war ich dem Markt acht Jahre voraus – und ich habe mehr als acht Jahre Verluste gemacht." – **He Feipeng** (aus dem Podcast-Interview mit The News Lens)
+
+> **📝 Kuratorennotiz**
+> Das Faszinierendste an He Feipengs Geschichte ist der Mut, Fehler einzugestehen. In einer Gesellschaft, die heroische CEOs vergöttert, wirkt ein Gründer, der „sich selbst entlässt", um das Unternehmen zu retten, aufwühlender als jede Erfolgsrezept-Literatur. Genau deshalb finden seine späteren Bücher der Reihe *Selbstvervollkommnung* (自慢), die sich in Taiwan über 500.000-mal verkauft haben, so großen Anklang.
+
+Angesichts des finanziellen Drucks ohne Boden traf er eine Entscheidung wider die Intuition von Gründern: **Er entließ sich selbst.** Nachdem er seine eigenen Management-Blindstellen erkannt hatte, gab er die operative Führung ab und zog sich in den Hintergrund zurück. Genau dieser Machtverzicht ermöglichte eine Neuverteilung der Ressourcen; die Zeitschrift erholte sich und entwickelte sich schließlich zur auflagenstärksten Wirtschaftswochenzeitschrift Taiwans.
+
+### Der Kauf der verlustreichsten Digitalabteilung
+
+Nach der Jahrtausendwende begann die eigentliche Bewährungsprobe. Das Internet stieg auf, der Printmarkt schrumpfte Jahr für Jahr.
+
+2007, als viele traditionelle Medien noch abwarteten, beschloss He Feipeng, für 100 Millionen NT-Dollar die Blogplattform PIXNET (痞客邦) zu übernehmen. Damals wirkte das wie Geld, das man ins Wasser wirft – PIXNET verlor anfangs jedes Jahr bis zu 30 Millionen NT-Dollar und wurde zum größten finanziellen Klotz am Bein des Konzerns.
+
+Doch er hatte etwas Entscheidendes verstanden: Die Printmedien selbst können die Printmedien nicht retten.
+
+„Die Beschäftigten der traditionellen Medien sind ‚digitale Migranten' – wir müssen ‚digitale Ureinwohner' an Bord holen." – **He Feipeng** (aus dem Interview mit *Business Next*)
+
+He Feipeng gab dem jungen Digitalteam größte Autonomie. Er erlaubte der Gruppe, jährlich bis zu 20 Prozent des Gewinns – etwa 80 Millionen NT-Dollar – in digitale Experimente zu stecken und unendliche Versuch-und-Irrtum-Schleifen auszuhalten. Nach acht Jahren Durchhalten wurde PIXNET 2015 endlich profitabel.
+
+### Der Zusammenprall der Werte beim Generationenwechsel
+
+Am Scheideweg der Zeiten sorgte He Feipeng mit seinen Äußerungen allerdings wiederholt für Kontroversen.
+
+2014 veröffentlichte er den Leitartikel *Ein faires Wort für die Arbeitgeber*, um das taiwanesische Verhältnis von Arbeit und Kapital auszuloten – doch die Online-Community brandmarkte ihn daraufhin scharf als „Handlanger des Kapitals". Auch seine öffentliche Wertschätzung für [Audrey Tang](/people/唐鳳) und andere politische Persönlichkeiten wurde in den letzten Jahren von Nutzern der Plattform PTT als realitätsfern kritisiert. Als Konzernführer, der die Ära des Wirtschaftsbooms durchlebt hat, ist der Zusammenprall der Generationenwerte beinahe unvermeidlich, sobald sein Publikum von „Finanzlesern, die Magazine kaufen" zu „Internetnutzern, die den Diskurs bestimmen" wechselt.
+
+Doch ungeachtet aller Kontroversen wurde He Feipeng 2020 mit dem Sonderbeitragspreis der Golden Tripod Awards (金鼎獎), der höchsten Auszeichnung des taiwanesischen Verlagswesens, geehrt. Der englischsprachige *Taipei Times* schrieb dazu, die Ehrung würdige sein langjähriges Engagement für die Verbesserung des taiwanesischen Verlagsumfelds.
+
+Der Zeitschriftenverleger, der 1987 vor seinen Bilanzen verzweifelte und sich sogar selbst entließ, hätte wohl kaum geahnt, dass sein damaliges Ausprobieren dreißig Jahre später zum wichtigsten Überlebensleitfaden der taiwanesischen Verlagsbranche gegen die digitale Welle werden würde.
+
+## Referenzen
+
+- [Website der Cite Publishing Group: Vorstellung des CEO](https://www.cite.com.tw/about/ceo) (Primärquelle)
+- [The News Lens: „Bei der Gründung des *Business Weekly* war ich dem Markt acht Jahre voraus – und habe mehr als acht Jahre Verluste gemacht"](https://www.thenewslens.com/article/145678)
+- [Business Next: Die digitale Transformation von Cite am Beispiel von PIXNETs Wende zur Profitabilität](https://www.bnext.com.tw/article/43317/cite-media-digital-transformation)
+- [Taipei Times: Publishing industry honors its own at Golden Tripod Awards](https://www.taipeitimes.com/News/taiwan/archives/2020/09/12/2003743261)
+- [Ministerium für Kultur: Gewinnerliste der 44. Golden Tripod Awards](https://www.moc.gov.tw/information_250_89456.html) (Primärquelle)

--- a/knowledge/de/People/yeh-ping-cheng-education-innovator.md
+++ b/knowledge/de/People/yeh-ping-cheng-education-innovator.md
@@ -1,0 +1,68 @@
+---
+title: 'Yeh Bing-cheng'
+description: 'Professor für Elektrotechnik an der National Taiwan University (NTU), der aus Unzufriedenheit mit dem Auswendiglernen die gamifizierte Lernplattform PaGamO schuf und 2014 einen globalen Preis für Bildungsinnovation gewann.'
+date: 2026-03-20
+category: 'People'
+tags:
+  [
+    'Bildung',
+    'Flipped Classroom',
+    'PaGamO',
+    'Gamifiziertes Lernen',
+    'NTU',
+    'Bildungsinnovation',
+  ]
+subcategory: '教育與社會'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-03-20
+lastHumanReview: false
+readingTime: 5
+curation: 'incubating'
+translatedFrom: 'People/葉丙成.md'
+sourceCommitSha: '69b3afd91'
+sourceContentHash: 'sha256:340bb6abbf6b93a5'
+sourceBodyHash: 'sha256:f85ae58b5cc5815d'
+translatedAt: '2026-09-03T00:00:00+08:00'
+---
+
+# Yeh Bing-cheng: Von der Wahrscheinlichkeitsvorlesung zur Revolution des spielerischen Lernens
+
+> **30-Sekunden-Überblick:** Yeh Bing-cheng, Professor für Elektrotechnik an der National Taiwan University, entwickelte 2013 gemeinsam mit seinen Studierenden PaGamO – ein Online-Spiel, in dem Lernende durch „Monster besiegen und Territorien erobern" ihr Fachwissen üben. 2014 setzte sich PaGamO unter 1.500 eingereichten Projekten durch und gewann den Wharton-QS Reimagine Education Award. Sein am häufigsten zitierter Satz lautet: „Schüler lieben Lernen durchaus – nur kein langweiliges Lernen."[^1]
+
+## Eine Rebellion in der Wahrscheinlichkeitsvorlesung
+
+2012 geschah in der Wahrscheinlichkeitsvorlesung der Elektrotechnik-Abteilung der NTU etwas, das Yeh Bing-cheng dazu brachte, einen anderen Weg einzuschlagen. Er beobachtete, wie die leistungsstärksten Studierenden im Hörsaal saßen, während ihre Blicke zum Fenster hin abschweiften – sie konnten Formeln auswendig, verstanden aber nicht wirklich, wozu man sie braucht. Die Paukschule („Auswendiglernen-Lernen") trainiert das „Richtig-Antworten" hervorragend, doch der Instinkt des „Wissen-Wollens" erlischt dabei nach und nach.
+
+Er entschied sich zunächst für das Konzept des Flipped Classroom: Studierende sehen sich zu Hause Unterrichtsvideos an, die Vorlesungszeit bleibt Diskussionen und dem Lösen von Aufgaben vorbehalten. Das galt damals in Taiwan als ungewöhnlicher Ansatz, veränderte aber die Atmosphäre in seinem Hörsaal spürbar. Doch er wollte mehr.
+
+## PaGamO: Lehrbücher als Spiel verpackt
+
+2013 baute Yeh Bing-cheng mit seinen Studierenden PaGamO (der Name leitet sich vom Taiwanesischen „phah game ooh" ab, „spielend lernen"). Die Gestaltungslogik ist unmittelbar einleuchtend: Jugendliche spielen gern Videospiele, weil Spiele sofortige Rückmeldung, Wettbewerb und Erfolgserlebnisse bieten. Warum diese Mechanismen nicht ins Lernen übertragen?
+
+In PaGamO „erobern" die Lernenden durch das Beantworten von Aufgaben Territorien auf einer virtuellen Landkarte und treten gegeneinander an. Richtige Antworten erweitern das eigene Gebiet, falsche Antworten laden zu Invasionen ein. Unter der spielerischen Hülle steckt echtes fachliches Üben. Wer seine Burg nicht verlieren will, schlägt selbst die Formeln nach.[^2]
+
+2014 gewann PaGamO den ersten Preis beim Wharton-QS Reimagine Education Award und setzte sich damit gegen mehr als 1.500 Bildungsinnovationsprojekte aus aller Welt durch. Dieser Preis lenkte zum ersten Mal internationale Aufmerksamkeit auf Taiwans Bildungsinnovation.[^3]
+
+Die Plattform wurde später an mehreren tausend Schulen in ganz Taiwan eingesetzt und erschloss Bildungsmärkte in Hongkong und Singapur; die Fächer reichen von Mathematik über Englisch bis hin zur Programmierung.
+
+## Vom Werkzeug zum Kampfplatz der Ideen
+
+Yeh Bing-cheng machte nicht an der Werkzeugebene halt. Er meldet sich seit Langem in öffentlichen Foren zu Themen wie Hochschulzugang, Kompetenzorientierung und digitalem Lernen zu Wort, hat mehrere Bildungsbücher veröffentlicht und eine große Anhängerschaft in den sozialen Medien aufgebaut.
+
+Seine Kernposition ist unverändert geblieben: Taiwans Bildungssystem trainiert Schüler darauf, „Aufgaben richtig zu beantworten", vermittelt aber nicht die Fähigkeit, „gute Fragen zu stellen" und „reale Probleme zu lösen". In einem Zeitalter, in dem KI zunehmend „Erinnern und Rechnen" übernimmt, so seine Überzeugung, prüfen Taiwans Schulen noch immer genau die Fähigkeiten, die am leichtesten zu ersetzen sind. Diese Kritik ist keine Anklage gegen Lehrkräfte, sondern stellt das Systemdesign als Ganzes infrage.
+
+**Weiterführendes**:
+
+- [Huang Kuo-chen](/people/黃國珍) — ein weiterer Bildungsinnovator, der Taiwans Lesekompetenz fördert
+- [Lu Guan-wei](/people/呂冠緯) — Vorstandsvorsitzender der Junyi-Bildungsplattform; gab die Medizin auf, um eine taiwanesische Variante der Khan Academy aufzubauen
+- [Yen Chang-shou](/people/嚴長壽) — Sozialunternehmer, der von der Tourismusbranche zur Bildung in ländlichen Regionen wechselte
+- [Audrey Tang](/people/唐鳳) — Schnittpunkt von digitaler Governance und Bildungsinnovation
+
+## Referenzen
+
+[^1]: Yeh Bing-cheng hat diesen Satz in zahlreichen öffentlichen Vorträgen und Medieninterviews wiederholt, darunter TEDx Taipei 2014 und der Bildungsschwerpunkt des Magazins „CommonWealth". Originaltexte finden sich in verschiedenen Medienberichten.
+
+[^2]: [Offizielle PaGamO-Website](https://www.pagamo.com/) — Erläuterung der Spielmechanik von PaGamO
+
+[^3]: [Wharton-QS Reimagine Education Awards 2014](https://www.reimagine-education.com/) — Globaler Preis für Bildungsinnovation, der jährlich die bahnbrechendsten Lehrinnovationen auszeichnet; PaGamO gewann 2014 den ersten Preis für „Best Gamified Learning".


### PR DESCRIPTION
## Summary

- 🇩🇪 New German translation: `knowledge/de/People/he-feipeng.md`
- Source: `People/何飛鵬.md`（城邦媒體集團創辦人、商業周刊創辦者）
- zh SSOT 投影（非照搬 en 重寫版），保留表格／兩段引言／策展人筆記／全部 5 個來源 URL

## Checklist

- [x] Reads like native German (not translationese)
- [x] Taiwan proper nouns preserved (Cite Publishing Group, Business Weekly, PIXNET, 金鼎獎)
- [x] Quote verbatim: „Bei der Gründung des *Business Weekly* war ich dem Markt acht Jahre voraus – und ich habe mehr als acht Jahre Verluste gemacht."
- [x] Frontmatter: `translatedFrom`(+byte-equal) / `sourceCommitSha 69b3afd91` / hashes / `translatedAt` all set
- [x] `subcategory`/`date`/`featured` mirror zh SSOT
- [x] `[[唐鳳]]` wikilink -> `[Audrey Tang](/people/唐鳳)` (existing de routing convention)
- [x] Verified: `translation-ratio-check.sh` ratio 3.08 (zh→de healthy 2.0–4.0), 5/5 source URLs preserved
- [x] File path follows `knowledge/de/People/he-feipeng.md` (same slug as EN)

🤖 Assisted by Dar's agent tooling
