### PR TITLE
translate(de): 阿婆鐵蛋 → ah-po-iron-eggs

### DIFF
--- a/knowledge/de/Food/ah-po-iron-eggs.md
+++ b/knowledge/de/Food/ah-po-iron-eggs.md
@@ -1,0 +1,110 @@
+---
+title: 'Eiserne Eier der Großmutter: Wie ein Missgeschick im „Grand Hotel der Seebeine" am Fährhafen von Tamsui zur härtesten kollektiven Erinnerung wurde'
+description: '1983 machte ein Bericht der Zeitung Min Sheng Bao die schwarzen geschmorten Eier aus dem „Grand Hotel der Seebeine" in Tamsui über Nacht berühmt. Dieses aus Versehen entstandene Gericht — vom Seewind immer wieder trocken geblasen, mit jedem Schmorgang härter — bezeugt Aufstieg und Wandel des Fährhafens von Tamsui und hinterließ im Markenstreit einen historischen Fall um die Gründerinnen A-nen-pó und Yang Bi-yun.'
+date: 2026-04-28
+category: 'Food'
+tags:
+  [
+    'Essen',
+    'Tamsui',
+    'Eiserne Eier',
+    'taiwanische Imbissgerichte',
+    'Esskultur',
+    'A-pó Tie Dan',
+    'Yang Bi-yun',
+    'Huang Zhang-nen',
+  ]
+subcategory: 'Kulinarische Szene'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-04-28
+lastHumanReview: false
+readingTime: 10
+imageNote: 'Die ursprüngliche Bilddatei wurde von Wikimedia Commons entfernt (404 Not Found); das Kartenbild fehlt vorerst und muss nachgereicht werden'
+translatedFrom: 'Food/阿婆鐵蛋.md'
+sourceCommitSha: 'e974b4c9e'
+sourceContentHash: 'sha256:f215fbcb32524845'
+sourceBodyHash: 'sha256:f4c6330bca417165'
+translatedAt: '2026-09-05T22:16:59+08:00'
+---
+
+# Eiserne Eier der Großmutter (阿婆鐵蛋)
+
+> **Überblick in 30 Sekunden:** Eiserne Eier wurden nicht erfunden — sie wurden „geblasen". In den 1970er Jahren blieben an einem kleinen Nudelstand am Fährhafen von Tamsui (淡水) die geschmorten Eier unverkauft liegen; unter dem immer wiederkehrenden Seewind und dem ständigen Zurück-in-den-Topf-Wandern schrumpften sie wie von selbst zu einem eigenartigen Eiergericht: schwarz wie Eisen, hart wie Stein, mit ordentlich Biss. Dieser Artikel führt zurück an jenen Ort, den man spöttisch das „Grand Hotel der Seebeine" nannte, seziert den Gründungsstreit und das Handwerksethos hinter Taiwans härtestem Imbiss und fragt nach der Chemie und der kulturellen Bedeutung dahinter.
+
+Am 24. Juli 1983 erschien auf Seite 12 der Zeitung Min Sheng Bao (民生報) ein Bericht mit der Überschrift „A-pós eiserne Eier — hart, aber gut" [^1]. Der Reporter Lin Ming-yu schrieb darin, dieses schwarz glänzende, steinharte geschmorte Ei sei garantiert eine besondere „Hilfe" für die Zahnkraft. Damals ahnte niemand, dass dieser eine Bericht einen namenlosen kleinen Nudelstand am Fährhafen von Tamsui in die bekannteste Souvenir-Pilgerstätte ganz Taiwans verwandeln würde.
+
+## Träger am Feldrand: der Anfang von allem
+
+Die Geburt des eisernen Eis zielte anfangs gar nicht auf Wohlgeschmack, sondern war ein Missgeschick aus Sparsamkeit — und eng verknüpft mit dem historischen Wandel des Hafens von Tamsui.
+
+In den 1970er Jahren verlor der Hafen von Tamsui allmählich seine Stellung als wichtiger Handelshafen und wandelte sich zum Ausflugsstädtchen. In dieser Zeit betrieb Huang Zhang-nen (黃張哖), von allen „A-nen-pó" (阿哖婆) genannt, einen Nudelstand am Fährhafen von Tamsui; das Geschäft lief mal gut, mal schlecht. An Regentagen, wenn kaum Besucher kamen und die geschmorten Eier liegen blieben, brachte A-nen-pó es nicht übers Herz, sie wegzuwerfen, und gab sie zurück in den Topf, um sie erneut zu schmoren. Der kräftige Seewind von Tamsui blies immer wieder darüber, die Schmorbrühe zog immer tiefer ein, das Wasser im Ei ging nach und nach verloren: Die Eier wurden kleiner und kleiner, mit jedem Schmorgang schwärzer, und ihre Konsistenz wandelte sich von weich-locker zu ausgesprochen zäh [^2].
+
+Dieser Stand am Fährhafen, den die einheimischen Fischer — die „Seebeine" (海腳, hái-kha) — scherzhaft „Grand Hotel der Seebeine" (海腳大飯店) tauften, wurde zum Ursprungsort des eisernen Eis. Die Fischer von damals stellten fest: So unansehnlich diese knochenharten schwarzen Eier auch waren, sie ließen sich endlos kauen — zusammen mit zwei Flaschen Shaoxing-Wein reichten sie für einen ganzen Abend [^3]. Das war zugleich kulinarische Neuerung und gelebter Ausdruck jener Haltung im Fischerhafen, nichts umkommen zu lassen.
+
+📝 **Anmerkung der Kuratoren:** Die Härte des eisernen Eis ist ein Abdruck, den Seewind und Zeit in Tamsui gemeinsam eingeprägt haben. Sie stammt nicht aus präziser Kalkulation in der Küche, sondern aus der Überlebensklugheit am Rand des Alltags — und ist zugleich ein Miniaturbild von Tamsuis Wandel vom Fischerhafen zum Ausflugsstädtchen.
+
+## Die Chemie dahinter: Maillard-Reaktion und Proteindenaturierung
+
+Dass das eiserne Ei seine eigentümliche Farbe und Textur entwickelt, beruht auf komplexen chemischen Vorgängen.
+
+Beim Schmoren denaturieren die Proteine im Ei unter Hitze, verlieren ihre ursprüngliche Struktur und machen die Textur fest und kompakt. Gleichzeitig reagieren die Zucker der Schmorbrühe mit den Proteinen in der „Maillard-Reaktion" (梅納反應, Maillard reaction); dabei entstehen komplexe Bräunungsprodukte, die dem eisernen Ei sein tiefes Schwarzbraun und sein reiches Aroma verleihen [^4]. Wiederholtes Schmoren und Trockenblasen konzentriert das Aroma weiter, entzieht dem Ei fortlaufend Feuchtigkeit und formt am Ende jene widerstandsfähige Konsistenz.
+
+## Die Wende: der Markenstreit vom „Urahn" zur „Großmutter"
+
+Mit Lin Ming-yus Bericht und Interviews japanischer Medien verbreitete sich der Ruf des eisernen Eis rasch. Doch der Ruhm brachte nicht nur Wohlstand, sondern auch einen jahrzehntelangen Streit um die Urheberschaft — ein Streit, der zugleich zeigt, wie wenig Markenbewusstsein es im frühen Taiwan gab.
+
+Der bekannteste Laden der Altstraße, „A-pó Tie Dan" (阿婆鐵蛋, „Eiserne Eier der Großmutter"), wurde von Frau Yang Bi-yun (楊碧雲) gegründet. Nach Yangs eigener Darstellung betrieb sie in den 1980er Jahren einen Frühstücksladen und ließ die geschmorten Eier vor lauter Betrieb versehentlich zu lange im Topf — so entdeckte sie zufällig, dass diese harten Eier bei den Gästen außerordentlich beliebt waren [^5]. Ursprünglich wollte sie die Marke „Yuanzu Tie Dan" (元祖鐵蛋, „Ur-eiserne Eier") nennen; weil das Wort „Yuanzu" (元祖) jedoch bereits von einem Mochi-Hersteller eingetragen war, änderte sie den Namen in „A-pó Tie Dan" und ließ ihn als Erste als Marke schützen [^6].
+
+In der Erinnerung der alten Tamsui-Bewohner jedoch ist die wahre Begründerin „A-nen-pó" Huang Zhang-nen. Huang Ling-hong, die Tochter von A-nen-pó, erklärte einmal, ihre Mutter habe damals eiserne Eier in großen Mengen produziert und an Händler abgegeben — und Yang Bi-yun sei eine dieser Großabnehmerinnen gewesen [^7]. Weil Yangs Laden an einer belebten Eckposition lag und sie geschäftstüchtig genug war, die Marke zuerst anzumelden, wurde „A-pó Tie Dan" zu ihrem exklusiven Warenzeichen. Den Nachfahren von A-nen-pó blieb am Ende nur, unter „Haibian A-nen Tie Dan" (海邊阿哖鐵蛋) oder „Haibian Tie Dan" (海邊鐵蛋) einen eigenen Laden aufzumachen; dieser „Streit um das Original" ist in der Altstraße von Tamsui ein offenes Geheimnis [^8]. Der Markenkonflikt macht deutlich, wie wichtig der Schutz geistigen Eigentums in einer frühen Phase wirtschaftlicher Entwicklung ist.
+
+## Handwerk: sieben Tage und sieben Nächte Schwarzgold-Askese
+
+Ein anständiges eisernes Ei muss den aufwendigen Kreislauf aus „Schmoren, Blasen, Auskühlen" durchlaufen — ein Gespräch mit Zeit und Hitze.
+
+Nach der überlieferten Methode wird das Ei täglich drei Stunden in einer hauseigenen Brühe aus Fünf-Gewürze-Pulver, Sojasauce und Pfeffer geschmort, danach herausgenommen und mit einem elektrischen Ventilator trocken geblasen; nach dem Auskühlen kommt es am nächsten Tag erneut in den Topf. Dieser Vorgang muss sieben Tage lang wiederholt werden, bis der Zustand „Ei mit Q-Biss, dünne Haut, ordentlich Kauwiderstand" erreicht ist [^9]. Die Rezeptur der Brühe, die Kontrolle der Hitze, der Grad des Trockenblasens — alles stellt Erfahrung und Geduld der Handwerkerinnen auf die Probe. Früher wurden meist Hühnereier verwendet; damit auch Kinder und ältere Menschen sie leichter essen können, entstand später eine Variante aus Wachteleiern (鵪鶉蛋, auf Taiwanisch „Vogeleier" 鳥蛋 genannt). Diese kleineren, schneller durchziehenden eisernen Wachteleier sind heute sogar zur verbreitetsten Variante am Markt geworden [^10].
+
+📝 **Anmerkung der Kuratoren:** In einer Gegenwart, die auf Effizienz getrimmt ist, sieben Tage für ein einziges Ei aufzuwenden — das ist für sich genommen eine Romantik des Widerstands gegen die Geschwindigkeit und ein Festhalten am überlieferten Handwerk, das jedes eiserne Ei das Gewicht der Zeit tragen lässt.
+
+## Herausforderung: wenn „Härte" auf „Kosten" und Markennachfolge trifft
+
+In der Altstraße von Tamsui reiht sich heute ein Laden für eiserne Eier an den nächsten, doch viele Feinschmecker seufzen: „Die eisernen Eier sind nicht mehr hart."
+
+Um Gas und Produktionszeit zu sparen, lassen manche Betriebe in Lohnfertigung produzieren oder kürzen den Schmorprozess ab; die Eier werden dadurch weich und fad und verlieren jenen Geist des „hart, aber gut" [^11]. Dieses „Cost down" stellt den überlieferten Geschmack des eisernen Eis infrage. Hinzu kommt: Seit Frau Yang Bi-yun 2022 an den Folgen eines Schlaganfalls starb, steht dieses traditionelle Gewerbe, das mit dem Aufstieg des Tourismus in Tamsui groß geworden ist, vor der neuen Herausforderung von Markennachfolge und Qualitätssicherung [^12]. Wie sich Kommerzialisierung und überliefertes Handwerk ausbalancieren lassen, ist die entscheidende Frage für die Zukunft der eisernen Eier von Tamsui.
+
+Das eiserne Ei ist nicht bloß ein Imbiss. Es trägt die Geschichte von Tamsuis Wandel vom Fischerhafen zum Touristenziel in sich und ebenso die unternehmerische Geschichte zweier Gründerinnen. Wem die Marke auch gehören mag — jenes schwarze geschmorte Ei, das im Seewind schrumpfte, bleibt für immer der zäheste Farbton in Taiwans Esskultur und eine gemeinsame kollektive Erinnerung der Menschen von Tamsui.
+
+---
+
+## Quellen
+
+[^1]: [Lin Ming-yu, „Da kuai duo yi" (大快朵頤), Linking Publishing, 1984](https://search.worldcat.org/zh-cn/title/903232266) — S. 21-25 enthalten den Originalbericht „Tamsuis eiserne Eier sind hart genug", Min Sheng Bao vom 24.07.1983, Seite 12 (ISBN 9789570813722, auch auffindbar über [FindBook](https://findbook.com.tw/amp/9789570813722))
+
+[^2]: [Woher kommen Tamsuis eiserne Eier der Großmutter? Jenes bissfeste „kleine schwarze Ei" war ein Missgeschick in einem Imbiss am Fährhafen](https://www.businesstoday.com.tw/article/category/183016/post/202207130042/) — Business Today, 13.07.2022
+
+[^3]: [Lin Ming-yu, „Da kuai duo yi" (大快朵頤), Linking Publishing, 1984](https://search.worldcat.org/zh-cn/title/903232266) — enthält die Ursprungsgeschichte der eisernen Eier von Tamsui sowie Schilderungen des Lebens im Fischerhafen
+
+[^4]: [Maillard-Reaktion — Wikipedia](https://zh.wikipedia.org/zh-tw/%E7%BE%85%E4%BC%AF%E7%89%B9%E6%A3%AE%E5%8F%8D%E6%87%89) — die nichtenzymatische Bräunungsreaktion zwischen Zuckern und Aminosäuren unter Hitzeeinwirkung, 1912 erstmals von Louis-Camille Maillard beschrieben; sie ist der zentrale Mechanismus für Farbe und Aroma geschmorter Speisen.
+
+[^5]: [A-pó Tie Dan wurde 1980 gegründet und blickt auf über vierzig Jahre Geschichte zurück](https://newtaipei.travel/zh-tw/shop/detail/206651) — Tourismusportal der Stadt New Taipei: Einzelheiten im verlinkten Originaltext
+
+[^6]: [Eiserne Eier](https://zh.wikipedia.org/zh-tw/%E9%90%B5%E8%9B%8B) — Wikipedia: Enzyklopädieeintrag
+
+[^7]: [Welches sind die echten „eisernen Eier der Großmutter"?](https://www.mobile01.com/topicdetail.php?f=37&t=2238805) — Diskussion im Forum Mobile01, 05.07.2011
+
+[^8]: [Dieser spöttisch „Grand Hotel der Seebeine" genannte kleine Nudelladen zog Kämpfer aus allen Richtungen zum Zahnwettstreit an](https://www.facebook.com/groups/1720009718276972/posts/2203868496557756/) — Facebook-Gruppe „Alte Fotos aus Tamsui", 23.10.2018
+
+[^9]: [Tamsuis eiserne Eier: von der Legende zum kulinarischen Kulturgut](https://www.kukfachi.com/pages/%E6%B7%A1%E6%B0%B4%E9%90%B5%E8%9B%8B%EF%BC%9A%E5%BE%9E%E5%82%B3%E5%A5%87%E5%88%B0%E7%BE%8E%E5%91%B3%E7%9A%84%E6%96%87%E5%8C%96%E5%B0%8F%E5%90%83) — Kolumne zur Esskultur bei Kukfachi
+
+[^10]: [Die Legende der Altstraße von Tamsui entschlüsselt: die Geschichte der eisernen Eier der Großmutter und das Missgeschick hinter dem Geschmack](https://uptogo.com.tw/%E7%BE%8E%E9%A3%9F/%E9%A3%9F%E5%93%81/%E9%98%BF%E5%A9%86%E9%90%B5%E8%9B%8B%E6%AD%B7%E5%8F%B2%EF%BC%9F/) — Reiseportal Uptogo, 22.02.2026
+
+[^11]: [Bitte kauft die „eisernen Eier der Großmutter" in Tamsui nicht mehr](http://80itguy.blogspot.com/2010/04/blog-post_29.html) — Blog „80er-Jahrgang IT-Mensch", 29.04.2010
+
+[^12]: [Gründerin von A-pó Tie Dan nach Schlaganfall gestorben! Ärzte nennen zwei Warnsignale für „starkes Schwitzen und Dehydrierung"](https://health.ettoday.net/news/2293316) — ETtoday News, 13.07.2022
+
+## Verwandte Themen
+
+- Nachtmarktkultur — eine eingehende Analyse des Nachtmarkts als sozialer Raum
+- Taiwanische Imbissgerichte — der bodenständige Mut der taiwanischen Alltagsküche
+- Taiwanisches Lu Rou Fan — die ethnische Erinnerung in einer Schale geschmortem Schweinefleisch auf Reis
+- Hakka-Esskultur — die kulinarische Klugheit der Hakka


### PR DESCRIPTION
﻿Adds German translation of `Food/阿婆鐵蛋.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 2.97 (de band 2.48-3.78, median 3.14) — `translation-ratio-check.sh` method, verdict OK

**Structure alignment**: sections 7→7 / footnotes 12→12 / URLs 13→13 — 100% preserved

**Gate run**: `scripts/tools/lang-sync/verify-translation.py` → 17 pass / 1 warn (the single warn is a local WSL path artifact when it shells out to `translation-ratio-check.sh`, not a content issue; ratio verified separately as above)

**Note**: `i18n/de/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT plus the established conventions of the existing de corpus (author passthrough, tags translated, `category` kept in English, Chinese proper nouns retained in parentheses).

Uncertain terminology flagged for reviewer:

- 海腳大飯店 → „Grand Hotel der Seebeine" · literal rendering of the fishermen's nickname (海腳/hái-kha = local term for seafarers); kept the Chinese in parentheses on first mention
- 鐵蛋 → „Eiserne Eier" · descriptive; no established German term. Brand name kept transliterated as „A-pó Tie Dan"
- 蛋 Q 皮薄 → „Ei mit Q-Biss, dünne Haut" · Taiwanese „Q" texture term has no German equivalent, kept as-is
- 惜物 → „nichts umkommen lassen" · paraphrase of the thrift/anti-waste ethos
- 相關主題 links converted to plain text — no corresponding de articles exist yet (per TRANSLATE_PROMPT wikilink rule)

Please review. Happy to iterate.
