### PR TITLE
translate(id): 水往上流 → water-running-uphill

### DIFF
--- a/knowledge/id/Geography/water-running-uphill.md
+++ b/knowledge/id/Geography/water-running-uphill.md
@@ -1,0 +1,84 @@
+---
+title: 'Air Mengalir ke Atas: Membaca Sejarah Pembukaan Lahan Suku Amis dan Batas Kognisi Otak dari Sebuah Ilusi Optik'
+description: 'Parit "Air Mengalir ke Atas" di Dulan, Taitung, sebenarnya miring ke bawah sekitar 0,5 derajat, tetapi karena jalan di sebelahnya jauh lebih curam, otak pengunjung membaca airnya seolah naik. Dari parit irigasi yang digali warga Amis pada masa lalu, dikemas menjadi keajaiban wisata pada 1980-an, hingga belakangan dinobatkan sebagai "objek wisata paling tidak berguna se-Taiwan" — parit selebar tak sampai setengah meter ini menyimpan sebuah tipuan ilusi tentang kerangka acuan penglihatan.'
+date: 2026-08-03
+category: 'Geography'
+tags:
+  [
+    'Taitung',
+    'Air Mengalir ke Atas',
+    'Desa Dulan',
+    'Suku Amis',
+    'Ilusi Optik',
+    'Sejarah Pembukaan Lahan Taiwan',
+  ]
+subcategory: 'Hidrologi dan Sumber Daya Air'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-08-03
+lastHumanReview: false
+readingTime: 15
+translatedFrom: 'Geography/水往上流.md'
+sourceCommitSha: '211401fe4'
+sourceContentHash: 'sha256:c6dd24e6a4e09fdc'
+sourceBodyHash: 'sha256:009e89e5797639ab'
+translatedAt: '2026-09-05T22:20:37+08:00'
+---
+
+> **Ikhtisar 30 detik:** "Air Mengalir ke Atas" (水往上流) di Desa Dulan, Kecamatan Donghe, Kabupaten Taitung, adalah parit irigasi selebar kurang dari setengah meter, sekaligus salah satu "objek wisata paling berlawanan dengan intuisi" yang paling terkenal di Taiwan. Pengukuran di lapangan menunjukkan parit itu sebenarnya miring ke bawah sekitar 0,5–0,6 derajat, sedangkan jalan di sebelahnya miring jauh lebih tajam. Ketika kedua garis kemiringan itu dilihat bersamaan, otak menjadikan jalan yang lebih miring sebagai bidang acuan horizontal, lalu membaca parit yang kemiringannya jauh lebih kecil sebagai "mengalir ke atas" — ini ilusi kerangka acuan pada sistem penglihatan, bukan gravitasi atau medan magnet yang mendadak tidak berfungsi. Saluran air ini semula parit irigasi yang digali warga suku Amis setempat; baru setelah demam wisata domestik pada 1980-an ia diberi prasasti resmi dan dikemas sebagai keajaiban, dan belakangan kembali ramai dibicarakan lewat penilaian daring "objek wisata paling tidak berguna se-Taiwan".
+
+Dalam peta wisata pantai timur Taiwan, "Air Mengalir ke Atas" di Desa Dulan, Kecamatan Donghe, Kabupaten Taitung, jelas merupakan keberadaan yang penuh ketegangan. Ia sekaligus objek wisata yang oleh banyak pelancong disebut "paling tidak berguna", dan laboratorium paling hidup bagi kalangan geografi maupun psikologi. Parit irigasi sepanjang beberapa puluh meter dan selebar tak sampai setengah meter ini bertaut dengan sejarah pembukaan lahan sebuah kelompok etnis, sekaligus dengan satu "zona sesat penglihatan" di dalam sistem persepsi manusia yang secara tak sengaja dirancang oleh bentang alam.
+
+## Lingkungan geografis dan latar geologis
+
+"Air Mengalir ke Atas" terletak di kaki timur Pegunungan Pantai, menghadap Samudra Pasifik. Struktur geologi kawasan ini rumit, terutama tersusun dari breksi vulkanik dan aglomerat. Gunung Dulan, sebagai puncak tertinggi di bagian selatan Pegunungan Pantai, bukan hanya gunung suci bagi suku Amis dan suku Puyuma; relief permukaannya yang berubah tajam juga melahirkan karakter kemiringan setempat yang sangat beragam.
+
+Permukaan tanah di sana bertaburan batu dalam jumlah besar yang tergali sewaktu lahan dibuka — dan justru dari situlah nama lama Desa Dulan, "Atolan" (bermakna "tempat tumpukan batu"), berasal. Di medan yang terpecah-pecah dengan kemiringan tidak merata seperti ini, mengalirkan sumber air menjadi pekerjaan rekayasa yang sangat menantang. Kondisi geografis khusus inilah yang kelak menyediakan panggung alami bagi terbentuknya "ilusi kemiringan"[^1].
+
+## Teknik bertahan hidup suku Amis: riwayat sebuah parit irigasi
+
+Meskipun pelancong masa kini memandangnya sebagai keajaiban, parit yang di kalangan warga dikenal sebagai "Saluran Dulan Nomor 4" ini semula adalah proyek irigasi warga Amis dari Desa Dulan[^2]. Nama tempat "Atolan" (都蘭) sendiri berarti "tempat tumpukan batu"; para pembuka lahan yang hendak menanam padi sawah dan palawija di lereng yang penuh batu berserakan lebih dulu harus memecahkan satu soal: bagaimana mengalirkan air dari kaki Gunung Dulan ke petak-petak sawah. Pada zaman tanpa alat ukur modern, warga mengandalkan pengamatan bertahun-tahun atas bentuk medan untuk menuntun air turun gunung mengikuti gravitasi. Kemiringan saluran harus ditekan sangat landai — terlalu curam, aliran akan menjebol tanggul tanah; terlalu landai, air justru mengendap dan tidak bergerak. Tuntutan yang nyaris keras kepala terhadap "kemiringan yang sangat kecil" inilah yang kelak menjadi dasar fisik mengapa parit ini bisa dipakai sebagai bahan ajar ilusi optik. Tahun penggalian yang pasti serta detail konstruksinya masih belum didukung sumber sejarah yang dapat diperiksa silang; riwayat ini untuk sementara sebagian besar berasal dari tuturan lisan setempat dan tulisan-tulisan wisata, dan masih menunggu penelusuran lebih jauh lewat kronik daerah atau sejarah lisan.
+
+📝 Catatan kurator: "Keajaiban" yang hari ini disebut-sebut pelancong pada mulanya hanyalah jalur air yang digali para leluhur sesekop demi sesekop, supaya bisa bertahan hidup di tanah berbatu.
+
+## Pengkhianatan otak: mekanisme psikologis di balik ilusi kemiringan
+
+Fenomena "air mengalir ke atas" dalam psikologi disebut "ilusi kemiringan" (The Slope Illusion), sebuah distorsi persepsi yang khas. Ketika otak manusia menilai apa itu "horizontal" dan "vertikal", sistem vestibular di telinga bagian dalam hanyalah salah satu petunjuk; "kerangka acuan" yang disediakan lingkungan visual justru kerap memikul bobot yang jauh lebih besar.
+
+Sebuah riset pameran sains dari SMP Baosang, Kabupaten Taitung, melakukan pengukuran langsung di lokasi: parit itu sendiri miring ke bawah sekitar 0,5–0,6 derajat, sedangkan jalan yang berdampingan dengannya miring jauh lebih kentara, terukur kebanyakan antara 3 sampai 5 derajat[^3]. Ketika pengunjung berdiri di tepi jalan, otak tanpa sadar menjadikan jalan yang lebih miring itu sebagai garis acuan horizontal. Di bawah isyarat visual semacam itu, parit yang kemiringannya jauh lebih kecil berbalik terbaca sebagai "menanjak" di dalam persepsi.
+
+Fenomena ini menyingkap sifat "ketergantungan pada kerangka acuan" milik sistem penglihatan. Ketika isyarat latar di lingkungan terlalu kuat, otak lebih dulu memercayai informasi visual, sehingga menekan penginderaan tubuh yang sebenarnya terhadap gravitasi. Itu pula sebabnya, kendati secara nalar kita tahu air mengalir ke bawah, mata terus-menerus meneruskan pesan keliru "mengalir ke atas"[^4].
+
+## Perubahan dari sarana pertanian menjadi objek wisata tingkat nasional
+
+Bagaimana saluran air ini menjelma menjadi objek wisata yang dikenal seluruh negeri? Kuncinya ada pada demam wisata domestik setelah ekonomi Taiwan melesat pada 1980-an.
+
+Kantor Pengelola Kawasan Wisata Pantai Timur waktu itu dengan jeli menangkap sifat "berlawanan dengan intuisi" pada bentang alam ini, lalu mendirikan prasasti batu bertuliskan dua aksara "keajaiban" (奇觀) di sisi parit. Penetapan nada dan penamaan resmi semacam itu memberi tempat ini warna misterius, sehingga ia melompat dari sekadar sarana pertanian menjadi tempat yang wajib disinggahi wisata massal. Pada zaman ketika informasi belum transparan, desas-desus tentang "anomali medan magnet" atau "gaya gravitasi yang tidak berfungsi" justru menambah sisi legendarisnya[^5].
+
+## Refleksi wisata masa kini: estetika objek wisata gagal dan pengalaman yang sebenarnya
+
+Seiring berkembangnya komunitas daring dan meluasnya pengetahuan, "Air Mengalir ke Atas" belakangan ini memicu pembalikan opini yang menarik. Di platform seperti Threads dan PTT, tempat ini kerap didudukkan di peringkat teratas "objek wisata paling tidak berguna di Taiwan".
+
+Pergeseran penilaian ini mencerminkan berubahnya definisi "keajaiban" di mata pelancong masa kini. Ketika rasa misterius lenyap dan yang tersisa hanya sebuah parit, sebagian pengunjung merasa kecewa. Namun pandangan lain justru menganggap "rasa kecewa" itu sendiri sebagai pengalaman wisata yang berharga — ia memaksa kita menghadapi keterbatasan persepsi, sekaligus memikirkan jurang antara kemasan pariwisata dan bentang alam yang sesungguhnya. "Estetika objek wisata gagal" ini perlahan menjadi label budaya baru yang menarik kelompok pencari pengalaman perjalanan non-konvensional[^6].
+
+## Perlindungan lingkungan dan kesejahteraan bersama warga setempat
+
+Beberapa tahun terakhir, sengketa pengembangan lahan di sekitar "Air Mengalir ke Atas" juga menyita perhatian publik. Karena lokasinya berdekatan dengan Teluk Jiamuzi dan Desa Dulan, rencana pembangunan resor berskala besar pernah memicu perdebatan tentang ancaman terhadap ekologi setempat dan wilayah adat masyarakat adat. Ini mengingatkan kita bahwa sembari menikmati sulap penglihatan ini, kita tidak boleh mengabaikan bobot nyata tanah ini sebagai wadah kebudayaan sebuah kelompok etnis.
+
+"Horizontal" yang dilihat mata adalah hasil negosiasi antara otak dan lingkungan sekitarnya — dan itu sebenarnya sama sekali tidak berkaitan dengan alasan mengapa sebuah parit irigasi digali pada mulanya.
+
+**Bacaan lanjutan**: Kabupaten Taitung (台東縣) · [[台灣原住民族16族文化地圖|peta budaya 16 suku masyarakat adat Taiwan (台灣原住民族16族文化地圖)]] · [[台灣島嶼地理特色與形成|ciri geografis dan pembentukan Pulau Taiwan (台灣島嶼地理特色與形成)]]
+
+## Referensi
+
+[^1]: Bank Memori Budaya Nasional. (n.d.). Desa Dulan. [https://tcmb.culture.tw/zh-tw/detail?indexCode=Culture_Object&id=263332](https://tcmb.culture.tw/zh-tw/detail?indexCode=Culture_Object&id=263332)
+
+[^2]: Tianlang Travel. (2020, 24 Februari). Penelusuran sejarah Saluran Dulan Nomor 4. [https://m.facebook.com/gorillaboss168/photos/a.1319712798093306/3077228615675040/](https://m.facebook.com/gorillaboss168/photos/a.1319712798093306/3077228615675040/)
+
+[^3]: SMP Baosang Kabupaten Taitung. (2019). Kajian fenomena ilusi optik Air Mengalir ke Atas: laporan riset pameran sains. [https://w01.boe.ttct.edu.tw/science/files/B04%E7%9C%BC%E8%A6%8B%E4%B8%8D%E7%82%BA%E6%86%91-%E5%8F%B0%E6%9D%B1%E6%B0%B4%E5%BE%80%E4%B8%8A%E6%B5%81%E8%A6%96%E9%8C%AF%E8%A6%BA%E7%8F%BE%E8%B1%A1%E6%8E%A2%E8%A8%8E.pdf](https://w01.boe.ttct.edu.tw/science/files/B04%E7%9C%BC%E8%A6%8B%E4%B8%8D%E7%82%BA%E6%86%91-%E5%8F%B0%E6%9D%B1%E6%B0%B4%E5%BE%80%E4%B8%8A%E6%B5%81%E8%A6%96%E9%8C%AF%E8%A6%BA%E7%8F%BE%E8%B1%A1%E6%8E%A2%E8%A8%8E.pdf)
+
+[^4]: Tang Rixin. (2004). Verifikasi pemisahan persepsi dan perilaku dalam riset ilusi optik. Advances in Psychological Science. [https://journal.psych.ac.cn/xlkxjz/EN/article/downloadArticleFile.do?attachType=PDF&id=1278](https://journal.psych.ac.cn/xlkxjz/EN/article/downloadArticleFile.do?attachType=PDF&id=1278)
+
+[^5]: Kantor Pengelola Kawasan Wisata Nasional Pantai Timur. (n.d.). Pengantar objek wisata Air Mengalir ke Atas. [https://www.eastcoast-nsa.gov.tw/zh-tw/attractions/detail/33/](https://www.eastcoast-nsa.gov.tw/zh-tw/attractions/detail/33/)
+
+[^6]: Threads. (2026, 24 Juni). Komentar masa kini tentang Air Mengalir ke Atas dan perbincangan objek wisata gagal. [https://www.threads.com/@1319travel/post/DZ_aTBqE5PZ/](https://www.threads.com/@1319travel/post/DZ_aTBqE5PZ/)


### PR DESCRIPTION
﻿Adds Indonesian translation of `Geography/水往上流.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 2.85 (id band 2.00-4.30, calibrated median ~2.78) — `translation-ratio-check.sh` method, verdict OK

**Structure alignment**: sections 7→7 / footnotes 6→6 / URLs 12→12 — 100% preserved

**Gate run**: `scripts/tools/lang-sync/verify-translation.py` → 17 pass / 1 warn (the single warn is a local WSL path artifact when it shells out to `translation-ratio-check.sh`, not a content issue; ratio verified separately as above)

**Note**: `i18n/id/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT plus the established conventions of the existing id corpus (author passthrough, ASCII tags, `category` kept in English, wikilinks in the `[[中文標題|terjemahan (中文標題)]]` alias form already used across `knowledge/id/`).

**Wikilink handling** (per TRANSLATE_PROMPT rule): of the three `延伸閱讀` links, `台灣原住民族16族文化地圖` and `台灣島嶼地理特色與形成` already exist in `knowledge/id/` and were kept as aliased wikilinks; `台東縣` has no id article yet and was flattened to plain text `Kabupaten Taitung (台東縣)`.

Uncertain terminology flagged for reviewer:

- 廢景點 → "objek wisata paling tidak berguna" / "objek wisata gagal" · internet slang with no fixed Indonesian equivalent; rendered descriptively and kept consistent across both occurrences
- 都蘭四號圳 → "Saluran Dulan Nomor 4" · irrigation-canal naming, no official Indonesian form
- 斜坡錯覺 → "ilusi kemiringan" · English term "The Slope Illusion" retained in parentheses on first mention
- 原住民 → "masyarakat adat" (Indigenous peoples), never "suku terasing"/"aborigin"
- 加母子灣 → "Teluk Jiamuzi" · pinyin transliteration; reviewer may prefer the Amis-language place name

Please review. Happy to iterate.
