### PR TITLE
translate(de): 豬心冬粉 → pork-heart-vermicelli

### DIFF
--- a/knowledge/de/Food/pork-heart-vermicelli.md
+++ b/knowledge/de/Food/pork-heart-vermicelli.md
@@ -1,0 +1,83 @@
+---
+title: 'Geduld im Aluminiumbecher: Die siebzigjährige Wasserbad-Philosophie von A-Mings Schweineherz-Glasnudeln'
+description: "In der Bao'an-Straße Nr. 72 in Tainan öffnet Huang Hsien-mings Imbiss A-Ming Schweineherz-Glasnudeln erst um 17 Uhr, doch jeden Abend bildet sich eine lange Schlange – 2022 wurde er in den Michelin-Führer als Bib Gourmand aufgenommen. Das Geheimnis liegt nicht in den Zutaten – Schweineherz ist billiges Innereien-Fleisch –, sondern in der Zubereitung: Dünne Scheiben garen im Aluminiumbecher im Wasserbad, sodass die Hitze langsam von außen eindringt und ein Herz entsteht, das weder streng riecht noch zäh ist, sondern zart-süß schmeckt."
+date: 2026-07-02
+category: 'Food'
+tags: ['Tainan', 'Schweineherz-Glasnudeln', 'West-Zentral-Distrikt', "Bao'an-Straße", 'Michelin', 'Streetfood', 'Innereien']
+subcategory: 'Klassisches Street Food'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-07-02
+lastHumanReview: false
+readingTime: 6
+curation: 'incubating'
+translatedFrom: 'Food/豬心冬粉.md'
+sourceCommitSha: '03b3aaae8f21'
+sourceContentHash: 'sha256:e420cc4599300aa5'
+sourceBodyHash: 'sha256:c3fe90467aad669d'
+translatedAt: '2026-09-06T04:09:46+08:00'
+translatedFromInferred: false
+---
+
+Um 16:40 Uhr warten die Ersten schon vor der Hausnummer 72 in der Bao'an-Straße. Geöffnet wird erst um 17 Uhr, aber Stammgäste wissen: Wer früh kommt, bekommt noch einen Platz – wer spät kommt, wartet bis Mitternacht. Die Schlange zieht sich langsam vom Eingang bis zur Gassenecke; die Wartenden schauen aufs Handy, blicken hin und wieder auf, um zu prüfen, ob sich vorne etwas bewegt. Diese Schlange wiederholt sich jeden Abend – seit siebzig Jahren ohne Unterbrechung.
+
+Eine Schale Schweineherz-Glasnudeln ist zwei Stunden Wartezeit wert. Wer einmal dort war, weiß, warum.
+
+## Von Ente mit Angelikawurzel zum Schweineherz
+
+Der Vorgänger von A-Mings Schweineherz-Glasnudeln war gar kein Schweineherz.
+
+In seinen jungen Jahren zog Huang Hsien-mings Vater mit einem Schubkarren durch die Gegend der Bao'an-Straße und verkaufte Ente mit Angelikawurzel (_dang-gui ya_), eine in Taiwan weit verbreitete Stärkungssuppe, deren Zutaten und Zubereitung vergleichsweise einfach sind. Später wandte er sich zunehmend Innereiengerichten zu, entwickelte eine Speisekarte rund um das Schweineherz und etablierte sich damit langsam in der Bao'an-Straße.
+
+Als Huang Hsien-ming den Stand übernahm, änderte er an der Handwerkskunst nichts. Siebzig Jahre, dieselbe Straße, dieselbe Suppe.
+
+📝 Kuratorennotiz: Viele Ursprungsgeschichten von Taiwans nächtlichen Garküchen ähneln sich – billige Zutaten, jemand, der eine Technik perfektioniert, und ein Ort, für den man weit fährt. Dass A-Mings Vater von Entensuppe zu Schweineherz wechselte, war kein Zufall, sondern das Aufspüren einer Marktlücke, die noch niemand besetzt hatte.
+
+## Die Physik im Aluminiumbecher
+
+Die Kerntechnik von A-Mings Schweineherz-Glasnudeln ist auf den ersten Blick simpel, aber schwer zu meistern.
+
+Der Besitzer schneidet das Schweineherz in dünne Scheiben, gibt sie in kleine Aluminiumbecher, würzt sie mit einer Mischung aus Heilkräutern und Brühe und stellt die Becher dann in kochendes Wasser – ein Wasserbad. Die Hitze wandert vom Wasser zur Außenwand des Bechers und dringt von dort langsam und gleichmäßig ins Schweineherz ein, von außen nach innen.
+
+Das Ergebnis: Das Herz ist gegart, doch die Fasern haben sich nicht durch direkte Hitze zusammengezogen. Es entsteht eine von außen bis innen gleichmäßige Zartheit, ganz ohne strengen Geruch, dafür mit einer feinen, natürlichen Süße – der Süße des Fleisches selbst, nicht der Brühe. Am Ende werden Sud und Herz zusammen mit vorbereiteten Glasnudeln in die Schale gegeben und mit Ingwerstreifen bestreut: die Schale, für die es sich zu warten lohnt.
+
+📝 Kuratorennotiz: Das Wasserbad (_bain-marie_) ist eine klassische Technik der französischen Küche für hitzeempfindliche Zutaten wie Schokolade, Vanillecreme oder Gänseleber. A-Ming überträgt dieselbe Logik auf Tainans Innereien: Schweineherz braucht gleichmäßige Hitze, die eine offene Flamme nicht liefern kann. Keine Kochschule hat das gelehrt – es wurde aus der Beschaffenheit der Zutat selbst rückwärts entwickelt.
+
+## Warum man es nicht beschleunigen kann
+
+Das Problem beim Garen im Wasserbad ist die Zeit.
+
+Während die Herzscheiben im Aluminiumbecher garen, darf man nicht drängen oder die Hitze erhöhen – egal wie stark das Wasser kocht, die Wärmeübertragung hat eine Obergrenze. Jeder Becher braucht eine feste Zeit, bis er fertig ist. Die Tagesproduktion des Standes ist genau diese feste Zeit multipliziert mit der Zahl der Becher, die eine Person gleichzeitig betreuen kann. Ist alles verkauft, wird geschlossen – es gibt kein Aufwärmen vom Vortag, keine zusätzliche Charge auf Vorrat.
+
+Man wartet nicht auf einen langsamen Koch, sondern auf die Physik.
+
+## Die Würde der Innereien
+
+Schweineherz, -leber und -darm gehörten historisch zur Kost der taiwanischen Arbeiterschicht – billig, kalorienreich, gedacht, um das im Tageswerk verbrauchte Blut und die Kraft wieder aufzufüllen.
+
+Aus billigen Zutaten ein Gericht zu machen, für das Menschen zwei Stunden anstehen, braucht zweierlei: Strenge im Handwerk und grundlegenden Respekt vor der Zutat. A-Mings Methode macht das Schweineherz nicht mehr zur Notlösung, sondern zu einem Essen, das man sich erst erwarten muss.
+
+In Tainan ist diese Haltung nicht selten: Milchfisch-Innereien, _shàn-yú fǎng-màn_ (Reisfeldaal, nach Aal-Art zubereitet), langsam im Wasserbad gegartes Schweineherz – billige Zutaten, mit Ernsthaftigkeit behandelt: das gemeinsame Fundament der Esskultur dieser Stadt.
+
+📝 Kuratorennotiz: 2022 wurde A-Mings Schweineherz-Glasnudeln als Michelin Bib Gourmand empfohlen. Der Bib Gourmand zeichnet „gutes Essen zu moderaten Preisen" aus, und Schweineherz-Glasnudeln sind ein Paradebeispiel dafür: Die Schale selbst ist günstig, dahinter stehen aber siebzig Jahre angesammeltes Handwerk und tägliches physikalisches Warten.
+
+## Spätnachts in der Bao'an-Straße
+
+A-Ming öffnet täglich um 17 Uhr und schließt um Mitternacht, montags ist Ruhetag.
+
+Bis in die frühen Morgenstunden verschwindet die Schlange vor der Hausnummer 72 nicht. Auf der Landkarte von Tainans nächtlichen Garküchen ist A-Ming ein fester Punkt: Wer nach Rindfleischsuppe oder Aalnudeln noch nicht nach Hause will, geht zur Bao'an-Straße und schaut nach, wie viele heute Abend anstehen.
+
+Manchmal ist die Länge der Schlange schon die Antwort.
+
+---
+
+## Quellen
+
+- [Taiwans Spätnacht-Schweineherz-Glasnudeln seit fast 70 Jahren verkauft! Erst mental auf die Warteschlange einstellen — ETtoday Reise-Cloud](https://travel.ettoday.net/article/2931941.htm)
+- [A-Ming Schweineherz-Glasnudeln: Bao'an-Straßen-Köstlichkeit, für die Innereien-Fans Schlange stehen (mit Speisekarte und Preisen) — Frühlings-Glück-Geschmack](https://springhappylife.tw/amingzhuxing/)
+- [A-Ming Schweineherz-Glasnudeln: Ein 70 Jahre altes Geschäft, das mit ganzem Herzen Kundenbindung pflegt — JUN Genussmagazin](https://hedonistjun.com/armins-pork-heart/)
+- [Tainans A-Ming Schweineherz-Glasnudeln, Michelin-Bib-Gourmand-Empfehlung | Die beliebteste Warteschlange der Bao'an-Straße — Bonnies Food-Talk](https://foodieteller.com/amin-pig-heart/)
+- [Original-Filiale von A-Ming Schweineherz-Glasnudeln in Tainans Bao'an-Straße. Berühmter Imbiss mit täglicher langer Schlange — Brians Ausblick](https://brianviews.com/tainan_aminprok/)
+- [Tainans Michelin-Bib-Gourmand-Empfehlung, beliebtes Warteschlangen-Lokal in Tainans Bao'an-Straße — upssmile, das aufwärts gerichtete Lächeln von Pingzi](https://upssmile.com/139287/a-ming-pig-hearts)
+- [A-Ming Schweineherz-Glasnudeln. Michelin-Bib-Gourmand empfohlen! Der stärkste Warteschlangen-Imbiss der Bao'an-Straße — ANIKO](https://anikofoodie.com/aminpig/)
+- [A-Ming Schweineherz-Glasnudeln: Tainans Snack mit Michelin-Bib-Gourmand-Auszeichnung (Speisekarte und Preise) — Darrens Apfelbaum-Reise- und Genussmagazin](https://appletrees.tw/blog/post/aminpigheart)


### PR DESCRIPTION
Adds German translation of `Food/豬心冬粉.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.39 (target median 3.14, healthy band 2.48-3.78)

**Structure alignment**: headings (6/6) / footnotes (0/0, source has no footnote markers) / links (8/8) — 100% preserved

**Note**: i18n/de/STYLE.md does not yet exist — followed TRANSLATE_PROMPT.md + established translation conventions from the existing German corpus (84 articles).

Uncertain terminology flagged for reviewer:

- 鱔魚仿鰻 (shàn-yú fǎng-màn) → kept romanized with a short German gloss ("Reisfeldaal, nach Aal-Art zubereitet") since there is no established German name for this Tainan dish
- 保安路 → "Bao'an-Straße" (romanized street name + German generic noun, per project convention)

Please review. Happy to iterate.
