### PR TITLE
translate(id): 台糖 → taiwan-sugar

### DIFF
--- a/knowledge/id/Economy/taiwan-sugar.md
+++ b/knowledge/id/Economy/taiwan-sugar.md
@@ -1,0 +1,79 @@
+---
+title: "Taisugar: Dari Kerajaan Manis Penopang 74% Devisa Taiwan, hingga 'Tuan Tanah Nyeleneh' Berlaba Tertinggi di 2025"
+description: "Pada 2025, laba bersih setelah pajak Taisugar mencetak rekor baru senilai NT$7,4 miliar, padahal perusahaan berusia seabad ini sudah lama tak lagi mengandalkan penjualan gula. Dari tulang punggung kolonial era pendudukan Jepang hingga urat nadi ekonomi pascaperang, simak bagaimana Taisugar berbalik arah dari tebu, dan mendefinisikan ulang arti 'manis' lewat anggrek, bioteknologi, serta bangunan sirkular."
+date: 2026-05-03
+category: 'Economy'
+tags: ['Taisugar', 'Sejarah Industri Gula', 'Transformasi', 'Ekonomi Sirkular', 'Anggrek Bulan']
+subcategory: 'Profil Perusahaan'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-05-03
+lastHumanReview: false
+readingTime: 8
+translatedFrom: 'Economy/台糖.md'
+sourceCommitSha: '4b6d28c54367'
+sourceContentHash: 'sha256:fe604aece0c5731f'
+sourceBodyHash: 'sha256:9631152a90e28115'
+translatedAt: '2026-09-06T04:09:46+08:00'
+translatedFromInferred: false
+---
+
+> **Ringkasan 30 detik:** Pada 1950-an, dari setiap NT$100 devisa Taiwan, NT$74 berasal dari gula Taisugar. Kini, bisnis gula Taisugar merugi setiap tahun, tetapi pada 2025 perusahaan ini justru mencetak rekor laba baru sebesar NT$7,468 miliar berkat minyak goreng, anggrek, dan pengembangan lahan. Tuan tanah terbesar di Taiwan ini sedang bertransformasi dari "perusahaan gula" menjadi pelopor "ekonomi sirkular".
+
+"Kereta memasuki stasiun, mohon mundur, harap perhatikan langkah saat naik-turun!" Di Stasiun Wushulin, Tainan, kepala stasiun kehormatan Lin Hai-hsi yang berusia 92 tahun masih berdiri tegak sambil mengibarkan bendera merah-hijau di tangannya[^1]. Ia bergabung dengan Wushulin sejak usia 16 tahun dan telah menghabiskan enam dekade di sana — bahkan dulu, saat mengantar seserahan pernikahan ke rumah calon istrinya, ia meminta bantuan "kereta patroli 109" milik Taisugar untuk mengantarnya dengan romantis[^2]. Kehidupan Lin Hai-hsi terikat erat dengan Taisugar, dan bendera merah-hijaunya menjadi saksi perjalanan seabad industri gula Taiwan — dari puncak kejayaan, kemunduran, hingga transformasi gemilang.
+
+### Kerangka Manis: Menopang Separuh Devisa Taiwan
+
+Di era "mendorong industri lewat pertanian", Taisugar bukan sekadar perusahaan — ia adalah kas negara Taiwan. Pada 1950-an, nilai ekspor gula pernah menyumbang 74% dari total pendapatan devisa Taiwan[^3]. Kala itu, di Dataran Chianan, jalur kereta "lima-fen" yang rapat bagai jaring laba-laba menghubungkan perkebunan milik sendiri dengan ladang tebu kontrak petani, sementara pabrik gula raksasa menjulang di tengah sawah — itulah puncak kejayaan ekonomi gula Taiwan[^4].
+
+Namun, manisnya ini ada harganya. Pada era pendudukan Jepang, Taisugar adalah alat yang melayani kepentingan negara induk kolonial; setelah perang, ia menjadi "mesin ATM" bagi pemerintah untuk mengendalikan ekonomi. Demi menjaga kesejahteraan petani tebu, Taisugar dalam jangka panjang membeli tebu dengan harga di atas harga gula internasional, sehingga bisnis intinya terjebak dalam siklus kerugian yang tak terhindarkan. Seiring fluktuasi harga gula internasional dan naiknya biaya tenaga kerja domestik, pabrik-pabrik gula tutup satu demi satu; dari lebih 40 pabrik gula di seluruh Taiwan, kini hanya tersisa segelintir yang masih beroperasi, seperti Huwei dan Shanhua[^5].
+
+📝 Catatan kurator: Sejarah Taisugar adalah cerminan ekonomi Taiwan — dari industri primer yang bergantung pada lahan, dipaksa mencari jalan bertahan di celah pasar internasional.
+
+### Anggrek Bulan dan Ekstrak Kerang: Ketika "Usaha Sampingan" Menjadi Bisnis Utama Baru
+
+Saat gula tak lagi manis, Taisugar mulai mencari peluang hidup dari "bisnis sampingan". Mengejutkannya, perusahaan gula ini justru menjadi pusat pembibitan anggrek bulan (Phalaenopsis) kelas dunia. Pada Pameran Anggrek Internasional Taiwan 2025, Taisugar sekaligus meraih 14 penghargaan, dengan "Nenek Taisugar" (Taisugar A-má) sebagai salah satu varietas hortikultura klasik yang tetap populer[^6].
+
+Bisnis bioteknologi menjadi sorotan transformasi lainnya. Dengan memanfaatkan teknologi inti dari produksi gula dan peternakan babi, Taisugar mengembangkan ekstrak kerang (clam essence) yang pangsa pasarnya pernah melampaui 60%, bahkan mengubah limbah seperti sisik ikan dan cangkang tiram menjadi kolagen dan produk bernilai tambah tinggi melalui teknologi[^7].
+
+> "Ini bukan soal teknologi, ini cerita tentang kepercayaan."
+
+Ketika skandal residu obat penambah otot "zilpaterol" mencuat pada 2024, kredibilitas merek Taisugar sempat tergoncang. Namun, setelah 84 sampel lanjutan seluruhnya dinyatakan negatif, dan pengadilan memutuskan bahwa hanya satu kotak sampel yang tercemar, kontroversi ini justru memperkuat kepercayaan konsumen terhadap daging babi produksi dalam negeri Taisugar[^8].
+
+### Tuan Tanah Terbesar di Taiwan: Menumbuhkan "Ekonomi Sirkular" di Atas Lahan
+
+Dengan sekitar 50.000 hektare lahan, Taisugar memang pantas disebut "tuan tanah terbesar" Taiwan. Namun Taisugar tak lagi sekadar hidup dari menjual warisan leluhur — ia mulai mencoba hidup berdampingan dengan lahannya.
+
+Di Shalun, Tainan, Taisugar menggagas "Kawasan Perumahan Sirkular Hijau Pintar" pertama di Taiwan. Bangunan ini bukan lagi soal jual-beli biasa, melainkan "sewa menggantikan jual" — setiap material bangunan memiliki "identitas", sehingga bisa didaur ulang setelah dibongkar di masa depan. Proyek ini bahkan tampil di Milan Design Week, Italia pada 2026, memperlihatkan kepada dunia kekuatan Taiwan dalam arsitektur berkelanjutan[^9].
+
+📝 Catatan kurator: Dari menjual gula ke menyewakan rumah, Taisugar sedang belajar bagaimana tidak lagi "menghabiskan" lahan, melainkan "mensirkulasikan" nilainya.
+
+### Penutup: Gaung Perusahaan Berusia Seabad
+
+Pada 2025, laba usaha Taisugar mencapai NT$4,698 miliar, dengan laba bersih setelah pajak mencetak rekor baru sebesar NT$7,468 miliar[^10]. Meski sebagian besar berasal dari investasi non-inti dan pengembangan lahan, langkah Taisugar di bidang bioteknologi dan energi hijau membuat perusahaan berusia seabad ini perlahan lepas dari label "beban warisan".
+
+Saat kita menaiki kereta lima-fen berkecepatan hanya 10 km/jam di Wushulin, menyaksikan Kepala Stasiun Lin Hai-hsi mengibarkan bendera hijau, irama hidup yang lambat itu mengingatkan kita: Taisugar mungkin bukan lagi kerajaan manis yang berkuasa seperti dulu, tetapi ia kini menjaga masa lalu dan masa depan tanah Taiwan ini dengan cara yang jauh lebih tangguh.
+
+---
+
+### Referensi
+
+[^1]: [Buletin Taisugar: Kepala Stasiun Bahagia dari Wushulin](https://www.taisugar.com.tw/monthly/CPN.aspx?ms=1454&p=1338733&s=13387772) — Data resmi situs Taisugar
+
+[^2]: [One Little Day: [Taisugar] Menyusuri Waktu Lama, Bernostalgia Bersama Pekerja Senior](https://onelittleday.com.tw/%E6%BC%AB%E9%81%8A%E8%88%8A%E6%99%82%E5%85%89-%E8%B7%9F%E8%91%97%E8%80%81%E8%81%B7%E4%BA%BA%E9%87%8D%E6%BA%AB%E7%B2%BE%E5%BD%A9/) — Kolom One Little Day
+
+[^3]: [Majalah Taiwan Panorama: Melintasi Abad, Taisugar Mencari "Manis" Baru dalam Transformasi](https://www.taiwan-panorama.com/Articles/Details?Guid=8ece1ddb-8ea5-4806-ad4e-8a1ef0e91495&CatId=9&postname=%E4%B8%96%E7%B4%80%E8%B5%B0%E9%81%8E%EF%BC%8C%E5%8F%B0%E7%B3%96%E8%BD%89%E5%9E%8B%E6%89%BE%E7%94%9C%E9%A0%AD) — Artikel Majalah Taiwan Panorama
+
+[^4]: [Our Island: [Sejarah Gula] Catatan Masa Senja Tebu Taiwan](https://ourisland.pts.org.tw/content/1084) — Public Television Service (PTS) News Network
+
+[^5]: [Situs Resmi Taisugar: Skala Usaha](https://www.taisugar.com.tw/chinese/CP2.aspx?n=10007) — Data resmi situs Taisugar
+
+[^6]: [Situs Resmi Taisugar: Keahlian Seni Memukau Dunia, Anggrek Bulan Taisugar Raih 14 Penghargaan di Pameran Anggrek](https://www.taisugar.com.tw/business/News_detail.aspx?p=158&n=12693&s=13778) — Data resmi situs Taisugar
+
+[^7]: [Ekonomi Sirkular Bioteknologi Taisugar Ciptakan Prestasi Gemilang BUMN](https://news.gbimonthly.com/tw/magazine/article_show.php?num=38430) — Laporan GBI Monthly
+
+[^8]: [Liberty Times: Kritik terhadap Wali Kota Lu Shiow-yen soal "Zilpaterol Rugikan Taisugar" Digugat, Hakim Nilai "Berdasar Fakta", Tak Dipidana](https://news.ltn.com.tw/news/society/breakingnews/5377549) — Laporan Liberty Times
+
+[^9]: [Siaran Pers Kementerian Ekonomi: Rumah Sirkular Taisugar Tampil di Milan Design Week, Kekuatan Baru Arsitektur Berkelanjutan Taiwan Pukau Dunia](https://www.moea.gov.tw/MNS/Populace/news/News.aspx?kind=1&menu_id=40&news_id=122490) — Siaran Pers Kementerian Ekonomi
+
+[^10]: [Economic Daily News: Taisugar Raup Laba NT$7,4 Miliar di 2025, Tertinggi Sepanjang Sejarah](https://money.udn.com/money/story/5612/9261034) — Laporan UDN Money


### PR DESCRIPTION
Adds Indonesian translation of `Economy/台糖.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 2.67 (target range 2.0-4.3, prior Indonesian corpus measured 2.32-3.58)

**Structure alignment**: headings (5/5, all `###`) / footnotes (10/10) / links (10/10) — 100% preserved

**Note**: i18n/id/STYLE.md does not yet exist — followed TRANSLATE_PROMPT.md + established translation conventions from the existing Indonesian corpus.

Uncertain terminology flagged for reviewer:

- 五分車 (narrow-gauge sugar-cane railway, lit. "one-half-scale car") → "kereta lima-fen", kept romanized with context since there's no standard Indonesian term for this specific Taiwanese sugar-industry railway gauge
- 西布特羅 (zilpaterol, a livestock feed additive) → "zilpaterol" (international chemical/generic name), matching the substance's actual name rather than a phonetic transliteration

Please review. Happy to iterate.
