### PR TITLE
translate(de): 台灣醬料與調味 -> taiwan-sauces-and-seasonings

### DIFF
--- a/knowledge/de/Food/taiwan-sauces-and-seasonings.md
+++ b/knowledge/de/Food/taiwan-sauces-and-seasonings.md
@@ -1,0 +1,76 @@
+---
+title: 'Taiwans Saucen und Gewürze'
+description: 'Dickflüssige Sojasauce, Satay-Sauce, süß-scharfe Sauce und Doubanjiang bilden die Grundlage von Taiwans einzigartigen Aromen und spiegeln eine Würzphilosophie wider, die aus der Verschmelzung vieler Kulturen entstanden ist'
+date: 2026-03-20
+category: 'Food'
+tags: ['Saucen', 'Gewürze', 'Esskultur', 'Taiwan-Geschmack', 'fermentierte Lebensmittel']
+subcategory: 'Zutaten und Würzen'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-03-20
+lastHumanReview: false
+difficulty: 'beginner'
+readingTime: 7
+curation: incubating
+imageNote: '原 Wikimedia 圖與文章主題不符，未收進庫，待換圖（圖片是美國麻州家庭自製深盤披薩（加番茄糊與少許醬油），非台灣醬料/調味場景，主體錯誤）'
+translatedFrom: 'Food/台灣醬料與調味.md'
+sourceCommitSha: 'e974b4c9e'
+sourceContentHash: 'sha256:80c0f5a5b4a4fc5f'
+translatedAt: '2026-09-06T05:12:41+08:00'
+---
+
+# Taiwans Saucen und Gewürze
+
+In taiwanischen Küchen sind Saucen die Seele des Essens. Eine Flasche dickflüssige Sojasauce, ein Glas Satay-Sauce, eine Packung süß-scharfe Sauce – diese unscheinbaren Würzmittel sind der Schlüssel zu Taiwans unverwechselbarem Geschmack. Sie harmonisieren nicht nur den Geschmack, sondern tragen auch die Erinnerung an das Verschmelzen verschiedener Kulturen in sich.
+
+## Die taiwanische Weiterentwicklung der Sojasauce
+
+Sojasauce ist der Grundstein der taiwanischen Küche, doch Taiwans Sojasauce-Kultur hat eigene Merkmale. Am charakteristischsten ist die „Sojasaucenpaste" (醬油膏), eine dickflüssige Eigenerfindung Taiwans. Anders als gewöhnliche flüssige Sojasauce enthält sie Zucker und Stärke, wodurch eine zähe Konsistenz und eine Süße-Salz-Balance entstehen – ideal zum Dippen und Vermengen.
+
+Die Sojasaucenpaste spiegelt die Geschmacksvorlieben der Taiwaner wider: Süße und Salzigkeit gleichermaßen betont. Ob zu Teigtaschen, blanchiertem Gemüse oder geschmortem Schweinefleisch mit Reis (Lu Rou Fan) – sie ist unverzichtbar.
+
+Traditionelle taiwanische Sojasauce wird aus schwarzen Sojabohnen gebraut und über ein halbes Jahr fermentiert, wodurch tiefe Farbe und komplexe Aromen entstehen. Marken wie Kimlan, Wan Ja Shan und Tung Wan blicken auf jahrzehntelange Brautradition zurück.
+
+## Die Lokalisierung südostasiatischer Aromen: Satay-Sauce
+
+Satay-Sauce ist ein weiterer zentraler Bestandteil von Taiwans Esskultur. Das ursprünglich südostasiatische Gewürz wurde in Taiwan lokal angepasst: süßer, milder, weniger scharf, mit stärkerem Erdnuss- und Sesamaroma als das Original.
+
+Satay-Sauce findet vielseitig Verwendung – als Hot-Pot-Dip, in gebratenen Satay-Nudeln oder gebratenem Satay-Rindfleisch. Die Satay-Sauce der Marke Bull Head (牛頭牌) ist für viele Taiwaner eine gemeinsame Kindheitserinnerung; ihr Erdnussaroma gilt fast als Synonym für den „Taiwan-Geschmack".
+
+## Die taiwanische Innovation der süß-scharfen Sauce
+
+Taiwans süß-scharfe Sauce verbindet süße, scharfe und saure Aromen und verkörpert das taiwanische Streben nach komplexem Geschmack. Die Sauce von A-Chien Wei (愛之味) führt den Markt an und ist Standardbeilage vieler Snacks.
+
+Sie dient als Dip für salzig-knuspriges Brathähnchen, als Beilage zu Frühlingsrollen oder als Würze für frittierte Hähnchenschnitzel. Süße von Zucker und Tomaten, Schärfe von Chilis, Säure von Essig – diese Balance schafft den unverwechselbaren Geschmack.
+
+## Die Sichuan-Erinnerung des Doubanjiang
+
+Mit Festlandchinesen, die nach Taiwan auswanderten, fasste auch Doubanjiang (Sichuan-Chilibohnenpaste) Fuß. Das fermentierte Würzmittel nimmt in taiwanischen Sichuan-Restaurants wie in Privatküchen einen wichtigen Platz ein. Taiwans Version ist weniger salzig und süßer als das Original.
+
+Doubanjiang wird vor allem in der Sichuan-Küche und in innovativer taiwanischer Küche verwendet – Mapo-Tofu, Kung-Pao-Hähnchen, Fisch in Doubanjiang-Sauce. Manche Köche integrieren es auch in traditionelle taiwanische Gerichte und schaffen neue Kombinationen.
+
+## Die vielfältige Welt der Chilisaucen
+
+Taiwans Chilisaucen-Kultur zeigt erstaunliche Vielfalt: von traditioneller Chili-Sojasauce über koreanische Chilipaste bis zu milder süß-scharfer Sauce oder feuriger Sichuan-Pfeffersauce. Jeder Schärfegrad findet seine Liebhaber.
+
+Am charakteristischsten sind Chilisaucen aus lokalen Chilis: Hakka-Chilisauce aus Miaoli, „Himmel-zeigende" Chilisauce aus Kaohsiung, Vogelaugen-Chilisauce aus Taitung. Sie kombinieren oft lokale Zutaten wie Hakka-Mandarinen-Chili oder die Chilisauce der indigenen Völker mit Makauy-Pfeffer (馬告) und bilden so unverwechselbare regionale Geschmäcker.
+
+## Die Weisheit fermentierter Würzmittel
+
+Taiwans fermentierte Würzmittel führen chinesische Esskultur fort und integrieren lokale Innovation. Fermentierter Tofu (豆腐乳), getrockneter Rettich (菜脯) und eingelegtes Gemüse (醬瓜) sind zugleich Würzmittel und Gericht – Ausdruck der Wertschätzung von Lebensmitteln.
+
+Ihre Herstellung braucht Zeit und Geduld: Fermentierter Tofu reift mehrere Monate, getrockneter Rettich verlangt präzise Kontrolle von Salz und Feuchtigkeit. Diese langsame Handwerkskunst spiegelt das Beharren auf Qualität wider.
+
+## Moderne Innovation und Internationalisierung
+
+Mit wachsender gesellschaftlicher Vielfalt entstehen viele neue Produkte: koreanische Chilipaste, japanische Mayonnaise, thailändische Fischsauce finden in Taiwan ihren Markt. Gleichzeitig treiben taiwanische Hersteller Innovationen voran, die dem modernen Leben entsprechen.
+
+Auch die Verpackung entwickelt sich weiter: vom Glasgefäß zur Quetschflasche, von einzelnen Geschmacksrichtungen zu Würzmischungen. Manche Hersteller bringen biologische, zusatzstofffreie Gewürze auf den Markt, um dem Gesundheitsbewusstsein zu entsprechen.
+
+## Der kulturelle Gehalt der Würzphilosophie
+
+Taiwans Würzkultur spiegelt den offenen Charakter der Insel wider. Gewürze verschiedener Kulturen treffen hier aufeinander und verschmelzen, wodurch neue Geschmäcker entstehen – eine Offenheit, die der Küche Anpassungsfähigkeit und Innovationskraft verleiht.
+
+Bemerkenswert ist zudem der Wert, den Taiwaner der Qualität beimessen: Ob traditionell gebraute Sojasauce oder moderne Sauce, Verbraucher zahlen für Qualität einen angemessenen Preis. Dieses Streben treibt die gesamte Branche voran.
+
+Im Zeitalter der Globalisierung steht Taiwans Gewürzkultur vor neuen Fragen: wie traditionelle Eigenart bewahren und zugleich internationalen Geschmäckern entgegenkommen, wie Bequemlichkeit und Gesundheit ausbalancieren. Sicher ist: Diese Gewürze, die Taiwans kulturelle DNA tragen, werden weiter Geschmäcker harmonisieren und Gefühle verbinden.


### PR DESCRIPTION
Adds German translation of `Food/台灣醬料與調味.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.06 (target median 3.14, healthy band 2.48-3.78 per `scripts/tools/lang-sync/ratio-bands.json`)

**Structure alignment**: headings (8/8) / footnotes (0/0, none in source) / links (0/0, none in source) — 100% preserved

**Note**: `i18n/de/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT.md + established translation conventions from the existing de corpus (e.g. `knowledge/de/Food/bubble-tea.md`).

Uncertain terminology flagged for reviewer:

- 醬油膏 → "Sojasaucenpaste" · coined compound term, no established German equivalent
- 朝天椒醬 (Kaohsiung) → "Himmel-zeigende Chilisauce" · literal rendering of the chili variety name, may not be idiomatic
- 馬告 → "Makauy-Pfeffer" · Indigenous-language romanization, essentially no existing German term for this spice

Please review. Happy to iterate.
