### PR TITLE
translate(id): 國家文化記憶庫 -> national-cultural-memory-bank

### DIFF
--- a/knowledge/id/Technology/national-cultural-memory-bank.md
+++ b/knowledge/id/Technology/national-cultural-memory-bank.md
@@ -1,0 +1,82 @@
+---
+title: 'Bank Memori Budaya Nasional: Kurasi Ingatan dan Ko-kreasi Budaya di Era Digital'
+description: 'Bank Memori Budaya Nasional bukan sekadar platform arsip digital, melainkan sebuah rekayasa sosial yang berpacu dengan waktu — melalui lisensi terbuka dan ko-kreasi, ingatan rakyat biasa Taiwan dihidupkan kembali di era digital.'
+date: 2026-04-29
+category: 'Technology'
+tags: ['Bank Memori Budaya Nasional', 'arsip digital', 'ko-kreasi budaya', 'ingatan Taiwan', 'hak cipta', 'budaya rakyat']
+subcategory: 'Digital dan Internet'
+author: 'idlccp1984'
+featured: false
+lastVerified: 2026-04-29
+lastHumanReview: false
+readingTime: 12
+translatedFrom: 'Technology/國家文化記憶庫.md'
+sourceCommitSha: '4b6d28c54'
+sourceContentHash: 'sha256:6f90dbf2e1df699d'
+translatedAt: '2026-09-06T05:16:23+08:00'
+---
+
+> ⚡ Ringkasan 30 Detik
+>
+> - **Apa ini**: Proyek arsip digital nasional yang digagas Kementerian Kebudayaan, dengan gagasan inti "narasi kecil pribadi berkumpul menjadi sejarah besar bangsa."
+> - **Mengapa penting**: Di tengah tekanan menghilangnya para tetua dan berubahnya lanskap, proyek ini mengawetkan ingatan rakyat biasa Taiwan yang paling otentik dan non-resmi melalui digitalisasi.
+> - **Titik inovasi**: Bukan sekadar "menyimpan", tetapi menekankan "menggunakan". Melalui transformasi 2.0 dan lisensi CC, ingatan menjadi bahan ko-kreasi yang bisa dipakai siapa saja.
+> - **Kasus ikonik**: Agen Perjalanan Lintas Waktu, Meja Makan Pulau Lintas Zaman, Pameran Khusus Ingatan Kuliner.
+
+---
+
+Di gang-gang kecil Taiwan, mungkin semangkuk mi sapi yang masih mengepul, mungkin pula suara riuh pedagang yang bersahutan di pasar tua — hal-hal yang tampak biasa ini justru merupakan serpihan ingatan paling otentik yang membentuk tekstur budaya Taiwan. Namun arus waktu tak kenal ampun; ingatan rakyat biasa yang berharga ini kian cepat hilang seiring wafatnya para tetua dan berubahnya lanskap. Untuk itu, Kementerian Kebudayaan meluncurkan proyek "Bank Memori Budaya Nasional" pada 2017 — bukan sekadar platform arsip digital, melainkan sebuah rekayasa sosial yang hangat dan berpacu dengan waktu, bertujuan memakai kekuatan teknologi agar memori budaya Taiwan dapat dilihat, disimpan, dan dihidupkan kembali.[^3]
+
+📝 Catatan Kurator: Nilai Bank Memori Budaya Nasional terletak pada caranya mengubah data digital yang dingin menjadi kisah yang hangat, membuat siapa pun bisa menemukan resonansi di dalamnya — bahkan berubah dari "pengamat" menjadi "ko-kreator ingatan".
+
+## Bank Memori Budaya Nasional: Dari Arsip Menuju Bank Budaya Ko-kreasi
+
+Gagasan inti Bank Memori Budaya Nasional adalah mengintegrasikan aset budaya Taiwan yang tersebar di berbagai tempat melalui mekanisme sistematis "inventarisasi, pengumpulan, penyimpanan, akses, dan pemanfaatan".[^8] Proyek ini menghimpun kekuatan pemerintah kabupaten/kota, lembaga swasta, kementerian-kementerian pusat, serta 12 museum di bawah Kementerian Pendidikan, untuk bersama-sama merawat potret kehidupan rakyat biasa Taiwan di masa besar sejarahnya.[^3] Ini adalah konsep "bank budaya nasional" — memandang ingatan budaya sebagai harta yang dapat disirkulasikan dan dipakai ulang, bukan sekadar koleksi statis yang terkunci di brankas.
+
+### Transformasi 2.0: Lebih Ramah, Tematik, dan Internasional
+
+Seiring perkembangan teknologi digital, Bank Memori Budaya Nasional dalam beberapa tahun terakhir mendorong rencana transformasi 2.0 dengan tiga tujuan utama: "platform yang lebih ramah pengguna, konten yang tematik, dan pembaca yang mendunia".[^10] Ini berarti platform tidak hanya mengoptimalkan antarmuka pencarian dan penanda lisensi, tetapi juga — melalui kurasi para pekerja sejarah dan budaya profesional — mengubah konten menjadi kisah tematik yang lebih menarik, sehingga publik lebih mudah mendekati kedalaman budaya Taiwan. Misalnya, melalui teknologi NLP (pemrosesan bahasa alami), pencarian tak lagi sekadar mencocokkan kata kunci, melainkan mampu memahami maksud penjelajahan penggunanya.[^9]
+
+## Menghidupkan Ingatan: Dari "Agen Perjalanan Lintas Waktu" hingga "Ingatan Kuliner"
+
+Daya tarik Bank Memori Budaya Nasional terletak pada caranya menghidupkan ingatan-ingatan yang telah didigitalkan ini, sehingga tidak lagi sekadar arsip, melainkan bahan budaya yang bisa dialami dan dikarya-ulangkan. Salah satu contohnya adalah "Agen Perjalanan Lintas Waktu", sebuah platform kurasi daring inovatif yang mendorong pengguna menjadi kurator, membagikan kisah Taiwan yang mereka kenal.[^7] Melalui kurasi tematik, seperti "Manisnya Taiwan: Rasa Manis Sang Pulau" atau "Meja Makan Pulau Lintas Zaman", bank memori ini memadukan budaya kuliner dengan konteks sejarah, membiarkan pembaca merasakan perubahan Taiwan lewat indra pengecap.[^12][^14]
+
+Kasus-kasus ini menunjukkan bagaimana bank memori berubah dari sekadar basis data murni menjadi ranah ko-kreasi budaya yang penuh vitalitas. Ia tidak hanya menyediakan bahan, tetapi juga memicu inspirasi para kreator, membawa ingatan-ingatan ini kembali ke hadapan publik dalam bentuk baru — seperti gambar, tulisan, karya seni, dan lainnya.[^13]
+
+## Tantangan dan Prospek: Menyeimbangkan Hak Cipta dan Keterbukaan Data
+
+Namun, dalam mendorong keterbukaan dan revitalisasi data, Bank Memori Budaya Nasional juga menghadapi isu hak cipta yang rumit.[^1][^4] Bagaimana menyeimbangkan antara mendorong pemanfaatan dan melindungi hak pencipta asli, adalah arah yang terus diupayakan bank memori ini. Platform berupaya mengarahkan pengguna memanfaatkan konten secara wajar melalui penanda lisensi yang jelas dan panduan lisensi CC, sambil menegaskan bahwa keterbukaan data bukan sekadar persoalan teknis, melainkan praktik nyata dari gagasan berbagi budaya.[^2][^6]
+
+Ke depan, Bank Memori Budaya Nasional akan terus memperdalam visinya bahwa "narasi kecil pribadi berkumpul menjadi sejarah besar bangsa",[^11] mendorong lebih banyak masyarakat berpartisipasi mengumpulkan dan membagikan ingatan. Melalui optimalisasi dan inovasi yang berkelanjutan, ia akan menjadi ekosistem budaya yang berkembang secara berkesinambungan, membuat DNA budaya Taiwan terus berevolusi di era digital, dan menceritakan kisah Taiwan yang unik dan kaya kepada dunia.
+
+## Referensi
+
+[^1]: [Diskusi Isu Hak Cipta Bank Memori Budaya Nasional](https://www.copyrightnote.org/paper/pa0106.pdf) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^2]: [Bank Memori 2.0 x CCTW-FAQ-Hak Cipta](https://tw.creativecommons.net/tcmb/faq-copyright/) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^3]: [Bank Memori Budaya Nasional — Bank Budaya Milik Seluruh Rakyat](https://www.ey.gov.tw/Page/5A8A0CB5B41DA11E/122e0cad-b31b-40c0-ab4e-155d4f117968) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^4]: [Isu Hak Cipta dalam Pembangunan dan Operasional Bank Memori Budaya Nasional](https://www.copyrightnote.org/ArticleContent.aspx?ID=3&aid=2935) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^5]: [Rencana Aplikasi Bank Memori Budaya Nasional dan Museum Digital Kementerian Kebudayaan](https://file.moc.gov.tw/001/Upload/470/relfile/10329/22/3219b754-1804-4eb2-b1f8-e56bf590f193.pdf) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^6]: [Bank Memori 2.0 x CCTW-FAQ-Penggunaan Wajar](https://tw.creativecommons.net/tcmb/faq-fair-use/) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^7]: [Platform Ganda Bank Memori Budaya Nasional 2.0 - Museum Sejarah Taiwan](https://www.nmth.gov.tw/News_Link2.aspx?n=7912&sms=13207) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^8]: [Setahun Peluncuran Bank Memori Budaya Nasional, Ke Depan Prioritaskan Optimalisasi Tema dan Layanan Digital](https://www.moc.gov.tw/News_Content.aspx?n=105&s=57777) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^9]: [Panduan Penggunaan Bank Memori Budaya Nasional 2.0 - YouTube](https://www.youtube.com/watch?v=XhhX3KbM4i4) — rekaman video YouTube
+
+[^10]: [Beranda - Platform Digital "Bank Memori Budaya Nasional 2.0"](https://web.nljh.tyc.edu.tw/modules/tadnews/index.php?nsn=8397) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^11]: [Bank Memori Nasional - Kementerian Kebudayaan Republik Tiongkok (Taiwan)](https://www.moc.gov.tw/News_Content.aspx?n=167&s=3814) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^12]: [Meja Makan Pulau Lintas Zaman: Rencana Promosi Ingatan Kuliner Bank Memori Budaya Nasional](https://tcmb.culture.tw/zh-tw/subject/392) — Bank Memori Budaya Nasional
+
+[^13]: [Membuka Peti Harta Karun Ingatan Budaya, Menemukan Jiwa Budaya Paling Berharga](https://www.facebook.com/TaiwanCulturalMemoryBank/videos/%E6%96%87%E5%8C%96dna%E6%88%91%E5%80%91%E7%9A%84%E5%B8%B8%E6%B0%91%E8%A8%98%E6%86%B6/374732050233054/) — Unggahan publik Facebook
+
+[^14]: [Cita Rasa Waktu: Pameran Khusus Ingatan Kuliner Taiwan](https://www.nmth.gov.tw/News_Content_Due.aspx?n=4106&s=230678) — lihat konten tautan asli untuk rincian lebih lanjut
+
+[^15]: [Satu kisah seorang manusia terkadang bisa menyingkap seluruh zaman. Dari "Chang Tsong-ming"... - Instagram](https://www.instagram.com/p/DWGzdnaAXa9/) — lihat konten tautan asli untuk rincian lebih lanjut


### PR DESCRIPTION
Adds Indonesian translation of `Technology/國家文化記憶庫.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.48 (target median 2.78, healthy band 2.0-4.3 per `scripts/tools/lang-sync/ratio-bands.json`)

**Structure alignment**: sections (4/4 `##`, plus matching `###` subheading) / footnotes (15/15) / URLs (15/15, exact multiset) — 100% preserved

**Note**: `i18n/id/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT.md + established translation conventions from the existing id corpus.

Uncertain terminology flagged for reviewer:

- 國家文化記憶庫 → "Bank Memori Budaya Nasional" · literal rendering, no confirmed official/existing Indonesian name for this institution
- 時空旅行社 → "Agen Perjalanan Lintas Waktu" · literal rendering of "time-space travel agency", not an idiomatic set phrase
- 常民文化 → "budaya rakyat" · closest approximation of this Chinese sociological term ("ordinary/folk culture"); may need a more precise equivalent

Please review. Happy to iterate.
