### PR TITLE
translate(de): 虱目魚粥 → milkfish-congee

### DIFF
--- a/knowledge/de/Food/milkfish-congee.md
+++ b/knowledge/de/Food/milkfish-congee.md
@@ -1,0 +1,80 @@
+---
+title: 'Nicht von Koxinga mitgebracht: Die 400-jährige Zuchtgeschichte des Milchfischs'
+description: 'Menschen in Tainan nennen den Milchfisch „Hausfisch", doch seine Ursprünge liegen in den Aquakultur-Techniken, die die Niederländische Ostindien-Kompanie aus Indonesien einführte – 37 Jahre bevor Koxinga überhaupt in Taiwan ankam. Die 4.500 Hektar Fischteiche in Qigu und die mehr als sieben Arten, einen einzigen Fisch zuzubereiten, sind lebende Fossilien dieser vierhundertjährigen Geschichte.'
+date: 2026-07-02
+category: 'Food'
+tags: ['Tainan', 'Milchfisch', 'Qigu', 'Aquakultur', 'Niederländer', 'Snacks', 'Frühstück']
+subcategory: '經典小吃'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-07-02
+lastHumanReview: false
+readingTime: 7
+curation: incubating
+translatedFrom: 'Food/虱目魚粥.md'
+sourceCommitSha: 'pre-toolkit'
+sourceContentHash: 'sha256:5890b2a9aad07932'
+translatedAt: '2026-09-06T21:30:00+08:00'
+---
+
+Um vier Uhr morgens ist es an den Fischteichen von Qigu noch dunkel. Die Fischer stapfen in Gummistiefeln durch den Schlamm, öffnen die Teichschleusen, und sobald die Fische das Wasser rauschen hören, beginnt es im Teich zu wimmeln. Milchfische vertragen keine Kälte – im Winter braucht es Heizvorrichtungen, und in der sommerlichen Erntesaison beginnt die Arbeit schon vor Tagesanbruch. Wird nicht rechtzeitig geerntet, bleiben am nächsten Morgen die Congee-Stände in der Innenstadt von Tainan leer. Diese Lieferkette von Qigu bis zur Guohua-Straße legte ihre erste Fahrt vor mehr als dreihundert Jahren zurück.
+
+Mit Koxinga (Zheng Chenggong) hat dieser Fisch nichts zu tun.
+
+## Die schönste Geschichte ist auch die ungenaueste
+
+Der Volksmund erzählt: Als Koxinga nach Taiwan kam, litt seine Armee unter Nahrungsmangel. Am Strand von Anping sah er einen Fisch und fragte seine Begleiter: „Was für ein Fisch ist das?" – die Aussprache von „was" (sit-mih) im Hokkien-Dialekt wurde zu „shimu" (虱目) verballhornt, und so bekam der Fisch seinen Namen.
+
+Diese Geschichte kursiert vor Tempeln, in Schulbüchern und Touristenbroschüren – sie ist emotional, bildhaft und leicht zu merken. Historiker weisen jedoch schon lange auf das Problem hin: Die Niederländische Ostindien-Kompanie brachte die Aquakultur-Technik für Milchfisch während der niederländischen Kolonialzeit (1624–1662) aus Indonesien nach Taiwan – mindestens siebenunddreißig Jahre bevor Koxinga 1661 überhaupt in Taiwan ankam. Die „Taiwan-Präfektur-Chronik" (Taiwan Fu Zhi) von 1694, aus dem späten 17. Jahrhundert, enthält bereits schriftliche Aufzeichnungen über Milchfischzucht; die ersten Zuchtgebiete lagen in der Gegend von Luerhmen – heute die Umgebung des Anping-Distrikts. Das sind über vierhundert Jahre.
+
+📝 Kuratorennotiz: Die Legende, „Koxinga habe den Milchfisch mitgebracht", zeigt genau eines: Die Lebenskraft einer guten Geschichte hält viel länger an als historische Beweise. Die Niederländer brachten die Zuchttechnik – doch Koxinga bekam die Namensrechte.
+
+## Qigu: Die Geographie der Fischteiche
+
+Tainan ist bis heute die größte Milchfisch-Produktionsregion Taiwans und liefert rund 50 % der landesweiten Jahresproduktion. Das Zentrum ist der Bezirk Qigu – mit über 4.500 Hektar Aquakulturfläche und mehr als 6.000 Fischteichen führt er landesweit die Statistik an.
+
+Die Topografie von Qigu ist entscheidend: Die Küstenlage ist flach, der Boden schlammig und der Salzgehalt moderat – natürliche Voraussetzungen für Fischteiche. Von der Innenstadt Tainans sind es etwa vierzig Minuten mit dem Auto, doch dort säumen endlose Wasserflächen beide Straßenseiten, Silberreiher stehen auf den Teichdämmen, und in der Ferne liegt die Taiwanstraße.
+
+Von Anping bis zu den Congee-Ständen an der Guohua-Straße sind es Luftlinie keine fünfzehn Kilometer. Selbst von Qigu aus sind es nicht mehr als vierzig Kilometer. Diese kurze Lieferkette ist die materielle Grundlage dafür, dass Tainans Milchfisch-Frühstück sowohl günstig als auch frisch ist.
+
+📝 Kuratorennotiz: Qigu züchtet nicht nur Milchfisch, sondern ist auch eines der wichtigsten Winterquartiere der Löffler weltweit. Der ökologische Anspruch auf Feuchtgebietsschutz und die Interessen der Fischerei ringen hier seit langem miteinander – die Fischteiche sind nicht nur Ausgangspunkt für Nahrung, sondern auch Schauplatz ökologischer Politik.
+
+## Die Anatomie des ganzen Fisches
+
+Menschen in Tainan verschwenden beim Milchfisch nichts. Das ist ein Erbe der Frühstückslogik der Hafenarbeiter: Jeder Teil hat seinen bestimmten Platz.
+
+Der Bauch (die Unterseite) hat den meisten Fettanteil und eignet sich am besten zum Trockenbraten – die Haut wird knusprig, das Fleisch bleibt weich, zwei Texturen in einem Bissen. Das Filet (Rückenfleisch) passt am besten in die Congee – süß, frisch, bissfest, mit einem dezenten Aroma, das nichts überdeckt. Die Haut ist reich an Kollagen und eignet sich am besten für Suppe; nach dem Trinken kleben die Lippen kurz zusammen – das ist Kollagen, kein Zusatzstoff. Der Fischdarm wird frittiert, knusprig und geschmackvoll, verlangt aber höchste Frische und ist die Zubereitungsart, die sich anderswo am schwersten nachmachen lässt. Der Fischkopf wird geschmort oder rot gekocht, reich an Gelatine, ideal zum langsamen Genießen. Der saisonale Fischrogen, gebraten oder eingelegt, ist etwas, das nur Stammgäste zu schätzen wissen.
+
+Jeder Schnitt sitzt, weil jeder Teil es verdient, für sich behandelt zu werden.
+
+📝 Kuratorennotiz: Die Kultur, den Milchfisch „nach Teilen getrennt zu essen", ist im Kern eine verschwendungsfreie Arbeiterlogik. Wer an einem Congee-Stand in Tainan bestellt, wählt nicht nur Zutaten, sondern eine bestimmte Sichtweise auf den Fisch. Wer „gemischt" bestellt, ist Tourist – wer eine Vorliebe hat, ist Stammgast.
+
+## Weißer Congee um fünf Uhr morgens
+
+Um halb sechs morgens blanchieren die Congee-Stände die einzelnen Teile getrennt, verteilen sie auf kleine Schälchen und stellen sie auf den Tisch, damit die Gäste sie selbst in den weißen Congee geben können.
+
+Dieses Selbstbedienungssystem ist keine kulinarische Erfindung, sondern schiere Effizienz. Hafenarbeiter beim Frühstück haben keine Zeit, darauf zu warten, dass ein Koch entscheidet, was in ihre Schüssel kommt. Die Zutaten stehen bereit, und man weiß selbst, was man heute braucht und was man meiden sollte – bei hoher körperlicher Anstrengung etwas mehr Fischdarm, nach einer durchzechten Nacht lieber klaren Congee mit Fischhautsuppe.
+
+Die Zuchtlogik von vor dreihundert Jahren lebt bis heute im Rhythmus dieses Morgens weiter.
+
+## Der Name bleibt bis heute ein Rätsel
+
+Wie der Name „Shimu-Fisch" (虱目魚) tatsächlich entstand, ist in der Wissenschaft bis heute ungeklärt.
+
+Manche sagen, der Name sei eine Lauttransliteration aus dem Niederländischen oder Malaiischen; andere vermuten eine Herkunft vom taiwanischen Wort „sè-ba̍k" (feine Augen) – bezogen auf die feinen Augen des Fisches; wieder andere glauben, Arbeiter in verschiedenen Zuchtgebieten hätten jeweils eigene Namen verwendet, bis sich im Taiwanischen ein Begriff durchsetzte.
+
+Die Geschichte von Koxinga, der „Was für ein Fisch" fragte, bleibt die am weitesten verbreitete Version. Manchmal ist die einprägsamste Geschichte nicht die genaueste – aber sie hat dafür gesorgt, dass eine vierhundert Jahre alte Zuchtindustrie bis heute einen Namen auf jedem Frühstückstisch hinterlässt.
+
+---
+
+## Quellen
+
+- [Milchfisch — Wikipedia](https://zh.m.wikipedia.org/zh-tw/%E8%99%B1%E7%9B%AE%E9%AD%9A)
+- [Welchen Zusammenhang hat die Benennung von „Shimu-Fisch" mit Koxinga? — Food Next](https://www.foodnext.net/life/culture/paper/5098989327)
+- [„Wandernde Geschichte Tainans": Der Milchfisch bereicherte die Fischteiche – und die Morgen und Mägen der Menschen in der alten Präfekturstadt — The News Lens](https://www.thenewslens.com/article/131368)
+- [Tainans Wahoo-Suppe und Milchfisch könnten aus europäischen Importen des 17. Jahrhunderts stammen — CNA](https://www.cna.com.tw/news/acul/202403060184.aspx)
+- [Taiwan durch die Linse des Milchfischs betrachtet (Teil 1) — Zeitschrift der Geographischen Gesellschaft der Republik China](https://blog.geogsoc.org.tw/milk-fish-calvin-hung-1/)
+- [Als Fischereiarbeiter in den Fischteichen von Qigu, Tainan: die morgendliche Ernte erleben — Smile Taiwan](https://smiletaiwan.cw.com.tw/article/5955)
+- [Milchfisch, Tilapia, Zackenbarsch: Lernen Sie die Aquakultur kennen, die Delikatessen auf unseren Tisch bringt! — PanSci](https://pansci.asia/archives/174611)
+- [Wirtschaftsüberblick des Bezirks Qigu — Bezirksamt Qigu, Stadt Tainan](https://cigu.tainan.gov.tw/cp.aspx?n=6308)
+- [Tainans Milchfisch — Integrierte Informationsplattform für Ernährungsbildung (Landwirtschaftsministerium)](https://fae.moa.gov.tw/map/food_item.php?type=AS02&id=2&local_id=6)


### PR DESCRIPTION
﻿Adds German translation of `Food/虱目魚粥.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.48 (repo ratio-bands.json de: healthy 2.48-3.78, calibrated 2026-09-05)

**Structure alignment**: headings (6/6) / footnotes (0/0, none in source) / links (9/9) — 100% preserved

**Note**: i18n/de/STYLE.md not yet exists — followed TRANSLATE_PROMPT.md + established translation conventions from the existing de corpus.

Uncertain terminology flagged for reviewer:

- 虱目魚 (shímù yú / milkfish) → kept as "Milchfisch" (the standard German name for *Chanos chanos*); the Hokkien folk-etymology wordplay in the naming legend doesn't translate directly, so I kept the Chinese characters (虱目) alongside a phonetic gloss to preserve the joke's logic.
- 鹿耳門 (Lu'ermen) → transliterated as "Luerhmen" per existing en corpus convention.

Please review. Happy to iterate.
