### PR TITLE
translate(id): 台灣長期照顧制度發展 → long-term-care-system-development

### DIFF
--- a/knowledge/id/Society/long-term-care-system-development.md
+++ b/knowledge/id/Society/long-term-care-system-development.md
@@ -1,0 +1,171 @@
+---
+title: 'Perkembangan Sistem Perawatan Jangka Panjang di Taiwan'
+description: 'Sistem perawatan jangka panjang paling maju di Asia, namun sekaligus menyimpan sistem perawatan tersembunyi terbesar'
+date: 2026-03-22
+category: 'Society'
+tags: ['perawatan jangka panjang', 'penuaan populasi', 'pekerja asing', 'Long-Term Care 2.0', 'kontradiksi sistem']
+subcategory: '社會福利'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-03-22
+lastHumanReview: false
+readingTime: 8
+translatedFrom: 'Society/台灣長期照顧制度發展.md'
+sourceCommitSha: 'pre-toolkit'
+sourceContentHash: 'sha256:318f46e5efc6bda8'
+translatedAt: '2026-09-06T21:30:00+08:00'
+---
+
+# Perkembangan Sistem Perawatan Jangka Panjang di Taiwan
+
+> **Ringkasan 30 detik:** Taiwan memiliki sistem perawatan jangka panjang paling lengkap di Asia — Long-Term Care 2.0 melayani 360.000 orang dengan tingkat kepuasan mencapai 85%. Namun di saat yang sama, ada 214.000 pekerja perawat asing yang diam-diam menopang sistem perawatan lain yang jauh lebih besar. Ini adalah kisah tentang desain kebijakan, nilai sosial, dan kompromi dengan kenyataan.
+
+Pada tahun 2017, pemerintahan Tsai Ing-wen meluncurkan Long-Term Care 2.0, dengan klaim akan membangun "sistem layanan perawatan jangka panjang yang berkesinambungan dan merata." Di tahun yang sama, jumlah pekerja perawat rumah tangga asing yang dipekerjakan di Taiwan untuk pertama kalinya menembus angka 200.000 orang.
+
+Ini bukan kebetulan — inilah kontradiksi terbesar dalam sistem perawatan jangka panjang Taiwan: di satu sisi ada sistem resmi pemerintah dengan anggaran tahunan 65 miliar NT Dollar, di sisi lain ada sistem tersembunyi yang terdiri dari 214.000 keluarga yang masing-masing mempekerjakan perawat asing sendiri. Yang pertama melayani 360.000 orang, yang kedua melayani sekitar 210.000 orang — dua dunia perawatan yang berjalan paralel, dan nyaris tidak pernah bersinggungan.
+
+> **📝 Catatan Kurator**
+> Hal paling kontra-intuitif dari kebijakan perawatan jangka panjang Taiwan: kita membangun sistem perawatan jangka panjang kelas dunia, sekaligus membina masyarakat yang paling bergantung pada perawat asing di dunia.
+
+## Lahirnya Sistem: Berpacu dengan Waktu Sebelum Menjadi Masyarakat Super-Tua
+
+Pada tahun 1993, proporsi penduduk Taiwan yang berusia 65 tahun ke atas mencapai 7%, secara resmi memasuki status masyarakat menua (aging society). Namun respons para politisi mengejutkan lambatnya — baru pada tahun 2007, empat belas tahun setelah status itu tercapai, "Rencana Sepuluh Tahun Perawatan Jangka Panjang" resmi diluncurkan.
+
+Rencana yang terlambat ini sejak awal tidak terlalu diharapkan. Anggarannya, NT$81,7 miliar selama sepuluh tahun, terdengar besar, tetapi rata-rata hanya NT$8,17 miliar per tahun — bahkan tidak sampai 2% dari anggaran asuransi kesehatan nasional saat itu. Lebih buruk lagi, sasaran layanannya hanya sekitar 20.000 orang, dengan tingkat cakupan hanya 1,5%.
+
+Pada pemilihan presiden 2016, isu perawatan jangka panjang menjadi topik yang tidak bisa dihindari oleh ketiga kandidat. Tsai Ing-wen berjanji untuk meningkatkannya menjadi "Long-Term Care 2.0", dengan sumber anggaran diubah dari alokasi tahunan biasa menjadi dana khusus dari cukai rokok, langsung dinaikkan menjadi lebih dari NT$30 miliar per tahun.
+
+> **⚠️ Sudut Pandang yang Diperdebatkan**
+> Kalangan medis mengkritik: pendanaan asuransi perawatan jangka panjang Jepang berasal dari pajak dan premi asuransi masing-masing separuh, dan itu pun dianggap sangat kurang — sementara Taiwan hanya mengandalkan pajak, sehingga keberlanjutan fiskalnya diragukan.
+
+| 2017: 29.000 orang | 2024: 360.000 orang |
+| --- | --- |
+| Jumlah pengguna layanan LTC 2.0 di tahun pertama | Jumlah pengguna saat ini (naik 12 kali lipat) |
+
+Namun angka-angkanya indah, kenyataannya keras.
+
+## Era Kekurangan Tenaga Kerja Akut: 7 Perawat Rumah Bergiliran Merawat 1 Orang
+
+"Tidak bisa menemukan orang" adalah titik sakit terbesar sistem perawatan jangka panjang. Tu Hsin-ning, ketua Aliansi Strategis Layanan Perawatan Rumah Taiwan, menunjukkan bahwa skala tenaga kerja unit layanan rumah mengalami keruntuhan struktural: pada 2016 ada 186 unit layanan rumah di seluruh Taiwan, rata-rata mempekerjakan 47,9 perawat per unit; pada 2024, jumlah unit meningkat menjadi 2.235, tetapi rata-rata hanya 24,3 orang per unit.
+
+Jumlah unit bertambah, tenaga kerja tersebar, hasilnya adalah ketidakmampuan menyusun jadwal secara fleksibel. Chen Wan-yu, manajer kasus di lembaga perawatan jangka panjang rumah Junwei di Taipei, pernah menemui kasus paling ekstrem: satu klien membutuhkan 7 perawat rumah yang bergiliran merawatnya, kadang dalam satu hari datang perawat berbeda di waktu berbeda — satu untuk memandikan, satu untuk mengantar jalan, satu untuk mengatur posisi tidur.
+
+> **💡 Tahukah Anda**
+> Layanan perawatan malam hampir mustahil mendapatkan tenaga kerja. Meski pemerintah menyediakan tunjangan malam NT$385, jumlah perawat yang bersedia bekerja malam tetap sangat sedikit. Pengasuh keluarga yang bekerja kantoran sulit "menghela napas" setelah pulang kerja.
+
+Yang lebih serius adalah hilangnya manajer kasus secara masif di tengah rantai tenaga kerja. Kementerian Kesehatan dan Kesejahteraan menetapkan batas maksimum 120 kasus per manajer, tetapi kenyataannya sering melebihi 150 kasus. Shih Sheng-mao, manajer kasus senior di Yayasan Hati Merah Taipei, berkata: "Pekerja sosial untuk lansia yang tinggal sendiri bisa memberi layanan mendalam untuk 30-60 kasus, tapi dengan 150 kasus, perawatan menyeluruh sama sekali tidak mungkin dilakukan."
+
+Ada humor gelap yang populer di kalangan perawatan jangka panjang: "Ke depannya, perawatan jangka panjang kita hanya bisa mengandalkan dua jenis: orang asing dan robot!"
+
+## Separuh yang Tersembunyi: Dunia Paralel yang Ditopang 240.000 Perawat Asing
+
+Ketika Long-Term Care 2.0 bersinar di media, sistem perawatan lain yang jauh lebih besar diam-diam berkembang.
+
+Pada 1992, ketika Taiwan membuka pintu bagi pekerja perawat rumah tangga asing, jumlahnya hanya 306 orang. Pada 2024, angka ini menjadi 214.514 orang — 80% berasal dari Indonesia, 10,8% dari Filipina, dan 8,9% dari Vietnam. Jika mereka dibariskan, barisannya bisa membentang dari Taipei hingga Kaohsiung.
+
+> **📊 Sumber Data**
+> Menurut statistik Kementerian Tenaga Kerja, per Maret 2024, ada 910.000 orang berusia 80 tahun ke atas di Taiwan, dan 41,7% di antaranya mengalami disabilitas dalam berbagai tingkat.
+
+214.000 keluarga dengan perawat asing ini membentuk dunia perawatan yang sepenuhnya paralel dengan Long-Term Care 2.0. Biaya mempekerjakan satu perawat asing sekitar NT$30.000 per bulan, dengan perawatan 24 jam; sebagai perbandingan, subsidi maksimum bulanan untuk penyandang disabilitas berat di LTC 2.0 hanya NT$32.340, dengan jam layanan yang terbatas.
+
+Yang lebih penting, kedua sistem ini nyaris tidak pernah bersinggungan. Menurut regulasi yang berlaku, keluarga yang mempekerjakan perawat asing pada dasarnya tidak dapat mengajukan layanan LTC 2.0 (kecuali untuk alat bantu dan modifikasi rumah tanpa hambatan). Klausul pengecualian ini menjadikan 210.000 keluarga sebagai pulau terisolasi dalam sistem.
+
+> **⚠️ Sudut Pandang yang Diperdebatkan**
+> Mulai 2026, Long-Term Care 3.0 akan memasukkan keluarga pengguna perawat asing ke dalam layanan perawatan komunitas, tetapi Kementerian Kesehatan dan Kesejahteraan khawatir hal ini bisa memicu lonjakan kebutuhan pekerja migran hingga 160.000 orang, sehingga menciptakan ketidakseimbangan penawaran-permintaan.
+
+## 24 Jam vs 8 Jam: Pertarungan Dua Filosofi Perawatan
+
+Mengapa keluarga Taiwan lebih memilih membayar NT$30.000 untuk mempekerjakan perawat asing daripada menggunakan LTC 2.0?
+
+Lien Chin-ying dari Hualien sedang merawat ibunya yang berusia 98 tahun dan menderita demensia, sekaligus merawat suaminya yang berusia 76 tahun. Ia berkata: "Perawat rumah (dari LTC) hanya datang 2 jam sehari, saya harus buru-buru pulang untuk memasak untuk suami saya saat itu, dan harus kembali sebelum jam 1 siang. Malam hari, hampir tidak mungkin menemukan orang."
+
+Inilah perbedaan mendasar kedua sistem: LTC 2.0 menyediakan "perawatan profesional bertahap", sementara perawat asing menyediakan "pendampingan sepanjang hari." Yang pertama sesuai dengan standar internasional perawatan profesional, yang kedua sesuai dengan kebutuhan nyata keluarga Asia Timur.
+
+> **📝 Catatan Kurator**
+> Pilihan model perawatan Taiwan sebenarnya adalah pergulatan antara dua nilai: model Skandinavia yang "profesional dan berbasis komunitas" versus model Asia Timur yang "berbasis keluarga dan menyeluruh."
+
+Akademisi dari National University of Singapore, Lynn Yu Ling Ng, membandingkan model perawatan Taiwan dan Singapura dan menemukan: perawat asing di Taiwan lebih berperan sebagai "pendukung pengasuh keluarga" daripada "pengganti pengasuh keluarga." Ini berasal dari ambang batas pengajuan yang ketat di Taiwan — harus lulus penilaian medis untuk bisa mempekerjakan perawat, sehingga majikan di Taiwan terpaksa mempelajari keterampilan perawatan dasar, dan tetap terlibat dalam pekerjaan perawatan meski sudah mempekerjakan perawat asing.
+
+Sebagai perbandingan, layanan perawatan profesional LTC 2.0 seringkali tidak hadir justru pada saat paling dibutuhkan. Wei Li-hu, salah satu dari sedikit perawat rumah yang khusus bekerja shift malam, berkata: "Kebanyakan orang tetap enggan bekerja malam, meski ada tunjangan NT$385."
+
+## Martabat di Lini Produksi: Ketika Perawatan Berubah Menjadi Kejar Target
+
+Dampak dari kekurangan tenaga kerja bukan hanya kesulitan penjadwalan, tetapi juga kompromi dalam kualitas perawatan.
+
+Chang Kai-chieh (nama samaran), pekerja sosial di panti perawatan, mengamati: bahkan layanan dasar seperti memandikan pun sudah berubah menjadi kerja lini produksi. "Mandi jam 8 pagi, saat musim dingin suhunya baru belasan derajat, harus bangun dari selimut hangat untuk mandi. Penghuni berbaris di depan pintu kamar mandi, dan 3 perawat membagi tugas: satu melepas baju, satu memapah tubuh, satu menyiram air."
+
+Li Shao-fen, asisten profesor di Institut Kesejahteraan dan Kesehatan Universitas Yang Ming Chiao Tung, menyebut fenomena ini sebagai "perawatan kejar target" — para pekerja perawatan hanya bisa mematikan rasa hari demi hari, mencari cara menyelesaikan tugas kerja, sementara ruang gerak perawatan menjadi terbatas dan risikonya ditanggung oleh penghuni.
+
+> **💡 Tahukah Anda**
+> Sebagian besar penghuni panti perawatan hanya mandi dua kali seminggu di musim dingin, karena kekurangan tenaga kerja membuat layanan tidak bisa diberikan pada waktu yang seharusnya.
+
+Xiaoshi (nama samaran), mantan perawat di panti perawatan, berkata: "Saat sesi mandi, kami harus memandikan sekitar 10 tempat tidur setiap hari, satu putaran setiap dua-tiga jam, terus-menerus membersihkan, menyuapi, memandikan, sangat seperti lini produksi, sangat terburu-buru. Setelah selesai, saya mandi keringat."
+
+Model perawatan "efisiensi di atas segalanya" ini adalah salah satu alasan mengapa keluarga Taiwan memilih perawat asing: setidaknya di rumah, martabat dasar masih bisa terjaga.
+
+## Perspektif Internasional: Keunikan Model Taiwan
+
+Sistem perawatan dua jalur Taiwan cukup unik di kancah internasional.
+
+Jerman membangun asuransi perawatan jangka panjang pada 1994, menggunakan model "pilih uang tunai atau layanan" — bisa memilih menerima uang tunai untuk mengatur perawatan sendiri, atau menerima layanan profesional. Asuransi perawatan Jepang berfokus pada pusat layanan terintegrasi berbasis komunitas, menekankan penyatuan medis, perawatan, dan perumahan. Belanda sudah membangun asuransi perawatan jangka panjang sejak 1968, dan kini menyediakan layanan terstandarisasi melalui sistem "paket perawatan."
+
+Namun tidak ada satu negara pun yang seperti Taiwan: menjalankan dua sistem perawatan dengan skala setara namun saling tidak kompatibel secara bersamaan.
+
+> **📝 Catatan Kurator**
+> Kontradiksi sistem perawatan jangka panjang Taiwan mencerminkan pergulatan masyarakat Asia Timur dalam proses modernisasi: apakah kita menginginkan model Skandinavia yang profesional, atau model keluarga yang manusiawi? Jawabannya adalah keduanya — tetapi kita tidak melakukan keduanya dengan baik.
+
+Akademisi Singapura, Liang Li-fang, menunjukkan: "Perawat asing di Taiwan tidak pernah dimaksudkan untuk menggantikan peran keluarga, melainkan untuk melengkapi kekurangan keluarga dalam hal perawatan. Ini sesuai dengan harapan budaya Konfusianisme terhadap tanggung jawab keluarga."
+
+Namun harga dari model ini adalah pemisahan sistem. 210.000 keluarga yang mempekerjakan perawat asing tidak bisa menikmati sumber daya komunitas, layanan istirahat (respite care), atau dukungan alat bantu dari LTC 2.0. Mereka hidup di luar jangkauan sistem, dibiarkan mengatasi sendiri.
+
+## Penyelamatan Tiga Anak Panah: Bagaimana Pemerintah Merespons Kekurangan Tenaga Kerja Akut
+
+Menghadapi krisis tenaga kerja perawatan jangka panjang, Kementerian Kesehatan dan Kesejahteraan meluncurkan tiga anak panah kebijakan:
+
+**Anak Panah Pertama: Program Percobaan Layanan Pendampingan Perawatan Beragam**
+Memungkinkan masyarakat membeli layanan perawatan sementara dan jangka pendek dengan biaya sendiri. Setelah 3 bulan diluncurkan pada 2025, 15 kabupaten/kota telah melayani total 485 kasus, menunjukkan adanya kebutuhan nyata.
+
+**Anak Panah Kedua: Program Kerjasama Industri-Akademik untuk Merekrut dan Mempertahankan Talenta Internasional**
+Merekrut mahasiswa dari Vietnam dan Indonesia untuk belajar di program diploma perawatan jangka panjang, dengan kontrak kerja 3 tahun setelah lulus. Angkatan pertama sebanyak 22 orang sudah sepenuhnya dipesan oleh industri, dan angkatan kedua akan diperluas menjadi 40 orang.
+
+**Anak Panah Ketiga: Membuka Jalur bagi Tenaga Teknis Asing Tingkat Menengah**
+Perawat asing yang telah bekerja lebih dari 6 tahun dengan gaji bulanan mencapai NT$29.000 dapat beralih menjadi "tenaga teknis tingkat menengah", tanpa batasan masa kerja. Hingga Februari 2024, sudah ada 15.000 orang yang memperoleh kualifikasi ini.
+
+> **⚠️ Sudut Pandang yang Diperdebatkan**
+> Tiga anak panah ini terlihat banyak, tetapi 22 mahasiswa Vietnam dibandingkan dengan kebutuhan tenaga kerja ratusan ribu orang dikritik sebagai "setetes air di lautan." Solusi sesungguhnya mungkin adalah meningkatkan status sosial dan tingkat upah pekerjaan perawatan.
+
+## Taruhan Long-Term Care 3.0: Integrasi atau Perpecahan Lebih Dalam?
+
+Mulai 2026, Long-Term Care 3.0 akan diluncurkan secara bertahap, dengan perubahan terbesar adalah memasukkan keluarga pengguna perawat asing ke dalam layanan komunitas. Apakah kebijakan ini akan menyelesaikan kontradiksi sistem dua jalur, atau justru membuat masalah semakin kompleks?
+
+Wakil Menteri Kesehatan dan Kesejahteraan, Lu Chien-te, berkata: "Pekerja asing adalah tenaga kerja pelengkap, dikerahkan saat pekerja lokal tidak mau melakukannya." Namun kenyataannya, 214.000 perawat asing bukan lagi sekadar "pelengkap", melainkan sudah menjadi tulang punggung sistem perawatan jangka panjang Taiwan.
+
+Jika LTC 3.0 berhasil mengintegrasikan kedua sistem, Taiwan berpotensi menciptakan "model perawatan hibrida" yang unik di dunia — menggabungkan standar kualitas layanan profesional dengan kehangatan manusiawi perawatan keluarga.
+
+Jika gagal, Taiwan mungkin akan menghadapi perpecahan sistem yang lebih parah: keluarga yang mampu membayar perawat asing menikmati layanan ganda, sementara keluarga yang tidak mampu hanya bisa mengantre menunggu sumber daya pemerintah — kesenjangan kelas semakin melebar justru pada saat kebutuhan perawatan paling mendesak.
+
+> **📝 Catatan Kurator**
+> Masa depan sistem perawatan jangka panjang Taiwan sebenarnya sedang menjawab pertanyaan yang lebih mendalam: masyarakat seperti apa yang ingin kita bangun? Masyarakat profesional yang mengutamakan efisiensi, atau masyarakat penuh kehangatan yang mengutamakan hubungan antarmanusia?
+
+## Catatan Penutup: Dua Cara Mencintai
+
+Tong Fu-chien, kakek berusia 86 tahun dari Tainan, menderita penyakit ginjal dan demensia. Perawat asal Indonesianya, Astuti, setiap hari menghaluskan tahu dan menyiapkan mi untuknya, karena "Kakek tidak bisa mengunyah, tapi suka makan mi." Astuti bilang sang kakek itu "yi ji bang" (nomor satu), dan putra sang kakek berkata Astuti seperti "anak perempuan lainnya."
+
+Di sisi lain, Lien Chin-ying, 69 tahun, dari Hualien, merawat ibunya yang berusia 98 tahun dan menderita demensia, menggunakan bantuan perawat LTC 2.0 untuk menyiapkan makanan, tetapi malam hari ia tetap harus menggelar tikar tidur di kamar ibunya sendiri. Ia berkata: "Ini ibu saya! Saya tidak bisa tidak mengurusnya."
+
+Kedua kisah ini mewakili dua cara masyarakat Taiwan memahami "perawatan": satu adalah pembagian kerja profesional, layanan dengan kualitas terkontrol yang dibeli; satu lagi adalah pendampingan menyeluruh, perpanjangan keluarga yang berdasar pada simbiosis emosional.
+
+Perkembangan sistem perawatan jangka panjang Taiwan adalah proses mencari keseimbangan di antara kedua cara mencintai ini. Kita masih belajar bagaimana menjaga kehangatan manusiawi sekaligus memastikan kualitas profesional; bagaimana mengejar efisiensi tanpa melupakan bahwa esensi perawatan adalah hubungan antarmanusia.
+
+Proses pembelajaran ini masih akan berlangsung lama. Namun setidaknya, kita sudah memulainya.
+
+## Referensi
+
+- [The Reporter: Di Era Kekurangan Tenaga Kerja Akut, Siapa yang Menopang LTC 3.0?](https://www.twreporter.org/a/long-term-care-plan-3-labor-shortage)
+- [The Straits Times: Taiwan is hiring more foreigners to care for its elderly](https://www.straitstimes.com/multimedia/graphics/2025/05/elders-taiwan-insight/index.html)
+- [iLong-TermCare: Belajar dari Sistem Perawatan Jangka Panjang Tujuh Negara Termasuk Belanda, Jerman, dan Austria](https://www.ilong-termcare.com/articles/2pK)
+- [Zona Perawatan Jangka Panjang Kementerian Kesehatan dan Kesejahteraan](https://1966.gov.tw/)
+- [Laporan Proyeksi Populasi Dewan Pembangunan Nasional](https://pop-proj.ndc.gov.tw/)
+- [Portal Layanan Ketenagakerjaan Asing Kementerian Tenaga Kerja](https://www.wda.gov.tw/)
+- [Taiwan News: Taiwan on track to be super-aged society](https://www.taiwannews.com.tw/news/5954295)
+- [The Straits Times: Taiwan further eases curbs on foreign caregivers](https://www.straitstimes.com/asia/se-asia/faster-ageing-taiwan-further-eases-curbs-on-foreign-caregivers)


### PR DESCRIPTION
﻿Adds Indonesian translation of `Society/台灣長期照顧制度發展.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.42 (repo ratio-bands.json id: healthy 2.0-4.3, calibrated 2026-07-18, n=3)

**Structure alignment**: headings (10/10) / footnotes (0/0, none in source) / links (8/8) — 100% preserved, including the comparison table and all callout blocks (curator notes, disputed-viewpoint boxes, data-source box, "did you know" box)

**Note**: i18n/id/STYLE.md not yet exists — followed TRANSLATE_PROMPT.md + established translation conventions from the existing id corpus.

Uncertain terminology flagged for reviewer:

- 長照 2.0 / 長照 3.0 → kept as "Long-Term Care 2.0" / "3.0" (English policy-brand name, matches how it's referenced in existing en/id corpus) rather than translating literally.
- 中階技術人力 → translated as "tenaga teknis tingkat menengah"; this is an official immigration-policy term without a fully standardized Indonesian equivalent yet, so flagging for a native speaker to confirm the phrasing matches how it's used in Indonesian-language labor-migration reporting.
- Named individuals (涂心寧, 陳婉瑜, 施勝茂, 李韶芬, 張凱傑, 魏力虎, 呂建德, 蓮金瑛) → romanized via standard Hanyu Pinyin (matching the transliteration convention already used in the existing id/hi corpus for this article family), since no official English/Indonesian spelling could be confirmed for these individuals.

Please review. Happy to iterate.
