### PR TITLE
translate(de): 台灣麵包與烘焙 → taiwan-bread-and-baking

### DIFF
--- a/knowledge/de/Food/taiwan-bread-and-baking.md
+++ b/knowledge/de/Food/taiwan-bread-and-baking.md
@@ -1,0 +1,105 @@
+---
+title: 'Taiwanisches Brot und Backhandwerk'
+description: 'Von Wu Pao-Chuns Weltmeistertitel bis zur internationalen Expansion von 85°C: eine Erkundung des einzigartigen Reizes taiwanischen Brots'
+date: 2026-03-19
+category: 'Food'
+tags: ['Brot', 'Backhandwerk', 'Wu Pao-Chun', 'taiwanisches Brot', '85°C']
+subcategory: 'Backwaren und Süßspeisen'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-03-19
+lastHumanReview: false
+image: '/article-images/food/taiwanese-pineapple-cake.webp'
+imageAlt: 'Taiwanischer Ananaskuchen'
+imageCredit: 'Kwb / Wikimedia Commons'
+imageLicense: 'Public domain'
+imageSource: 'https://commons.wikimedia.org/wiki/File:TaiwanesePineappleCake.jpg'
+translatedFrom: 'Food/台灣麵包與烘焙.md'
+---
+
+# Taiwanisches Brot und Backhandwerk
+
+Die Backkultur Taiwans zeigt ein einzigartiges Gesicht der Verschmelzung von Ost und West. Von den während der japanischen Kolonialzeit eingeführten Grundtechniken über den amerikanischen Einfluss der Nachkriegszeit bis hin zur europäischen Welle der letzten Jahre hat die taiwanische Backbranche ihren ganz eigenen Weg gefunden. Im Jahr 2010 gewann [[吳寶春]] in Paris die Einzelwertung des Mondial du Pain (Weltmeisterschaft im Brotbacken) und verschaffte dem taiwanischen Backhandwerk damit erstmals internationales Ansehen.[^1]
+
+## Das Phänomen Wu Pao-Chun und der Weg zum Weltmeistertitel
+
+Im März 2010 sorgte [[吳寶春]] aus dem südtaiwanischen Pingtung beim Mondial du Pain (der von Lesaffre veranstalteten Weltmeisterschaft im Brotbacken) auf der Europain-Messe in Paris für weltweites Aufsehen: Mit seinem Siegerbrot „Litschi-Rosen-Wein-Sauerteig" (hergestellt aus Litschi, Rose und einem mit Rotwein-Enzymen der Puli-Brennerei angesetzten alten Sauerteig) gewann er die Einzelwertung.[^1] Es war ein Meilenstein in der Geschichte des taiwanischen Backhandwerks. Wichtig ist dabei die Unterscheidung: Der Mondial du Pain ist nicht mit der größeren, als Mannschaftswettbewerb ausgetragenen Coupe du Monde de la Boulangerie zu verwechseln.
+
+Hinter Wu Pao-Chuns Erfolg steckt eine bewegende Geschichte. Aus ärmlichen Verhältnissen stammend, begann er nach dem Abschluss der Mittelschule eine Lehre in einer Bäckerei – ganz unten, mit den einfachsten Reinigungsarbeiten. In einer Zeit, in der es noch keine eigenen Ausbildungsgänge für das Bäckerhandwerk gab, war die mündliche Weitergabe des Wissens durch den Meister der einzige Weg zum Lernen. Getragen von seiner Leidenschaft fürs Brot und unermüdlichem Fleiß, verfeinerte er Schritt für Schritt sein Handwerk.
+
+Die Kreativität hinter dem „Litschi-Rosen-Wein-Sauerteig" speist sich aus einheimischen taiwanischen Zutaten: die tropische Süße der Litschi, der Blumenduft der Rose, kombiniert mit einem aus Rotwein der Puli-Brennerei fermentierten alten Sauerteig – all das erzeugte eine bis dahin unbekannte Geschmackstiefe. Dieser Ansatz, taiwanische Zutaten in die westliche Backkunst einzubringen, wurde später zu einem der Markenzeichen des taiwanischen Brots.
+
+Wu Pao-Chuns Sieg war nicht das Ende der taiwanischen Erfolgsgeschichte bei diesem Wettbewerb: Wu Tzu-Ching gewann 2015, Chen Yao-Hsun 2017 und Wang Peng-Chieh 2022 ebenfalls die Einzelwertung des Mondial du Pain – womit Taiwan zu einem der Länder mit den meisten Titeln in der Geschichte dieses Wettbewerbs wurde.[^2]
+
+## Die einzigartige Ästhetik des taiwanischen Brots
+
+Die taiwanische Backkultur vereint zahlreiche Elemente zu einer eigenen „taiwanischen Ästhetik". Deren größtes Merkmal ist die Grenzenlosigkeit: Praktisch jede Zutat kann zur Brotfüllung werden, jeder Geschmack ist einen Versuch wert.
+
+Das Frühlingszwiebelbrot ist die typischste taiwanische Innovation. Für europäische Augen wirken Frühlingszwiebeln und Brot wie eine völlig unpassende Kombination – doch die Taiwaner haben daraus einen Klassiker gemacht. Der Teig ist locker und weich, die Oberfläche mit reichlich gehackten Frühlingszwiebeln und Mayonnaise bestreut; das Zusammenspiel von salzig und süß überrascht immer wieder. Dieser mutige Innovationsgeist ist der eigentliche Kern des taiwanischen Brots.
+
+Das Fleischflocken-Brot ist ein weiteres Aushängeschild. Fleischflocken, eine traditionelle taiwanische Beilage, verbindet sich mit westlichem Brot zu einem ganz eigenen Geschmackserlebnis: Die äußere Schicht aus Fleischflocken liefert Umami und Biss, während das Brot im Inneren weich und süß bleibt – ein reizvoller Kontrast.
+
+Das Ananasbrot (Bo-Lo-Bao) stammt ursprünglich aus Hongkong und hat sich nach seiner Ankunft in Taiwan zu einer eigenen Variante weiterentwickelt. Trotz seines Namens enthält es keine Ananas – der Name rührt vielmehr von der an eine Ananasschale erinnernden Musterung der Kruste. Die taiwanische Version ist in der Regel süßer und die Kruste dicker als das Hongkonger Original, was der taiwanischen Vorliebe für Süßes entgegenkommt.
+
+## Europäisches Brot vs. taiwanisches Brot: ein Dialog zweier Philosophien
+
+In den letzten Jahren hat europäisches Brot in Taiwan einen regelrechten Trend ausgelöst; viele Bäckermeister reisten eigens nach Frankreich, um die authentische Technik zu erlernen. Diese europäische Welle führt einen interessanten Dialog mit dem traditionellen taiwanischen Brot.
+
+Europäisches Brot strebt nach „Reinheit": natürlicher Sauerteig, lange Gärzeiten, hoher Anspruch an Mehlqualität und Wassertemperatur. Das Ergebnis ist meist außen knusprig, innen weich, mit fester Krume und einer natürlichen Säure. Ein solches Brot will in Ruhe gekostet und langsam gekaut werden, damit sich die Süße des Mehls entfalten kann.
+
+Taiwanisches Brot hingegen strebt nach „Fülle": verschiedenste Füllungen, verschiedenste Geschmacksrichtungen, verschiedenste Formen – das Ziel ist maximale Zufriedenheit der Kundschaft. Der Teig ist meist weicher, süßer und für den schnellen Verzehr gedacht. Dieser Unterschied spiegelt ein unterschiedliches kulturelles Verständnis von Essen wider.
+
+Interessanterweise schließen sich die beiden Stile in Taiwan nicht gegenseitig aus, sondern ergänzen sich. Viele Bäckereien verkaufen sowohl europäisches als auch taiwanisches Brot nebeneinander, um unterschiedlichen Kundenbedürfnissen gerecht zu werden. Manche innovativen Bäckermeister kombinieren sogar beide Techniken und schaffen damit die neue Kategorie des „taiwanisch-europäischen Brots" (Tai-Ou-Bao).
+
+## Die internationale Erfolgsgeschichte von 85°C
+
+Wenn Wu Pao-Chun für die technische Spitzenleistung des taiwanischen Backhandwerks steht, dann symbolisiert 85°C dessen kommerziellen Erfolg. Die 2003 gegründete Marke entwickelte sich von einem einheimischen taiwanischen Kaffeehaus zu einem internationalen Filialunternehmen: 2008 der Einstieg in den chinesischen Markt, 2016 die Expansion in die USA.[^3]
+
+Das Erfolgsgeheimnis von 85°C liegt in der Positionierung als „erschwinglicher Luxus". Das Unternehmen bietet Kuchen und Gebäck auf dem Niveau eines Fünf-Sterne-Hotels an – zum Preis eines gewöhnlichen Cafés. Diese Strategie trifft präzise die Psychologie der Konsumenten: Auch gewöhnliche Menschen können sich raffinierte Backwaren leisten.
+
+Die Internationalisierung verlief keineswegs reibungslos. Im chinesischen Markt musste sich 85°C intensiver lokaler Konkurrenz stellen; im US-Markt galt es, sich an andere Konsumgewohnheiten anzupassen. Doch durch ständige Anpassung von Produktangebot und Betriebsmodell konnte sich 85°C im Ausland allmählich etablieren.
+
+Der Auslandserfolg von 85°C ist zugleich ein Beweis für die internationale Wettbewerbsfähigkeit taiwanischen Backhandwerks. Auch wenn die Techniken ursprünglich aus Europa, Amerika und Japan stammen, hat Taiwan durch eigene Innovation und Verfeinerung einen unverwechselbaren Stil und eigene Stärken entwickelt. Diese Art von „Soft-Power"-Export ist überzeugender als jede offizielle Propaganda.
+
+## Backausbildung und Wissensweitergabe
+
+Die Entwicklung der taiwanischen Backbranche wäre ohne die Unterstützung durch das Bildungssystem nicht denkbar. Vom frühen Meister-Lehrling-System bis zu den heutigen Berufsschulen hat die Backausbildung einen tiefgreifenden Wandel durchlaufen.
+
+Die Backabteilungen der Berufsschulen haben der Branche eine große Zahl an Fachkräften ausgebildet. Die Studierenden lernen nicht nur die Grundtechniken, sondern erwerben auch Fachwissen in Lebensmittelwissenschaft, Ernährungslehre und Kostenkontrolle. Diese systematische Ausbildung hat das professionelle Niveau der gesamten Branche gehoben.
+
+Auch die zahlreichen Backwettbewerbe spielen eine wichtige Rolle. Von schulinternen Wettbewerben bis zu internationalen Meisterschaften sind diese Wettbewerbe sowohl Plattform für den fachlichen Austausch als auch Kaderschmiede für neue Talente. Viele bekannte Bäckermeister haben sich zuerst durch Wettbewerbe einen Namen gemacht.
+
+In den letzten Jahren hat sich die Backausbildung zudem zunehmend diversifiziert. Neben der klassischen technischen Ausbildung sind Kurse zu Unternehmensgründung, Lebensmittelsicherheit und internationalen Zertifizierungen hinzugekommen. Dieses ganzheitliche Ausbildungsmodell macht taiwanische Backfachkräfte auf dem internationalen Markt konkurrenzfähiger.
+
+## Herausforderungen bei der Lebensmittelsicherheit und Branchenwandel
+
+Lebensmittelsicherheit ist die größte Herausforderung, vor der die Backbranche steht. Vom Weichmacher-Skandal bis zum Streit um Aromastoffzusätze – jeder Lebensmittelskandal traf die Branche schwer. Die Verbraucher stellen immer höhere Ansprüche an die Lebensmittelsicherheit, und die Unternehmen müssen strengere Qualitätskontrollsysteme aufbauen.
+
+Viele Betriebe setzen inzwischen auf eine Strategie der „Transparenz" und legen Zutatenherkunft und Herstellungsprozess offen. Manche Bäckereien richten sogar offene Küchen ein, in denen die Kunden den Herstellungsprozess direkt beobachten können. Das erhöht zwar die Kosten, stärkt aber auch das Vertrauen der Verbraucher.
+
+Auch das wachsende Gesundheitsbewusstsein treibt den Branchenwandel voran. Brote mit weniger Zucker, weniger Fett und Vollkorn erfreuen sich zunehmender Beliebtheit. Auch wenn der Geschmack womöglich nicht an traditionelles Brot heranreicht, erfüllen sie die Bedürfnisse gesundheitsbewusster Konsumenten.
+
+Technologische Innovation ist ein weiterer wichtiger Trend. Automatisierte Anlagen steigern die Produktionseffizienz, Gefriertechnik verlängert die Haltbarkeit, neue Backverfahren eröffnen neue Möglichkeiten. Diese Innovationen verbessern nicht nur die Produktqualität, sondern senken auch die Personalkosten.
+
+Die Entwicklung der taiwanischen Brot- und Backbranche lässt sich klar nachzeichnen: von Wu Pao-Chuns erstem Titelgewinn 2010 über die drei weiteren Mondial-du-Pain-Einzeltitel in den Jahren 2015, 2017 und 2022 bis zur Expansion von 85°C nach Europa, Amerika und Asien. Die international aufgebaute Wettbewerbsfähigkeit der taiwanischen Backbranche ist durch handfeste Ergebnisse belegt – sie ist nicht nur eine technische, sondern eine vollständige Weiterentwicklung von der Produktion bis zur Marke.[^4]
+
+## Bildquelle
+
+- Hero-Bild: Taiwanischer Ananaskuchen, fotografiert von Kwb, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:TaiwanesePineappleCake.jpg), gemeinfrei.
+
+## Referenzen
+
+[^1]: [Offizielle Website von Wu Pao-Chun Bakery](https://www.wu-pao-chun.com/) — Vorstellung des Siegerbrots „Litschi-Rosen-Wein-Sauerteig" und Bericht über den Sieg beim Mondial du Pain 2010.
+
+[^2]: [Offizielle Website des Mondial du Pain](https://www.mondialdupain.com/) — Liste der bisherigen Einzelsieger, mit den taiwanischen Titelgewinnen 2010/2015/2017/2022.
+
+[^3]: [85°C Investor Relations](https://www.85cafe.com/) — Markengeschichte von 85°C und Informationen zur Filialexpansion im Ausland.
+
+[^4]: [Chinese Cereal & Food Research Institute](https://www.cgprdi.org.tw/) — Taiwanisches Forschungsinstitut für Backtechnik, mit Informationen zu Wettbewerbstraining und technischer Beratung.
+
+[^5]: [Nationaler Verband der Bäckerei-Berufsverbände der Republik China](https://www.twbakery.org.tw/) — Berufsverband der Backbranche mit Branchenstatistiken und Informationen zu internationalen Wettbewerben.
+
+## Weiterführende Links
+
+- [Wu Pao-Chun Bakery](https://www.wu-pao-chun.com/) — Wu Pao-Chuns Flagship-Store in Tainan, mit den preisgekrönten Broten im Sortiment
+- [Chinese Cereal & Food Research Institute](https://www.cgprdi.org.tw/) — Forschungsinstitut für Backtechnik


### PR DESCRIPTION
Adds German translation of `Food/台灣麵包與烘焙.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.58 (target median 2.60, p10-p90 2.20-4.00)

**Structure alignment**: headings / footnotes / links — 100% preserved

**Note**: i18n/de/STYLE.md not yet exists — followed TRANSLATE_PROMPT.md + established translation conventions from existing de corpus (e.g. `de/Art/national-taichung-theater.md`, `de/Food/bubble-tea.md`).

Uncertain terminology flagged for reviewer:

- 米釀荔香 → „Litschi-Rosen-Wein-Sauerteig" · descriptive translation of the product name, no official German brand name known
- 蔥花麵包 → „Frühlingszwiebelbrot" · no established German term exists for this Taiwanese bread
- 台式歐包 → „taiwanisch-europäisches Brot" (Tai-Ou-Bao) · neologism in the original Chinese, no fixed German equivalent

Please review. Happy to iterate.
