### PR TITLE
translate(id): 巴拉告 → palakaw

### DIFF
--- a/knowledge/id/Nature/palakaw.md
+++ b/knowledge/id/Nature/palakaw.md
@@ -1,0 +1,76 @@
+---
+title: 'Palakaw: Apartemen Ikan Tiga Lantai dan Perjanjian Ekologis di Lahan Basah Fataan'
+description: 'Di lahan basah Fataan, Hualien, masyarakat suku Amis memanfaatkan "sampah" dari alam untuk membangun tempat tinggal tiga lantai bagi ikan dan udang. Metode penangkapan ikan tradisional bernama "Palakaw" ini tidak mengandalkan perburuan, melainkan "memberi" untuk menerima kembali anugerah alam — mewujudkan kearifan ekologi yang diwariskan selama ribuan tahun.'
+date: 2026-05-08
+category: 'Nature'
+tags: ['Suku Amis', 'Fataan', 'Palakaw', 'kearifan ekologi', 'metode penangkapan ikan tradisional']
+subcategory: 'Kearifan Ekologi Masyarakat Adat'
+author: 'Taiwan.md Contributors'
+featured: false
+readingTime: 8
+lastVerified: 2026-05-08
+lastHumanReview: false
+translatedFrom: 'Nature/Palakaw.md'
+---
+
+> **Ringkasan 30 detik:** "Palakaw" adalah kearifan menangkap ikan berbasis ekologi yang diwariskan selama ribuan tahun oleh masyarakat suku Amis di Kampung Fataan, Hualien. Warga memanfaatkan batang bambu, ranting pohon, dan tumbuhan air untuk membangun sebuah "apartemen tiga lantai" di lahan basah bagi ikan dan udang, meniru habitat alami untuk menarik satwa agar tinggal di dalamnya. Metode "menangkap tanpa menangkap" ini adalah perintis teknologi terumbu karang buatan di Taiwan, sekaligus dianggap oleh dunia akademis modern sebagai contoh global Pengetahuan Ekologi Tradisional (Traditional Ecological Knowledge, TEK) — sebuah perjanjian keberlanjutan antara manusia dan alam.
+
+"Ini rumah bagi ikan, bukan sampah yang dibuang begitu saja." Di lahan basah Fataan, Kecamatan Guangfu, Hualien, para tetua sering menunjuk tumpukan kayu dan batang bambu yang tampak berserakan di tepi sungai sambil menjelaskan makna mendalam "Palakaw" kepada generasi muda. Dalam bahasa suku Amis, "Lakaw" awalnya berarti sampah atau barang buangan dalam kehidupan sehari-hari, tetapi ketika ditambahkan awalan kata kerja "Pa", kata ini berubah makna menjadi sebuah tindakan perlindungan yang aktif — "membuatkan rumah bagi ikan dan udang".[^1]
+
+Lahan basah Fataan memiliki lingkungan mata air alami yang istimewa; aliran Sungai Fudeng yang tak pernah berhenti sepanjang tahun menyuburkan beragam ikan dan udang air tawar. Menurut legenda, dewa sungai Fataan bernama "Idek" pernah mengajarkan warga cara menangkap ikan dan bercocok tanam — meski dalam cerita rakyat ia digambarkan sakti namun berwatak nakal, lingkungan lahan basah yang ditinggalkannya menjadi fondasi kehidupan bagi warga setempat.[^2] Berbeda dari gaya masyarakat maritim yang aktif berburu, suku Amis yang telah lama tinggal di sini mengembangkan sebuah "rekayasa ekologis" yang jauh lebih halus dan penuh semangat siklus.
+
+📝 Catatan Kurator: Daya tarik terbesar Palakaw terletak pada pergeseran maknanya — mengubah "sampah" menjadi "rumah". Transformasi ini bukan sekadar daur ulang materi, melainkan juga pergeseran cara pandang, dari "pemburu" menjadi "pembangun".
+
+## Apartemen Tiga Lantai untuk Ikan: Simulasi Habitat yang Presisi
+
+Inti dari struktur Palakaw adalah sebuah "apartemen" tiga lantai yang dirancang dengan cermat, di mana setiap lantai disesuaikan dengan kebiasaan spesies tertentu, mengubah bahan alami yang terbuang menjadi terumbu buatan yang penuh kehidupan.[^3] Teknik ini dianggap oleh para peneliti sebagai perintis teknologi terumbu buatan modern di Taiwan, yang bahkan telah ada jauh sebelum masa pemerintahan Belanda di Taiwan.[^4]
+
+| Lantai | Bahan Utama | Penghuni | Karakteristik Ekologis |
+| :--- | :--- | :--- | :--- |
+| **Lantai bawah** | Batang bambu besar atau kayu berongga | Belut, sidat, ikan lele | Ikan dasar yang menyukai ruang persembunyian yang gelap dan stabil. |
+| **Lantai tengah** | Ikatan ranting pohon jiu-xiong (Lagerstroemia) | Ikan dan udang kecil | Celah-celah rapat menjadi tempat berlindung dari predator sekaligus tempat tumbuhnya biofilm sebagai makanan. |
+| **Lantai atas** | Batang bambu kecil, tumbuhan air, daun pinang | Ikan mujair, ikan kuhua, ikan sungai | Menaungi dari sinar matahari dan menyediakan ruang yang sejuk dan tenang untuk mengapung. |
+
+Logika kerja sistem ini sangat cermat: batang bambu besar di lantai paling bawah menyediakan tempat berlindung bagi ikan tak bersisik; ranting pohon jiu-xiong di lantai tengah bagaikan ruang penitipan alami, membiarkan ikan dan udang kecil tumbuh dengan aman di celah-celah sempit; sementara daun pinang dan tumbuhan air yang menutupi lantai atas menghalangi sinar matahari yang menyengat sekaligus mengatur suhu air.[^5] Yang lebih menakjubkan lagi, kotoran ikan dari lantai atas jatuh berlapis-lapis ke bawah dan menjadi makanan bagi ikan dan udang kecil di lantai tengah, membentuk siklus rantai makanan mini.[^6]
+
+## Menangkap Tanpa Menangkap: Filosofi Pengendalian Diri dalam Mengambil dari Alam
+
+Setelah "apartemen" ini ditempatkan di kolam untuk sementara waktu, ikan dan udang akan dengan sendirinya berpindah dan menetap di dalamnya. Saat memanen, warga tidak perlu bersusah payah mengeringkan air kolam — cukup menyingkirkan ranting-ranting di lantai tengah, ikan dan udang pun akan terlihat. Pada saat itulah warga menggunakan bubu ikan tradisional (kanas) atau jaring (cadiway) untuk mengumpulkannya.[^7]
+
+📝 Catatan Kurator: Di era perikanan modern yang mengejar efisiensi, Palakaw mengingatkan kita akan kekuatan "kelambatan". Ia bukan tentang mengejar ikan, melainkan membuat ikan dengan sukarela datang dan menetap.
+
+Inti dari metode penangkapan ini terletak pada "pengendalian diri". Suku Amis meyakini prinsip menangkap secukupnya untuk dimakan, dan struktur Palakaw sendiri secara alami berfungsi sebagai penyaring — ikan dan udang kecil dapat dengan mudah meloloskan diri melalui celah-celah ranting, sehingga hanya individu yang sudah dewasa yang tertinggal.[^8] Metode penangkapan selektif semacam ini memastikan kelangsungan reproduksi populasi tidak terputus, sekaligus mewujudkan pemanfaatan yang benar-benar berkelanjutan.
+
+## Dari "Tanah Air Mata" Menuju Contoh Ekologi Global
+
+"Fataan" dalam bahasa suku Amis, selain merujuk pada "kacang gude" (Fataan), dalam sebagian legenda juga bermakna "tempat berkumpulnya air mata", yang melambangkan kesulitan dan keterikatan emosional warga terhadap tanah ini selama proses migrasi mereka.[^10] Kini, Palakaw di tanah ini telah bertransformasi dari metode penangkapan ikan tradisional menjadi senjata pelestarian ekologi modern.
+
+Dari sudut pandang ekologi modern, Palakaw dipandang sebagai mahakarya "Pengetahuan Ekologi Tradisional" (Traditional Ecological Knowledge, TEK).[^11] Pada tahun 2021, keterampilan Palakaw dari Kampung Fataan secara resmi memperoleh perlindungan sebagai "Hak Cipta Kearifan Tradisional Masyarakat Adat", yang menandakan bahwa kearifan ini telah menjadi aset budaya tingkat nasional.[^12] Bahkan lembaga pemerintah pun memerlukan izin khusus untuk menggunakan teknik tradisional ini ketika melakukan restorasi sungai.[^13]
+
+Di panggung internasional, Palakaw juga mendapat perhatian luas. Kongres Internasional Etnobiologi (International Society of Ethnobiology, ISE) tahun 2026 menjadikannya studi kasus utama teknologi perikanan lintas budaya, membahas bagaimana kearifan masyarakat adat dapat memberikan solusi bagi restorasi lahan basah di tengah perubahan iklim modern.[^14] Penelitian akademis menunjukkan bahwa model yang memadukan budaya lokal dengan pengetahuan lingkungan semacam ini adalah kunci pengembangan berkelanjutan industri budaya setempat.[^15]
+
+📝 Catatan Kurator: Ketika dunia sibuk membicarakan "Satoyama Initiative", warga Fataan sebenarnya telah mempraktikkannya selama ratusan tahun. Palakaw bukan hanya teknik menangkap ikan, tetapi juga sistem pengelolaan sumber daya air dan organisasi sosial yang utuh.
+
+Bagi warga Fataan, Palakaw adalah cara mereka berdialog dengan tanah. Ia mengingatkan kita bahwa sebelum manusia mengambil dari alam, kita harus terlebih dahulu belajar memberi.[^16] Selama rumah bagi ikan itu masih ada, daya hidup sungai tidak akan pernah kering. Kearifan hidup berdampingan dengan alam semacam ini terus disebarkan pengaruhnya yang mendalam ke seluruh dunia melalui pendidikan lingkungan dan wisata ekologi modern.[^17][^18]
+
+**Bacaan lanjutan**: kearifan ekologi dan pelestarian lingkungan masyarakat adat Taiwan (台灣原住民生態智慧與環境保育) ｜ [[離島與海洋文化]]
+
+## Referensi
+
+[^1]: [Bank Ingatan Budaya Nasional: Penjelasan Materi Palakaw](https://tcmb.culture.tw/zh-tw/detail?indexCode=Culture_Object&id=264809) — menjelaskan secara rinci pergeseran makna kata "Lakaw" dari sampah menjadi habitat ikan.
+[^2]: [Pulima: Mengalami Sebuah Sungai dengan Tubuh](https://www.pulima.com.tw/websites/Pulima/xxxx_21111514310733457.aspx) — mencatat legenda dewa sungai Fataan, Idek, dan konteks budaya terbentuknya lahan basah ini.
+[^3]: [Buletin Elektronik Badan Sumber Daya Air Edisi 0582: Palakaw Fataan Memulihkan Daya Hidup Sungai](https://www.wra.gov.tw/epaper/Article_Detail.aspx?s=8949&n=30173) — mencatat secara rinci struktur tiga lantai Palakaw, bahan yang digunakan, dan spesies ikan yang sesuai.
+[^4]: [Sistem Nilai Tambah Pengetahuan Tesis Nasional Taiwan: Penelitian Metode Penangkapan Ikan Palakaw Suku Amis Kampung Fataan](https://ndltd.ncl.edu.tw/handle/94101679425572461386) — menyebutkan bahwa Palakaw adalah perintis teknologi terumbu buatan Taiwan.
+[^5]: [Persembahan Kearifan Tradisional Masyarakat Adat: Ketika Akuaponik Bertemu Palakaw](https://library.yabit.org.tw/literature/introduction/161) — membahas penerapan kearifan alam Palakaw dalam bidang biologi dan ekologi.
+[^6]: [Stasiun Peningkatan Pertanian Wilayah Hualien: Palakaw, Rumah Susun Nasional untuk Ikan](https://www.hdares.gov.tw/upload/hdares/files/web_structure/6173/121_5.pdf) — menjelaskan siklus nutrisi dan struktur rantai makanan di dalam Palakaw.
+[^7]: [Situs Informasi Perlindungan Hak Cipta Kearifan Tradisional Masyarakat Adat: Keterampilan Menangkap Ikan Tradisional Palakaw Kampung Fataan](https://www.titic.cip.gov.tw/app/caseDetail?num=1050425000006) — data pendaftaran resmi yang menegaskan status hukum Palakaw sebagai kearifan yang dilindungi.
+[^8]: [IPCF: Keberlanjutan Ekologi! Metode Menangkap Ikan Ramah Lingkungan Palakaw yang Diwariskan Turun-temurun di Fataan](https://www.ipcf.org.tw/-/News/Detail?newsId=23041020441105872) — menekankan nilai keberlanjutan lingkungan Palakaw berdasarkan prinsip tidak mengeringkan kolam untuk menangkap ikan.
+[^10]: [Vocus: Tangisan dan Harapan Sungai Fataan](https://vocus.cc/article/68d8c50afd8978000179c2c3) — membahas makna budaya nama tempat Fataan sebagai "tempat berkumpulnya air mata" dalam bahasa suku Amis.
+[^11]: [NTU Scholars: Tinjauan Literatur Penelitian Etnobotani dan Pengetahuan Ekologi Tradisional Masyarakat Adat Taiwan](https://scholars.lib.ntu.edu.tw/bitstreams/0f675ea8-4144-45e8-a76c-6cc5b483dc58/download) — menempatkan Palakaw sebagai contoh penting Pengetahuan Ekologi Tradisional (TEK) masyarakat adat Taiwan.
+[^12]: [Kementerian Pertanian: Merasakan Pengalaman Menangkap Ikan Ekologis Palakaw di Taman Pertanian Xinlu](https://www.moa.gov.tw/ws.php?id=2506483) — memperkenalkan promosi Palakaw dalam pertanian rekreasi dan pendidikan lingkungan modern.
+[^13]: [Taipei Times: Bureau licensed to use Aboriginal technology](https://www.taipeitimes.com/News/taiwan/archives/2021/08/05/2003762071) — melaporkan bagaimana lembaga pemerintah memperoleh izin untuk menggunakan teknik tradisional ini.
+[^14]: [ISE 2026 Event Info: A Cross-Cultural Fishing Technology Workshop](https://kaigi.eventsair.com/QuickEventWebsitePortal/international-society-of-ethnobiology-congress-2026/ise2026eventinfo/Agenda/AgendaItemDetail?id=451c7199-4805-4984-9e6f-6c18f28faead) — Kongres Internasional Etnobiologi 2026 menjadikan Palakaw sebagai studi kasus percontohan global.
+[^15]: [MDPI Sustainability: Sustainable Development in Local Culture Industries](https://www.mdpi.com/2071-1050/14/6/3404) — membahas model kebangkitan budaya masyarakat adat dan pengembangan berkelanjutan dengan mengambil contoh Fataan.
+[^16]: [Taiwan Panorama: Organic, Eco-Friendly, and Sustainable Agriculture](https://www.taiwan-panorama.com/en/Articles/Details?Guid=42376353-5d3d-4c9b-b22a-91404bfc66c4) — memperkenalkan kontribusi kearifan masyarakat adat dalam pertanian organik dan berkelanjutan di Taiwan.
+[^17]: [Badan Taman Nasional Kementerian Dalam Negeri: Rencana Konservasi dan Pemanfaatan Lahan Basah Penting Nasional Fataan](https://www.nps.gov.tw/uploads/files/300ecc84dfc2c6a5d476ed7127321bf3.pdf) — rencana konservasi resmi yang menjadikan Palakaw sebagai inti pemanfaatan bijak lahan basah.
+[^18]: [Smile Taiwan: Merasakan Pengalaman Menangkap Ikan Tradisional Palakaw di Taman Pertanian Xinlu, Guangfu, Hualien](https://smiletaiwan.cw.com.tw/article/5152) — memperkenalkan praktik dan pewarisan budaya Palakaw dalam wisata ekologi modern.


### PR DESCRIPTION
Adds Indonesian translation of `Nature/Palakaw.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 2.66 (target median 2.78, p10-p90 2.29-3.34)

**Structure alignment**: headings / table / footnotes / links — 100% preserved (footnote numbering gap at [^9], absent in the source, preserved as-is)

**Note**: i18n/id/STYLE.md not yet exists — followed TRANSLATE_PROMPT.md + established translation conventions from the existing id corpus.

Wikilink handling:

- `[[台灣原住民生態智慧與環境保育]]` — no `id` version exists yet, converted to plain text with Chinese gloss per TRANSLATE_PROMPT.md wikilink rules
- `[[離島與海洋文化]]` — `id` version already exists (`knowledge/id/Geography/offshore-islands-and-maritime-culture.md`), wikilink preserved as-is

Uncertain terminology flagged for reviewer:

- "Lakaw" / "Pa" — Amis-language morphology breakdown kept as given in the source, not independently verified with a native speaker
- "kanas" (traditional fish trap) and "cadiway" (net) — Amis-language terms kept with an Indonesian gloss, no standard equivalent exists

Please review. Happy to iterate.
