### PR TITLE
Add German translation for People (Morris Chang)

### DIFF
--- a/knowledge/de/People/tsmc-morris-chang.md
+++ b/knowledge/de/People/tsmc-morris-chang.md
@@ -1,0 +1,456 @@
+---
+title: 'Morris Chang'
+description: 'Der Pate der Halbleiter und Gründer von TSMC: Der legendäre Unternehmer, der mit dem reinen Foundry-Modell die globale Technologiebranche veränderte.'
+date: 2026-03-17
+category: 'People'
+tags:
+  [
+    'People',
+    'Morris Chang',
+    'TSMC',
+    'Halbleiter',
+    'Unternehmer',
+    'Wafer-Foundry',
+    'Schutzberg der Nation',
+  ]
+subcategory: '科技與企業'
+author: 'Taiwan.md Contributors'
+featured: true
+lastVerified: 2026-09-01
+lastHumanReview: false
+translatedFrom: 'People/張忠謀.md'
+sourceCommitSha: '26d30c32f'
+sourceContentHash: 'sha256:6c3058ba108a44f9'
+sourceBodyHash: 'sha256:1043d3e7799eba77'
+translatedAt: '2026-09-08T18:35:55+08:00'
+---
+
+# Morris Chang
+
+Morris Chang, der legendäre Unternehmer, den man den „Paten der Halbleiter" nennt, war der Gründer der Taiwan Semiconductor Manufacturing Company (台積電, TSMC). Er schuf weltweit das erste reine Wafer-Foundry-Unternehmen und entwickelte ein Geschäftsmodell, das das Ökosystem der globalen Technologiebranche neu gestaltete. Vom chinesischen Spitzenmanager bei Texas Instruments in den USA bis zur Gründung von TSMC in Taiwan – seine Lebensbahn spiegelt die Entwicklung der globalen Halbleiterindustrie wider und begründete Taiwans Schlüsselposition in der globalen Technologie-Lieferkette.
+
+## 30-Sekunden-Überblick
+
+**Warum sollte die Welt Morris Chang kennen?**
+
+Die von Morris Chang gegründete TSMC ist das nach Marktkapitalisierung wertvollste Wafer-Foundry-Unternehmen der Welt und ein wichtiger Grundpfeiler der modernen digitalen Zivilisation. Von Smartphones und Computern bis zu KI-Chips: Die überwiegende Mehrheit der weltweit fortschrittlichen Halbleiter wird von TSMC gefertigt. Das von ihm entwickelte Modell des „reinen Foundry" erlaubte unzähligen Technologieunternehmen, sich auf das Chip-Design zu konzentrieren, statt riesige Summen in den Bau eigener Fabriken zu investieren – und veränderte damit das Ökosystem der globalen Technologiebranche grundlegend.
+
+TSMC wird Taiwans „Schutzberg der Nation" (護國神山) genannt und besitzt in der Geopolitik eine unersetzliche strategische Position. Morris Chang ist einer der wenigen Menschen des 20. Jahrhunderts, die eine Branchenstruktur wirklich verändert haben: Er definierte die kommerzielle Grenze der Halbleiterindustrie neu und verhalf Taiwan dazu, vom Foundry-Ausgangspunkt zum Kernknoten der globalen Technologie-Lieferkette zu werden.
+
+1931 in Ningbo, Zhejiang, geboren, 1987 in Taiwan die TSMC gegründet: Morris Changs Leben ist selbst ein Sinnbild für den technologischen Aufstieg Asiens im 20. Jahrhundert.
+
+## Frühes Leben und Ausbildung
+
+### Aufwachsen in turbulenten Zeiten
+
+**Geburt und familiärer Hintergrund:**
+Am 10. Juli 1931 wurde Morris Chang in Ningbo in der chinesischen Provinz Zhejiang geboren[^1]. Sein Vater Chang Wei-kuan war Bankier, seine Mutter Hsu Yun-cheng stammte aus einer Gelehrtenfamilie. In jenen turbulenten Jahren war der Vater, ein Kenner von Literatur und Geschichte, in einem Haus voller Bücher zu Hause – dieses Umfeld sorgte dafür, dass Chang auf seinem Ingenieursweg stets ein humanistisches Gespür behielt.
+
+**Kindheit voller Umzüge:**
+Weil die Kriege tobten, war Changs Kindheit von Umzügen geprägt. Von Ningbo über Shanghai, Nanjing, Chongqing und wieder Shanghai bis nach Guangzhou, Hongkong und schließlich in die USA – diese entwurzelten Jahre formten seine Anpassungsfähigkeit und seinen internationalen Horizont.
+
+**Schulzeit in Hongkong:**
+1945 zog der vierzehnjährige Chang mit seiner Familie nach Hongkong und besuchte dort im britischen Kolonialbildungssystem die Mittelschule. Hongkongs internationale Atmosphäre und englischsprachige Erziehung legten das Fundament für sein späteres Studium und seine Arbeit in den USA.
+
+### Die entscheidende Wende in der US-Ausbildung
+
+**Die kurze Harvard-Zeit:**
+1949 trat der achtzehnjährige Chang in die Harvard University ein[^2] und studierte zunächst Literatur. Doch nach einem Jahr wechselte er – wegen fehlender Leidenschaft für Literatur und aus wirtschaftlichen Erwägungen – an das Massachusetts Institute of Technology (MIT).
+
+**Die Ingenieursausbildung am MIT:**
+Am MIT wählte Chang Maschinenbau als Hauptfach. Diese Entscheidung wirkte zufällig, verschaffte ihm aber im Kern der Halbleiterfertigung (der hochpräzisen mechanischen Prozesstechnik) ein unmittelbares ingenieurtechnisches Gespür – eine wichtige Grundlage für seine spätere Steuerung der Prozessverbesserungen bei TSMC.
+
+**Bachelorabschluss 1952:**
+1952 erwarb Chang den Bachelor in Maschinenbau am MIT[^3]. Bei seinem Abschluss tobte gerade der Koreakrieg; wegen seines Status als ausländischer Student blieben ihm Jobs im militärisch gebundenen Umfeld der USA verwehrt – eine Einschränkung, die ihn paradoxerweise zur Zivilindustrie führte.
+
+## Der Berufseinstieg: bei Sylvania
+
+### Der erste Schritt in die Halbleiterbranche
+
+**Die Chance von 1955:**
+Nach dem Studium arbeitete Chang drei Jahre bei der Firma Sylvania[^4] – sein erster Kontakt mit der Halbleiterindustrie. Die Branche steckte damals noch in den Kinderschuhen, doch Chang spürte sofort das enorme Potenzial dieses jungen Sektors.
+
+**Aufbau technischer Fähigkeiten:**
+Bei Sylvania war Chang für die Fertigung von Halbleiterbauelementen zuständig und lernte die Grundlagen der Halbleiterfertigung. Diese Erfahrung machte ihm die Komplexität und Präzision der Halbleiterherstellung bewusst und schulte sein Gespür für technische Details.
+
+**Erste Anzeichen von Führungsqualität:**
+Selbst auf der untersten technischen Ebene zeigte Chang herausragende Managementfähigkeiten. Er verstand es, Teams zu organisieren und technische Probleme zu lösen – diese drei Jahre lehrten ihn die hohen Präzisionsanforderungen der Halbleiterfertigung.
+
+## Die Texas-Instruments-Ära: Führungsqualitäten unter Beweis
+
+### Das entscheidende Jahr 1958
+
+**Der Eintritt bei Texas Instruments:**
+1958 kam Chang zu Texas Instruments (TI)[^5] – der entscheidende Wendepunkt seiner Karriere. Damals baute TI sein Halbleitergeschäft massiv aus und brauchte genau Leute, die Ingenieurswissen und Management in einer Person vereinen konnten.
+
+**Vom Ingenieur zum Manager:**
+Bei TI begann Chang als Halbleiteringenieur und kümmerte sich um die Wafer-Produktion. Technisch exzellent und zugleich mit herausragenden Führungsqualitäten ausgestattet, zog er schnell die Aufmerksamkeit der Vorgesetzten auf sich.
+
+**Beitrag zur Prozessverbesserung:**
+Während seiner Zeit bei TI verbesserte Chang die Halbleiterfertigungsprozesse des Unternehmens erheblich und steigerte Ausbeute sowie Produktionseffizienz. Diese Verbesserungen sparten dem Konzern viel Geld und brachten ihm Ansehen ein.
+
+### Promotionsstudium an der Stanford University
+
+**Die Lernmöglichkeit von 1961:**
+1961 unterstützte TI Changs Promotion in Elektrotechnik an der Stanford University. Das war eine Anerkennung seiner Fähigkeiten und zugleich ein Zeichen dafür, wie viel Wert die amerikanischen Unternehmen auf die Förderung von Talenten legten.
+
+**Der Ertrag der Promotion:**
+1964 erwarb Chang den Doktortitel in Elektrotechnik an der Stanford University[^6]. Diese Weiterbildung machte ihn in theoretischer Tiefe und in seinen Branchenkontakten stärker und führte nach seiner Rückkehr zu TI zu einer schnellen Beförderung.
+
+**Die neue Rolle im Unternehmen:**
+Nach der Promotion kehrte Chang zu Texas Instruments zurück und übernahm höhere Managementpositionen. Nacheinander wurde er General Manager der Germanium-Transistor-, der Silizium-Transistor- und der Integrierte-Schaltkreis-Sparte; im Takt der Ergebnisse stieg sein Status bei TI Jahr für Jahr.
+
+### Die Überwindung der Rassengrenze
+
+**Die historische Beförderung von 1972:**
+1972 wurde Chang zum Group Vice President von Texas Instruments befördert[^7] – einer der höchstrangigen chinesischstämmigen Top-Manager in einem großen US-Unternehmen. Diese Beförderung war im damaligen amerikanischen Geschäftsumfeld eine äußerst seltene Leistung.
+
+**General Manager der Halbleitersparte:**
+Zugleich wurde Chang General Manager der Halbleitersparte von TI und verantwortete das Kerngeschäft des Konzerns. Unter seiner Führung wuchs das Halbleitergeschäft von TI rasant und machte das Unternehmen zu einem der größten Halbleiterlieferanten der Welt.
+
+**Bilanz der 25 US-Jahre:**
+In 25 Jahren bei Texas Instruments stieg Chang vom einfachen Ingenieur zum Top-Manager auf und verstand dabei das technische Tempo und die Geschäftslogik der Halbleiterbranche aus erster Hand. Diese Erfahrung machte ihn 1987 bei der Gründung in Taiwan in seinen Markteinschätzungen weit präziser als jeden rein akademisch geprägten Menschen.
+
+## Der Ruf Taiwans: die Präsidentschaft des ITRI
+
+### Der Wendepunkt von 1985
+
+**Die Einladung von Sun Yun-suan:**
+1985 folgte Chang der dringenden Einladung von Premierminister Sun Yun-suan[^8], des ITRI-Vorsitzenden Hsu Hsien-hsiu, von Premierminister Yu Kuo-hwa und von Staatsminister Li Kuo-ting und wurde Präsident des Industrial Technology Research Institute (ITRI). Sun Yun-suan hatte den Hochtechnologie-Aufschwung Taiwans seit Langem vorangetrieben und war der wichtigste Motor hinter der Rückberufung Changs. Diese Entscheidung veränderte seinen Lebensweg – und das Schicksal der taiwanesischen Technologiebranche.
+
+**Der Mut, die Komfortzone zu verlassen:**
+Morris Chang war damals 54 Jahre alt und hatte in den USA eine erfolgreiche Karriere und ein komfortables Leben. Die Rückkehr nach Taiwan war eine Entscheidung voller Risiken und Herausforderungen – sie zeigte seinen Auftragssinn für die technologische Entwicklung Taiwans.
+
+**Die Reform des ITRI:**
+Als ITRI-Präsident trieb Chang die enge Verbindung von Forschung und Industrie voran und straffte die Forschungsausrichtung des Instituts mit amerikanischem Managementdenken. Sein internationaler Horizont verwandelte das ITRI von einer staatlichen Forschungseinrichtung in einen kommerziell denkenden Technologie-Inkubator.
+
+### Einschätzung der taiwanesischen Halbleiterindustrie
+
+**Analyse des Industriestandorts:**
+Chang bewertete sorgfältig das industrielle Umfeld und die Stärken Taiwans. Er erkannte, dass Taiwan über ausgezeichnete Ingenieure, niedrige Kosten und flexible Fertigungsfähigkeiten verfügte – ideale Voraussetzungen für den Aufbau einer Halbleiterfertigung.
+
+**Die Idee des Foundry-Modells:**
+Schon während seiner ITRI-Zeit entwickelte Chang die Idee eines revolutionären Geschäftsmodells – des reinen Wafer-Foundry. Diese Vorstellung entsprang seinem tiefen Blick in die Branchentrends und war die Frucht jahrzehntelanger Industrieerfahrung.
+
+**Die Bedeutung der staatlichen Unterstützung:**
+Chang verstand, dass die Entwicklung der Halbleiterindustrie umfassende staatliche Unterstützung brauchte – Kapital, Politik und Talentförderung. In engem Austausch mit Regierungsvertretern sicherte er für die Gründung von TSMC eine besondere Konstruktion aus ITRI-Technologielizenz und staatlicher Kapitalbeteiligung.
+
+## Die Geburt von TSMC: die Innovation von 1987
+
+### Die Innovation des reinen Foundry-Modells
+
+**Der Durchbruch des Foundry-Gedankens:**
+1987 brachte Chang das Konzept des „reinen Wafer-Foundry" auf den Weg[^11]. Anders als die traditionellen integrierten Hersteller (IDM) sollte sich TSMC ganz auf die Auftragsfertigung von Chips für Kunden konzentrieren, ohne eigene Produkte zu entwerfen.
+
+**Die Revolutionarität des Geschäftsmodells:**
+Seine Revolution lag darin, dass dadurch auch Unternehmen ohne eigene Fabriken fortschrittliche Chips entwerfen konnten. Die Eintrittshürde in die Halbleiterbranche sank dramatisch – die Zahl der Chip-Designfirmen wuchs von den 1990ern bis in die 2020er exponentiell.
+
+**Die Wirkung auf das Industrie-Ökosystem:**
+Das reine Foundry-Modell schuf ein völlig neues Ökosystem: Designfirmen konnten sich auf Innovation konzentrieren, Foundries auf die Fertigung. Diese Arbeitsteilung erhöhte die Effizienz der gesamten Branche.
+
+### Der Gründungsprozess von TSMC
+
+**Der historische Moment des 21. Februar 1987:**
+Am 21. Februar 1987 wurde die Taiwan Semiconductor Manufacturing Company offiziell gegründet, mit einem Anfangskapital von 22 Milliarden Taiwan-Dollar[^9] – das Ergebnis der Zusammenarbeit von Staat, privaten Unternehmen und ausländischen Investoren.
+
+**Die Gestaltung der Aktionärsstruktur:**
+Zur Aktionärsstruktur von TSMC gehörten das ITRI, der niederländische Philips-Konzern und taiwanesische Privatfirmen[^10]. Diese vielfältige Struktur brachte TSMC Technologie, Kapital und Marktressourcen.
+
+**Changs Doppelrolle:**
+Chang war zugleich Vorstandsvorsitzender und General Manager von TSMC (später CEO) und verantwortete die Gesamtstrategie sowie das Tagesgeschäft. Sein Führungsstil verband die Effizienz des amerikanischen Managements mit der Weisheit der chinesischen Kultur.
+
+## Die Entwicklung von TSMC
+
+### Frühe Herausforderungen und Durchbrüche
+
+**1987–1990: die entbehrungsreiche Gründungszeit:**
+In der Anfangsphase stand TSMC vor großen Herausforderungen. Das reine Foundry war ein völlig neues Geschäftsmodell; der Markt war skeptisch, die Kunden mussten das Konzept erst akzeptieren. Chang musste gleichzeitig Fertigungskapazität aufbauen und Kunden überzeugen.
+
+**Aufbau technologischer Fähigkeiten:**
+Die frühe Technologie von TSMC stammte aus dem Transfer des ITRI und der Kooperation mit Philips. Chang führte sein Team zu schnellem Lernen und rascher Verbesserung der Prozesse und etablierte eine verlässliche Fertigungskompetenz.
+
+**Die ersten Kunden:**
+TSMCs erste Kunde waren vor allem US-amerikanische fabless Halbleiterunternehmen. Genau diese Firmen brauchten das professionelle Foundry-Angebot und gaben TSMC damit das frühe Geschäftsfundament.
+
+### Rasche Entwicklung in den 1990er Jahren
+
+**Die Strategie der Technologieführerschaft:**
+In den 1990ern verfolgte Chang die Strategie der „Technologieführerschaft": enorme Investitionen in Forschung und Entwicklung, damit TSMC in jeder Prozessgeneration keinen Rückstand gegenüber der Konkurrenz hatte. TSMC baute in Taiwan schrittweise mehrere Fabriken auf; seine Kundenbasis wuchs von den frühen US-Fabless-Firmen auf weltweit führende Designer wie Qualcomm, Broadcom und NVIDIA.
+
+### Führungsposition im 21. Jahrhundert
+
+**Der Kampf um die fortschrittlichsten Prozesse:**
+Im 21. Jahrhundert wurde die Entwicklung der Halbleiterprozesse immer schwieriger und teurer. TSMC sicherte sich mit jährlichen F&E-Ausgaben über dem Branchendurchschnitt die Führung bei den fortschrittlichsten Prozessen.
+
+**Der Durchbruch von 28 nm bis 5 nm:**
+Von 28 nm über 16 nm und 7 nm bis zu 5 nm und 3 nm behielt TSMC in jeder Generation der fortschrittlichen Prozesse die technische Führung und festigte seine Position im Premiumsegment.
+
+**Der Meilenstein der Apple-Partnerschaft:**
+Ab 2013, beginnend mit den A-Serien-Chips, fertigte TSMC die Kernprozessoren von iPhone und iPad. Diese enorme Auftragsmenge verschaffte TSMC zugleich die härteste kommerzielle Prüfung seiner fortschrittlichen Prozessfähigkeit.[^12]
+
+## Betriebsphilosophie und Managementphilosophie
+
+### Das Festhalten an technologischer Innovation
+
+**Hohe Investitionen in Forschung und Entwicklung:**
+Chang betonte stets die Bedeutung technologischer Innovation. TSMC investiert jährlich rund 8 Prozent des Umsatzes in F&E, um technisch nicht hinter die Konkurrenz zu fallen.[^13] In einer Ära, in der das Mooresche Gesetz an physische Grenzen stößt, führte Chang TSMC durch die aufeinanderfolgenden Durchbrüche bei 7 nm, 5 nm und 3 nm und lieferte so der gesamten Halbleiterbranche die Fertigungsbasis.
+
+**Die Balance zwischen Technologie und Markt:**
+Chang verstand es, zwischen technologischer Führung und Marktnachfrage zu balancieren: Technologievorsprung halten, ohne dabei den kommerziellen Wert zu gefährden und ohne durch zu großes Vorauseilen die Kosten ausufern zu lassen.
+
+### Talentförderung und Unternehmenskultur
+
+**Eine Unternehmenskultur der Integrität:**
+Chang formte bei TSMC eine Unternehmenskultur, deren Kern Integrität und Aufrichtigkeit sind. Er betonte die Kernwerte „Integrität, Engagement, Innovation und Kundenzutrauen" – sie wurden zum kulturellen Fundament von TSMC.
+
+**Die Bedeutung der Talentförderung:**
+Chang legte größten Wert auf die Ausbildung von Talenten und etablierte bei TSMC ein systematisches System zur Schulung und Beförderung von Ingenieuren. Er sah in den Menschen den Kern der Wettbewerbsfähigkeit – bei einer weit unter dem Branchendurchschnitt liegenden Fluktuationsrate bildete TSMC zugleich das Führungsteam heran, das später das Unternehmen übernehmen sollte: Liu Te-yin und C. C. Wei.
+
+**Ein internationaler Managementstil:**
+Chang brachte die Effizienz und Transparenz des amerikanischen Managements in TSMC ein und etablierte eine moderne Unternehmensführung. Zugleich verband er sie mit der Weisheit der chinesischen Kultur und schuf eine besondere Unternehmenskultur.
+
+### Strategisches Denken und Umsetzungskraft
+
+**Die Formulierung langfristiger Strategien:**
+Chang besaß herausragendes strategisches Denken: Er konnte Branchentrends erkennen und langfristige Entwicklungsstrategien formulieren. Die „Technologieführerschaft"-Strategie von TSMC ist der Ausdruck seines strategischen Blicks.
+
+**Die Bedeutung der Umsetzungskraft:**
+Neben der Strategie legte Chang großen Wert auf die Umsetzung. Er schuf ein präzises Managementsystem, das technische Fahrpläne von der Entscheidung bis zur Fabrik bringt – der entscheidende Grund dafür, dass TSMC das Tempo jeder Prozessgeneration mitging.
+
+**Weisheit in der Krisenbewältigung:**
+In zahllosen Krisen und Herausforderungen bewies Chang herausragende Führung und Krisenkompetenz; er führte TSMC durch viele schwierige Phasen und sicherte die stabile Entwicklung des Unternehmens.
+
+## Ruhestand und Nachfolge
+
+### Der erste Ruhestand im Jahr 2005
+
+**Der Start des Nachfolgeplans:**
+2005 kündigte der 74-jährige Chang seinen Ruhestand an und übergab das Amt des CEO an Rick Tsai[^14]. Das war Teil seines sorgfältig vorbereiteten Nachfolgeplans und Ausdruck seiner Verantwortung für die nachhaltige Entwicklung des Unternehmens.
+
+**Das Behalten des Vorsitzes:**
+Obwohl er das CEO-Amt abgab, behielt Chang den Vorsitz, blieb in die wichtigen strategischen Entscheidungen eingebunden und gab dem Nachfolgeteam Anleitung und Unterstützung.
+
+**Die Gestaltung des Ruhestandslebens:**
+Auch im Ruhestand zog er sich nicht vollständig aus dem Geschäftsleben zurück: Er vertrat Taiwan auf internationalen Foren wie der APEC und teilte in vielen Vorträgen seine Ansichten über Geopolitik und die Zukunft der Halbleiter.
+
+### Das Comeback im Jahr 2009
+
+**Die Herausforderung der Finanzkrise:**
+Die globale Finanzkrise von 2008 traf TSMC schwer: Das Unternehmen stand vor der doppelten Herausforderung sinkender Ergebnisse und wachsender Konkurrenz. In diesem kritischen Moment entschied sich Chang zur Rückkehr.
+
+**Die erneute Übernahme des CEO-Amts:**
+2009 wurde der 78-jährige Chang erneut CEO von TSMC[^15] und führte das Unternehmen persönlich durch die Krise. Sein Comeback stabilisierte das Vertrauen des Marktes und gab der Erholung Führungskraft.
+
+**Die Förderung von Liu Te-yin und C. C. Wei:**
+In seiner zweiten Amtszeit förderte Chang gezielt Nachfolger wie Liu Te-yin und C. C. Wei und schuf so die personelle Basis für die künftige Entwicklung des Unternehmens.
+
+### Der formelle Ruhestand im Jahr 2018
+
+**Der Abschluss des Nachfolgeplans:**
+Im Juni 2018 trat der 87-jährige Chang offiziell in den Ruhestand und beendete seine 31-jährige Legende bei TSMC[^16]. Er übergab den Vorsitz an Liu Te-yin und das CEO-Amt an C. C. Wei.
+
+**Die Einführung des Systems der Doppelspitze:**
+Chang etablierte die „Doppelspitze": Liu Te-yin, der als Vorsitzender für das Äußere zuständig war, und C. C. Wei als CEO für das Innere. Diese institutionelle Lösung förderte die stabile Entwicklung des Unternehmens.
+
+**Ein Vorbild des rechtzeitigen Abtretens:**
+Changs Ruhestand gilt als Vorbild für die Unternehmensnachfolge: Er trat zum richtigen Zeitpunkt zurück, ließ der neuen Führungsgeneration Raum zur Entfaltung und sicherte zugleich den stabilen Übergang.
+
+## Der Einfluss auf die globale Halbleiterindustrie
+
+### Die Innovation im Geschäftsmodell
+
+**Die Verbreitung des reinen Foundry-Modells:**
+Das von Chang geschaffene reine Foundry-Modell ist inzwischen eines der Standardgeschäftsmodelle der Halbleiterbranche. Weltweit sind hunderte fabless Unternehmen auf die Dienste der Foundries angewiesen – dieses Modell hat die Entwicklung der Branche enorm beschleunigt.
+
+**Die Neugestaltung des Industrie-Ökosystems:**
+Das reine Foundry-Modell hat das Ökosystem der Halbleiterbranche neu geformt: Es förderte die Arbeitsteilung, erhöhte die Effizienz und senkte die Hürde für Innovation, sodass mehr Unternehmen am Chip-Design teilnehmen konnten.
+
+**Der Aufbau der globalen Lieferkette:**
+TSMC wurde zum Schlüsselknoten der globalen Halbleiter-Lieferkette und liefert Fertigungsdienste an Technologieunternehmen auf der ganzen Welt – eine wirklich globalisierte Halbleiter-Lieferkette entstand.
+
+### Die Vorantreibung des technischen Fortschritts
+
+**Führung in der Prozesstechnik:**
+Unter Changs Führung behielt TSMC weltweit die Führung in der Prozesstechnik, trieb den technischen Fortschritt der gesamten Halbleiterbranche voran und verlängerte die Lebenskraft des Mooreschen Gesetzes.
+
+**Die Demokratisierung der fortschrittlichen Prozesse:**
+Die Foundry-Dienste von TSMC erlauben auch kleineren Designfirmen den Zugang zur neuesten Technologie – eine „Demokratisierung" der fortschrittlichen Prozesse: Schon ein Start-up mit ein paar Dutzend Leuten kann bei TSMC 7-nm-Chips in Serie fertigen lassen.
+
+**Die Erschließung neuer Technologiefelder:**
+Die Fertigungskompetenz von TSMC deckt digitale Chips, KI-Beschleuniger und Automobil-Halbleiter ab und bietet damit allen möglichen neuen Technologien eine Fertigungsbasis.
+
+## Die Bedeutung für Taiwan: Begründer einer Tech-Insel
+
+### Die Entwicklung der Technologiebranche
+
+**Die Entstehung des „Schutzbergs der Nation":**
+TSMC wird Taiwans „Schutzberg der Nation" genannt – nicht nur wegen seines enormen wirtschaftlichen Werts, sondern auch wegen seiner Schlüsselstellung in der globalen Technologie-Lieferkette. Morris Chang verschaffte Taiwan damit ein strategisches Pfand, das neben der Landesverteidigung am schwersten zu ersetzen ist.
+
+**Die Ausbildung von Technologietalenten:**
+Die Entwicklung von TSMC hat zahllose Halbleiterexperten ausgebildet. Diese Talente stützen nicht nur TSMC selbst, sondern bilden auch die personelle Grundlage der gesamten taiwanesischen Tech-Branche.
+
+**Die Entstehung eines Industrieclusters:**
+Rund um TSMC entstand in Taiwan ein Halbleitercluster aus Anlagenausrüstern, Materiallieferanten und Verpackungs- und Testfirmen – mit einem enormen industriellen Wert.
+
+### Der Beitrag zur wirtschaftlichen Entwicklung
+
+**Ein wichtiger Beitrag zum BIP:**
+TSMC ist inzwischen das größte Unternehmen Taiwans und steuert einen sehr wichtigen Teil zum BIP bei. Der Erfolg des Unternehmens zog auch verwandte Branchen mit und schuf zahlreiche Arbeitsplätze.
+
+**Eine tragende Säule des Außenhandels:**
+Halbleiter machen rund ein Drittel der gesamten taiwanesischen Exporte aus. Der Erfolg von TSMC hob die Position Taiwans im globalen Handel erheblich und stärkte die Wettbewerbsfähigkeit der taiwanesischen Wirtschaft.[^17]
+
+**Die Verbesserung des Investitionsumfelds:**
+Der Erfolg von TSMC zog mehr internationale Investitionen an, verbesserte das Investitionsumfeld Taiwans und hob den Status des Landes in den Augen globaler Investoren.
+
+### Die geopolitischen Auswirkungen
+
+**Die Bedeutung der Technologiesouveränität:**
+Im aktuellen geopolitischen Umfeld ist Halbleitertechnologie zum zentralen Pfand im Wettstreit der Großmächte geworden. Weil TSMC über die fortschrittlichsten Prozesse der Welt verfügt, hat Taiwan eine im internationalen Raum schwer ersetzbare strategische Position.
+
+**Ein Pfand in den internationalen Beziehungen:**
+Die Schlüsselstellung von TSMC in der globalen Technologie-Lieferkette verschafft Taiwan in Halbleiterfragen eine Stimme, die selbst die Großmächte nicht ignorieren können. Dass die USA, die EU und Japan nacheinander mit Subventionen um TSMC-Fabriken warben, zeigt das reale Gewicht dieser Position.
+
+**Überlegungen zur Sicherheitsstrategie:**
+Die Wertschätzung, die alle Länder der Halbleitertechnologie entgegenbringen, stellt Taiwan zugleich vor neue Sicherheitsherausforderungen und -chancen. Wie man die Interessen aller Seiten ausbalanciert und Taiwans Wettbewerbsvorteile erhält, gehört zu den Kernthemen der taiwanesischen Außen- und Sicherheitspolitik.
+
+## Persönliche Eigenschaften und Führungsstil
+
+### Die Verbindung von Weitblick und Umsetzungskraft
+
+**Ein herausragender strategischer Blick:**
+Changs größte Eigenschaft war sein herausragender strategischer Blick. Er konnte Branchentrends erkennen und zukünftige Entwicklungsrichtungen vorhersehen – dieser Weitblick war ein Schlüsselfaktor des TSMC-Erfolgs.
+
+**Pragmatische Umsetzungskraft:**
+Neben dem Weitblick besaß Chang auch eine herausragende Fähigkeit zur Umsetzung. Er konnte strategische Ideen in konkrete Aktionspläne verwandeln und jedes Detail der Umsetzung verfolgen – die Kombination aus strategischem Denken und Umsetzungskraft ist in der Wirtschaftswelt äußerst selten.
+
+**Lebenslanges Lernen:**
+Auch im hohen Alter las Chang weiter intensiv und verfolgte die Branchenentwicklung. Er gab offen zu, sich noch immer mit Literatur und Philosophie zu beschäftigen – diese Haltung hielt sein Denken bis ins hohe Alter scharf.
+
+### Besonderheiten des Führungsstils
+
+**Charismatische Führung:**
+Chang besaß eine starke persönliche Ausstrahlung und Überzeugungskraft und konnte Teams für gemeinsame Ziele begeistern. Seine Vorträge und Texte brachten komplexe Sachverhalte stets klar auf den Punkt und genossen tiefen Respekt bei Mitarbeitern und in der Branche.
+
+**Das Festhalten an rationaler Entscheidungsfindung:**
+Bei wichtigen Entscheidungen bestand Chang stets auf rationaler Analyse und urteilte auf der Grundlage von Fakten und Daten, statt Gefühle oder politische Erwägungen in die Entscheidung einfließen zu lassen.
+
+**Die Praxis des langfristigen Denkens:**
+Chang hielt konsequent am langfristigen Denken fest und ließ sich von kurzfristigen Schwierigkeiten oder Vorteilen nicht beeinflussen. Mitten in der tiefsten Finanzkrise von 2008 gab er die F&E-Budgets für die fortschrittlichen Prozesse frei – genau diese Langfristperspektive ließ TSMC nach der Krise den Abstand zur Konkurrenz eher noch vergrößern.
+
+## Ehrungen und Anerkennung
+
+### Internationale Auszeichnungen und Anerkennung
+
+**IEEE-Ehrenmedaillen:**
+Chang erhielt mehrere Ehrenmedaillen des IEEE (Institute of Electrical and Electronics Engineers) – eine wichtige Anerkennung seiner Beiträge zur Entwicklung der Halbleitertechnologie.
+
+**Ehrendoktorwürden verschiedener Länder:**
+Viele renommierte Universitäten, darunter Stanford, das MIT und die Tsinghua-Universität, verliehen Chang die Ehrendoktorwürde als Würdigung seiner Beiträge zur Technologiebranche und zur Bildung.
+
+**Auszeichnungen der Wirtschaftspresse:**
+Mehrfach führten internationale Wirtschaftsmedien wie das _Fortune Magazine_ und _BusinessWeek_ Chang unter den Spitzenführern der Technologiebranche – das festigte seinen Status in der globalen Wirtschaftswelt.
+
+### Die Würdigung in Taiwan
+
+**Staatliche Orden und Medaillen:**
+Die taiwanesische Regierung verlieh Chang für seine herausragenden Beiträge zur wirtschaftlichen und technologischen Entwicklung des Landes mehrere wichtige Orden.
+
+**Die Hochachtung der Industrie:**
+In der taiwanesischen Industrie wird Chang als „Pate der Halbleiter" verehrt; seine Erfahrung und Weisheit gelten jungen Unternehmern als Vorbild.
+
+**Die Anerkennung seiner gesellschaftlichen Wirkung:**
+Über den wirtschaftlichen Erfolg hinaus ist auch Changs gesellschaftlicher Einfluss breit anerkannt; seine Beiträge zur gesellschaftlichen Entwicklung Taiwans werden in allen Kreisen hoch geschätzt.
+
+## Philosophische Betrachtungen und Lebensweisheit
+
+### Das Verständnis von Erfolg
+
+**Die Verbindung von Substanz und Gelegenheit:**
+Chang glaubte, dass Erfolg die Verbindung von Substanz und Gelegenheit verlangt: Die Substanz ist die Grundlage, aber man muss auch den Moment nutzen. Er betonte die Bedeutung der Vorbereitung – Gelegenheiten warten auf die Vorbereiteten.
+
+**Der Wert langfristigen Durchhaltens:**
+Er betonte den Wert langer Ausdauer: Erfolg braucht Zeit und lässt sich nicht überstürzen. Der Erfolg von TSMC ist das Ergebnis langfristigen Durchhaltens.
+
+**Die Notwendigkeit von Innovation:**
+Chang war überzeugt, dass Innovation in der Technologiebranche eine Notwendigkeit ist. Die Geschichte von TSMC zeigt: Sobald man bei den Prozessdurchbrüchen stehen bleibt, füllt die Konkurrenz die Lücke.
+
+### Betrachtungen zum Leben
+
+**Die Balance zwischen Arbeit und Leben:**
+Trotz seines großen Erfolgs betonte Chang die Bedeutung der Balance zwischen Arbeit und Leben. Er liebte das Lesen und die Musik – diese Leidenschaften gaben ihm geistige Nahrung.
+
+**Die Übernahme gesellschaftlicher Verantwortung:**
+Chang war der Ansicht, dass erfolgreiche Unternehmer Verantwortung gegenüber der Gesellschaft tragen. Er veranlasste TSMC zu Spenden an akademische Einrichtungen wie die Tsinghua-Universität, beteiligte sich an bildungspolitischen Diskussionen und gab konkrete Vorschläge zur Reform der taiwanesischen Hochschulbildung.[^18]
+
+**Die Bedeutung der Weitergabe:**
+Er legte großen Wert auf die Weitergabe von Wissen und Erfahrung – nicht nur im eigenen Unternehmen mit der Förderung von Nachfolgern, sondern auch durch viele Wege, seine Erfahrung und Weisheit zu teilen.
+
+## Historische Bewertung
+
+Als Chang 2018 in den Ruhestand ging, übertraf die Marktkapitalisierung von TSMC die von Intel – TSMC wurde das wertvollste Halbleiterunternehmen der Welt.[^19] In 31 Jahren bewahrheitete er einen intuitiv widerstreitenden Satz: Eine Foundry, die keine eigenen Chips entwirft, kann zur Fertigungsbasis des gesamten digitalen Zeitalters werden.
+
+Von Ningbo über Harvard und das MIT, vom Spitzenmanager bei Texas Instruments bis hin zur Rückkehr in ein komfortloses Leben in Taiwan mit 54: Jede seiner Wendungen war keine Mainstream-Entscheidung, doch alle führten in dieselbe Richtung. Die heutige Position von TSMC ist das Ergebnis der Halbleiter-Konkurrenz – und zugleich das Ergebnis seiner Wette auf ein Geschäftsmodell aus dem Jahr 1987, an das damals nur wenige glaubten.
+
+2024 überschritt die Marktkapitalisierung von TSMC die Marke von zehn Billionen Taiwan-Dollar; das Unternehmen gehört damit zu den wertvollsten Tech-Unternehmen Asiens[^20] – eine Größenordnung, die sich Chang bei seiner Wette von 1987 kaum vorstellen konnte. Es ist die klarste Fußnote seines Lebens.
+
+## Weiterführende Links
+
+- Taiwanesische Unternehmen: TSMC – Der „Schutzberg der Nation", den er 1987 mit dem Foundry-Modell gründete und der heute über 60 Billionen Taiwan-Dollar wert ist, ist selbst die vollständigste Fußnote zu Morris Chang.
+- Stan Shih – der Acer-Gründer, den er über einundzwanzig Jahre als TSMC-Direktor berief und der Autor der „Smile Curve" ist; die „Mittelfertigung", die TSMC betreibt, ist genau jenes Segment, das diese Kurve einst schlechtredete, obwohl es sich in der Realität als das wertvollste erweist.
+- [Terry Gou](/de/people/terry-gou) – ein weiterer taiwanesischer Unternehmer, der mit „Auftragsfertigung" die Welt veränderte; Hon Hais Komponentenmontage und TSMCs Wafer-Foundry sind die zwei Wege, auf denen die taiwanesische Fertigung den Weg in die Welt fand.
+- [Halbleiterindustrie](/de/technology/taiwan-semiconductor-industry) – vom RCA-Technologietransfer 1976 bis zum „Schutzberg der Nation": das gesamte industrielle Schlachtfeld, in das Morris Chang Taiwan hineinführte.
+- Huang Chung-jen – der Mann, der Ende der 1990er zu Morris Chang kam, als Powerchip fast von UMC übernommen worden wäre; er ging einen anderen, mit Abgründen gesäumten Weg der taiwanesischen Halbleiter.
+- Taiwans industrielle Transformation und Modernisierung – TSMC ist das konkreteste Beispiel dafür, wie Taiwan sich von einer „Fertigungsinsel" in eine „Tech-Insel" verwandelte, und zugleich das Kernkoordinatensystem dieser vier Jahrzehnte währenden Transformation.
+
+---
+
+## Referenzen
+
+[^1]: Morris Chang wurde am 10. Juli 1931 in Ningbo in der chinesischen Provinz Zhejiang geboren. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^2]: 1949 trat er in Harvard ein und studierte Literatur; ein Jahr später wechselte er an das MIT für Maschinenbau. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^3]: 1952 erwarb er den Bachelor in Maschinenbau am MIT. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^4]: Ab 1955 arbeitete er etwa drei Jahre bei Sylvania in der Halbleiterfertigung. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^5]: 1958 kam er als Halbleiteringenieur zu Texas Instruments. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^6]: 1964 erwarb er den Doktortitel in Elektrotechnik an der Stanford University. Siehe: englischer Wikipedia-Eintrag „Morris Chang" <https://en.wikipedia.org/wiki/Morris_Chang>
+
+[^7]: 1972 wurde er zum Group Vice President von Texas Instruments und General Manager der Halbleitersparte befördert. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^8]: Sun Yun-suan (1913–2006), Premierminister Taiwans (1978–1984), trieb während seiner Amtszeit die Halbleiter- und Technologiebranche voran. Siehe: Wikipedia-Eintrag „孫運璿" <https://zh.wikipedia.org/wiki/%E5%AD%AB%E9%81%8B%E7%92%87>
+
+[^9]: Am 21. Februar 1987 wurde TSMC mit einem Anfangskapital von 22 Milliarden Taiwan-Dollar gegründet. Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+[^10]: Zu den Gründungsaktionären von TSMC gehörte der niederländische Philips-Konzern. Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+[^11]: 1987 entwickelte Chang das reine Foundry-Modell. Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+[^12]: Seit den 2010er Jahren fertigte TSMC die A-Serien-Einheiten von Apple und wurde ab 2013 der Hauptlieferant der Kernchips für das iPhone. Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+[^13]: TSMC investiert seit Jahren rund 8 Prozent des Umsatzes in Forschung und Entwicklung (der Anteil schwankt leicht je nach Jahresbericht). Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+[^14]: 2005 übergab Chang das Amt des CEO an Rick Tsai. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^15]: 2009 kehrte der 78-jährige Chang wegen der globalen Finanzkrise als CEO von TSMC zurück. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^16]: Am 5. Juni 2018 trat Chang offiziell in den Ruhestand; Liu Te-yin wurde Vorsitzender, C. C. Wei CEO. Siehe: Wikipedia-Eintrag „張忠謀" <https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80>
+
+[^17]: [Wirtschaft Taiwans – Wikipedia (Chinesisch)](https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%B6%93%E6%BF%9F) — Halbleiter machen seit Jahren etwa ein Drittel der taiwanesischen Exporte aus.
+
+[^18]: [Wohltätigkeit von Unternehmen: Einweihung der „TSMC-Halle" der Verwaltungshochschule – National Tsing Hua University](https://www.nthu.edu.tw/hotNews/content/708) — TSMC spendete 180 Millionen Taiwan-Dollar für die „TSMC-Halle" der Tsing-Hua-Verwaltungshochschule, eingeweiht im April 2008; Spenderin war TSMC, nicht Morris Chang persönlich.
+
+[^19]: Als Chang 2018 in den Ruhestand ging, hatte die Marktkapitalisierung von TSMC Intel bereits übertroffen. Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+[^20]: In den 2020er Jahren überschritt die Marktkapitalisierung von TSMC die Marke von zehn Billionen Taiwan-Dollar; das Unternehmen gehört zu den wertvollsten Tech-Unternehmen Asiens. Siehe: Wikipedia-Eintrag „台灣積體電路製造" <https://zh.wikipedia.org/wiki/%E5%8F%B0%E7%81%A3%E7%A9%8D%E9%AB%94%E9%9B%BB%E8%B7%AF%E8%A3%BD%E9%80%A0>
+
+_Referenzen:_
+
+- [Autobiografie von Morris Chang (Band 1 + Band 2)](https://www.books.com.tw/products/0010784799)
+- [TSMC-Geschäftsberichte und offizielle Unterlagen](https://investor.tsmc.com/english/annual-reports)
+- [Industrial Technology Research Institute (ITRI)](https://www.itri.org.tw/)
+- [Wikipedia-Eintrag „張忠謀"](https://zh.wikipedia.org/zh-hant/%E5%BC%B5%E5%BF%A0%E8%AC%80)
+- [National Tsing Hua University – Materialien zu Morris Chang](https://www.nthu.edu.tw/)


### PR DESCRIPTION
## 新增德文翻譯：張忠謀（Morris Chang）

本 PR 新增 `knowledge/de/People/tsmc-morris-chang.md`（德文），內容自 `knowledge/People/張忠謀.md` 完整重寫翻譯，非逐字直譯。

### 品質檢查（全部通過）

| 檢查 | 結果 |
|---|---|
| `article-health.py --profile=ci-deploy` | ✅ `hard=0 warn=0` `passed=True` |
| `verify-translation.py` | ✅ **18/18 PASS** |
| 德中字元比 | ✅ **3.02**（de 健康區間 2.0–4.0） |
| 章節結構 | ✅ 17 個 H2 / 30 個 H3 與原文一致 |
| 腳註 | ✅ 20 個 `[^N]` 全部保留 |
| URL | ✅ 25 個 URL 完全保留（exact multiset） |
| 延伸閱讀 | ✅ 有 de 版文章的保留 `/de/` 連結；無 de 版的降級為純文字（避免壞連結） |
| 違禁片語 | ✅ 無 `part of china` / `province of china` / `chinese taipei` / `aborigines` |
| CJK 標點 | ✅ 正文無 `；`、`——`、`：` |
| YAML | ✅ js-yaml 驗證通過；tags 全 ASCII；`featured/lastHumanReview` 為布林 |
| slug 一致 | ✅ 檔名與 en sibling `tsmc-morris-chang` 相同 |

### 本文件特色

- 涵蓋網路用語「**護國神山**」主題（德文譯作「Schutzberg der Nation / 護國神山」）：出現在 tags、30 秒概覽、「台灣意義」章節及延伸閱讀連結中，德文全篇完整呈現。
- 對應 en sibling：en 版不含 `lifeTree` frontmatter，故德文版亦省略，與 en 版結構一致。