### PR TITLE
Add German translation for People (Lo Ta-yu)

### DIFF
--- a/knowledge/de/People/luo-dayou.md
+++ b/knowledge/de/People/luo-dayou.md
@@ -1,0 +1,255 @@
+---
+title: 'Lo Ta-yu: Der Mann, der Taiwans Entwurzelung besang, neunzehnmal umzog und immer noch nach dem Weg sucht'
+description: 'In den 1970er-Jahren versteckte sich ein Radiologiestudent im Seziersaal einer Medizinhochschule in Taichung und übte heimlich Gesang, denn „dort war das Echo sehr gut, und niemand würde wissen, dass ich singe“. Später schrieb er „Lukang, die kleine Stadt“, „Das Waisenkind Asiens“ und „Die Perle des Ostens“ und stellte für eine ganze Generation die Frage „Wer bin ich?“. Doch dieser Mann, der so viel Entwurzelung besang, zog selbst von Taipeh nach New York, Hongkong und Peking – in 29 Jahren neunzehnmal um. Mit siebzig sagte er über sich selbst nur: ein „bemerkenswerter Überlebender“.'
+date: 2026-06-19
+category: 'People'
+tags:
+  [
+    'Musik',
+    'Singer-Songwriter',
+    'Gesellschaftskritik',
+    'Popmusik',
+    'Zhi Hu Zhe Ye',
+    'Waisenkind Asiens',
+    "Queen's Road East",
+    'Driften',
+  ]
+subcategory: '音樂'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-06-19
+lastHumanReview: false
+researchReport: reports/research/2026-06/羅大佑.md
+translatedFrom: 'People/羅大佑.md'
+sourceCommitSha: '09ffe560f'
+sourceContentHash: 'sha256:a360c7a135e403dc'
+sourceBodyHash: 'sha256:fe7b545ee2048324'
+translatedAt: '2026-09-08T18:35:55+08:00'
+image: '/article-images/people/lo-ta-yu-2011.webp'
+imageAlt: 'Lo Ta-yu bei einem Auftritt 2011, der „schwarze Lo Ta-yu“ mit seiner Markensonnenbrille'
+imageCredit: 'Daniel M Shih'
+imageLicense: 'CC BY-SA 2.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Lo_Ta-yu_羅大佑_2011.jpg'
+---
+
+> **30-Sekunden-Überblick:** Lo Ta-yu (geboren 1954) ist ein Singer-Songwriter mit Ausbildung zum Radiologen. Sein Album _Zhi Hu Zhe Ye_ von 1982 verwandelte Poptitel von emotionalem Schmuck in etwas, das eine Haltung transportieren kann; taiwanesische Musikkritiker wählten es später zum ersten der hundert besten klassischen Alben. Er schrieb über die Entwurzelung in „Lukang, die kleine Stadt“, die Isolation in „Das Waisenkind Asiens“ und die Entfremdung in „Die Perle des Ostens“ und fragte dabei immer wieder „Wer bin ich?“. Die Pointe: Dieser Mann, der Taiwans Umhertreiben so vollständig besang, irrte selbst von Taipeh nach New York, Hongkong und Peking – Forscher haben ausgerechnet, dass er in 29 Jahren neunzehnmal umzog. Mit siebzig kehrte er nach Taiwan zurück, trat auf die Bühne und sagte, von den Musikern seiner Generation seien „mindestens 70 Prozent ausgemustert worden“; alle, die blieben, seien bemerkenswerte Überlebende.
+
+Taichung, die 1970er-Jahre. Im Seziersaal des China Medical College stach der Geruch von Formalin so scharf in die Nase, dass die meisten Studenten es dort nicht lange aushielten. Doch ein Medizinstudent versteckte sich ausgerechnet dort gern – nicht um zu lernen, sondern um zu singen.
+
+„Dort waren weniger Leute, und das Echo war sehr gut, und niemand würde wissen, dass ich singe.“[^1]
+
+Dieser Student hieß Lo Ta-yu. Mehr als ein Jahrzehnt später würden seine Lieder die gesamte chinesischsprachige Welt erreichen; die Melodien, die er einst heimlich und in Angst vor Entdeckung geübt hatte, würden zum gemeinsamen Gedächtnis einer Generation. Doch in jenen Jahren im Seziersaal war er nur ein Kind aus einer Arztfamilie, das heimlich etwas übte, das seine Familie nicht wollte.
+
+Das ist der tiefste Riss in Lo Ta-yu: Später sang er sein Leben lang über Taiwans Entwurzelung und über die Frage ohne Antwort „Wer bin ich?“ – und er selbst war der gründlichste Wanderer innerhalb genau dieser Frage.
+
+## Niemand wusste, dass er sang
+
+Um zu verstehen, warum Lo auf diese Weise Lieder schrieb, muss man zuerst wissen, was für ein Mensch aus ihm eigentlich hätte werden sollen.
+
+Er wurde am 20. Juli 1954 in Taipeh geboren[^2], in einer typischen Arztfamilie; Eltern und ältere Geschwister arbeiteten alle im Gesundheitswesen. In einer solchen Familie war Medizin fast die voreingestellte Option, und Lo selbst sagt, er sei als Kind „sehr brav und regelkonform“ gewesen. Er folgte tatsächlich der vorgezeichneten Bahn: Er kam an die Medizinische Fakultät des China Medical College, schloss etwa 1980 bis 1981 ab[^3] und wurde später Radiologe.
+
+Doch dieser brave Medizinstudent trug die Musik in sich verborgen. Die Geschichte vom Seziersaal hat er selbst erzählt: Es war der ruhigste, am wenigsten besuchte Winkel der Hochschule, mit gutem Echo – ideal zum Alleine-Singen[^1]. Ein angehender Arzt übte in einem Raum, in dem man mit Leichen umging, etwas, das nichts mit Lebensrettung zu tun hatte.
+
+Die Familie war nicht ohne Widerstand. Lo beschrieb es später so, dass er „die Familie verraten“ habe, um Musik zu machen, und dass es etwa zehn Jahre gedauert habe, bis ihn die Familie wirklich akzeptierte[^4]. Zehn Jahre – eine lange Versöhnung. Mit seinem Vater gab es eine Vereinbarung: Erst die ärztliche Qualifikation erwerben und beweisen, dass man den Weg der Medizin gehen kann, dann durfte er seinen eigenen Weg gehen. Er bekam die Stelle als Radiologe, erfüllte damit sein Versprechen – und wandte sich dann ab.
+
+> 📝 **Notiz des Kurators**
+> Lo wählte Radiologie, nicht Chirurgie. Jahre später sagte er einen Satz, der es wert ist, stehen zu bleiben: Schreiben und Operieren seien sich ähnlich, beides verlange das Öffnen von Herz und Seele, „aber man muss den Schnitt nicht wirklich machen. Das ist das Gute am Schaffen!“[^5] Er wählte die Position der „Diagnose“: genau erkennen, wo die Krankheitsstelle liegt, und sie aussprechen – ohne selbst hineinschneiden zu müssen. Diese radiologische Perspektive wurde später seine Methode des Liederschreibens. Seine Wut verlässt sich selten auf Geschrei; sie verlässt sich darauf, die Krankheitsstelle einer Gesellschaft so klar zu benennen, dass man sie selbst sieht.
+
+Seine eigene Erklärung dieser Wahl war nüchtern: „Unter so vielen Ärzten braucht es keinen weiteren Lo Ta-yu; aber in der Musik gibt es noch viel Raum für Entwicklung.“[^6] Das war ein Urteil nach Abwägung: Die Welt braucht einen Arzt weniger nicht, aber im Feld der Musik gab es noch etwas für ihn zu tun – ganz ohne die Tragik eines hitzköpfigen jungen Mannes.
+
+## Der Schnitt, den er nicht machen musste
+
+Am 21. April 1982 veröffentlichte Lo Ta-yu sein erstes Soloalbum _Zhi Hu Zhe Ye_[^7]. Mit Sonnenbrille, einer Mähne krauser Locken und komplett in Schwarz stand das Bild des „schwarzen Lo Ta-yu“ in hartem Kontrast zu den warmherzigen Campus-Folksongs jener Zeit.
+
+Dieses Album wurde später von _Taiwans 100 besten Pop-Alben_ auf Platz eins gewählt[^7] – eine Position, die kaum zu erschüttern war. Was es dorthin brachte, war etwas, das Mandarin-Popsongs damals nur selten taten: Es behandelte Texte als Argumente, als etwas, das eine Haltung tragen kann. Der junge Mann in „Lukang, die kleine Stadt“, der vom Land nach Taipeh zieht, um sich durchzuschlagen, nur um zu entdecken, dass er auch in die Heimat nicht mehr zurückkann, singt die Entwurzelung eines ganzen industrialisierenden Zeitalters. „Phänomen 72 Wandlungen“ ist beinahe ein sozialkritischer Beobachtungsbericht. Pop konnte also auch ein Diagnosebericht eines Radiologen über die Gesellschaft sein.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/Xgjny7YFMD4" title="羅大佑 Lo Da-Yu【鹿港小鎮 Lukang, The Little Town】Official Music Video" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Das offizielle Musikvideo zu „Lukang, die kleine Stadt“ von Lo Ta-yu. Offizieller Kanal von Rock Records. Es singt die Entwurzelung des Zeitalters der Industrialisierung: Menschen zogen vom Land nach Taipeh, um sich durchzuschlagen, nur um festzustellen, dass sie nicht mehr nach Hause konnten._
+
+Doch im Taiwan von 1982 hatte klares Reden seinen Preis. Es war die Zeit des Kriegsrechts: Lieder mussten zur Zensur eingereicht werden, und die Zensur war wie ein unsichtbares Netz. Los Methode gegen dieses Netz: die Wahrheit in geschickte Tarnung verstecken.
+
+Das Titellied von _Zhi Hu Zhe Ye_ war ein direkter Hohn. Der ursprüngliche Text schrieb schlicht: „Werden Lieder zensiert, bestehen sie oder nicht?“ – eine offene Satire auf die Zensur selbst. Zur Einreichung wurde daraus „Ein Auge offen, durch den Mund geblasen …“ und endete schließlich mit „alle sind höchst zufrieden“[^8]. Oberflächlich harmlos; im Kern ein kaltes Lachen über das gesamte System.
+
+## Ein falscher Untertitel für eine wahre Aussage
+
+Die berühmteste Tarnung war „Das Waisenkind Asiens“.
+
+Der Titel des Liedes stammte aus Wu Zhuolius gleichnamigem Roman und beschrieb Taiwans Isolation im Spalt der Geschichte – von niemandem gewollt, von niemandem anerkannt. Im Taiwan des Kriegsrechts war das eine äußerst heikle Metapher. Um die Zensur zu passieren, fügte Lo einen Untertitel hinzu: „Roter Albtraum – den Flüchtlingen der Indochinesischen Halbinsel gewidmet“[^9].
+
+Dieser Untertitel verschob die Stoßrichtung des gesamten Liedes geschickt von „Taiwans eigener Waisensituation“ auf „Flüchtlinge der Indochinesischen Halbinsel“. Die Zensoren sahen ein Lied, das mit den Flüchtlingen aus Vietnam und Kambodscha sympathisierte – passend zur antikommunistischen Atmosphäre der Zeit. Und alle, die wirklich zuhören konnten, wussten: Das Waisenkind Asiens, das war diese Insel selbst. Eine Zeile falscher Untertitel erkaufte eine Wahrheit, die man nicht direkt aussprechen durfte.
+
+> 💡 **Wusstest du?**
+> Die Zeile in „Das Waisenkind Asiens“ – „das gelbe Gesicht trägt roten Schlamm“ – wurde über Jahre als Chiffre für die Beziehungen zwischen beiden Seiten der Taiwanstraße und für Identität gelesen. Doch der Untertitel „Den Flüchtlingen der Indochinesischen Halbinsel gewidmet“, den Lo damals hinterließ, ist selbst ein Museumsexponat der Kriegsrechts-Ära. Er sagt dir: Ein Kreativer jener Zeit musste, um einen ehrlichen Satz ans Ohr der Zuhörer zu bringen, dem Zensor zuerst eine Geschichte liefern, die dieser glauben wollte. Das Lied wurde nicht geändert; geändert wurde nur das Etikett, das man von außen darauf klebte.
+
+Das war das Faszinierende am frühen Lo Ta-yu: Er war nicht der Mann, der auf der Straße Parolen rief. Er war der, der mit Untertiteln, mit Doppeldeutigkeiten, mit einem offenen und einem geschlossenen Auge das Unsagbare in Millionen Ohren schmuggelte. Die Präzision des Radiologen, angewandt auf Versteckspiel mit der Zensur.
+
+## Ein gestohlenes Lied
+
+Nicht jede Begegnung mit dem System gewann Lo.
+
+1985 wurde ein Lied namens „Morgen wird es besser“ geboren. Es war ein großes Wohltätigkeitslied, inspiriert vom amerikanischen „We Are the World“, das mehr als sechzig Sänger versammelte. Die Melodie stammte von Lo, aber den Text verfassten sieben Menschen gemeinsam (Lo Ta-yu, Chang Ta-chun, Hsu Nai-sheng, Li Shou-chuan, Chiu Fu-sheng, Sylvia Chang und Chan Hung-chih), das Arrangement schrieb Chen Chih-yuan[^10]. Anders gesagt: Von diesem nationalen Hit, von dem alle dachten, „Text und Musik von Lo Ta-yu“, stammte nur die Hälfte von ihm – er war für die Melodie verantwortlich.
+
+Was ihn mehr schmerzte, war das spätere Schicksal des Liedes. Der ursprüngliche Text von „Morgen wird es besser“ wurde um mehr als hundert Zeichen verändert und von der damals regierenden Kuomintang als Wahlkampflied vereinnahmt[^10]. Ein Wohltätigkeitslied für die Gesellschaft wurde zum Werkzeug politischer Mobilisierung. Zahlreichen Berichten zufolge ist es eines der Werke, über die Lo am wenigsten sprechen mag; er sah tatenlos zu, wie eine Schöpfung, an der er mitgewirkt hatte, angeeignet und umgeschrieben wurde.
+
+Wenn „Das Waisenkind Asiens“ der Sieg des Kreativen über das System mit List war, dann war „Morgen wird es besser“ die harte Lektion, die das System demselben Kreativen erteilte. Man kann die Wahrheit in einem falschen Untertitel verstecken, aber nicht verhindern, dass andere das eigene Lied wegtragen, um damit ihr Eigenes zu sagen. Dieser Vorfall wurde zusammen mit den vielen Fesseln, die das Kriegsrecht-Taiwan dem Schaffen auferlegte, zum Hintergrundgeräusch seines späteren Aufbruchs.
+
+## Von Taipeh nach Peking, auf der Suche nach den Wurzeln
+
+Am 9. März 1985 verließ Lo Ta-yu Taiwan in Richtung New York[^11]. Das war der Anfang von mehr als zwanzig Jahren Umherziehen.
+
+Die Zahl, die die englische Wikipedia zitiert, ist verblüffend: In den folgenden Jahren zog er in 29 Jahren neunzehnmal um – von New York nach Hongkong, nach Peking[^12]. Er ging nicht auf Tournee oder um sich zu veredeln; er ließ sich in jeder Stadt wirklich nieder – und zog wieder weiter. Und das Seltsamste: Die Lieder, die er an jeder Station schrieb, handelten fast alle von der „Heimat“, davon, wie ein Außenseiter auf den Ort blickte, an dem er vorübergehend lebte.
+
+```tw-timeline
+1985 | Verlässt Taiwan Richtung New York | Am 9. März in die USA, Beginn von über zwanzig Jahren Umherziehen
+1987 | Lässt sich in Hongkong nieder | Chinesische Quellen nennen 1987 (englische Wikipedia: 1986, eine Abweichung von einem Jahr)
+1990 | Gründet die Music Factory in Hongkong | Gemeinschaftsunternehmen mit Rock Records, auf Hongkong vor 1997 ausgerichtet; endet 1999
+2000 | Entsperrung in Festlandchina, Jahrhundert-Tournee | Konzerte in Shanghai, Hangzhou, Nanchang und Kunming
+2002 | Music Factory zieht nach Peking | Pressekonferenz im Konfuziustempel: „Ich spürte, wie der Boden unter meinen Füßen zitterte“
+```
+
+> **Quellen:** englischer Wikipedia-Eintrag zu Lo Ta-yu, Baidu-Baike-Eintrag zur Music Factory, Sina-Vor-Ort-Bericht aus Peking 2002.
+
+Die zweite Station war Hongkong. 1987 ließ er sich dort nieder (chinesische Quellen nennen 1987, die englische Wikipedia schreibt 1986 – ein Jahr Unterschied)[^13]. 1990 gründete er zusammen mit Rock Records die „Hongkong Music Factory“[^14] und richtete seine schöpferische Linse auf Hongkong, das auf die Übergabe zuraste. Das repräsentative Werk war „Queen’s Road East“, erschienen im Januar 1991; die Melodie schrieb Lo, den Text Lin Xi, gesungen von Lo und Ram Chiang[^15]. Lo erklärte später das Wortspiel im Titel: „Die Straße ist der Weg, den das Leben gehen sollte … Kommt man nach Osten, wird daraus Queen’s Road East, also Hongkong.“[^15] Ein Taiwaner, der aus einer feinsinnigen Außenseiterperspektive die kollektive Angst Hongkongs am Vorabend der Übergabe aufschrieb.
+
+Der Blick des Außenseiters wird in „Die Perle des Ostens“ noch deutlicher. Das Lied erschien zuerst 1986 in einer kantonesischen Version, Melodie Lo, Text Cheng Kwok-kong, gesungen von Michael Kwan; erst in der Mandarin-Version von 1991 schrieb Lo den Text selbst neu[^16]. Ein Kritiker verglich die beiden Versionen und sagte, „Cheng’s Text ist schlicht und geerdet, Lo’s ist voller Pathos“; der Unterschied liege genau darin: das Solide eines Hongkonger Texters, der von innen über Hongkong schreibt, gegen die akademisch distanzierte Erhabenheit eines taiwanesischen Schöpfers über Hongkong. So tief er auch empfand – es war doch immer das Empfinden eines Fremden.
+
+Die dritte Station war Peking. 2000 wurden seine Lieder in Festlandchina freigegeben; er startete eine Jahrhundert-Tournee und sang in Shanghai, Hangzhou, Nanchang und Kunming[^17]. 2002 zog die Hongkong Music Factory nach Peking[^17]; im selben Jahr sagte er bei einer Pressekonferenz im Pekinger Konfuziustempel einen Satz, der jene Zeit des Umbruchs treffend erfasst: „Das ist eine großartige Stadt … Ich spürte, wie der Boden unter meinen Füßen zitterte, weil sich alles verändert!“[^17]
+
+Selbst der Boden unter den Füßen zittert – das ist fast das ehrlichste Bekenntnis von Los halbem Leben im Unterwegssein. Ein Mann, der Taipeh verließ und zwischen New York, Hongkong und Peking neunzehnmal umzog, spürte überall, dass die Erde sich bewegt. In einem Interview 2004 sagte er es noch präziser: Er komme und gehe zwischen Festlandchina, Hongkong und Taiwan, es sehe aus, als treibe er überall umher, aber tatsächlich suche er seine Wurzeln (im englischen Original: „in fact, I’m seeking my roots“)[^18].
+
+> 📝 **Notiz des Kurators**
+> Hier ist eine leicht übersehene Tatsache. Eine akademische Arbeit von 1993 im chinesischen _China Quarterly_ der Universität Cambridge schrieb über Lo Ta-yu: „obwohl er nie auf dem Festland auftrat, blieben seine Werke weithin beliebt“ („despite never performing on the mainland, his work remained widely popular“)[^19]. Das heißt: Jahre bevor er chinesischen Boden betrat, waren seine Lieder bereits dort angekommen. Die Lieder eines Menschen können früher an einem Ort ankommen als er selbst und früher von dessen Menschen aufgenommen werden – vielleicht eine Art Entschädigung für den Wanderer: Der Körper ist immer unterwegs, aber die Lieder sind für ihn schon eingezogen.
+
+## Die Lieder, die er schrieb – und die Lieder, die er für andere schrieb
+
+Redet man über Lo Ta-yu, kommt fast zwangsläufig die Frage: Welche Lieder hat er eigentlich geschrieben?
+
+Los Lieder werden oft fälschlich zugeordnet; geht man sie einzeln durch, sieht man einen vollständigeren Lo. Er war ein produktiver Schöpfer, der nicht nur seine eigenen Lieder sang, sondern auch für viele Stars der damaligen chinesischsprachigen Musikwelt schrieb. 1981 schrieb er für Sylvia Changs Album _Kindheit_ die Titel „Kindheit“ und „Die Geschichte der Zeit“ und produzierte das Album; diese beiden Lieder erschienen tatsächlich 1981 zum ersten Mal, nicht 1982, wie viele sich erinnern[^20]. Noch früher, zwischen 1977 und 1978, schrieb er für Liu Wen-cheng „Glänzende Tage“[^21]. 1983 schrieb er für Michelle Pan „Auch die wilde Lilie hat ihren Frühling“[^22]. „Die Träumerin“ von 1990 schrieb er für Fong Fei-fei. Bei „Wie ein alter Freund, der zurückkommt“, gesungen 1991 von Anita Mui, stammte die Melodie von ihm – aber den Text schrieb Lin Xi[^23].
+
+> 💡 **Wusstest du?**
+> Einige Lieder halten fast alle für „Text und Musik komplett von Lo Ta-yu“ – was nicht stimmt. Beim Text von „Vier Strophen der Heimweh“ war es der Dichter Yu Kwang-chung, Lo vertonte nur. Die Texte von „Queen’s Road East“ und „Wie ein alter Freund, der zurückkommt“ stammen beide von Lin Xi; Lo war für die Melodien zuständig. Und das machtvolle „Ein Lachen im weiten Meer“ – Text und Musik sind beide von James Wong; Lo sang nur die Mandarin-Version und war selbst nicht der Schöpfer[^24]. Warum das eine ums andere klären? Weil was ein Schöpfer geschrieben hat und was nicht, selbst ein Teil dessen ist, wer er ist.
+
+Ein weiteres Lied, das oft unter Los Namen gezählt wird, ist „Roter Staub“. Die Fakten: Text und Musik stammten beide von Lo Ta-yu, die erste Sängerin war Sarah Chen, und die Schriftstellerin Sanmao war Drehbuchautorin des gleichnamigen Films – nicht Textdichterin oder Komponistin des Liedes[^25]. Was „Dein Gesicht“ angeht: Es ist auf dem Album _Geliebter Genosse_ von 1988 enthalten, nicht auf _Heimat_ von 1984, wie manche Quellen sagen[^26].
+
+Werden diese Lieder eines nach dem anderen geklärt, entdeckt man etwas: Los Schaffenslandkarte spannt sich über die gesamte chinesischsprachige Popmusik der 1980er und 1990er Jahre. Seine Lieder flossen durch die Stimmen von Sylvia Chang, Liu Wen-cheng, Michelle Pan, Fong Fei-fei und Anita Mui – und durch seine eigene, leicht raue Kehle. Ein Radiologe wurde am Ende zum Autor einer halben Geschichte der chinesischsprachigen Popmusik.
+
+## Der Preis der Schärfe
+
+Wenn ein Artikel nur schriebe, wie großartig Lo Ta-yu war, wäre er nicht ehrlich. Er war nicht durchgehend erfolgreich, und er war nicht von Anfang bis Ende so scharf.
+
+Schon in der Hongkonger Zeit fanden manche, er habe sich verändert. Es gab Stimmen, die meinten, nach Hongkong habe Los „Schärfe nachgelassen, er rückte dem Kommerz näher“, denn ein großer Teil der Produktion der Music Factory in dieser Zeit war Filmmusik[^27]. Von einem kritischen Sänger, der im Taiwan des Kriegsrechts mit der Zensur kämpfte, zu einem kommerziellen Musikschaffenden, der für Hongkong-Filme Titelsongs schrieb – da lag tatsächlich ein Sprung, den Fans des frühen Lo nicht unbedingt mitgingen.
+
+Direktere Kritik kam an seinen späteren Werken. 2009 schrieb ein Portrait im _Southern People Weekly_, seine Lieder seien „nicht spitz; eher fehlt es an Schärfe bei einem Übermaß an Gehässigkeit“, und es fehle „der Nachklang“[^28]. Der Mann, der einst mit einem einzigen Lied die Krankheitsstelle einer Epoche treffen konnte, hatte nach Meinung vieler eine gewisse Genauigkeit verloren.
+
+> 📝 **Notiz des Kurators**
+> Die gängige Erzählung lautet: „Lo Ta-yu ist alt geworden, nicht mehr wütend, hat sich dem Kommerz gebeugt.“ Doch diese Erzählung könnte Ursache und Wirkung umdrehen. Die Kraft eines Menschen, der aus der Perspektive der „Diagnose“ Lieder schreibt, kommt aus seiner Distanz zu einer konkreten Krankheitsstelle; im Kriegsrecht-Taiwan lag diese Stelle klar und deutlich vor ihm. Als er Taiwan verließ und in Städte trieb, die dieses Zensursystem nicht hatten, Städte, in denen er selbst der Außenseiter war, verlor er nicht nur die Wut – sondern die Position, von der aus er präzise schneiden konnte. Wer ihm „nicht scharf genug“ vorwarf, übersah vielleicht: Schärfe hängt immer mit dem Boden zusammen. Wenn die Erde ständig zittert, findet das Messer keinen genauen Ansatzpunkt.
+
+Auch das ist ein Preis des Umherziehens. „Die Perle des Ostens“ wurde als „pathetisch“ bemängelt, die Hongkonger Zeit als „kommerziell“, das Spätwerk als „stumpf“ – hinter all dieser Kritik steckt dasselbe: Ein Mensch, der seine festen Koordinaten verloren hat, kann die Präzision, die einst den Nerv traf, schwer durchhalten. Das aufzuschreiben heißt nicht, ihn schlechtzumachen. Es ist genau die wahrste andere Seite des großen Themas „des Wanderers“.
+
+## Ein bemerkenswerter Überlebender
+
+Nach der Rückkehr von Peking nach Taiwan machte Lo Ta-yu nicht halt. 2008 gründete er mit Jonathan Lee, Wakin Chau und Chang Chen-yue die zeitlich begrenzte Supergroup „Superband“. Vier Menschen, die alle von alten Liedern hätten leben können, gingen gemeinsam auf Tournee und veröffentlichten zwei Alben, bis zur Auflösung Anfang 2010[^30].
+
+![Superband bei einem Auftritt 2009, bestehend aus vier Schwergewichten der chinesischsprachigen Musikwelt: Lo Ta-yu, Jonathan Lee, Wakin Chau und Chang Chen-yue](/article-images/people/lo-ta-yu-superband-2009.webp)
+
+_Superband auf Welttournee 2009, die zeitlich begrenzte Band aus Lo Ta-yu, Jonathan Lee, Wakin Chau und Chang Chen-yue. Foto: Tat Lau, 2009. [CC BY-SA 2.0](https://commons.wikimedia.org/wiki/File:SuperbandTaiwan.jpg)._
+
+2024 stand der siebzigjährige Lo Ta-yu auf der Konzertbühne. Er sang mehr als zwanzig Lieder und spielte mehrere Stücke am Klavier[^29]. Im Publikum saßen Zuhörer aus mehreren Generationen: die Älteren, die ihn unter dem Kriegsrecht Dinge hatte singen hören, die man nicht aussprechen durfte; die Mittleren, für die seine Lieder der Soundtrack der Jugend waren; und die Jungen, die ihn erst durch Covers und Streaming kennenlernten.
+
+Der Student, der sich einst im Seziersaal versteckte, weil er nicht gehört werden wollte – mit siebzig hörte ihm die ganze Halle zu.
+
+![Lo Ta-yu erhält 2021 den Sonderbeitragspreis der 32. Golden Melody Awards](/article-images/people/lo-ta-yu-gma-2021.webp)
+
+_2021 erhielt Lo Ta-yu den Sonderbeitragspreis der 32. Golden Melody Awards; die Jurybegründung lautete „die Höhe eines Denkers“. Foto: 化城再来人, 2021. [CC BY-SA 4.0](https://commons.wikimedia.org/wiki/File:20210822CPKK35c_TAIWAN_GMA_LO_TAYOU_EN0822LA07-1.jpg)._
+
+Doch er stellte sich nicht als groß dar. Was er auf der Bühne sagte, war dieser Satz: „Mindestens 70 Prozent der Musiker wurden ausgemustert – alle auf dieser Bühne heute sind bemerkenswerte Überlebende!“[^29] Er sagte nicht, er sei ein Pate, eine Legende; er sagte, er sei nur einer, der überlebt hat. Gegenüber den Kollegen, die die Zeit aussortierte, hatte er nur Glück gehabt – er stand noch.
+
+Wie hat Lo Ta-yu, nachdem er den Großteil seines Lebens umhergezogen war, am Ende die Frage „Wer bin ich?“ versöhnt? Die Antwort könnte in einer ganz alltäglichen Szene versteckt sein. Mit 58 wurde er Vater. Über die kleine Sache, seine Tochter täglich zur Schule zu bringen, sagte er, es sei „maßlos unterhaltsam“. Dann sagte er einen Satz, der sein ganzes Wanderleben zusammenraffte: „Das Leben ist ein Zyklus. Wenn es zum Kreis wird, ist nichts mehr schwierig.“[^5] Und er fügte hinzu: Es kommt darauf an, ob man bereit ist, an den Ausgangspunkt zurückzukehren.
+
+Vom Seziersaal in Taipeh aus, über New York, Hongkong und Peking, neunzehn Umzüge, singend über die Entwurzelung und das Verwaistsein einer Insel – an einem Morgen, an dem er seine Tochter an der Hand zur Schule brachte, schien dieser Wanderer endlich die Antwort gefunden zu haben, nach der er sein Leben lang gesungen hatte. Nicht, dass irgendein Ort seine Wurzel wäre, sondern: „zurück an den Ausgangspunkt“ ist es selbst. Wenn das Leben sich zum Kreis rundet, zittert die Erde nicht mehr.
+
+Mit seinem ganzen Leben voller Umherziehen stellte er für eine ganze Generation die taiwanesische Frage „Wer bin ich?“. Und mit siebzig noch auf der Bühne zu stehen und zu singen – das ist selbst die ehrlichste Antwort auf diese Frage bisher.
+
+---
+
+**Weiterführende Links**:
+
+- Taiwanesische Popmusik: Von Nakasi bis Jay Chou, wie eine Insel das Lied zu ihrer eigenen Stimme machte – Lo Ta-yu ist in dieser Gesamtgeschichte die Schlüsselfigur zwischen den Epochen
+- Die taiwanesische Folk-Bewegung: Wie „Singt eure eigenen Lieder“ die taiwanesische Popmusik umschrieb – die Welle vor Los Aufstieg; wer ihn verstehen will, muss zuerst diese Zeit verstehen
+- Popmusik und die Golden Melody Awards: Wie Taiwan mit einem Preis die chinesischsprachige Musik definiert – Lo Ta-yu erhielt 2021 den Sonderbeitragspreis der 32. Golden Melody Awards
+- [Sylvia Chang](/de/people/sylvia-chang) – mit dem Album _Kindheit_ von 1981 kamen „Kindheit“ und „Die Geschichte der Zeit“ von Lo Ta-yu erstmals heraus
+- Sanmao: Die Generationenlegende der wandernden Literatur – Drehbuchautorin des Films „Roter Staub“ (Text und Musik des Liedes stammen tatsächlich von Lo Ta-yu)
+
+## Bildquellen
+
+Dieser Artikel verwendet drei CC-lizenzierte Bilder, alle gecacht in `public/article-images/people/`, um Hotlinking von Quellservern zu vermeiden; das Video ist ein offizieller YouTube-Embed:
+
+- [Lo Ta-yu bei einem Auftritt 2011 (Hero)](https://commons.wikimedia.org/wiki/File:Lo_Ta-yu_羅大佑_2011.jpg) — Foto: Daniel M Shih, 2011, CC BY-SA 2.0
+- [Superband 2009](https://commons.wikimedia.org/wiki/File:SuperbandTaiwan.jpg) — Foto: Tat Lau, 2009, CC BY-SA 2.0
+- [Lo Ta-yu, Sonderbeitragspreis der Golden Melody Awards 2021](https://commons.wikimedia.org/wiki/File:20210822CPKK35c_TAIWAN_GMA_LO_TAYOU_EN0822LA07-1.jpg) — Foto: 化城再来人, 2021, CC BY-SA 4.0
+- Video: „Lukang, die kleine Stadt“, offizieller YouTube-Embed des Kanals von Rock Records
+
+## Referenzen
+
+[^1]: [ETtoday: Lo Ta-yu verlässt die Medizin für die Musik, Erinnerungen an das Gesangsüben im Seziersaal](https://star.ettoday.net/news/2197225) — berichtet Los eigene Schilderung, wie er während seiner Medizinstudienzeit im Seziersaal das Singen übte, und bewahrt den berühmten Satz „das Echo war sehr gut, und niemand würde wissen, dass ich singe“ (Anmerkung: Eine andere Version bei udn lautet im Titel „Gitarre üben“, im Text steht jedoch „Gesang üben“; dieser Artikel übernimmt die konservativere Formulierung aus dem Fließtext, „Gesang üben/Musik üben“).
+
+[^2]: [Wikipedia: 羅大佑](https://zh.wikipedia.org/zh-hant/羅大佑) — verzeichnet Los vollständige Biografie: Geburt in Taipeh am 20. Juli 1954, medizinischer Bildungshintergrund, Umzug nach Hongkong 1987, Karriere in Peking ab 2000, Gründung der Music Factory 1990 und den Sonderbeitragspreis der 32. Golden Melody Awards 2021.
+
+[^3]: [Alumni-Profil der China Medical University: Lo Ta-yu](https://cmualumni.cmu.edu.tw/) — offizielle Alumni-Datenbank seiner Alma Mater; dokumentiert Los Medizinstudium, den Abschluss um 1980/81 (Studienjahr 69), die Approbation und den Eintritt bei Rock Records 1981.
+
+[^4]: [United Daily News: Lo Ta-yu über das Verlassen der Medizin und die zehnjährige Versöhnung mit der Familie](https://udn.com/) — berichtet Los eigene Schilderung, er habe „die Familie verraten“, um zur Musik zu wechseln, und die Familie habe etwa zehn Jahre gebraucht, um es wirklich zu akzeptieren (die Originalseite ist nicht mehr verfügbar; zitiert wird nach der Zusammenfassung des Berichts).
+
+[^5]: [50＋ (Fiftyplus): Interview mit Lo Ta-yu, mit 58 Vater und „das Leben ist ein Kreis“](https://www.fiftyplus.com.tw/articles/14688) — ausführliches Spätinterview, in dem Lo über den Unterschied zwischen Schaffen und Arztpraxis spricht („man muss den Schnitt nicht wirklich machen“), über das Vaterwerden mit 58 und das Bringen der Tochter zur Schule sowie über die Erkenntnis „das Leben ist ein Zyklus; wenn es zum Kreis wird“.
+
+[^6]: [Fount Media: Los Entscheidung, für die Musik die Medizin aufzugeben](https://www.fountmedia.io/topic_article/75050) — berichtet Los Erklärung, warum er die Arztlaufbahn aufgab, mit der Aussage „unter so vielen Ärzten braucht es keinen weiteren Lo Ta-yu, aber in der Musik gibt es noch viel Raum für Entwicklung“.
+
+[^7]: [Newton Wiki: 之乎者也](https://www.newton.com.tw/wiki/之乎者也/1846734) — verzeichnet die Veröffentlichung von _Zhi Hu Zhe Ye_ am 21. April 1982, die Arrangements von Minoru Yamazaki und Lo Ta-yu sowie die Wahl auf Platz eins der _100 besten Pop-Alben Taiwans_.
+
+[^8]: [Story StoryStudio: die Geschichte der verbotenen Lieder Taiwans und die zensurtäuschenden Texte von „Zhi Hu Zhe Ye“](https://storystudio.tw/article/gushi/banned-songs-taiwan) — zeichnet die Liedzensur der Kriegsrechtszeit nach und dokumentiert, wie der ursprünglich die Zensur verspottende Text „Werden Lieder zensiert, bestehen sie oder nicht?“ bei der Einreichung zu „alle sind höchst zufrieden“ geändert wurde.
+
+[^9]: [Epoch Times: der Untertitel von „Das Waisenkind Asiens“ und die Liedzensur](https://www.epochtimes.com/b5/) — dokumentiert die Strategie, dem Lied zum Bestehen der Zensur den Untertitel „Roter Albtraum – den Flüchtlingen der Indochinesischen Halbinsel gewidmet“ zu geben, und den Zusammenhang mit Taiwans Identitätssituation.
+
+[^10]: [Wikipedia: 明天會更好](https://zh.wikipedia.org/zh-hant/明天會更好) — verzeichnet für „Morgen wird es besser“ die Melodie von Lo Ta-yu, den gemeinsam von Lo Ta-yu, Chang Ta-chun, Hsu Nai-sheng, Li Shou-chuan, Chiu Fu-sheng, Sylvia Chang und Chan Hung-chih verfassten Text, das Arrangement von Chen Chih-yuan sowie den Streit um die um mehr als hundert Zeichen veränderten Originaltexte, die die Kuomintang als Wahlkampflied vereinnahmte.
+
+[^11]: [Fount Media: Los Spur des Umherziehens](https://www.fountmedia.io/topic_article/75050) — dokumentiert Los Aufbruch nach New York am 9. März 1985, die Niederlassung in Hongkong 1987 und die Entstehung seines „Wer bin ich?“-Themas des Umherziehens.
+
+[^12]: [Wikipedia: Lo Ta-yu](https://en.wikipedia.org/wiki/Lo_Ta-yu) — englischer Wikipedia-Eintrag; verzeichnet neunzehn Umzüge zwischen New York, Hongkong und Peking in 29 Jahren sowie die Gründung der Music Factory (Musikfabrik) 1990.
+
+[^13]: [Wikipedia: 羅大佑](https://zh.wikipedia.org/zh-hant/羅大佑) — chinesische Quellen vermerken die Niederlassung in Hongkong 1987 (die englische Wikipedia nennt 1986; ein Jahr Unterschied; dieser Artikel folgt der chinesischen Version und markiert die Abweichung).
+
+[^14]: [Baidu Baike: 音乐工厂](https://baike.baidu.com/item/音乐工厂/10732964) — verzeichnet die Gründung der Hongkong Music Factory 1990 als Gemeinschaftsunternehmen von Rock Records und Lo Ta-yu sowie das Ende 1999; sie war Los Schaffensbasis in der Hongkonger Zeit.
+
+[^15]: [Baidu Baike: 皇后大道東](https://baike.baidu.com/item/皇后大道東) — verzeichnet die Veröffentlichung von „Queen’s Road East“ im Januar 1991, Melodie Lo Ta-yu, Text Lin Xi, Arrangement Hua Bi-ao, gesungen von Lo Ta-yu und Ram Chiang, sowie Los Erklärung des Wortspiels „der Weg, den das Leben gehen sollte“.
+
+[^16]: [Wikipedia: 東方之珠（羅大佑曲作）](<https://zh.wikipedia.org/zh-tw/東方之珠_(羅大佑曲作)>) — verzeichnet die kantonesische Version von „Die Perle des Ostens“ 1986 (Melodie Lo Ta-yu, Text Cheng Kwok-kong, Gesang Michael Kwan) und die Mandarin-Version von 1991 mit Los eigenem Text sowie die Kritikerbewertung „Cheng’s Text schlicht und geerdet, Lo’s voller Pathos“.
+
+[^17]: [Sina News: Los Music Factory zieht nach Peking, Pressekonferenz im Konfuziustempel](https://news.sina.cn/sa/2002-05-14/detail-ikkntiak6998184.d.html) — Erstbericht von 2002 über den Umzug der Music Factory nach Peking, die Jahrhundert-Tournee nach der Freigabe ab 2000 und Los Rede auf der Pressekonferenz im Pekinger Konfuziustempel: „Ich spürte, wie der Boden unter meinen Füßen zitterte“.
+
+[^18]: [The China Project: Lo Ta-yu, „Hong Kong, Pearl of the Orient“](https://thechinaproject.com/2019/07/20/friday-song-lo-ta-yu-hong-kong-pearl-of-the-orient/) — englische Musikkritik, die Los Interview von 2004 zitiert, in dem er sagt, sein Umherziehen zwischen beiden Seiten der Straße und Hongkong sei eigentlich die Suche nach seinen Wurzeln („seeking my roots“), und die Angst Hongkongs vor der Übergabe in „Die Perle des Ostens“ analysiert.
+
+[^19]: [Cambridge, The China Quarterly: Gold, „Go with Your Feelings“ (1993)](https://www.cambridge.org/core/journals/china-quarterly/article/abs/go-with-your-feelings-hong-kong-and-taiwan-popular-culture-in-greater-china/DF64A167E65A9B30EFFE5B28C6CF37E2) — begutachteter akademischer Aufsatz über den Einfluss der Popkultur Hongkongs und Taiwans in Großchina; stellt fest, Lo Ta-yu sei „obwohl er nie auf dem Festland auftrat, mit seinen Werken weithin beliebt“ gewesen.
+
+[^20]: [Douban: Sylvia Changs Album _Kindheit_](https://book.douban.com/) — verzeichnet die Erstveröffentlichung von „Kindheit“ und „Die Geschichte der Zeit“ auf Sylvia Changs Album _Kindheit_ im September 1981 mit Lo Ta-yu als Textdichter, Komponist und erstem Produzenten (korrigiert die verbreitete falsche Jahresangabe 1982).
+
+[^21]: [KKBOX: 閃亮的日子](https://www.kkbox.com/tw/tc/) — Songdaten zu „Glänzende Tage“: Text und Musik Lo Ta-yu, Originalsänger Liu Wen-cheng, Filmmusik 1977, Albumveröffentlichung 1978.
+
+[^22]: [Mojim: 野百合也有春天](https://mojim.com/) — Daten zu „Auch die wilde Lilie hat ihren Frühling“: Text und Musik Lo Ta-yu, gesungen von Michelle Pan, Veröffentlichung 1983; klärt zudem, dass „Tian Tian Tian Lan“ einen Text von Hsieh Tsai-chun und eine Melodie von Li Shou-chuan hat und nicht von Lo stammt.
+
+[^23]: [Wikipedia: 似是故人來](https://zh.wikipedia.org/zh-hant/似是故人來) — verzeichnet für „Wie ein alter Freund, der zurückkommt“ die Melodie von Lo Ta-yu, den Text von Lin Xi, den Gesang von Anita Mui und die Veröffentlichung 1991.
+
+[^24]: [Wikipedia: 滄海一聲笑](https://zh.wikipedia.org/zh-tw/滄海一聲笑) — dokumentiert, dass Text und Musik von „Ein Lachen im weiten Meer“ beide von James Wong stammen (Arrangement Ku Ka-fai) und Lo Ta-yu nur die Mandarin-Version sang, also nicht der Schöpfer ist; räumt die häufige Fehlzuschreibung auf.
+
+[^25]: [Newton Wiki: 滾滾紅塵](https://www.newton.com.tw/wiki/滾滾紅塵) — verzeichnet Text und Musik von „Roter Staub“ durch Lo Ta-yu, den ersten Gesang von Sarah Chen und klärt, dass die Schriftstellerin Sanmao Drehbuchautorin des gleichnamigen Films war, nicht Textdichterin oder Komponistin des Liedes.
+
+[^26]: [LINE music: 你的樣子](https://www.line-music.com/) — verzeichnet, dass „Dein Gesicht“ auf dem Album _Geliebter Genosse_ von 1988 enthalten ist und als Abschlusslied des Films _The Story of Ah-Long_ diente (korrigiert die verbreitete falsche Angabe _Heimat_, 1984).
+
+[^27]: [Fount Media: Los Wandel in der Hongkonger Zeit](https://www.fountmedia.io/topic_article/75263) — erörtert die Einschätzung, in der Zeit der Hongkong Music Factory habe Los „Schärfe nachgelassen, er rückte dem Kommerz näher“, und weist darauf hin, dass die Hauptproduktion jener Zeit Filmmusik war.
+
+[^28]: [Sina: _Southern People Weekly_, Lo-Ta-yu-Schwerpunkt 2009](http://news.sina.com.cn/c/2009-03-20/111717447483_4.shtml) — Portrait-Kritik von 2009, die sagt, Los spätere Werke seien „nicht spitz, sondern eher ohne Schärfe bei Übermaß an Gehässigkeit“ und „ohne Nachklang“; repräsentative Kritik am Nachlassen seiner schöpferischen Schärfe.
+
+[^29]: [Hong Kong 01: Lo Ta-yus Konzert zum siebzigsten Geburtstag und „bemerkenswerte Überlebende“](https://www.hk01.com/1057674) — berichtet das Konzert des Siebzigjährigen mit 27 Liedern und fünf Klavierstücken und zitiert seine Rede: „Mindestens 70 Prozent der Musiker wurden ausgemustert – alle auf dieser Bühne heute sind bemerkenswerte Überlebende“.
+
+[^30]: [Wikipedia: 縱貫線（樂團）](<https://zh.wikipedia.org/zh-tw/縱貫線_(樂團)>) — Superband war eine zeitlich begrenzte Supergroup, gegründet 2008 und aufgelöst im Januar 2010, bestehend aus Lo Ta-yu, Jonathan Lee, Wakin Chau und Chang Chen-yue; sie veröffentlichte die beiden Alben _Northbound Train_ und _Southbound Line_ und unternahm eine Welttournee.


### PR DESCRIPTION
## 新增德文翻譯：羅大佑（Lo Ta-yu）

本 PR 新增 `knowledge/de/People/luo-dayou.md`（德文），內容自 `knowledge/People/羅大佑.md` 完整重寫翻譯，非逐字直譯。

### 品質檢查（全部通過）

| 檢查 | 結果 |
|---|---|
| `article-health.py --profile=ci-deploy` | ✅ `hard=0 warn=0` `passed=True` |
| `verify-translation.py` | ✅ **18/18 PASS** |
| 德中字元比 | ✅ **2.79**（de 健康區間 2.0–4.0） |
| 章節結構 | ✅ 10 個 H2 與原文一致 |
| 腳註 | ✅ 30 個 `[^N]` 全部保留並對應正文引用 |
| URL | ✅ 36 個 URL 完全保留（exact multiset） |
| 媒體 | ✅ 3 圖（1 hero + 2 inline）＋ YouTube 嵌入＋ `tw-timeline` 時序表完整保留 |
| 延伸閱讀 | ✅ 有 de 版文章的保留 `/de/` 連結（Sylvia Chang）；無 de 版的降級為純文字（避免壞連結） |
| 違禁片語 | ✅ 無 `part of china` / `province of china` / `chinese taipei` / `aborigines` |
| CJK 標點 | ✅ 正文無 `；`、`——`、`：` |
| YAML | ✅ js-yaml 驗證通過；tags 全 ASCII；`featured/lastHumanReview` 為布林 |
| slug 一致 | ✅ 檔名與 en sibling `luo-dayou` 相同 |
| frontmatter | ✅ 含 `imageAlt`（德文）與 `researchReport`，與 zh 全部 16 個欄位對齊 |

### 本文件特色

- 完整翻譯十段主題：解剖室練唱、之乎者也與審查、〈亞細亞的孤兒〉假副標、〈明天會更好〉、台北→紐約→香港→北京的漂泊、歌曲歸屬釐清、銳氣的代價、了不起的倖存者。
- 保留 7 個 callout 區塊（30 秒概覽／策展人筆記／你知道嗎／資料來源）。
- 歌名採「德文譯名＋原文」雙軌，人名依慣用羅馬拼音，與既有 de 音樂文章（張雨生）風格一致。