### PR TITLE
translate(de): 鼎泰豐 → din-tai-fung

### DIFF
--- a/knowledge/de/Food/din-tai-fung.md
+++ b/knowledge/de/Food/din-tai-fung.md
@@ -1,0 +1,95 @@
+---
+title: 'Din Tai Fung: Vom Ölhandel zum Michelinstern – wie ein Xiaolongbao die Welt eroberte'
+description: '1958 gründete Yang Bing-yi in Taipeh den Ölhandel Din Tai Fung. Nach dem Wandel des Unternehmens und der Führung durch die zweite Generation, Yang Chi-hua, brachte Din Tai Fung mit dem strengen „18-Falten-21-Gramm“-Standard und einer menschenzentrierten Servicephilosophie den taiwanischen Xiaolongbao auf die internationale Bühne und wurde zur Michelin-Stern-Legende der Gastronomie.'
+date: 2026-06-25
+category: 'Food'
+tags:
+  [
+    'Din Tai Fung',
+    'Xiaolongbao',
+    'taiwanische Küche',
+    'Michelin',
+    'Yang Chi-hua',
+    'Dienstleistungsbranche',
+    'Unternehmenskultur',
+    'atypische Führung',
+    'Stimmmanagement',
+  ]
+subcategory: '精緻餐飲'
+author: 'Taiwan.md Contributors'
+featured: false
+lastVerified: 2026-06-25
+lastHumanReview: false
+readingTime: 15
+curation: incubating
+translatedFrom: 'Food/鼎泰豐.md'
+sourceCommitSha: '69b3afd91'
+sourceContentHash: 'sha256:bb2620bf409796b4'
+translatedAt: '2026-09-09T05:18:03+08:00'
+---
+
+> **30-Sekunden-Überblick:** 1958 gründete Yang Bing-yi in Taipeh den Ölhandel Din Tai Fung, doch eine Krise bei Speiseöl zwang ihn wenige Jahre später zur Umstellung auf den Verkauf von Xiaolongbao – der unfreiwillige Beginn einer außergewöhnlichen Erfolgsgeschichte. Die zweite Generation unter Yang Chi-hua verband eine geradezu industrielle Standardisierung nach der berühmten „18-Falten-21-Gramm“-Regel mit einer konsequent „menschenzentrierten“ Servicephilosophie. Das brachte Din Tai Fung nicht nur mehrere Michelinsterne ein, sondern führte auch zu einer Expansion auf über 175 Filialen in 15 Ländern und machte das Unternehmen zur international bekanntesten Visitenkarte der taiwanischen Küche überhaupt. Die einzigartige Unternehmenskultur aus „atypischer Führung“ und „Stimmmanagement“ macht Din Tai Fung in der gesamten Gastronomiebranche zu einem Sonderfall – und trotz der Herausforderungen der Globalisierung hält das Unternehmen bis heute konsequent an seinen ursprünglichen Grundwerten fest.
+
+Im Jahr 1958 eröffnete Herr Yang Bing-yi, der ursprünglich aus der chinesischen Provinz Shanxi stammte, in der Yongkang-Straße im Herzen von Taipeh ein bescheidenes Geschäft namens „Din Tai Fung Ölhandel“, das hauptsächlich Erdnussöl in Flaschen abfüllte und an die Haushalte der Nachbarschaft verkaufte [^1]. Damals war das Xiaolongbao – ein gedämpftes Teigtäschchen mit Fleischfüllung und einer Portion würziger Suppe im Inneren – lediglich ein kleines Nebengeschäft des Ölhandels, mit dem das Ehepaar sein Haushaltseinkommen aufbessern wollte. Doch die 1972 ausbrechende Speiseölkrise, die zahlreiche Ölhändler in wirtschaftliche Bedrängnis brachte, zwang das Ehepaar Yang zu einer schwierigen und schmerzhaften Entscheidung: Sie gaben den angestammten Ölhandel vollständig auf und konzentrierten sich fortan ausschließlich auf die Herstellung und den Verkauf von Xiaolongbao [^1] [^2]. Dieser zunächst wie eine bloße Notlösung wirkende, im Grunde erzwungene Wandel sollte sich rückblickend als der unerwartete Auftakt zu einem der eindrucksvollsten Kapitel der gesamten taiwanischen Gastronomiegeschichte erweisen.
+
+### Vom Ölhandel zum Xiaolongbao-Königreich: Präzise Weitergabe und Innovation
+
+Der eigentliche Aufstieg von Din Tai Fung begann erst, als die zweite Generation unter Yang Chi-hua die Geschäftsführung vollständig übernahm. Er hob die Philosophie seines Vaters – „Qualität zuerst, der Kunde immer im Mittelpunkt“ – vom bescheidenen Modell eines traditionellen Imbisses auf das Niveau eines modern und professionell geführten Unternehmens [^3] [^4]. Yang Chi-hua wusste aus eigener Erfahrung, dass Xiaolongbao nur dann auf der internationalen Bühne bestehen konnte, wenn sowohl Qualität als auch Service bis ins kleinste Detail perfektioniert wurden. Er importierte eigens Präzisionswaagen aus Japan und verlangte, dass jedes einzelne Xiaolongbao einem strengen, unverhandelbaren Standard entsprach: „5 Gramm Teighülle, 16 Gramm Fleischfüllung, insgesamt genau 21 Gramm, und mit exakt 18 sorgfältig gedrehten Falten“ [^5] [^6] [^7]. Diese fast schon obsessive Detailversessenheit sorgte dafür, dass die Xiaolongbao von Din Tai Fung nicht nur außerordentlich köstlich, sondern vor allem von durchgehend gleichbleibender Qualität waren – egal in welcher Filiale der Welt man saß, die Kundschaft konnte überall auf der Welt dasselbe goldene Verhältnis von Teig, Fleisch und Suppe schmecken.
+
+📝 Kurator:innen-Notiz: Die „18-Falten-21-Gramm“-Regel von Din Tai Fung ist weit mehr als nur eine technische Zahl – sie ist ein anschauliches Musterbeispiel dafür, wie sich traditionelles Handwerk in einen reproduzierbaren, industriellen Standard übersetzen lässt, ohne dabei seine Seele zu verlieren. Dieses unermüdliche Streben nach Präzision bildet das eigentliche Fundament des internationalen Erfolgs und spiegelt zugleich den weithin bekannten taiwanischen Sinn fürs kleinste Detail wider.
+
+### Menschenzentrierte Unternehmenskultur: Atypische Führung und Stimmmanagement
+
+In einer Branche, in der die meisten Betriebe kompromisslos auf Kostenkontrolle setzen, geht Din Tai Fung bewusst den entgegengesetzten Weg und investiert einen ungewöhnlich hohen Anteil seines Umsatzes in Mitarbeiterwohlfahrt und laufende Schulungen [^8] [^9]. Yang Chi-hua ist fest davon überzeugt: „Menschen sind das mit Abstand wichtigste Kapital des Unternehmens“ [^5]. Din Tai Fung bietet seiner Belegschaft nicht nur deutlich überdurchschnittliche Gehälter sowie großzügige Feiertags- und Jahresendboni, sondern hat darüber hinaus eine eigene „Vitalitätshalle“ mit kostenlosen Sportkursen eingerichtet und beschäftigt festangestellte Physiotherapeut:innen, die den Mitarbeitenden gezielt helfen, körperliche Beschwerden zu lindern, die durch das lange Stehen im Berufsalltag entstehen [^10] [^11].
+
+Diese umfassende und ernstgemeinte Fürsorge für die körperliche wie seelische Gesundheit der Belegschaft hat nicht nur die Zahl der Krankheitstage deutlich gesenkt, sondern gleichzeitig ein außergewöhnlich hochqualifiziertes, effizientes und spürbar leidenschaftliches Serviceteam hervorgebracht [^10]. Die Unternehmensphilosophie von Din Tai Fung gilt in Fachkreisen als „atypischer“ Hidden Champion [^4]: Statt sichtbarer, zählbarer Rekorde – etwa der meisten Filialen oder der größten Verkaufsfläche – jagt das Unternehmen bewusst einer unsichtbaren, kaum messbaren Qualität nach, dem Streben nach echter Einzigartigkeit, und hat auf diese Weise eine Unternehmenskultur geschaffen, die tief genug verankert ist, um ganz Taipeh und letztlich ganz Taiwan international zu repräsentieren [^4]. Vorstandsvorsitzender Yang Chi-hua besucht bis zum heutigen Tag persönlich die einzelnen Filialen und bedient dort mitunter selbst Kund:innen – ein deutlicher Ausdruck seines bodenständigen, geradezu unternehmerisch-demütigen Führungsstils [^18].
+
+Darüber hinaus ist der geradezu extreme Anspruch, den Din Tai Fung an das gesprochene Wort stellt, eine der auffälligsten Besonderheiten seiner gesamten Serviceästhetik. Das Unternehmen hat ein eigens entwickeltes Schulungsprogramm eingeführt, in dem sogar die Köchinnen und Köche in der Küche einen verpflichtenden Stimmkurs besuchen müssen [^12]. Personalleiterin Lin Mei-ying weist ausdrücklich darauf hin, dass selbst jene Mitarbeitenden im Backoffice, die niemals direkten Kundenkontakt haben, dennoch über eine gute mündliche Ausdrucksfähigkeit verfügen müssen [^12]. Din Tai Fung engagierte sogar eigens die professionelle Stimmtrainerin Wei Shi-fen für einen zehnstündigen Stimmtrainingskurs, in dem den Mitarbeitenden systematisch beigebracht wird, wie sie allein durch Tonfall, Tonhöhe und Sprechrhythmus echte Aufrichtigkeit und Servicegeist vermitteln können – sodass selbst ein schlichtes „Willkommen, bitte kommen Sie herein!“ wie eine herzliche, persönlich gemeinte Einladung klingt [^12]. Dieses „Stimmmanagement“, das den Dienst am Kunden konsequent zu einer eigenen Kunstform erhebt, gilt intern als der eigentliche Schlüssel zu ihrem vielgerühmten „fehlerfreien“ Service [^9] [^12].
+
+### Globale Expansion und lokale Herausforderungen: Entscheidungen im Glanz des Michelinsterns
+
+Der durchschlagende Erfolg von Din Tai Fung ermöglichte es dem Unternehmen, nach der Eröffnung seiner allerersten Filiale außerhalb Taiwans 1996 im japanischen Shinjuku sein Filialnetz binnen weniger Jahrzehnte rasant auf die Vereinigten Staaten, Singapur, Indonesien, Malaysia, die Vereinigten Arabischen Emirate und insgesamt 15 Länder mit heute über 175 Filialen auszuweiten [^5] [^13]. Die Filialen in Hongkong wurden dabei wiederholt mit begehrten Michelinsternen ausgezeichnet und festigten damit weiter den Ruf des Unternehmens als eine der bedeutendsten internationalen Gastronomiemarken überhaupt [^13].
+
+Doch die globale Geschäftstätigkeit brachte, wie so oft bei internationaler Expansion, auch erhebliche Herausforderungen mit sich. Im August 2024 kündigte Din Tai Fung überraschend die Beendigung der Lizenzvereinbarung mit seinem bisherigen Betreiber in Nordchina an und schloss in der Folge gleich 14 Filialen in Peking, Tianjin, Qingdao und Xi'an – eine Entscheidung, die in der Öffentlichkeit für erhebliches Aufsehen sorgte [^14] [^15]. Taiwanische Medien berichteten übereinstimmend, dass der plötzliche Rückzug aus Nordchina eng mit langwierigen Streitigkeiten über Geldflüsse zwischen den beteiligten Anteilseignern sowie mit grundlegend unterschiedlichen Einschätzungen zu den mittelfristigen Aussichten der chinesischen Gastronomiebranche zusammenhing [^16]. Diese Episode verdeutlicht eindrücklich, dass selbst etablierte internationale Marken angesichts der Komplexität unterschiedlicher Märkte und ihrer jeweiligen lokalen Eigenheiten immer wieder gezwungen sind, sich anzupassen und flexibel zu reagieren – ohne dabei jemals ihre ursprünglichen Grundwerte aus den Augen zu verlieren.
+
+### Fazit: Eine taiwanische Geschichte in einem Xiaolongbao
+
+Vom kleinen Ölhandel in der Yongkang-Straße bis hin zu Michelin-Stern-Restaurants rund um den gesamten Globus – die Geschichte von Din Tai Fung ist weit mehr als nur eine erfolgreiche Unternehmenslegende, sie ist auch der eigentliche taiwanische Geist, verdichtet in der Form eines einzigen, sorgfältig gefalteten Xiaolongbao. Sie vereint auf einzigartige Weise die Beharrlichkeit traditionellen Handwerks, die schier unmenschliche Präzision modernen Managements und eine ganz und gar warmherzige, humanistische Fürsorge für den einzelnen Menschen. Trotz aller Rückschläge und Herausforderungen im Zuge der weltweiten Expansion erzählt Din Tai Fung der Welt mit seiner ganz eigenen, unverwechselbaren Unternehmensphilosophie unermüdlich weiter eine zutiefst taiwanische Geschichte über Qualität, aufrichtigen Service und die Weitergabe von Wissen über Generationen hinweg.
+
+### Referenzen
+
+[^1]: [Threads – Der Eigentümer (aktuelle Vorstandsvorsitzende) von Din Tai Fung ist Yang Chi-hua.](https://www.threads.com/@luleon.12/post/DZ4TFGPE1HJ/2026-%E9%BC%8E%E6%B3%B0%E8%B1%90%E7%9A%84%E8%80%81%E9%97%8B%E7%92%B0%E7%8F%BE%E4%BB%BB%E8%91%A3%E4%BA%8B%E9%95%B7%E6%98%AF-%E6%A5%8A%E7%B4%80%E8%8F%AF%E5%A6%82%E6%9E%9C%E5%BE%9E%E5%93%81%E7%89%8C%E7%9A%84%E7%99%BC%E5%B1%95%E6%AD%B7%E5%8F%B2%E4%BE%86%E7%9C%8B%E6%9C%89%E5%85%A9%E4%BD%8D%E9%9D%88%E9%AD%82%E4%BA%BA%E7%89%A9%E5%89%B5%E8%BE%A6%E4%BA%BA%E7%88%B6%E8%A6%AA%E6%A5%8A%E7%A7%89%E5%BD%9D%E8%88%87%E5%A6%BB%E5%AD%90%E8%B3%B4%E7%9B%86%E5%A6%B9%E6%96%BC-1958-%E5%B9%B4%E5%89%B5%E7%AB%8B%E9%BC%8E%E6%B3%B0%E8%B1%90%E6%B2%B9%E8%A1%8C%E5%BE%8C%E4%BE%86%E5%9B%A0%E9%A3%9F%E7%94%A8%E6%B2%B9%E5%8D%B1%E6%A9%9F%E6%96%BC-1) — Details siehe Originalquelle
+
+[^2]: [YouTube – Die Legende von Din Tai Fung enthüllt](https://www.youtube.com/watch?v=vjwAy_dpIZ8) — YouTube-Videodokumentation
+
+[^3]: [Facebook – Als Din Tai Fung ins Taipei Veterans General Hospital einzog: Serviceästhetik vom Esstisch bis zur Medizin](https://www.facebook.com/vghtpe/posts/%E7%95%B6%E9%BC%8E%E6%B3%B0%E8%B1%90%E8%B5%B0%E9%80%B2%E5%8C%97%E6%A6%AE%E5%BE%9E%E9%A4%90%E6%A1%8C%E5%88%B0%E9%86%AB%E7%99%82%E7%9A%84%E6%9C%8D%E5%8B%99%E7%BE%8E%E5%AD%B8%E8%B5%B0%E9%80%B2%E9%BC%8E%E6%B3%B0%E8%B1%90%E6%82%A8%E6%84%9F%E5%8F%97%E5%88%B0%E7%9A%84%E4%B8%8D%E5%8F%AA%E6%98%AF%E7%BE%8E%E5%91%B3%E9%82%84%E6%9C%89%E9%82%A3%E4%BB%BD%E8%A2%AB%E7%B4%B0%E5%BF%83%E5%B0%8D%E5%BE%85%E7%9A%84%E6%BA%AB%E5%BA%A6%E9%80%99%E6%A8%A3%E7%9A%84%E4%BB%A5%E4%BA%BA%E7%82%BA%E6%9C%AC%E7%B2%BE%E7%A5%9E%E6%AD%A3%E6%98%AF%E9%BC%8E%E6%B3%B0%E8%B1%90%E6%88%90%E7%82%BA%E4%B8%96%E7%95%8C%E7%B4%9A%E5%93%81%E7%89%8C%E7%9A%84%E9%97%9C%E9%8D%B510%E6%9C%8821%E6%97%A5%E7%9A%84%E5%A4%A7%E5%B8%AB%E8%AC%9B/1426101962858637/) — öffentlicher Facebook-Beitrag
+
+[^4]: [Global Views Monthly – Der „atypische“ Hidden Champion – Din Tai Fung](https://bookzone.cwgv.com.tw/article/2029) — Details siehe Originalquelle
+
+[^5]: [Economic Daily News – Dampft man einen Bao nicht perfekt, kommt er nicht auf den Tisch! Vorstandsvorsitzender Yang Chi-hua formt mit „18 Falten, 21 Gramm“ das Markenimage](https://money.udn.com/money/story/5612/9086340) — Bericht der Economic Daily News
+
+[^6]: [Instagram – Der Schlüssel dazu, dass Din Tai Fung Xiaolongbao international etablieren konnte, liegt in der Verbindung von extremer „industrieller Standardisierung“ und „handwerklichem Können“.](https://www.instagram.com/p/DZQ7z-woNQI/) — Details siehe Originalquelle
+
+[^7]: [FLAT43 – Perfektion durch Details definiert: Din Tai Fung](https://theflat43.com/culture/60-ding-tai-fung) — Details siehe Originalquelle
+
+[^8]: [Threads – Die Gewinn- und Verlustrechnung von Din Tai Fung ist wirklich besonders! 56 % des Umsatzes gehen an die Mitarbeitenden](https://www.threads.com/@marktosay/post/DV7sHZRgW1g/%E9%BC%8E%E6%B3%B0%E8%B1%90%E7%9A%84%E6%90%8D%E7%9B%8A%E7%B5%90%E6%A7%8B%E7%9C%9F%E7%9A%84%E5%BE%88%E7%89%B9%E5%88%A5%E4%BB%9656%E7%87%9F%E6%94%B6%E4%BB%98%E7%B5%A6%E5%93%A1%E5%B7%A5%E6%98%AF%E9%A4%90%E9%A3%B2%E6%A5%AD%E5%B9%B3%E5%9D%87%E7%9A%842%E5%80%8D%E8%80%8C%E4%BB%96%E4%B9%8B%E6%89%80%E4%BB%A5%E8%87%AA%E6%96%BC%E6%9D%B1%E8%A5%BF%E5%A5%BD%E5%90%83%E6%9C%8D%E5%8B%99%E5%A5%BD%E6%89%80%E4%BB%A5%E8%87%AA%E5%B8%B6%E6%B5%81%E9%87%8F%E5%8F%AF%E4%BB%A5%E8%AB%87%E5%88%B0%E4%BE%BF%E5%AE%9C%E7%9A%84%E5%95%86%E5%A0%B4%E7%A7%9F%E9%87%91%E5%A3%93%E4%BD%8E%E5%BB%A3%E5%91%8A%E8%B2%BB%E5%9B%A0%E8%80%8C%E5%A3%93%E4%BD%8E%E5%85%B6%E4%BB%96%E6%88%90%E6%9C%AC) — Details siehe Originalquelle
+
+[^9]: [Instagram – Die goldene Regel der Gastronomiebranche lautet, Personalkosten zu kontrollieren – warum geht Din Tai Fung den umgekehrten Weg?](https://www.instagram.com/p/DVpPxmMgZub/) — Details siehe Originalquelle
+
+[^10]: [CSR@天下 – Fitnesskurse und Physiotherapeut:innen: Krankheitstage bei Din Tai Fung um 400 Tage reduziert](https://csr.cw.com.tw/article/40470) — Details siehe Originalquelle
+
+[^11]: [Yahoo Aktien – Din Tai Fung-Vorstandsvorsitzender Yang Chi-hua verwöhnt Mitarbeitende mit außergewöhnlichen Sozialleistungen](https://tw.stock.yahoo.com/news/%E9%BC%8E%E6%B3%B0%E8%B1%90%E8%91%A3%E4%BA%8B%E9%95%B7%E6%A5%8A%E7%B4%80%E8%8F%AF-%E8%B6%85%E7%8B%82%E7%A6%8F%E5%88%A9%E5%AF%B5%E5%93%A1%E5%B7%A5-201000662.html) — Yahoo-Nachrichtenbericht
+
+[^12]: [CommonWealth Magazine – Din Tai Fung wird zum profitabelsten Restaurant der USA! Der Nachfolger der dritten Generation enthüllt das Erfolgsgeheimnis](https://www.cw.com.tw/article/5138450) — Details siehe Originalquelle
+
+[^13]: [Din Tai Fung US – Discover](https://dtf.com/en-us/discover) — Details siehe Originalquelle
+
+[^14]: [RFI – Din Tai Fung kündigt Schließung von 14 Filialen in Nordchina an – Überraschung](https://www.rfi.fr/cn/%E4%B8%AD%E5%9B%BD/20240826-%E9%BC%8E%E6%B3%B0%E4%B8%B0%E5%AE%A3%E5%B8%83%E5%85%B3%E9%97%AD%E4%B8%AD%E5%9B%BD%E5%8D%8E%E5%8C%9714%E5%AE%B6%E9%97%A8%E5%B8%82%E5%BC%95%E6%83%8A%E8%AE%B6) — Details siehe Originalquelle
+
+[^15]: [Yahoo Finanzen – Wegen schwacher Konsumlage zieht sich Din Tai Fung aus dem nordchinesischen Markt zurück](https://hk.finance.yahoo.com/news/%E8%B2%A1%E7%B6%93-%E6%B6%88%E8%B2%BB%E4%BD%8E%E9%9D%A2-%E9%BC%8E%E6%B3%B0%E8%B1%90%E9%80%80%E5%87%BA%E4%B8%AD%E5%9C%8B%E8%8F%AF%E5%8C%97%E5%B8%82%E5%A0%B4-091449664.html) — Yahoo-Nachrichtenbericht
+
+[^16]: [Meihua News – Die Pandemie überstanden, aber nicht den internen Streit! Der 460-Millionen-Geldfluss-Streit und der Bruch zwischen den Anteilseignern bei Din Tai Fung Nordchina aufgedeckt](https://www.i-meihua.com/Article/Detail/42910) — Details siehe Originalquelle
+
+[^17]: [Human Communication Agency – Din Tai Fung mit Herz führen: Yang Chi-hua schafft Wärme in der Perfektion](https://www.lnanews.com/news/73958) — Details siehe Originalquelle
+
+[^18]: [Threads – Dass er bis heute persönlich die Filialen besucht und Kund:innen bedient, ist wirklich bewundernswert](https://www.threads.com/@marktosay/post/DYSTKejAQgN/%E6%A5%8A%E8%80%81%E9%97%8B%E7%9A%84%E7%B6%93%E7%87%9F%E5%93%B2%E5%AD%B8%E7%A2%BA%E5%AF%A6%E6%9C%89%E5%BE%88%E5%A4%9A%E5%80%BC%E5%BE%97%E5%AD%B8%E7%BF%92%E7%9A%84%E5%9C%B0%E6%96%B9%E4%BB%96%E5%88%B0%E7%8F%BE%E5%9C%A8%E9%82%84%E6%9C%83%E8%A6%AA%E8%87%AA%E5%88%B0%E9%96%80%E5%B8%82%E5%B7%A1%E5%BA%97%E6%9C%8D%E5%8B%99%E5%AE%A2%E4%BA%BA%E9%80%99%E9%BB%9E%E4%B9%9F%E5%BE%88%E4%BB%A4%E4%BA%BA%E6%AC%BD%E4%BD%A9/) — Details siehe Originalquelle


### PR DESCRIPTION
Adds German translation of `Food/鼎泰豐.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 2.48 (target median 2.60, p10-p90 2.20-4.00)

**Structure alignment**: headings (### × 4) / footnotes (18/18) / links (18/18 URLs, exact multiset) — 100% preserved

**Note**: i18n/de/STYLE.md not yet exists — followed TRANSLATE_PROMPT + established translation conventions from existing de corpus (e.g. `## Referenzen` heading, existing de/Food articles).

Uncertain terminology flagged for reviewer:

- 非典型領導 → "atypische Führung" · direct compound rendering of the Chinese business term describing Din Tai Fung's unconventional "hidden champion" management style; no fixed German business-press equivalent found
- 聲音管理 → "Stimmmanagement" · coined compound for the company's internal "voice management" training program; not an established German HR term

Please review. Happy to iterate.
