### PR TITLE
translate(id): 陳樹菊 → chen-shu-chu-vegetable-vendor-philanthropist

### DIFF
--- a/knowledge/id/People/chen-shu-chu-vegetable-vendor-philanthropist.md
+++ b/knowledge/id/People/chen-shu-chu-vegetable-vendor-philanthropist.md
@@ -1,0 +1,117 @@
+---
+title: 'Chen Shu-chu: Pedagang Sayur Taitung yang Menyumbangkan Puluhan Juta dari Uang Sayur Selama 50 Tahun'
+description: 'Seorang pedagang sayur dari Taitung yang menyumbangkan puluhan juta dolar Taiwan dari uang hasil berjualan sayur selama lima puluh tahun, namun tetap menyebut dirinya "hanya seorang penjual sayur"'
+date: 2026-03-19
+category: 'People'
+tags: ['Tokoh', 'Filantropi', 'Taitung', 'Pedagang Sayur', 'Majalah TIME', 'Penghargaan Ramon Magsaysay', 'Donasi Pendidikan']
+subcategory: '慈善與社會'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-05-16
+lastHumanReview: true
+translatedFrom: 'People/陳樹菊.md'
+sourceCommitSha: '85926aa3b'
+sourceContentHash: 'sha256:884e3106e00c3ed4'
+translatedAt: '2026-09-09T05:22:47+08:00'
+---
+
+> **Ringkasan 30 detik:** Chen Shu-chu, lahir tahun 1950, adalah pedagang sayur di Pasar Sentral Taitung. Pada usia 13 tahun ia berhenti sekolah untuk berjualan sayur setelah ibunya meninggal saat melahirkan. Sejak itu, selama lebih dari lima puluh tahun, ia telah menyumbangkan puluhan juta NT dolar kepada sekolah, panti asuhan, dan rumah sakit. Pada tahun 2010 ia masuk dalam daftar 100 Orang Paling Berpengaruh di Dunia versi majalah _TIME_; sutradara Ang Lee sendiri yang menulis profil pencalonannya. Ketika ia pergi ke New York untuk menerima penghargaan, ia berkata: "Saya cuma seorang penjual sayur."[^1]
+
+## Ibu Meninggal di Perjalanan ke Rumah Sakit
+
+Tahun 1963, di Taitung. Ibu Chen Shu-chu sedang mengandung anak ketujuh dan mengalami persalinan sulit. Keluarganya tidak sanggup mengumpulkan uang jaminan yang diminta rumah sakit. Dalam perjalanan menuju rumah sakit, sang ibu dan janin yang dikandungnya meninggal bersamaan.[^2]
+
+Tahun itu Chen Shu-chu berusia 13 tahun, baru saja lulus dari Sekolah Dasar Ren'ai Taitung. Ia tidak melanjutkan sekolah — ia mengambil alih lapak sayur ibunya di pasar dan mulai menafkahi empat adik laki-laki dan dua adik perempuannya.[^3] Beberapa tahun sebelumnya, adik laki-lakinya yang berusia 11 tahun pernah jatuh sakit, dan juga karena keluarga tidak punya uang untuk berobat, akhirnya para guru sekolahlah yang menggalang dana hingga terkumpul biaya pengobatannya.[^4]
+
+Terlalu miskin bahkan untuk berobat ke dokter tanpa bantuan orang lain — kenangan itulah yang kelak mendorong seluruh donasinya.
+
+## Matematika di Lapak Sayur
+
+Lapak sayur Chen Shu-chu berada di Pasar Sentral Taitung. Setiap hari ia sudah bekerja sebelum pukul empat pagi — orang pertama yang datang dan orang terakhir yang pulang di pasar itu. Agar bisa bangun tepat waktu, ia tidur di lantai. Dalam setahun ia hanya libur satu hari.[^4]
+
+Lapaknya tidak besar, tetapi lokasinya bagus — ketika pasar itu pertama kali dibangun dan lokasi lapak diundi, keluarganya mendapat tempat yang strategis. Ia kemudian mengembangkan model bisnisnya sendiri: memasok sayur untuk garnisun militer di Pulau Green (Lyudao), karena mengirim langsung dari Taitung lebih murah dibanding mengangkutnya dari tempat lain.[^4] Cara ini membuat penghasilannya stabil, meski tetap saja penghasilan seorang pedagang sayur.
+
+Uangnya terkumpul seikat sayur demi seikat sayur, tanpa satu pun keuntungan besar yang datang tiba-tiba atau jalan pintas. Ia hampir tidak pernah menghabiskan uang untuk dirinya sendiri — tidak makan di luar, tidak membeli baju baru, tinggal di rumah tua dekat pasar. Uang yang berhasil ia hemat, ia gunakan untuk hal lain.
+
+## Kronik Donasi
+
+Tahun 1993, ayah dan adik laki-laki keduanya meninggal berturut-turut. Chen Shu-chu menyumbangkan NT$1 juta kepada Fo Guang College (sekarang Universitas Fo Guang). Itulah kali pertama ia mengeluarkan tabungannya.[^5]
+
+Sejak tahun 1996, ia mulai menyumbang NT$36.000 setiap tahun kepada Rumah Anak Elijah (阿尼色弗兒童之家) di Taitung, mengasuh tiga orang anak panti. Belakangan ia juga menyumbangkan NT$1 juta sekaligus kepada lembaga tersebut.[^6]
+
+Tahun 1997, ia menyumbangkan NT$1 juta kepada almamaternya, Sekolah Dasar Ren'ai, untuk mendirikan beasiswa bantuan darurat. Tahun 2005, ia kembali menyumbangkan NT$4,5 juta untuk membangun perpustakaan.[^7] Ia memilih almamaternya karena, ketika ia masih kecil dan keluarganya miskin, para guru sekolah pernah membantu adiknya. "Orang lain pernah membantu saya, saya harus membalasnya" — begitu sederhana logikanya.[^4]
+
+Ketika majalah _TIME_ mulai memperhatikannya pada tahun 2010, ia sudah menyumbangkan hampir NT$10 juta secara kumulatif.[^1]
+
+Namun ia tidak berhenti di situ.
+
+Tahun 2012, ia menerima Penghargaan Ramon Magsaysay dari Filipina (kerap disebut Hadiah Nobel Perdamaian-nya Asia), dengan hadiah sebesar 50.000 dolar AS. Ia menyumbangkan seluruh hadiah itu kepada Rumah Sakit Mackay Memorial Taitung.[^8]
+
+Pada 10 Oktober 2018, ia menyumbangkan dua polis asuransi dengan nilai tunai NT$16 juta, mempercayakan Rumah Sakit Mackay Taitung dan Rumah Sakit Kristen Taitung untuk mendirikan "Dana Kepedulian Kemiskinan Medis dan Pasien Kanker Chen Shu-chu".[^9]
+
+Pada 28 Agustus 2021 — hari peringatan wafatnya sang ibu — ia kembali menyumbangkan polis asuransi senilai NT$15 juta kepada Pemerintah Kabupaten Taitung, dengan tujuan khusus mendirikan "Dana Bantuan Persalinan dan Kedaruratan" untuk membantu para ibu yang secara ekonomi kesulitan.[^10] Ia terharu sampai tersedu di konferensi pers: "Setelah menunggu 59 tahun, akhirnya saya bisa mewujudkan keinginan ini."[^11]
+
+Lima puluh sembilan tahun sebelumnya, ibunya meninggal dalam perjalanan menuju rumah sakit.
+
+## Seorang Pedagang Sayur di Panggung Dunia
+
+April 2010, majalah _TIME_ mengumumkan 100 Orang Paling Berpengaruh di Dunia tahun itu; Chen Shu-chu menempati posisi kedelapan dalam kategori "Pahlawan" — sejajar dengan Barack Obama dan para pengusaha energi bersih.[^1] Sutradara Ang Lee sendiri yang menuliskan profil pencalonannya. Di tahun yang sama, majalah _Forbes_ memilihnya sebagai salah satu Pahlawan Filantropi Asia.[^12] _Reader's Digest_ menganugerahinya Penghargaan Pahlawan Asia ke-4.[^5]
+
+Ketika diberi tahu bahwa ia memenangkan penghargaan itu, ia bahkan tidak tahu apa itu majalah _TIME_. Pergi ke New York untuk menerima penghargaan itu adalah kali pertama ia bepergian ke luar negeri. Ia mengenakan pakaian sehari-harinya untuk berjualan sayur dan berkata kepada wartawan: "Saya cuma seorang penjual sayur, tidak tahu kenapa mereka memilih saya."[^1]
+
+Segala kehormatan itu tidak mengubah satu hari pun dalam hidupnya. Kembali ke Taitung, ia tetap berjualan di lapaknya sejak pukul empat pagi seperti biasa.
+
+Penghargaan Ramon Magsaysay tahun 2012, asteroid 278986 yang dinamai menurut namanya pada tahun 2018[^5], dan gelar doktor kehormatan dari Universitas Nasional Taitung pada tahun 2025[^13] — setiap kali ia naik ke atas panggung untuk menerima penghargaan, ia selalu buru-buru kembali ke lapak sayurnya.
+
+## Ketika Tubuhnya Tak Lagi Kuat
+
+Februari 2018, Chen Shu-chu pingsan di depan lapaknya dan dilarikan ke rumah sakit untuk menjalani operasi darurat.[^5] Dokter memintanya beristirahat; ia baru berbaring sebulan lalu sudah ingin kembali berjualan sayur. Namun kali ini tubuhnya tidak mengabulkan keinginannya — ditambah lagi adiknya juga sedang sakit dan butuh perawatan, ia akhirnya resmi menutup lapaknya pada tahun 2018.[^4]
+
+Setelah lebih dari lima puluh tahun berjualan sayur, lapak itu kemudian berubah menjadi lapak daging.
+
+Setelah pensiun ia tetap tinggal di Taitung, tetap peduli pada orang-orang yang membutuhkan bantuan. Donasi NT$15 juta pada tahun 2021 justru diselesaikan setelah ia pensiun. Ia berkata: "Uang tidak dibawa lahir, tidak dibawa mati. Uang pensiun nasional sudah cukup untuk saya — sisanya harus diberikan kepada yang membutuhkan."[^10]
+
+## Sebuah Hitungan Matematika Sederhana
+
+Kisah Chen Shu-chu sering dibungkus sebagai "perbuatan baik yang mengharukan", tetapi jika diurai, sesungguhnya ini adalah soal matematika: jika seseorang menabung sedikit setiap hari dan bertahan selama lima puluh tahun, berapa banyak yang bisa terkumpul?
+
+Jawabannya: puluhan juta.
+
+Pertanyaan yang lebih dalam adalah: mengapa seorang pedagang sayur mau melakukan ini? Jawabannya tidak pernah berubah — karena pada usia 13 tahun, ibunya meninggal dalam perjalanan menuju rumah sakit, dan saat itu ia tidak bisa berbuat apa-apa. Lima puluh tahun kemudian, ia akhirnya punya kemampuan untuk memastikan ibu-ibu lain tidak mengalami nasib yang sama.[^11]
+
+Tahun 2025, Universitas Nasional Taitung menganugerahinya gelar doktor kehormatan. Ia berpidato di atas panggung: "Terima kasih semua sudah tidak memandang rendah lapak pinggir jalan saya."[^13]
+
+## Bacaan Lanjutan
+
+- [Pasar Sentral Taitung](/lifestyle/台東市集) — lokasi lapak sayur Chen Shu-chu selama lima puluh tahun, representasi ekonomi rakyat kecil di Taitung
+- [Budaya Filantropi Taiwan](/society/台灣慈善文化) — dari Master Cheng Yen dan Yayasan Tzu Chi hingga Chen Shu-chu si pedagang sayur: dua contoh filantropi rakyat Taiwan
+- [Pendidikan di Daerah Terpencil Taiwan](/society/台灣偏鄉教育) — arah utama donasi Chen Shu-chu selama bertahun-tahun: dukungan jangka panjang untuk perpustakaan, sekolah, dan panti asuhan
+
+## Daftar Pustaka
+
+[^1]: "The 2010 TIME 100 — Chen Shu-chu," _TIME Magazine_, 2010. https://content.time.com/time/specials/packages/article/0,28804,1984685_1984949_1985237,00.html
+
+[^2]: "Chen Shu-chu," Wikipedia. Ibunya meninggal karena persalinan sulit dan keluarga tidak sanggup mengumpulkan uang jaminan rumah sakit; ia meninggal dalam perjalanan ke rumah sakit bersama janin yang dikandungnya. https://zh.wikipedia.org/zh-tw/陳樹菊
+
+[^3]: "Chen Shu-chu, Menepati Janji dengan Kekuatan Seumur Hidup," _Global Views Monthly_. https://www.gvm.com.tw/article/14164
+
+[^4]: "Taiwan in Time: Donating millions from a vegetable stall," _Taipei Times_, 2023-08-27. https://www.taipeitimes.com/News/feat/archives/2023/08/27/2003805339
+
+[^5]: "Chen Shu-chu," Wikipedia, bagian "Kehormatan dan Penghargaan". https://zh.wikipedia.org/zh-tw/陳樹菊
+
+[^6]: "Membalas Budi dengan Rasa Syukur, Nenek Chen Shu-chu Berderma Lebih dari Sepuluh Juta," Buddha Land on Earth Community. Sejak 1996 menyumbang NT$36.000 setiap tahun untuk mengasuh tiga anak panti. https://www.buddhalandonearth.org/family/2021/10/charitable/8290/
+
+[^7]: "Pedagang Sayur Sumbangkan Perpustakaan, Terus Menabung untuk Bantu Orang Miskin," laporan yang menyebutkan Chen Shu-chu menyumbangkan NT$1 juta untuk beasiswa dan NT$4,5 juta untuk membangun perpustakaan bagi almamaternya, Sekolah Dasar Ren'ai.
+
+[^8]: "Chen Shu-chu," Wikipedia, bagian "Penghargaan Ramon Magsaysay". Menerima penghargaan pada 2012; menyumbangkan seluruh hadiah 50.000 dolar AS kepada Rumah Sakit Mackay Memorial Taitung. https://zh.wikipedia.org/zh-tw/陳樹菊
+
+[^9]: "Chen Shu-chu Kembali Sumbangkan NT$16 Juta, Penerima Manfaat Asuransi Diubah Jadi Rumah Sakit," _Liberty Times_, 2018-10-10. https://news.ltn.com.tw/news/life/breakingnews/2576050
+
+[^10]: "Pada Hari Peringatan Wafat Ibu, Kembali Sumbangkan NT$15 Juta — Chen Shu-chu: Uang Pensiun Nasional Sudah Cukup," Central News Agency, 2021-08-28. https://www.cna.com.tw/news/ahel/202108280119.aspx
+
+[^11]: "Sumbangkan NT$15 Juta pada Hari Peringatan Wafat Ibu, Chen Shu-chu Terharu: Sudah Menunggu 59 Tahun," dimuat ulang oleh Yahoo News. https://tw.news.yahoo.com/母親忌日捐1500萬元-陳樹菊哽咽-等了59年-085532746.html
+
+[^12]: "48 Heroes of Philanthropy," _Forbes Asia_, 2010.
+
+[^13]: "Terima Gelar Doktor Kehormatan dari Universitas Nasional Taitung, Chen Shu-chu: Terima Kasih Semua Sudah Tidak Memandang Rendah Lapak Pinggir Jalan Saya," _United Daily News_, 2025-06-08. https://udn.com/news/story/6928/8791319
+


### PR DESCRIPTION
Adds Indonesian translation of `People/陳樹菊.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 4.5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.10 (target median 2.78, p10-p90 2.29-3.34)

**Structure alignment**: headings (## × 8) / footnotes (13/13) / links (11/11 URLs, exact multiset) — 100% preserved

**Note**: i18n/id/STYLE.md not yet exists — followed TRANSLATE_PROMPT + established translation conventions from existing id corpus (e.g. `## Bacaan Lanjutan`, `## Daftar Pustaka` headings, per existing id/Food articles).

Uncertain terminology flagged for reviewer:

- 阿尼色弗兒童之家 → "Rumah Anak Elijah" (kept Chinese name in parentheses on first mention) · this is the proper name of a specific Taitung children's home; rendered the transliterated English name used elsewhere in the corpus rather than inventing an Indonesian gloss
- Further Reading links (`/lifestyle/台東市集`, `/society/台灣慈善文化`) kept as literal zh-slug paths since no Indonesian equivalent articles exist yet — matches the pattern used in existing id translations (e.g. id/Food/braised-pork-rice.md)

Please review. Happy to iterate.
