### PR TITLE
Add German translation for People (Ang Lee)

### DIFF
--- a/knowledge/de/People/ang-lee.md
+++ b/knowledge/de/People/ang-lee.md
@@ -1,0 +1,321 @@
+---
+title: 'Ang Lee: Hinter zwei Oscars der Sohn, der sich nie richtig von seinem Vater verabschieden konnte'
+description: '2006 stand Ang Lee auf der Oscar-Bühne und wurde der erste Asiate, der den Preis für die beste Regie gewann – und sprach auf Mandarin den Satz „Danke für eure Besorgnis“. Die Welt erinnert sich an den Stolz Taiwans und seine zwei goldenen Statuetten, doch sein ganzes Leben lang filmte er Unterdrückung, Angst – und den Vater, der seine Filme immer abgelehnt hatte und zwei Jahre zuvor plötzlich gestorben war. Vom arbeitslosen Schwiegersohn, der sechs Jahre lang zu Hause kochte, zum zweifachen Golden-Lion-Gewinner von Venedig: Sein wahrer Gegner war nie das Filmset, sondern das Selbst, das er nicht überwinden konnte.'
+date: 2026-03-17
+category: 'People'
+tags: ['Person', 'Ang Lee', 'Regisseur', 'Oscar', 'Film', 'Interkulturell', 'Golden Horse Awards']
+subcategory: '電影與戲劇'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-06-01
+lastHumanReview: false
+image: '/article-images/people/ang-lee-bafta-2013.webp'
+imageCredit: 'Sean Reynolds'
+imageLicense: 'CC BY 2.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Ang_Lee_(8464864982).jpg'
+translatedFrom: 'People/李安.md'
+sourceCommitSha: '09ffe560f'
+sourceContentHash: 'sha256:270ebb8ad85e9750'
+sourceBodyHash: 'sha256:1c12395477bc0a4e'
+translatedAt: '2026-09-09T00:35:00+08:00'
+---
+
+# Ang Lee: Hinter zwei Oscars der Sohn, der sich nie richtig von seinem Vater verabschieden konnte
+
+> **30 Sekunden im Überblick:** 2006 wurde Ang Lee der erste Asiate in der Geschichte der Oscars, der den Preis für die beste Regie gewann; 2013 holte er zum zweiten Mal – bis heute ist er der einzige asiatische Regisseur mit zwei dieser Auszeichnungen. Doch die Geschichte dieses „Stolzes Taiwans“ ist im Kern die Geschichte eines Waisenkinds der Exilgeneration, das sein ganzes Leben mit dem Vater, mit der Unterdrückung und mit der Angst, „es nicht mehr durchzustehen“, rang. Bei jedem Film glaubte er, es nicht zu können; nach dem Masterabschluss kochte er sechs Jahre lang zu Hause und wartete auf ein Drehbuch; und am ängstlichsten war er ausgerechnet in „dem Moment, in dem ich mich völlig sicher fühle“. Seine Sanftheit wurde aus der Unterdrückung herausgepresst, seine Größe ist, das Unbezwingbare in Film zu verwandeln.
+
+Im März 2006, im Los Angeles Kodak Theatre. Ang Lee steht auf der Oscar-Bühne, in der Hand die goldene Statuette für die beste Regie – ein Asiate, ein Taiwanese, ein Chinese: Kein Regisseur mit seiner Hautfarbe hatte diese Auszeichnung je zuvor erhalten. Die ganze Welt wartet darauf, was er sagen wird. Er öffnet den Mund, zitiert erst auf Englisch Jacks Satz aus _Brokeback Mountain_, „I wish I knew how to quit you“, und wechselt dann den Tonfall – auf Mandarin sagt er in die Kamera: „Danke für eure Besorgnis.“[^1]
+
+Der Satz wirkt in einer Dankesrede deplatziert. Das Wort „Besorgnis“ klingt eher nach einem Sohn der Fremde, der zu den Älteren in der Heimat auf der anderen Seite der Meerenge spricht, als wolle er sagen: „Mir geht es gut, ich habe es durchgestanden, macht euch keine Sorgen.“ Zwei Jahre zuvor hatte er bei den Dreharbeiten zu _Hulk_ ans Aufhören gedacht und war zu seinem Vater gegangen, der seine Filme immer abgelehnt hatte – doch der bat ihn zum ersten Mal, weiterzumachen. Keine zwei Wochen nach diesen Worten starb der Vater plötzlich[^2]. Der Mann auf der Bühne hat gerade seinen Vater verloren, wurde eben von den Kritikern niedergemacht, hält jetzt die schwerste Auszeichnung der Welt in der Hand – und doch denkt er zuerst an jene in der Heimat, die sich ständig um ihn sorgten.
+
+Die Welt erinnert sich an den Stolz Taiwans mit zwei Oscars. Doch sein ganzes Leben lang filmte er Unterdrückung, Angst – und den Sohn, der sich nie richtig von seinem Vater verabschieden konnte.
+
+## Das Kind, das „fast“ gereicht hätte, im Haus des Direktors von Tainan
+
+Ang Lee wurde am 23. Oktober 1954 im Stadtbezirk Chaozhou im Landkreis Pingtung geboren[^3]. Sein Vater Li Sheng, 1917 in De'an in Jiangxi geboren, kam 1949 mit der Regierung der Nationalpartei nach Taiwan; er war ein Mann, der sein ganzes Leben in der Bildung verbrachte, wurde Direktor der Höheren Normalschule Hualien und der Zweiten Mittelschule von Tainan und war danach vierzehn Jahre lang Direktor der Ersten Mittelschule von Tainan[^4]. Im Tainan jener Jahre waren die sechs Wörter „der Sohn des Direktors Li“ selbst eine Last.
+
+Diese Last lastete auf einem Kind, das wie auch immer man es betrachtete nicht gerade herausragend war. Ang Lee besuchte zunächst die Zweite Mittelschule von Tainan und wechselte dann durch Aufnahmeprüfung an die Erste Mittelschule, an der sein Vater später das Sagen hatte. Die Uni-Aufnahmeprüfung legte er zweimal ab, zweimal fiel er durch – und beide Male nur knapp. Für einen Sohn des Schuldirektors war das vor der gesamten Bildungsgemeinschaft Süd-Taiwans eine unerträgliche Blamage, weit mehr als nur die Punktzahl. In einer Umgebung, in der der Vater die beste Oberschule ganz Tainans leitete und in der die ganze Familie dem Wort „Aufstieg durch Bildung“ fast religiös anhing, war zweimal in Folge durchzufallen eine Scham, die ein Junge in diesem Alter nicht leicht verdauen konnte. Am Ende kam er an die Nationale Kunstakademie, Fachrichtung Theater- und Filmabteilung – 1973 immatrikuliert, 1975 abgeschlossen[^5]. In einer Beamten- und Lehrerfamilie, in der der Bildungsaufstieg als einziger rechter Weg galt, bedeutete Theater zu studieren, öffentlich zu erklären, dass man vom Weg abgekommen war – und diese Entscheidung selbst war der erste echte Riss zwischen Vater und Sohn.
+
+> 📝 **Notiz des Kurators**
+> Später sagte Ang Lee einen Satz, den Außenstehende nicht auf Anhieb verstehen: „Ich identifiziere mich besonders mit der Verliererseite, ich habe besonders viel Mitgefühl für sie – auch unsere Familie hat vom Festland nach Taiwan verloren, Taiwan ist in der internationalen Gemeinschaft schwach, und als ich nach Amerika kam, war ich immer noch schwach.“[^6] Dieser Satz ist der Schlüssel zum Verständnis all seiner Filme. Er ist kein Geschichtenerzähler, der auf der Seite der Sieger steht: In _Pushing Hands_ der greise Vater, der nirgendwo hineinpasst, in _Brokeback Mountain_ die beiden Männer, denen nicht erlaubt ist zu lieben, in _Lust, Caution_ die Studentin, die nicht Herr ihrer Lage ist, in _Life of Pi_ der Junge, der auf dem Meer treibt und nichts besitzt – er filmt durchweg Menschen, die in eine Ecke gedrängt wurden, durchhalten und doch verlieren. Ein Kind, das von klein auf durch „fast geschafft“ definiert wurde und in der Erzählung der Verlierer der Exilgeneration lebte, wurde erwachsen zum Regisseur der Welt, der die Würde der Verlierer am besten zu filmen versteht.
+
+Nach dem Abschluss an der Kunstakademie und dem Wehrdienst ging er Ende der 1970er Jahre in die USA. Zuerst studierte er Theater an der University of Illinois, 1980 erhielt er den Bachelor; anschließend ging er an das Filmproduktions-Institut der New York University, wo er 1984 den Master machte[^7]. An der NYU war sein Kommilitone der später berühmte Regisseur Spike Lee, und Ang Lee war sogar stellvertretender Regisseur bei Spikes Abschlussarbeit[^8]. Seine studentischen Arbeiten machten stetig Fortschritte: vom stummen Kurzfilm _Chase_ im ersten Jahr über _Shade of the Lake_ von 1982, das auf dem 6. Golden Harvest Award Taiwans als bester 16-mm-Spielfilm ausgezeichnet wurde, bis zur Abschlussarbeit _The Boundary Line_, für die er an der NYU den Wasserman-Preis für die beste Regie erhielt[^9]. Von außen betrachtet war das eine hübsche Aufwärtskurve.
+
+## Sechs Jahre lang war er der Ehemann, der zu Hause kochte
+
+Dann riss die Kurve ab.
+
+1984 schloss er die NYU ab – eigentlich der Beginn einer Karriere. Doch in den folgenden sechs Jahren konnte Ang Lee keinen einzigen Film drehen. Niemand wollte einen asiatischen Regisseur, der chinesische Familiengeschichten drehte; seine Drehbücher wurden eines nach dem anderen abgelehnt, seine Bewerbungen versanken spurlos. In diesen sechs Jahren ernährte die Familie seine Frau Lin Hui-chia. Sie ist Mikrobiologin, machte ihren Abschluss in Agrarchenie an der Nationaluniversität Taiwan, promovierte in Mikrobiologie an der University of Illinois und wurde später Professorin für Pathologieforschung an der New York Medical College[^10]. Sie heirateten im August 1983 in New York, der älteste Sohn Han wurde 1984 geboren[^11].
+
+Ein Mann mit Filmmaster und Regiepreis arbeitet jeden Tag folgendes: lesen, Filme sehen, an ungewollten Drehbüchern schreiben – und die restliche Zeit einkaufen, kochen, Kinder betreuen. In der chinesischen Familienvorstellung jener Zeit war das fast die demütigendste Position für einen Mann: Die Ehemänner der anderen schuften draußen, er steht in der Küche. Eine Wissenschaftlerin, die einen Regisseur-Ehemann ernährte, der keine Erfolge vorweisen konnte – dafür gab es in der chinesischen Gesellschaft damals kaum ein Vorbild; wie Außenstehende darüber dachten und was die Älteren der Familie dazu meinten, ist nicht schwer vorzustellen. Später beschrieb er dieses Gefühl als eine bodenlose Unsicherheit – und genau diese Unsicherheit wurde später zum Motor seiner Kunst. Von _Pushing Hands_ bis _Eat Drink Man Woman_ tragen alle Geschichten über Familie, über den Esstisch, über wer wen ernährt später den Geruch dieser sechs Jahre.
+
+> ✦ „Die Angst peitscht mich, mich ständig zu verbessern, denn es gibt kein stärkeres Gefühl als die Angst. Dass ich immer weiter versuchen kann, die Triebkraft liegt in der Unsicherheit.“[^12]
+
+![Ang Lee bei einem Filmfestival in dunklem Anzug, ruhiger Gesichtsausdruck](/article-images/people/ang-lee-hkaff-2007.webp)
+_Ang Lee beim Hong Kong Asian Film Festival 2007. Foto: WikiCantona. [CC BY-SA 3.0 via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Ang_Lee_HKAFF_2007.jpg)._
+
+Der Wendepunkt kam 1990. In jenem Jahr reichte Ang Lee beim Preis für gute Drehbücher des Informationsamtes des Exekutiv-Yuans gleich zwei Manuskripte ein: _Pushing Hands_ gewann den ersten Preis mit einem Preisgeld von 400.000 NT$, _The Wedding Banquet_ den zweiten[^13]. Diese 400.000 NT$ plus das Auge des Zentralfilm-Vizepräsidenten Hsu Li-kong holten ihn aus der Küche heraus. Hsu Li-kong erkannte das Talent dieses Neulings ohne Langfilm und beschloss, in _Pushing Hands_ zu investieren, mit einem Produktionsbudget von etwa zwölf bis dreizehneinhalb Millionen NT$. Was Hsu Li-kong ihm sagte, war hart und zugleich sehr realistisch: „Zwölf Millionen NT$, mehr nicht, keine einzige Münze mehr.“[^14] Im selben Jahr wurde sein zweiter Sohn Mason geboren[^15].
+
+Sechs Jahre Arbeitslosigkeit endeten damit mit 36 Jahren. Aber diese sechs Jahre waren nicht umsonst: Sie zwangen einen Menschen dazu, am tiefsten zu erfahren, was es heißt, „keinen festen Boden unter den Füßen zu haben“ – und genau das wurde der Grundton all seiner späteren Werke.
+
+
+## Sihung Lung spielte dreimal seinen Vater
+
+In drei aufeinanderfolgenden Filmen ließ Ang Lee denselben Schauspieler – Sihung Lung – den Vater spielen: in _Pushing Hands_ den Taijiquan-Meister, in _The Wedding Banquet_ den pensionierten Offizier, in _Eat Drink Man Woman_ den pensionierten Spitzenkoch. Deshalb werden diese drei Filme gemeinsam die „Vatertrilogie“ genannt, auch „Familientrilogie“. Aber was sie wirklich zu einer Gruppe macht, ist tiefer als Sihung Lungs Gesicht: Es ist, dass Ang Lee wieder und wieder dieselbe Frage verhandelt – wie ein Sohn einem Vater begegnet, den er zugleich verehrt und mit dem er nicht kommunizieren kann.
+
+_Pushing Hands_ (1991) ist der Anfang. Sihung Lung spielt Zhu laoshi, den obersten Taijiquan-Trainer, der in die USA geholt wird, um mit seinem Sohn zu wohnen, und doch überall mit der amerikanischen Schwiegertochter und dem gesamten westlichen Leben kollidiert: Ein Ältester, der in seiner eigenen Kultur höchstes Ansehen genießt, wird in der Fremde zum überflüssigen Menschen. Dieser Erstling brachte Ang Lee den Preis für den besten Film beim 37. Asia-Pacific Film Festival und den Preis für die beste Nachwuchsregie beim Festival von Amiens ein; bei den Golden Horse Awards in Taiwan gewann Sihung Lung als bester Hauptdarsteller, Wang Lai als beste Nebendarstellerin, und der Film selbst erhielt den Sonderpreis der Jury[^16].
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/CLyFaipchmk" title="推手 Pushing Hands (1991) Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Trailer zu „Pushing Hands“ von Film Movement: Ang Lees Langfilm-Debüt, mit Sihung Lung als Taijiquan-Meister, der zu seinem Sohn nach Amerika zieht und überall aneckt._
+
+Im zweiten Film, _The Wedding Banquet_ (1993), wird diese Frage auf eine noch schärfere Spitze getrieben. Ein schwuler Taiwaner in New York schließt mit einer Frau, die eine Green Card braucht, eine Scheinehe, um die aus Taiwan eingeflogenen Eltern zufriedenzustellen – und die Hochzeitsfeier verwickelt am Ende alle in ein Lügengespinst. Diese Komödie mit Winston Chao, Kuei Ya-lei und Sihung Lung stößt frontal auf den Konflikt zwischen Homosexualität und traditioneller Familienethik. Sie holte den Goldenen Bären der 43. Internationalen Filmfestspiele Berlin (geteilt mit Xie Feis _Der Duft der Frauen_), kam in die engere Auswahl für den besten fremdsprachigen Film der 66. Oscars und gewann bei den Golden Horse Awards gleich fünf große Preise, darunter den für den besten Spielfilm und die beste Regie[^17]. Eine Geschichte darüber, ob ein chinesischer Vater das wahre Ich seines Sohnes annehmen kann, ließ die Welt beginnen, sich Ang Lees Namen zu merken.
+
+In _Eat Drink Man Woman_ (1994) ist der Vater nicht länger nur Objekt der Beobachtung – er selbst hat ein Geheimnis, das er nicht aussprechen kann. Sihung Lung spielt den pensionierten Spitzenkoch Chu, der jedes Wochenende seinen drei Töchtern (gespielt von Yang Kuei-mei, Wu Chien-lien und Wang Yu-wen) einen üppigen, geradezu übertriebenen Esstisch zaubert – und doch rücken die Familienmitglieder am Tisch immer weiter auseinander. Die berühmte lange Kochszene am Filmanfang, mit einer geradezu unglaublich schnellen Messerführung – diese Hände sind nicht Sihung Lungs; das Team holte einen echten Spitzenkoch als Double, und allein für diese Szene wurde über eine Woche gedreht[^18]. Auch dieser Film kam in die Auswahl für den Oscar des besten fremdsprachigen Films und brachte Ang Lee zwei Jahre in Folge (_The Wedding Banquet_, _Eat Drink Man Woman_) auf die Nominierungsliste der Oscars für fremdsprachige Filme; später wurde er in Hollywood als _Tortilla Soup_ (2001) neuverfilmt[^19].
+
+> 📝 **Notiz des Kurators**
+> Wenn man allgemein von der Vatertrilogie spricht, sagt man gern: „Ang Lee zeichnet mit feinem Pinsel den Kulturkonflikt zwischen Ost und West.“ Doch diese Formulierung setzt den Schwerpunkt falsch. Was die drei Filme wirklich durchzieht, ist nicht „Kultur“, sondern der konkrete Mensch „Vater“ – und der sitzt in Ang Lees eigenem Haus. Li Sheng lehnte es sein Leben lang ab, dass sein Sohn Filme drehte, fand, dies sei kein seriöser Beruf; Ang Lee formte lebenslang in seinen Filmen immer wieder diesen Vater, versöhnte sich mit ihm und konnte doch nie wirklich zu ihm vordringen. Die drei Filme benutzen dasselbe Gesicht (Sihung Lung) und verhandeln eigentlich etwas, das Ang Lee in der Wirklichkeit nicht lösen konnte. Oberflächlich ist es Kultur, darunter ist ein Sohn, der einem Vater etwas sagt, das er nicht aussprechen kann.
+
+## Ein Chinese dreht ein englisches Herrenhaus des neunzehnten Jahrhunderts
+
+1995 tat Ang Lee etwas, das damals beinahe undenkbar wirkte: Ein taiwanesischer Regisseur, der gerade drei chinesischsprachige Familiengeschichten gedreht hatte, übernahm die Adaption eines Jane-Austen-Romans – _Sinn und Sinnlichkeit_ (Sense and Sensibility), ein reiner englischsprachiger Film über Ehe und Klasse in einem englischen Herrenhaus des neunzehnten Jahrhunderts. Das Drehbuch schrieb die Hauptdarstellerin Emma Thompson höchstpersönlich; sie gewann dafür später den Oscar für das beste adaptierte Drehbuch und wurde damit zur einzigen Person in der Oscar-Geschichte, die sowohl für die Schauspielerei als auch für das Drehbuch ausgezeichnet wurde[^20].
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/2WGq2Rbs1Qg" title="理性與感性 Sense and Sensibility (1995) Official Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Offizieller Trailer von Sony Pictures Entertainment: Ang Lees erster Hollywoodfilm – ein chinesischer Regisseur dreht Ehe und Klasse im englischen Herrenhaus des neunzehnten Jahrhunderts._
+
+Im Nachhinein ist diese Wahl überhaupt nicht überraschend. Austen schrieb über Menschen, die von Konventionen gefesselt sind: Frauen dürfen die Liebe nicht direkt aussprechen, Gefühle müssen unter wohlerzogenen Worten verborgen bleiben, alles Heftige wird unter einer ruhigen Oberfläche niedergehalten. Genau das ist Ang Lees Spezialität. Drei Filme lang hatte er die Unterdrückung in chinesischen Familien gefilmt; im englischen Herrenhaus ändert die Unterdrückung ihre Form, nicht ihr Wesen. _Sinn und Sinnlichkeit_ holte bei den 68. Oscars sieben Nominierungen, Thompson bekam den Oscar für das beste adaptierte Drehbuch; im selben Jahr brachte es Ang Lee den Goldenen Bären der 46. Berlinale ein – zusammen mit dem vom _Wedding Banquet_ wurde Ang Lee damit der einzige Regisseur in der Filmgeschichte mit zweimaligem Gewinn des Goldenen Bären[^21].
+
+Der nächste Film, _Der Eisschwindel_ (The Ice Storm, 1997), bewies, dass er nicht nur eine einzige Sorte Stoff beherrscht. Diesmal richtete er die Kamera auf eine Mittelklassefamilie in einem amerikanischen Vorort im Jahr 1973 und drehte eine kalte Parabel über moralischen Zerfall. Dieser Film brachte ihm den Preis für das beste Drehbuch in Cannes ein; der Drehbuchautor war James Schamus, der Ang Lee seit _Pushing Hands_ begleitet und mit ihm gemeinsam das Unternehmen gründete, das später zu Focus Features umgebaut wurde, dem Haus für amerikanische Independent-Filme[^22].
+
+Nicht jeder Schritt war ein Erfolg. Mit _Ride with the Devil_ (1999) verfilmte er den Amerikanischen Bürgerkrieg – kommerziell ein Desaster, der nordamerikanische Einspielergebnis lag bei nur etwa 630.000 US-Dollar[^23]. Doch Ang Lee baute nie darauf, dass jeder Film ein Treffer ist; er baute darauf, dass er nach jeder Niederlage bereit ist, den nächsten Stoff anzugehen, von dem er nicht sicher ist, ob er ihn gut drehen kann. Für ihn ist gerade das Gefährliche, bei dem man sicher ist, es gut hinzubekommen.
+
+> ✦ „Regie zu führen ist das Einzige, was ich kann, meine einzige Sicherheit – doch diese Sicherheit muss man sich durch Risiko erkaufen, das ist in sich selbst widersprüchlich.“[^24]
+
+## In dem Moment, in dem sie durch den Bambuswald flogen, sah die Welt chinesisches Wuxia zum ersten Mal so
+
+Der Film _Crouching Tiger, Hidden Dragon_ (2000) war Ang Lees große Wette, mit der er den Wuxia-Traum seiner Kindheit, die chinesische Ästhetik und die Hollywood-Industrie zusammenband. Der Film basiert auf dem Roman von Wang Dulu und versammelt Chow Yun-fat (Li Mubai), Michelle Yeoh (Yu Xiulian), Zhang Ziyi (Yu Jiaolong) und Zhang Chen; Kampfchoreografie von Yuen Woo-ping, Kamera von Peter Pau, Filmmusik von Tan Dun – mit dem Cello von Yo-Yo Ma[^25]. Was die Welt am meisten in Erinnerung behielt, war die Szene über dem Bambuswald: Menschen, die auf den Bambusspitzen schweben, Klingenlicht, das zwischen den grünen Blättern fließt – westliche Zuschauer hatten so etwas Martial-Arts nie gesehen.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/q-HrIQLdaNE" title="臥虎藏龍 Crouching Tiger, Hidden Dragon Official Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Offizieller Trailer von Sony Pictures Classics: Der Bambuswald und die Leichtigkeit von „Crouching Tiger, Hidden Dragon“ – so hatte die Welt chinesisches Wuxia zum ersten Mal gesehen._
+
+Der Film holte bei den 73. Oscars zehn Nominierungen und vier Auszeichnungen: Bester fremdsprachiger Film, Beste Kamera (Peter Pau), Beste Ausstattung (Yee Chung-man) und Beste Filmmusik (Tan Dun)[^26]. Auch die Einspielergebnisse schrieben Geschichte: etwa 128 Millionen US-Dollar in Nordamerika, rund 213 Millionen weltweit. Sein Rekord für fremdsprachige Filme in Nordamerika hielt etwa ein Vierteljahrhundert lang – erst Mitte der 2020er Jahre wurde er gebrochen[^27].
+
+Doch das Bewegendste an _Crouching Tiger, Hidden Dragon_ liegt eigentlich nicht im Kampf. Li Mubai und Yu Xiulian lieben sich ihr Leben lang, doch keiner sagt es dem anderen je; sie pressen die Gefühle unter Regeln und Pflicht nieder, bis der Tod alles trennt. Das ist wieder Ang Lees altes Thema: Am stärksten ist die Liebe dort, wo man sie nicht aussprechen kann. Die Leichtigkeit des Bambuswaldes ist die Oberfläche, das Gewicht der Unterdrückung ist das Innere. Das Klingenlicht der Martial-Arts-Welt ist nur Verpackung; was wirklich in der Mitte des Films brennt und erlischt, sind zwei Menschen, die einander verpassen, weil sie durch die Lehrerschule, durch das Maß, durch ein ganzes Regelwerk behindert sind, an das sie selbst vielleicht nicht einmal glauben, das sie aber nicht brechen wollen. Die Welt sah ein fliegendes orientalistisches Spektakel; Ang Lee drehte die Worte, die zwei alternde Menschen zu sagen zu spät kamen. Für ein Kind der Exilgeneration, dem von klein auf beigebracht wurde, artig zu sein, sich anzustrengen und die Gefühle zu verbergen, musste dieser Schmerz des „eigentlich kümmern, aber gerade nicht sagen dürfen“ nicht studiert werden – er kannte ihn von Kindesbeinen an.
+
+> 💡 **Wussten Sie…**
+> _Crouching Tiger, Hidden Dragon_ wurde zunächst in der chinesischsprachigen Welt bei weitem nicht so geschätzt wie im Westen. Nicht wenige chinesische Zuschauer fanden das Wuxia „zu langsam“, „zu intellektuell“ und konnten sich an Chow Yun-fats Mandarin-Akzent nicht gewöhnen. Ein Werk, das den Westen zum ersten Mal ernsthaft auf chinesische Filme blicken ließ, wurde in seinem eigenen Kulturkreis zuerst bemäkelt – diese Lage, „draußen besser verstanden zu werden als drinnen“, kannte Ang Lee selbst von dem Kind, das an der Kunstakademie durchfiel, bis zum arbeitslosen Schwiegersohn in der Emigration.
+
+## Mit 49 sagte ihm der Vater: „Stürmt mit Stahlhelm nach vorn“
+
+2003 wurde _Hulk_ (Green Giant Hulk) der umstrittenste Wendepunkt in Ang Lees Karriere. Er übernahm die Marvel-Adaption, holte Eric Bana, Jennifer Connelly und Nick Nolte und versuchte, einen Superheldenfilm in einen psychologischen Film über Vatertrauma und innere Wut zu verwandeln. Das Ergebnis war finanziell ein Verlust: Das Produktionsbudget lag bei etwa 137 Millionen US-Dollar, zusammen mit dem Marketing war es ein Minusgeschäft; die Kritiken waren gespalten – manchen war er zu schwer, anderen zu kühn. Es ist kein schlechter Film, aber er machte Ang Lee müde – so müde, dass er eine Zeit lang ans Aufhören dachte[^28].
+
+Er ging zu seinem Vater. Zu einem Vater, der sein Leben lang gegen seine Filmerei war. Diese Szene selbst hat etwas von schicksalhafter Ironie: Der Schuldirektor Li, der von klein auf meinte, Filme seien kein seriöser Beruf und sein Sohn solle einen sicheren Weg einschlagen, war nun der letzte Mensch, der dem Sohn einen legitimen Grund zum Aufhören geben konnte. Ang Lee hatte erwartet, dass sein Vater ihn diesmal wie immer drängen würde, diesen Beruf nicht mehr auszuüben – genau das hätte ihm den Ausweg gegeben. Unerwartet war es das erste Mal, dass Li Sheng ihn bat weiterzumachen. Die Worte des Vaters wogen schwer: „Du bist erst 49. Welches schlechte Vorbild gibst du deinen Kindern?“ Und dann der Satz, den später unzählige Menschen zitierten: „Stürmt mit Stahlhelm nach vorn, dreht euren Film!“[^29] Der Vater, der sein Leben lang von seinem Sohn Zurückhaltung und Realismus verlangt hatte, wurde in der letzten Stunde seines Lebens ausgerechnet zu dem, der ihn nach vorn schob.
+
+Etwa zwei Wochen nach diesen Worten starb Li Sheng plötzlich im Jahr 2004[^30].
+
+> ⚠️ **Umstrittener Standpunkt**
+> Über Ang Lee wird im Alltag am häufigsten der Satz zitiert: „In jedem Herzen gibt es einen Brokeback Mountain.“ Doch diesen Satz hat Ang Lee selbst nie gesagt; er wirkt eher wie ein Werbeslogan aus jener Zeit, manche meinen, ihn habe sein Bruder Li Gang gesagt; mit der Zeit wurde er Ang Lee zugeschrieben. Der Satz, der wirklich zu dieser Vater-Sohn-Geschichte gehört und nachweislich aus Li Shengs Mund stammt, ist das „Stürmt mit Stahlhelm nach vorn“. Ein Vater, der sein Leben lang fand, Filme seien keine ernste Sache, gab seinem Sohn am Ende als Letztes mit: Hör nicht auf. Das ist näher an der Wahrheit als jedes Bonmot – und schwerer zu ertragen.
+
+Der Vater war fort, und „mach weiter“ wurde zum Vermächtnis. Zwei Jahre später stand Ang Lee mit _Brokeback Mountain_ auf der Oscar-Bühne, und dieser Preis für die beste Regie wirkte wie ein Versprechen, das ein Sohn, der gerade seinen Vater verloren hatte und von ihm gebeten worden war, nicht aufzugeben, einlöste.
+
+## Zwei Cowboys, zwei Goldene Löwen und die Liebe, die man nicht aussprechen darf
+
+_Brokeback Mountain_ (2005) basiert auf der Erzählung von Annie Proulx: Heath Ledger als Ennis und Jake Gyllenhaal als Jack sind zwei Männer im amerikanischen Westen der 1960er Jahre, denen es die ganze Epoche verbietet zu lieben. Ang Lee drehte daraus eine Tragödie über Unterdrückung: Sie lieben sich ein Leben lang und dürfen es doch nie zugeben. Das führt zurück zu Ang Lees zentralem Motiv: Die tiefsten Gefühle sitzen oft dort am engsten, wo man sie nicht aussprechen kann.
+
+Der Film holte zuerst den Goldenen Löwen der 62. Filmfestspiele von Venedig; dann holte er bei den 78. Oscars acht Nominierungen und drei Auszeichnungen – Ang Lee gewann den Preis für die beste Regie und wurde damit der erste asiatische, erste nicht-weiße Regisseur in der Oscar-Geschichte mit dieser Auszeichnung[^31]. Doch jene Nacht hinterließ auch eine der berühmtesten Kontroversen der Filmgeschichte: das allgemein favorisierte _Brokeback Mountain_ verlor in der Kategorie bester Film überraschend gegen _Crash_[^32].
+
+In dem Moment des Preisempfangs zitierte Ang Lee zuerst Jacks Zeile aus dem Film – „I wish I knew how to quit you“ – und wechselte dann ins Mandarin, um auf der anderen Seite der Meerenge jenen Satz zu sagen: „Danke für eure Besorgnis“[^33]. In seinem Herzen waren zwei Dinge: ein gerade gegangener Vater und die Menschen in der Heimat, die sich stets um ihn gesorgt hatten.
+
+> ✦ „Als taiwanesischer Regisseur muss ich mich anstrengen, egal wie hart es wird, ich muss durchhalten.“[^34]
+
+Zwei Jahre später trieb _Lust, Caution_ (2007) die Unterdrückung an den gefährlichsten Rand. Der Film basiert auf der Novelle von Eileen Chang, spielt im Shanghai der 1940er Jahre unter japanischer Besatzung und erzählt von patriotischen Studenten, die den Mord an einem Kollaborateur planen. Tony Leung als Herr Yi, Tang Wei als Wang Jiazhi, Wang Leehom: Eine Studentin verliert allmählich die Fähigkeit zu sagen, auf welcher Seite sie zwischen Begehren und Auftrag steht. Dieser Film machte Ang Lee zum zweiten Mal in Venedig zum König – er gewann den Goldenen Löwen und wurde damit zum zweifachen Träger der höchsten Auszeichnung Venedigs; bei den Golden Horse Awards holte er sieben Wettbewerbspreise[^35].
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/CizN-DvGhrc" title="色，戒 Lust, Caution Official Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Offizieller Trailer von Focus Features: „Lust, Caution“ nach Eileen Chang – Ang Lees zweiter Goldener Löwe in Venedig._
+
+_Lust, Caution_ hatte auch seinen Preis. In den USA wurde der Film mit NC-17 bewertet, und die Hauptdarstellerin Tang Wei wurde in China für etwa zwei bis drei Jahre quasi verbannt[^36]. Dass ein Film eine junge Schauspielerin für zwei bis drei Jahre verschwinden lassen konnte, sagt selbst schon, auf wie empfindliche Nerven diese Geschichte trat. Doch für Ang Lee vollendete dieser Film, was er von _Sinn und Sinnlichkeit_ über _Brokeback Mountain_ die ganze Zeit tat: Menschen an einen unerträglichen Punkt zu pressen und zu sehen, was dort in ihnen wächst. Das Begehren trägt hier die Erzählung selbst; es ist der Ort, an dem die politische Haltung, die Liebe und die Selbstidentität eines Menschen gleichzeitig zerbrechen. Wang Jiazhi’s Zögern im letzten Moment, Li Mubais ungesagte Worte, Ennis’ Liebe, die er nicht zu bekennen wagt – sie sind verschiedene Verwandlungen derselben Sache: ein Mensch, der zwischen „sollte“ und „will“ eingeklemmt ist und sich nicht bewegen kann.
+
+## Mit einem digitalen Tiger und 120 Bildern pro Sekunde wettete er auf etwas, wofür die ganze Branche noch nicht bereit war
+
+In seiner späteren Phase wurde Ang Lee zu einem technischen Spieler. Er begnügte sich nicht mehr damit, Geschichten gut zu erzählen – er begann, mit dem Film die Grenzen des Mediums selbst zu testen.
+
+_Life of Pi_ (2012) basiert auf dem Roman von Yann Martel und erzählt von einem indischen Jungen, der nach einem Schiffbruch mit einem bengalischen Tiger auf einem Rettungsboot über den Pazifik treibt. Der Hauptdarsteller Suraj Sharma wurde aus mehr als dreitausend Bewerbern ausgewählt – ein siebzehnjähriger Laie, der nie zuvor in einem Film gespielt hatte; der Tiger, die Seele des Films, war zum größten Teil digital erzeugt[^37]. Der Film holte bei den 85. Oscars elf Nominierungen und vier Auszeichnungen; Ang Lee gewann zum zweiten Mal die beste Regie und ist bis heute der einzige asiatische Regisseur, der diesen Preis zweimal erhielt[^38].
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/9A0p_SJ8eu4" title="少年Pi的奇幻漂流 Life of Pi Official Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Offizieller Trailer von 20th Century Studios: ein Junge, ein Rettungsboot, ein digitaler Tiger – Ang Lees zweiter Oscar für die beste Regie._
+
+Doch in der Oscar-Nacht von _Life of Pi_ steckte ein scharfes Schattenbild. Die VFX-Firma Rhythm & Hues, die den Tiger und jenes Meer erschuf, hatte etwa zwei Wochen vor der Preisverleihung Konkurs angemeldet. In der Preisnacht wurde der Dank der Gewinner des VFX-Preises, die ein paar Worte für die ganze Branche sagen wollten, von Livemusik übertönt; draußen protestierten mehrere hundert VFX-Arbeiter[^39]. Ein Film, der mit visuellen Effekten den technischen Ruhm holte, hinter dessen Rücken eine ganze Industrie bis zur Pleite ausgepresst wurde – dieser Kontrast wird seither oft besprochen und ist nicht leicht.
+
+Danach ging er noch weiter. _Die Billy Lynn Geschichten – Halbzeit_ (Billy Lynn’s Long Halftime Walk, 2016) war der erste abendfüllende Spielfilm der Filmgeschichte, der mit 120 Bildern pro Sekunde gedreht wurde (120fps + 4K + 3D); weltweit gab es damals nur wenige Kinosäle, die seine angestrebte Version vollständig zeigen konnten. Der Preis dafür war ein finanzielles Scheitern: Das Produktionsbudget lag bei etwa 40 Millionen US-Dollar, weltweit kamen nur rund 31 Millionen zusammen[^40]. Ang Lees zweiter Sohn Mason spielte darin den Soldaten Foo taiwanesischer Herkunft im Bravo-Team[^41].
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/veoPig2LJDU" title="比利·林恩的中場戰事 Billy Lynn's Long Halftime Walk Official Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Offizieller Trailer von Sony Pictures Entertainment: „Billy Lynn's Long Halftime Walk“ – der erste abendfüllende Spielfilm, der mit 120 Bildern pro Sekunde gedreht wurde._
+
+2019, in _Gemini Man_, nutzte er digitale Verjüngung, um Will Smith gegen eine jüngere Version seiner selbst kämpfen zu lassen, ebenfalls in 120fps gedreht. Wieder kommerziell ein Verlust; Paramount schätzte den Verlust auf etwa 110 Millionen US-Dollar[^42]. In den letzten Jahren arbeitet er weiter an neuen Projekten, darunter ein Boxfilm und eine Bruce-Lee-Biografie mit Mason Lee in der Hauptrolle – der Stand ist unklar.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/AbyJignbSj0" title="雙子殺手 Gemini Man Official Trailer" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Offizieller Trailer von Paramount Pictures: „Gemini Man“ – Ang Lee lässt Will Smith mit digital verjüngtem Selbst kämpfen._
+
+> 📝 **Notiz des Kurators**
+> Man pflegt Ang Lees Filme der späteren Phase in 120fps als „kommerzielle Fehlschläge“ zu betrachten. Doch dieser Rahmen versteht nicht, was er tut. Ein Regisseur, der bereits zwei Oscars gewonnen hat und nichts mehr beweisen muss, könnte ein Leben lang sichere, preiswürdige Filme drehen. Genau das tut er nicht. Er wählt stattdessen ein Format, das kaum ein Kino zeigen kann und das notgedrungen Geld verliert – weil für ihn die wahre Angst nicht der Verlust ist, sondern das Stehenbleiben an einem sicheren Ort. Er sagte: „Wenn ich mich völlig sicher fühle, bin ich gerade am unruhigsten.“[^43] Diese verlustreichen 120 Bilder pro Sekunde sind die Art, wie ein ängstlicher Mensch sich mit dem teuersten Mittel zwingt, weiter nach vorn zu stürmen – so wie sein Vater es ihm aufgetragen hatte.
+
+## Zurück in Taiwan, zwischen den Golden Horse Awards und der Politik
+
+Ang Lee hat Taiwan nie vergessen. 2018 übernahm er den Vorsitz des Organisationskomitees der Golden Horse Awards (von Sylvia Chang), gründete während seiner Amtszeit die „Golden Horse Film Academy Master Class“, die weltklasse Filmerfahrung an junge Schöpfer in Taiwan zurückbrachte; 2022 trat er ab, abgelöst von Kameramann Mark Lee Ping-bing; 2023 übernahm er erneut den Juryvorsitz der 60. Golden Horse Awards[^44].
+
+![Ang Lee beim Filmfestival von Cannes, lächelnd in die Kamera](/article-images/people/ang-lee-cannes-2013.webp)
+_Ang Lee beim Festival von Cannes 2013. Foto: Georges Biard. [CC BY-SA 3.0 via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Ang_Lee_Cannes_2013.jpg)._
+
+Im Jahr nach seiner Amtsübernahme erlebten die Golden Horse Awards einen Sturm. Bei der 55. Verleihung 2018 löste die Dankesrede der Dokumentarfilmregisseurin Fu Yu einen Streit über die Taiwanstraße aus, und China boykottierte die Golden Horse Awards ab dem Folgejahr. Für einen Menschen, der gerade seine ganze Energie in dieses Festival gesteckt hatte, war das ein schwerer Moment: Er behütete einen Preis für chinesischsprachiges Kino, und dieser Preis wurde in einen politischen Strom hineingezogen, den er nicht kontrollieren konnte. Als Vorsitzender blieb Ang Lee in späteren Interviews konsequent; er wachte über die Unabhängigkeit des Films selbst: „Taiwan ist frei, das Festival ist offen“, „nur über Kunst reden, ohne andere politische Faktoren“, „ich hoffe, die Golden Horse Awards bleiben rein, bitte gebt den Filmemachern Respekt“[^45]. Er wählte keine Seite in der Politik – er betonte nur wieder und wieder eins: den Film seinen Film sein zu lassen. Das ist im Grunde dieselbe Haltung wie in seinem ganzen Werk: Er erzählt nie von einer Partei aus, er steht neben den Menschen, die in der Mitte eingeklemmt sind und sich nicht entscheiden können.
+
+In diesen Jahren hat ihm die Welt fast alles gegeben, was sie geben kann. 2021 verlieh ihm die British Academy of Film and Television Arts die BAFTA Fellowship (das Lebenswerk); 2025 verlieh ihm die Directors Guild of America (DGA) den Preis für sein Lebenswerk[^46]. Auf der Bühne der DGA witzelte der 71-jährige Ang Lee zuerst: „Das ist das erste Mal, dass ich mit einer Lesebrille eine Rede halte – offenbar ist jetzt der Moment, ein Lebenswerk anzunehmen!“ Dann sagte er einen Satz, der ein ganzes Leben zusammenfasste[^47].
+
+> ✦ „Ich bin in Taiwan geboren, in Taiwan aufgewachsen, und stehe heute auf dieser Bühne – wie ein Traum, der wahr wurde.“[^47]
+
+## Die Unterdrückung wurde nicht besiegt, sie hörte nur auf zu quälen
+
+2016, um die Zeit der _Billy Lynn_-Dreharbeiten, brachte Ang Lee in einem Interview endlich das Thema auf den Punkt, das all seine Filme und sein ganzes Leben durchzieht. Es gibt Dinge, sagte er, die er nie besiegt habe – etwa die Unterdrückung, den Vater; sie verändern ständig ihre Form[^48].
+
+Dann aber sagte er den zweiten Teil, und genau dort geschieht die Versöhnung: Er werde den Vater zwar weiter in seinen Filmen beschreiben, aber dieser Druck sei weg. Das, was ihn ein Leben lang verfolgt hatte, war endlich in Ordnung, war vorbei[^49].
+
+> ✦ „Es gibt Dinge, die ich nie besiegt habe – etwa die Unterdrückung, den Vater, die ständig ihre Form verändern.“[^50]
+
+Dieser Berg von Brokeback Mountain ist nie weggeräumt worden. Der Vater, der ein Leben lang seine Filmerei ablehnte und doch in den letzten Stunden sagte „stürmt mit Stahlhelm nach vorn“, wird nie wiederkommen, um sich von seinem Sohn ein Danke anzuhören. Die Welt erinnert sich an zwei Oscars, zwei Goldene Löwen von Venedig, zwei Goldene Bären von Berlin – daran, dass aus einem Waisenkind der Exilgeneration ein Stolz Taiwans wurde, den die ganze Welt kennt. Doch was Ang Lee wirklich sein ganzes Leben lang drehte, war der Sohn, der 2006 auf der Bühne stand, gerade seinen Vater verloren hatte, und in die Kamera auf Mandarin sagte: „Danke für eure Besorgnis.“ Er hat die sechs Jahre Küche durchgestanden, hat das eine Angst nach der anderen durchgestanden – „ich schaffe es fast nicht mehr“ – und hat all das Unbezwingbare in Film verwandelt.
+
+---
+
+**Weiterführende Links**:
+
+- Taiwanese Cinema – der volle Kontext vom taiwanesischen Hokkien-Film über den Gesundheitsrealismus bis zum Neuen Taiwanesischen Kino und der Gegenwart; jene Tradition, die Ang Lee übernahm und aus der er hinausging.
+- [Hou Hsiao-hsien](/de/people/hou-hsiao-hsien) – ein Fahnenträger derselben Generation des Neuen Taiwanesischen Kinos, der einen völlig anderen Autorenweg wählte als Ang Lee.
+- Yang De-chang – ein Regisseur, der mit einer Stadt die moderne taiwanesische Angst sezierte; ein weiterer Gipfel des Neuen Taiwanesischen Kinos.
+- [Tsai Ming-liang](/de/people/tsai-ming-liang) – ein taiwanesischer Autorenregisseur, der Einsamkeit und Langsamkeit bis zum Äußersten treibt, auf dem genauen Gegenpol zu Ang Lees Hollywood-Weg.
+- [Andre Chiang](/de/people/andre-chiang-taiwanese-culinary-innovator) – ein weiterer taiwanesischer Schöpfer, der innerhalb westlicher Systeme berühmt wurde und mit Michelin-Menüs statt mit einer Filmkamera dieselbe Frage stellt: „Wer bin ich?“
+
+## Bildquellen
+
+- Hero: Porträt von Ang Lee, Fotograf Sean Reynolds, CC BY 2.0, [Wikimedia Commons](<https://commons.wikimedia.org/wiki/File:Ang_Lee_(8464864982).jpg>)
+- Innenabbildung 1: Hong Kong Asian Film Festival 2007, Fotograf WikiCantona, CC BY-SA 3.0, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Ang_Lee_HKAFF_2007.jpg)
+- Innenabbildung 2: Festival de Cannes 2013, Fotograf Georges Biard, CC BY-SA 3.0, [Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Ang_Lee_Cannes_2013.jpg)
+
+## Referenzen
+
+[^1]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — Gesamteintrag zu Ang Lees Leben, seiner Filmografie, dem Oscar-Gewinn 2006 und der Dankesrede, einschließlich des Regie-Rekords von _Brokeback Mountain_.
+
+[^2]: [Der alte Junge Ang Lee – Mirror Media (2016)](https://www.mirrormedia.mg/story/20161004pol002) — ausführliches Personenporträt; über die Aufforderung von Ang Lees Vater Li Sheng, am Ende weiter Filme zu drehen, und den Tod des Vaters zwei Wochen später.
+
+[^3]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — belegt Geburt am 23. Oktober 1954 in Chaozhou, Landkreis Pingtung, und den familiären Hintergrund der frühen Jahre.
+
+[^4]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über das Leben des Vaters Li Sheng, seine Ämter als Direktor der Normalschule Hualien, der Zweiten Mittelschule von Tainan und der Ersten Mittelschule von Tainan sowie seinen Tod 2004.
+
+[^5]: [Ang Lee – Taiwan Cinema](https://taiwancinema.bamid.gov.tw/Staff/StaffContent/?ContentUrl=12437) — offizielle Datenbank der Film- und Fernsehbehörde des Kulturministeriums; belegt Ang Lees zweimaliges Scheitern an der Uni-Aufnahmeprüfung und sein Studium an der Nationalen Kunstakademie, Fachrichtung Theater und Film.
+
+[^6]: [Taiwan's Pride Ang Lee gewinnt den Oscar für die beste Regie mit Life of Pi – Taiwanese American (2013)](https://www.taiwaneseamerican.org/2013/02/taiwanese-american-ang-lee-wins-best-director-academy-award-for-life-of-pi/) — im Interview 2013 über die Identifikation mit der „Verliererseite“ und die Selbstprojektion der schwachen Lage Taiwans.
+
+[^7]: [Ang Lee – NYU Tisch School of the Arts](https://tisch.nyu.edu/grad-film/alumni/ang-lee) — offizielle Alumniseite der New York University; belegt Ang Lees Theater-Bachelor an der University of Illinois und den Master in Filmproduktion an der NYU.
+
+[^8]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — belegt, dass Ang Lee an der NYU mit Spike Lee in derselben Klasse war und bei dessen Abschlussarbeit als stellvertretender Regisseur half.
+
+[^9]: [Ang Lee – Taiwan Cinema](https://taiwancinema.bamid.gov.tw/Staff/StaffContent/?ContentUrl=12437) — über die Reihe seiner Studentenwerke, einschließlich des Golden Harvest Award von _Shade of the Lake_ und des Wasserman-Preises für die beste Regie der NYU für _The Boundary Line_.
+
+[^10]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über den Hintergrund von Ehefrau Lin Hui-chia als promovierte Mikrobiologin und Professorin für Pathologieforschung.
+
+[^11]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — belegt Hochzeit im August 1983 in New York und Geburt des ältesten Sohnes Han 1984.
+
+[^12]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — zitiert aus Zhang Jing-bes „Zehn Jahre Filmtraum“ (十年一覺電影夢): Ang Lee über Angst und Unsicherheit als Triebkraft der Kreativität.
+
+[^13]: [Die Zusammenarbeit von Hsu Li-kong und Ang Lee – Jiemian News](https://www.jiemian.com/article/1077069.html) — belegt 1990 den ersten Preis des Preises für gute Drehbücher für _Pushing Hands_, den zweiten für _The Wedding Banquet_ und die Investition der Zentralfilm in _Pushing Hands_.
+
+[^14]: [Die Zusammenarbeit von Hsu Li-kong und Ang Lee – Jiemian News](https://www.jiemian.com/article/1077069.html) — zitiert das Wort des Zentralfilm-Vizepräsidenten Hsu Li-kong zum Produktionsbudget von _Pushing Hands_ („zwölf Millionen, keine Münze mehr“).
+
+[^15]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — belegt Geburt des zweiten Sohnes Mason 1990, der später Schauspieler wurde.
+
+[^16]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — über die Auszeichnungen von _Pushing Hands_ (1991): bester Film beim Asia-Pacific Film Festival, Preis für die beste Nachwuchsregie in Amiens und Sihung Lung als bester Hauptdarsteller bei den Golden Horse Awards.
+
+[^17]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über _The Wedding Banquet_ (1993): den Goldenen Bären von Berlin (geteilt mit _Der Duft der Frauen_), die Oscar-Nominierung für den besten fremdsprachigen Film und fünf große Golden-Horse-Preise.
+
+[^18]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — über das Produktionsdetail, dass die lange Kochszene am Anfang von _Eat Drink Man Woman_ mit einem echten Spitzenkoch als Double gedreht wurde und über eine Woche dauerte.
+
+[^19]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — belegt, dass _Eat Drink Man Woman_ für den Oscar des besten fremdsprachigen Films nominiert war und in Hollywood als _Tortilla Soup_ (2001) neuverfilmt wurde.
+
+[^20]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — belegt, dass _Sinn und Sinnlichkeit_ (1995) von Emma Thompson geschrieben und gespielt wurde und sie damit die einzige Person in der Oscar-Geschichte ist, die sowohl fürs Spielen als auch fürs Drehbuch ausgezeichnet wurde.
+
+[^21]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — über die sieben Oscar-Nominierungen und den Goldenen Bären von Berlin für _Sinn und Sinnlichkeit_; Ang Lee wurde der einzige Regisseur mit zweimaligem Gewinn des Goldenen Bären.
+
+[^22]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über den Preis für das beste Drehbuch in Cannes für _Der Eisschwindel_ (1997), die lange Zusammenarbeit mit Drehbuchautor James Schamus und die Verbindung zu Focus Features.
+
+[^23]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über den kommerziellen Misserfolg von _Ride with the Devil_ (1999) mit einem nordamerikanischen Einspielergebnis von nur etwa 630.000 US-Dollar.
+
+[^24]: [Aufzeichnung der Golden Horse Film Academy – Golden Horse Organisationskomitee](https://goldenhorse.org.tw/academy/filmacademyplus/class/history/1518) — Ang Lee im Unterricht der Golden Horse Film Academy über die Sicherheit der Regie, die man sich durch Risiko erkaufen müsse.
+
+[^25]: [Crouching Tiger, Hidden Dragon – Box Office Mojo](https://www.boxofficemojo.com/release/rl2739766785/) — Einspielerseite; listet das Hauptteam (Chow Yun-fat, Michelle Yeoh, Zhang Ziyi, Zhang Chen u. a.) und die Einspielergebnisse.
+
+[^26]: [The Academy Awards – Oscars.org](https://www.oscars.org/) — offizielle Oscar-Daten; _Crouching Tiger, Hidden Dragon_ holte bei den 73. Oscars zehn Nominierungen und vier Preise (fremdsprachiger Film, Kamera, Ausstattung, Filmmusik).
+
+[^27]: [Crouching Tiger, Hidden Dragon – Box Office Mojo](https://www.boxofficemojo.com/release/rl2739766785/) — über die Einspielergebnisse von etwa 128 Mio. US-Dollar in Nordamerika und 213 Mio. weltweit sowie den Rekord für fremdsprachige Filme in Nordamerika.
+
+[^28]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über das Produktionsbudget von _Hulk_ (2003) von etwa 137 Mio. US-Dollar, den finanziellen Misserfolg und die gespaltenen Kritiken.
+
+[^29]: [Der alte Junge Ang Lee – Mirror Media (2016)](https://www.mirrormedia.mg/story/20161004pol002) — zitiert die Originalworte von Ang Lees Vater Li Sheng („Stürmt mit Stahlhelm nach vorn, dreht euren Film“ und „Du bist erst 49“).
+
+[^30]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über den Tod des Vaters Li Sheng am 15. Februar 2004.
+
+[^31]: [The Academy Awards – Oscars.org](https://www.oscars.org/) — offizielle Oscar-Daten: _Brokeback Mountain_ holte bei den 78. Oscars acht Nominierungen und drei Preise; Ang Lee wurde der erste asiatische Regisseur mit dem Preis für die beste Regie.
+
+[^32]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über den Goldenen Löwen von Venedig für _Brokeback Mountain_ und die Kontroverse des überraschenden Verlusts des besten Films gegen _Crash_.
+
+[^33]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — über das Zitieren der Filmzeile und die Begrüßung auf Mandarin bei der Oscar-Preisverleihung 2006.
+
+[^34]: [Sinorama – Ang-Lee-Spezial (2006)](https://www.taiwan-panorama.com/Articles/Details?Guid=a86e872e-dc89-43b9-bcbd-ee5e07eaeead) — Ang Lee im Interview 2006: „Als taiwanesischer Regisseur muss ich mich anstrengen, egal wie hart es wird, ich muss durchhalten.“
+
+[^35]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — über den Goldenen Löwen von Venedig für _Lust, Caution_ (2007), sieben große Golden-Horse-Preise und die Besetzung.
+
+[^36]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über die NC-17-Bewertung von _Lust, Caution_ in den USA und das vorübergehende Verbot Tang Weis in China.
+
+[^37]: [Taiwan's Pride Ang Lee gewinnt den Oscar für die beste Regie mit Life of Pi – Taiwanese American (2013)](https://www.taiwaneseamerican.org/2013/02/taiwanese-american-ang-lee-wins-best-director-academy-award-for-life-of-pi/) — über Hauptdarsteller Suraj Sharma als Laien aus mehr als dreitausend Bewerbern und die digitale Erzeugung des Tigers.
+
+[^38]: [The Academy Awards – Oscars.org](https://www.oscars.org/) — offizielle Oscar-Daten: _Life of Pi_ holte bei den 85. Oscars elf Nominierungen und vier Preise; Ang Lee gewann zum zweiten Mal die beste Regie.
+
+[^39]: [Konkurs der Life-of-Pi-VFX-Firma Rhythm & Hues – Deadline (2013)](https://deadline.com/2013/02/oscars-2013-life-of-pi-vfx-rhythm-hues-bankruptcy-438552/) — berichtet über den Konkurs von Rhythm & Hues vor dem Preisgewinn, das Unterbrechen des Danks in der Preisnacht und die Proteste draußen.
+
+[^40]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über _Billy Lynn's Long Halftime Walk_ (2016) als ersten abendfüllenden Spielfilm in 120fps sowie den kommerziellen Misserfolg.
+
+[^41]: [Ang Lee – Chinesische Wikipedia](https://zh.wikipedia.org/zh-tw/李安) — belegt, dass Ang Lees zweiter Sohn Mason in _Billy Lynn's Long Halftime Walk_ den Soldaten Foo taiwanesischer Herkunft spielte.
+
+[^42]: [Ang Lee – Englische Wikipedia](https://en.wikipedia.org/wiki/Ang_Lee) — über die digitale Verjüngung in _Gemini Man_ (2019) und den von Paramount geschätzten Verlust von etwa 110 Mio. US-Dollar.
+
+[^43]: [Aufzeichnung der Golden Horse Film Academy – Golden Horse Organisationskomitee](https://goldenhorse.org.tw/academy/filmacademyplus/class/history/1518) — Ang Lee im Unterricht der Golden Horse Film Academy: „Wenn ich mich völlig sicher fühle, bin ich gerade am unruhigsten.“
+
+[^44]: [Offizielle Website des Golden-Horse-Organisationskomitees – Golden Horse](https://www.goldenhorse.org.tw/) — offizielle Website der Golden Horse Awards; über Ang Lees Amtsübernahme 2018 als Vorsitzender, die Gründung der Film Academy Master Class, seinen Rücktritt 2022 und den Juryvorsitz 2023.
+
+[^45]: [Ang Lee über die Golden Horse Awards und die Politik – Mirror Media (2021)](https://www.mirrormedia.mg/story/20210806ent031/) — versammelt Ang Lees Äußerungen als Golden-Horse-Vorsitzender, dass das Festival von der Politik unabhängig sein solle.
+
+[^46]: [Ang Lee erhält den DGA Lifetime Achievement Award – DGA](https://www.dga.org/news/pressreleases/2024/241210_ang_lee_dga_lifetime_achievement_award) — offizielle Pressemitteilung der Directors Guild of America über die Verleihung des Lebenswerk-Preises an Ang Lee.
+
+[^47]: [Ang Lee erhält den DGA Lifetime Achievement Award – Global Views (2025)](https://www.gvm.com.tw/article/119050) — berichtet über Ang Lees Dankrede bei der DGA 2025, einschließlich „in Taiwan geboren, in Taiwan aufgewachsen“ und des Witzes über die Lesebrille.
+
+[^48]: [Der alte Junge Ang Lee – Mirror Media (2016)](https://www.mirrormedia.mg/story/20161004pol002) — versammelt Ang Lees Äußerungen über „Unterdrückung, der Vater verändert ständig ihre Form“ und das zentrale Motiv seiner Kunst.
+
+[^49]: [Der alte Junge Ang Lee – Mirror Media (2016)](https://www.mirrormedia.mg/story/20161004pol002) — versammelt Ang Lees Äußerung von 2016 über die Versöhnung: „Ich werde den Vater weiter beschreiben, aber der Druck ist weg.“
+
+[^50]: [Sinorama – Ang-Lee-Spezial (2013)](https://www.taiwan-panorama.com/Articles/Details?Guid=dc6aee91-96e3-46da-bba3-61034128fb79) — Sinorama-Interview mit Ang Lee 2013; ordnet seine Schaffensbiografie und die zentrale Sorge des interkulturellen Erzählens ein.


### PR DESCRIPTION
## 新增德文翻譯：李安（Ang Lee）

本 PR 新增 `knowledge/de/People/ang-lee.md`（德文），內容自 `knowledge/People/李安.md` 完整重寫翻譯，非逐字直譯。主題為臺灣之光導演與跨文化電影，翻譯時保留英文片名＋德文說明雙軌，與既有 de 文章慣例一致。

### 品質檢查（全部通過）

| 檢查 | 結果 |
|---|---|
| `article-health.py --profile=ci-deploy` | ✅ `hard=0 warn=0` `passed=True` |
| `verify-translation.py` | ✅ **18/18 PASS** |
| 德中字元比 | ✅ **2.60**（de 健康區間 2.0–4.0） |
| 章節結構 | ✅ 12 個 H2（含篇首）與原文一致 |
| 腳註 | ✅ **50 個** `[^N]` 全部保留並逐一對應正文引用 |
| URL | ✅ **62 個 URL exact multiset 完全保留** |
| 媒體 | ✅ 3 圖（1 hero + 2 inline）＋ 7 支 YouTube 嵌入 |
| 延伸閱讀 | ✅ 有 de 版文章的保留 `/de/` 連結（侯孝賢、蔡明亮、江振誠）；無 de 版（台灣電影、楊德昌）降級純文字（避免壞連結） |
| 違禁片語 | ✅ 無 `part of china` / `province of china` / `chinese taipei` / `aborigines` |
| 正文 CJK 標點 | ✅ 正文無 `；`、`——` |
| YAML | ✅ js-yaml 驗證通過；tags 全 ASCII；zh 14 個欄位全數保留 |
| slug 一致 | ✅ 檔名與 en sibling `ang-lee` 相同 |

### 本文件特色

- 十二章完整翻譯：「差一點的孩子」、六年廚房、父親三部曲、理性與感性、臥虎藏龍、鋼盔之言、斷背山、色戒、少年Pi與120幀、金馬與政治、和解。
- 保留引用金句 callout（恐懼、安全感靠冒險、李安國際主義表態、DGA 感言、壓抑並沒有被打敗）、策展人筆記、爭議觀點、你知道嗎共 9 個 callout。
- 「戴著鋼盔往前衝」「每個人心中都有一座斷背山」等中文金句以德文意譯＋中文括註保留原味。