### PR TITLE
Add German translation for People (Audrey Tang)

### DIFF
--- a/knowledge/de/People/audrey-tang.md
+++ b/knowledge/de/People/audrey-tang.md
@@ -1,0 +1,322 @@
+---
+title: 'Audrey Tang: Jede ihrer berühmten Entscheidungen war eine Ablehnung des Etiketts „Genie“'
+description: 'Mit 8 wird sie von Mitschülern bewusstlos getreten, mit 14 lehnt sie die Empfehlung für die Jianguo-Oberschule ab, mit 24 outet sie sich als transgender, will aber keine Sprecherin sein, und mit 35 ist ihre erste Bedingung beim Amtsantritt „kein Büro“. 2020 ändert sie mitten in der Nacht mit Chiang Ming-tsung Code im g0v-Slack für die Maskenkarte; am 2. Dezember 2025 nimmt sie in Stockholm den Right Livelihood Award entgegen – alle erwarten ihre persönliche Geschichte, doch sie betont auf der Bühne nur das Wort „wir“. Die Welt sieht sie als Genie; jede ihrer berühmten Entscheidungen war eine Ablehnung dieser Position.'
+date: 2026-05-16
+category: 'People'
+tags: ['Person', 'Audrey Tang', 'Digitalministerin', 'g0v', 'Öffentlichkeit', 'Offene Daten', 'Taiwan']
+subcategory: '教育與社會'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-05-16
+lastHumanReview: true
+readingTime: 14
+image: '/article-images/people/audrey-tang-portrait-2016.webp'
+imageAlt: 'Porträtfoto von Audrey Tang, im März 2016 in Paris aufgenommen; dunkle Kleidung, ein weiches Porträt bei natürlichem Licht.'
+imageCredit: 'Camille McOuat (Flickr / Wikimedia Commons, CC BY 2.0)'
+curation: incubating
+translatedFrom: 'People/唐鳳.md'
+sourceCommitSha: '29ff6f481'
+sourceContentHash: 'sha256:97c9b6fe6c788bcc'
+sourceBodyHash: 'sha256:223451ab2ee89544'
+translatedAt: '2026-09-09T00:55:00+08:00'
+---
+
+# Audrey Tang: Jede ihrer berühmten Entscheidungen war eine Ablehnung des Etiketts „Genie“
+
+> **30 Sekunden im Überblick:**
+> Mit 8 Jahren wird sie von Mitschülern bewusstlos getreten und verlässt die Schule, mit 14 lehnt sie die Empfehlung für die Jianguo-Oberschule ab, mit 24 outet sie sich als transgender, will aber keine Sprecherrolle übernehmen, und mit 35 ist ihre erste Bedingung beim Amtsantritt „kein Büro“. 2020 verbessert sie mitten in der Nacht mit Chiang Ming-tsung im g0v-Slack den Code der Maskenkarte; am 2. Dezember 2025 nimmt sie in Stockholm den Right Livelihood Award entgegen – das Publikum erwartet ihre persönliche Geschichte, doch auf der Bühne betont sie nur das Wort „wir“. Die Welt behandelt sie als Genie; jede ihrer berühmten Entscheidungen war eine Ablehnung dieser Position.
+
+## Eine Maskenkarte, die zwanzigtausend US-Dollar verbrannte
+
+Ende Januar 2020 breitete sich die Covid-19-Pandemie in Taiwan aus. Die Maskenversorgung in den Apotheken wurde knapp, die Regierung kündigte den Kauf mit Namensregistrierung ab dem 6. Februar an. Ein Ingenieur des Studios „Good Job“ in Tainan, Wu Chan-wei (Howard), baute sich in der Nacht des 2. Februar aus eigener Initiative mit der Google-Maps-API eine Karte, auf der man den Maskenbestand der nahegelegenen Läden abfragen konnte. Er deployte sie mitten in der Nacht und teilte sie in den sozialen Netzwerken[^1].
+
+Am Mittag kam er vom Essen zurück an den Computer – die Rechnung im Google-API-Backend war bereits auf 20.000 US-Dollar gestiegen: Innerhalb von 24 Stunden hatte ihn der Ansturm der Nutzung verbrannt.
+
+An diesem Tag tauchte Audrey Tang im g0v-Slack-Kanal auf. Sie kam nicht, um Befehle zu erteilen. Sie koordinierte erst mit dem Google-Ingenieurteam, um die laufende Rechnung zu drücken; zugleich holte sie ein paar alte g0v-Freunde dazu – Chiang Ming-tsung (kiang, ehemaliger Exekutivsekretär des Smart-City-Büros von Tainan) und die Informatikabteilung des Krankenversicherungsamts (Chang Ling-chih, Chen Tzu-yu) –, um gemeinsam zu überlegen: Wie könnte der Maskenbestand der mehr als 6.000 Apotheken Taiwans alle 30 Sekunden auf eine Karte synchronisiert werden, die jeder öffnen kann[^2]?
+
+Bis zum 8.00 Uhr des 6. Februar, im selben Moment, in dem das Krankenversicherungsamt die offenen Daten offiziell freigab, ging die Apotheken-Maskenkaufkarte online. Innerhalb von 24 Stunden wurde sie von mehr als einer Million Menschen genutzt. Bis zum 15. Februar waren auf HackMD 101 verwandte Anwendungen zusammengekommen, und die g0v-Community hatte über 140 Werkzeuge hervorgebracht[^2][^3].
+
+Chiang Ming-tsung hinterließ später in der Wort-für-Wort-Aufzeichnung seines Vortrags diese Passage:
+
+> ✦ „Die Staatsministerin kennt die Informationsarchitektur sehr gut; was für Anforderungen wir auch stellen, sie versteht es sofort. Das Wichtigste ist: Audrey Tang hat Entscheidungsbefugnis und kann Code selbst ändern, also müssen wir nicht nach Taipei fahren, um einem höheren Beamten Bericht zu erstatten.“[^4]
+
+Der Held dieser Geschichte ist nicht allein Audrey Tang. Es sind Chiang Ming-tsung, Wu Chan-wei, jene Beamtinnen im Informatikbereich des Krankenversicherungsamts, die Hunderte von Ingenieuren der g0v-Community und die Nächte, in denen die Menschen im Büro von Audrey Tang reihum Code änderten.
+
+Doch nach 2020 war in allen Versionen ausländischer Medien nur sie die Heldin. Die BBC schrieb „Audrey Tang used code to save Taiwan“, Wired „The Hacker Who Became Taiwan's Digital Minister“, die TIME nahm sie in ihre Liste der „globalen Führungspersönlichkeiten im Kampf gegen die Pandemie“ auf.
+
+In jedem Interview schiebt sie die Verdienste zurück. Doch die Erzählung „Das Genie-Minister rettet Taiwan“ klebt seit über vierzig Jahren an ihr und lässt sich nicht so leicht abnehmen.
+
+## Mit 8 von Mitschülern bewusstlos getreten, mit 14 lehnt sie die Jianguo-Oberschule ab
+
+Am 18. April 1981 wurde Audrey Tang in Taipeh geboren. Ursprünglich hieß sie Tang Chung-han. Ihr Vater Tang Kuang-hua war ehemaliger stellvertretender Chefredakteur der China Times, ihre Mutter Li Ya-ching stellvertretende Leiterin der Interviewabteilung derselben Zeitung[^5].
+
+Sie hat einen angeborenen Herzfehler. Die Schule führte dreimal einen Intelligenztest durch, jedes Mal mit dem Ergebnis „mindestens 160“ (der höchsten Stufe des Testinstruments). Mit 8 Jahren hatte die Familie noch keinen Computer; sie las ein Programmierbuch über Applesoft BASIC und zeichnete daraufhin am Computer-Tastatur und Bildschirm von Hand auf Papier und schrieb auf, welche Knöpfe was in den Computer eingeben könnten[^5].
+
+Doch das Etikett „Wunderkind“ – vielleicht das häufigste Adjektiv neben ihrem Namen im Jahr 2026 – hatte keinen Platz auf dem Kind von 1989. An jener Stelle standen nur Prügelei, Blutergüsse und das Wort „Warum bist du nicht gestorben“.
+
+In sechs Grundschuljahren wechselte sie drei Kindergärten und sechs Grundschulen. An einem Tag in der zweiten Klasse verteilte die Lehrerin die Prüfungsbögen und verließ das Klassenzimmer. Audrey Tang war früh fertig; einige Mitschüler, die nicht weiterwussten, streckten die Hand aus, um ihr den Bogen zu entreißen. Sie rannte mit dem Bogen davon, stürzte, und einer der Mitschüler trat mit aller Kraft auf sie ein; sie prallte gegen die Wand und verlor das Bewusstsein[^6]. Später fiel über jenen Mitschüler ein Satz, den Business Today wörtlich festhielt:
+
+> ✦ „Warum bist du nicht gestorben? Wenn du tot wärst, wäre ich der Beste.“[^6]
+
+Sie erzählte zu Hause nichts. Als ihre Mutter sie eines Tages beim Baden sah und die Blutergüsse auf ihrem Bauch bemerkte, entschied sie sich auf der Stelle, sie von der Schule abzumelden[^6].
+
+Ihre Mutter Li Ya-ching ging später nach Deutschland, um alternative Erziehung zu studieren, und gründete 1994 in Wulai die experimentelle Grundschule „Zhongzi“ (Samen), deren erste Schulleiterin sie wurde[^7]. 1995, nach einer Zeit des Rückzugs in den Bergen von Wulai, erklärte die 14-jährige Audrey Tang ihren Eltern: keine weitere Schule mehr, sie verzichte auf die Empfehlung für die Jianguo-Oberschule[^8].
+
+Das war nicht die Wahl „Ich bin zu genial für die Schule“. Das war ein Kind, das mit acht gelernt hatte, sich zu verstecken, und mit vierzehn entschied: Dass man mich in die Schublade „Hochbegabte“ steckt, ist die Version, die ich nicht will.
+
+Sie hat es seither oft gesagt: „Ich glaube nicht, dass die moderne Welt noch etwas vom Genie versteht. Im Zeitalter des Internets ist eigentlich jeder Mensch mit einem IQ von 180.“[^9]
+
+
+## Mit 24 änderte sie ihren Namen, lehnte es aber ab, Sprecherin der Transgemeinschaft zu sein
+
+Mit 12 begann sie, Perl zu lernen[^10]. Mit 19 (2000) arbeitete sie bereits als Ingenieurin in einer Softwarefirma im kalifornischen Silicon Valley[^11].
+
+Am 1. Februar 2005, mit 24, startete sie das Pugs-Projekt – einen Compiler und Interpreter, der Perl 6 in Haskell implementiert[^12]. Pugs war in der Perl-Community ein Bootstrap-Projekt: eine Sprache, die sich selbst durch eine andere Sprache implementiert. Zwischen 2001 und 2006 startete sie auf CPAN mehr als 100 Perl-Projekte[^13]. Die internationale Open-Source-Community nannte sie Audrey oder au.
+
+Ende 2005 erklärte sie auf ihrem Blog blog.elixus.org selbst öffentlich, transgender zu sein[^14]. Sie nahm Östrogen, ließ sich aber nicht operieren. Ihren chinesischen Namen änderte sie von Tang Chung-han in „Tang Feng“ (唐鳳), aus dem englischen Namen Autrijus wurde Audrey.
+
+In jenem Blogpost schrieb sie:
+
+> ✦ „Ob jetzt, in der Vergangenheit oder in der Zukunft: Es ist mir sehr willkommen, wenn man mich mit weiblichen Begriffen anspricht.“[^14]
+
+Die Antwort ihres Vaters Tang Kuang-hua in einem Interview wurde später von vielen Medien wörtlich festgehalten:
+
+> ✦ „Wenn sie meint, die Änderung der Geschlechtsidentität mache sie glücklicher, könne ihre Kreativität besser zur Geltung kommen und verletze niemanden, gibt es keinen Grund, es nicht anzunehmen.“[^15]
+
+Sie lehnte die Rolle der „Sprecherin der Transgemeinschaft“ ab. 2020 trug sie im Geschlechterfeld ihres Personaldatensatzes im Kabinett „keine Angabe“ (無) ein. Gegenüber Journalisten erklärte sie damals[^16]:
+
+> ✦ „Ich bin ‚post-kategorial‘. Im Geschlechterstreit stelle ich mich auf keine Seite. Nicht dass ich das Thema für unwichtig hielte, sondern weil ich meine, dass Streit kein Problem löst.“[^16]
+
+In einem Interview mit Marie Claire hinterließ sie einen anderen Satz, der oft zitiert wird:
+
+> ✦ „Wenn du mit der Ratlosigkeit zusammenleben kannst, siehst du nach und nach vielleicht, dass es weder dein Problem noch das Problem der Gesellschaft ist, sondern die Lücke dazwischen. Alles hat eine Lücke, und die Lücke ist der Eingang des Lichts.“[^17]
+
+Von 2010 bis 2016 war sie nebenbei Beraterin bei Apple und wirkte an der Entwicklung von Siri mit; ihr Stundenlohn soll dem Gegenwert eines Bitcoin entsprochen haben[^18]. Mit 33 (2014) übergab sie die Arbeit bei Socialtext und Apple und erklärte ihren „Ruhestand“[^11].
+
+## g0v und der Sunflower-Saal: den Ruhm an die Unsichtbaren abgeben
+
+Im Oktober 2012 gründete sie gemeinsam mit Kao Chia-liang (clkao), Wu Tai-hui (Kirby) und Chu Hsiao-wei (ipa) u. a. g0v – die Regierung auf Null. Der Ausgangspunkt war der Unmut über einen Werbespot des Exekutiv-Yuans zum „Programm zur Ankurbelung der Wirtschaftskraft“ – einen Propagandaspot mit einem Budget von 33 Millionen NT$, nach dem man immer noch nicht wusste, was die Regierung eigentlich tun wollte[^19].
+
+Das erste Projekt von g0v war die Visualisierung des Zentralhaushalts: Die schweren Haushaltsbücher wurden zu einem Klick-für-Klick-Bild[^19]. Später folgten MoeDict, der Legislative-Videodienst IVOD und die Livestreams des Sunflower-Saals (der besetzten Legislative).
+
+In der Nacht des 18. März 2014 besetzten Studenten den Saal der Legislative. Sämtliche Kabel, Kameras und Livestream-Geräte im Saal wurden von Audrey Tang höchstpersönlich aufgebaut[^20].
+
+Doch sie blieb nur eine Stunde im Saal und ging dann. Später befragte sie das PNN des öffentlich-rechtlichen Senders PTS; sie sagte:
+
+> ✦ „Wenn die Kameras aus fünf verschiedenen Winkeln filmen und direkt übertragen, wird jede Aktivität zur reinen Schaustellung und zum Ritual.“[^20]
+
+Sowohl für die Besetzung als auch für die eigenen Stellungnahmen war sie „nicht interessiert“. Ihr ging es um die Werkzeuge und Techniken. Zugleich ließ sie aus eigener Tasche Wort-für-Wort-Aufzeichnungen der Regierungssitzungen erstellen – damit auch die, die nicht dabei waren, das vollständige Gespräch lesen konnten[^20].
+
+Nach dem Ende des Sunflower-Aufstands, im April 2014, trat die damalige Staatsministerin Tsai Yu-ling in den g0v-Hackathon ein. Von diesem Moment an begannen die beiden eigentlich gegensätzlichen Wörter „Regierung“ und „g0v“, einen Mittelstreifen hervorzubringen[^21].
+
+Dieser Mittelstreifen hieß vTaiwan. Von 2015 bis 2018 behandelte die Plattform 26 Themen, von denen 80 % zu konkreten Regierungshandlungen führten[^22]. Das bekannteste Beispiel ist die Diskussion um die Uber-Regulierung: Taxiunternehmer und Uber-Befürworter standen sechs Jahre lang unversöhnlich gegenüber und schließlich wurde Uber unter sieben Bedingungen legalisiert[^22].
+
+Das Herzstück der Plattform war die Konsens-Maschine Pol.is – eine große Menge von Meinungen wird maschinell in wenige Cluster sortiert, sodass jeder Teilnehmer sehen kann: „Mit wem denke ich ähnlich, mit wem ganz anders, und welche Positionen teilen alle.“ Es stimmt nicht ab, es konfrontiert nicht, es zeichnet nur die Form der Meinungsverschiedenheit.
+
+## Kein Büro, vollständig öffentliche Wortprotokolle, drei Tage die Woche aus der Ferne
+
+Am 9. August 2016 traf die 35-jährige Audrey Tang zum ersten Mal den damaligen Ministerpräsidenten Lin Chuan. Am 15. August stimmte sie zu, Staatsministerin zu werden. Ende September kehrte sie aus dem Silicon Valley zurück. Am 1. Oktober betrat sie das Exekutiv-Yuan[^23].
+
+Die drei Bedingungen, die sie vorher ausgehandelt hatte, wurden später zum ersten Einbruch im taiwanesischen Beamtenapparat: mittwochs und freitags aus der Ferne arbeiten; alle Sitzungen mit öffentlich zugänglichem Wortprotokoll; nicht jeden Tag ins Ministerium müssen[^23].
+
+Lin Chuan erklärte damals gegenüber Journalisten:
+
+> ✦ „Das Exekutiv-Yuan hat derzeit keine Regelung für Fernarbeit, doch ihre langjährige Arbeitsweise war immer die aus der Ferne. Ich denke, solange die Arbeit nicht beeinträchtigt wird, ist es machbar, Gedanken oder politische Weisungen per Computer aus der Ferne zu übertragen.“[^24]
+
+Sie wurde zu drei Dingen: der jüngste Staatsminister in der Geschichte Taiwans, die erste politische Persönlichkeit auf Ministerebene der Welt mit öffentlicher Transidentität, und Taiwans erste „Digitalministerin“[^25].
+
+Im Exekutiv-Yuan hatte sie kein festes Büro. Sie sagte, das ganze Weithaus sei ihr Arbeitsraum. Nach den Sitzungen kamen die Wortprotokolle auf sayit.pdis.nat.gov.tw, und jeder konnte darin suchen[^26].
+
+Sie stellte eine Gruppe von 20 Personen zusammen, die sie PDIS (Public Digital Innovation Space) nannte. Die Hälfte waren Fachleute aus der Zivilgesellschaft, die Hälfte Freiwillige aus den verschiedenen Ministerien. Im Sommer kamen 30 Praktikanten dazu[^26]. Es war keine bürokratische Organisation – es war ein Arbeitsraum.
+
+2019 wurde sie in die Liste der hundert globalen Denker des _Foreign Policy_ (Kategorie Leserwahl) aufgenommen[^27]. Die Medien schrieben über sie als „die weltweit einzige offen transidente Ministerin“ und „Programmierstar“. In jedem Interview schiebt sie die Verdienste zurück – doch die Geschichte vom „Genie-Minister“ lässt sich leichter weitererzählen als ihre eigenen Worte.
+
+![Audrey Tang beim Vortrag auf der digitalen Gesellschaftskonferenz re:publica in Berlin, Mai 2019](/article-images/people/audrey-tang-re-publica-2019.webp)
+_Audrey Tang mit Julia Kloiber beim Gespräch „Digital Social Innovation“ der re:publica am 8. Mai 2019 in Berlin. Foto: Jan Michalko. [CC BY-SA 2.0 via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Re_publica_19_-_Day_3_(32860400897).jpg)._
+
+## Konservativer Anarchismus: Befehle ablehnen und es ablehnen, befehligt zu werden
+
+Audrey Tang bezeichnet sich selbst als „konservative Anarchistin“. Auf den ersten Blick ein Widerspruch in sich.
+
+„Konservativ“ bedeutet: das Bestehende, die gut funktionierenden Institutionen erhalten; „anarchistisch“ bedeutet: gegen die Konzentration von Macht, gegen den Zwang von oben nach unten. Ein Mensch, der diese beiden Wörter verbindet, meint damit meist: Ich glaube, dass an den bestehenden Institutionen etwas Wertvolles ist, aber ich glaube nicht, dass irgendjemand das Recht hat, andere mit Autorität zur Zustimmung zu zwingen.
+
+In einem Interview mit Rest of World hinterließ sie einen Satz, der fast wie ein Manifest klingt:
+
+> ✦ „Any top-down, coercion, whether it's from the capitalists or from the state, is equally bad.“ (Jeder Zwang von oben nach unten – ob er von den Kapitalisten oder vom Staat ausgeht – ist gleichermaßen schlecht.)[^28]
+
+In ihrem Gespräch mit dem Ökonomen Tyler Cowen wurde sie gefragt, worin ihre Rolle bestehe; sie sagte:
+
+> ✦ „I'm working _with_ the government; I'm not working _for_ the government.“ (Ich arbeite _mit_ der Regierung zusammen; ich arbeite nicht _für_ die Regierung.)[^29]
+
+Auch in der Fragerunde der internationalen Informatikkonferenz (ICFP) 2020 warf sie einen solchen Satz hin:
+
+> ✦ „In Taiwan we have this strange idea that broadband internet access is a human right. Everyone has broadband. And if you don't, it's my fault, personally.“ (In Taiwan haben wir diese seltsame Idee, dass Breitbandinternet ein Menschenrecht ist. Jeder hat Breitband. Und wenn du es nicht hast, ist das meine persönliche Schuld.)[^30]
+
+Das Wort „Menschenrecht“ verwendet sie sehr schwer, aber die „persönliche Schuld“ sagt sie sehr leicht. Die Haltung, mit der sie ein Regierungsamt bekleiden wollte, lautet: „Wenn irgendwo etwas fehlt, gehe ich hin und fülle die Lücke.“
+
+Eine Maxime ihrer Arbeitsphilosophie heißt humor over rumor. Wenn das CoFacts-System eine sich viral verbreitende Fehlinformation erkennt, bringt ihr Team innerhalb von zwei Stunden ein zwei Minuten langes Video oder zwei Bilder (unter 200 Zeichen) heraus, um mit Humor auf die Falschmeldung zu reagieren – das sogenannte 2-2-2-Prinzip[^31].
+
+Im Februar 2020 war die „Klopapier-Panik“ der von internationalen Medien am häufigsten zitierte Fall: Das Gerücht kursierte, Masken und Klopapier bestünden aus derselben Papierfaser, die Menschen legten panisch Vorräte an; das Exekutiv-Yuan brachte innerhalb weniger Stunden ein bebildertes Bild heraus (auf dem der damalige Ministerpräsident Su Tseng-chang mit dem Satz „咱只有一粒卡臣“ ironisch beruhigt), dazu eine Erklärung der Lieferkette, dass die Rohstoffe verschiedene wären – und das Gerücht kühlte noch am selben Tag ab[^31]. Bei TED und in vielen internationalen Interviews benutzt sie dies als Beleg für humor over rumor: Gerüchte bekämpft man nicht mit Gesetzen, sondern deckt sie mit einem Bild zu, das lustiger ist als sie und zugleich die Fakten mitliefert.
+
+Am 27. August 2022 wurde das Ministerium für digitale Entwicklung (MoDA) offiziell eröffnet, und sie übernahm das Amt der ersten Ministerin[^32]. Der Personalbestand betrug im ersten Jahr 598 Stellen, das Haushaltsbudget 5,7 Milliarden NT$ plus 16 Milliarden aus dem Ausblick-Programm, zusammen 21,7 Milliarden[^33].
+
+Während ihrer Amtszeit trieb sie die digitale Resilienz voran (sie überzeugte die britische OneWeb und das luxemburgische SES, Endgeräte für Satelliten in mittlerer und niedriger Erdumlaufbahn in Taiwan zu stationieren), erneuerte das seit zwanzig Jahren unangetastete _Gesetz über die elektronische Signatur_, brachte die 111-Kurznummer der Regierung für Nachrichten an den Start, um Betrug abzuwehren, und verlangte, dass 47 Ministerien der Stufe A binnen zwei Jahren den einheitlichen Übertragungsstandard T-Road einführen[^34][^35].
+
+Doch sie erhielt auch viel öffentliche Kritik. Der Vorsitzende der Volkspartei TPP, Ko Wen-je, fragte: „Durchschnittlich 30 Millionen NT$ pro Person – was ist das für eine Arbeit?“; der DDP-Abgeordnete Liu Shyh-fang sagte, das Digitalministerium „habe noch nicht seine Richtung gefunden“; der KMT-Abgeordnete Wu I-ting sagte, die „Internetbetrügereien, die die Menschen am meisten bewegen, hätten keine konkreten Maßnahmen erlebt“[^36][^37].
+
+Selbst die vom PDIS in die Ministerien entsandten PO-Beamten (Fachleute für partizipative Öffentlichkeit) waren selbst verunsichert. The Reporter erreichte einen PO und hielt dessen Worte fest:
+
+> ✦ „Ich bin seit zwei Monaten PO und habe das Gefühl, eine Aufgabe mehr zu haben; ich verstehe derzeit noch nicht genau, wie weit wir eingreifen können und wie viel Vollmacht wir bekommen ... Ich weiß nicht, was in Zukunft unsere Rolle auf diesen Plattformen sein wird.“[^38]
+
+Auf diese Frage konnte sie nicht antworten. Oder besser: Ihre Antwort war – entscheid du selbst.
+
+Der Preis von „Vorbild statt Befehl“ ist Langsamkeit, sind unschöne KPIs, ist die Tatsache, dass nach zwei Jahren niemand klar sagen kann, „was das Digitalministerium eigentlich getan hat“. Ihre Wette galt dem Kulturwandel – und Kulturwandel gelingt, oder er gelingt nicht.
+
+Doch das öffentliche Wortprotokollsystem SayIt des PDIS hat bis zu ihrem Amtsende über 7.000 vollständige Sitzungsaufzeichnungen angesammelt[^26]. Jeder, der das Stichwort „Uber“, „Maske“ oder „LINE Pay“ eingibt, kann jedes ihrer Worte lesen, das sie damals gegenüber Unternehmen, Beamten und Abgeordneten gesagt hat. Dieses System existierte nicht, bevor sie in die Regierung kam, und niemand hat es entfernt, nachdem sie gegangen war. Sie kann es nicht in einem Satz Erfolgsbilanz zusammenfassen, aber sie hat tatsächlich sieben Jahre durchsuchbare Regierungsgespräche hinterlassen – das erste Mal in der politischen Geschichte Taiwans.
+
+## Auf der Bühne von Stockholm sagte sie „wir“
+
+Am Abend des 20. Mai 2024, nach der Amtseinführungszeremonie von Präsident Lai Ching-te, eilte Audrey Tang direkt zum Flughafen Taoyuan. In den folgenden drei Monaten bereiste sie zwanzig Länder[^39].
+
+Im April desselben Jahres veröffentlichte sie zusammen mit dem Ökonomen Glen Weyl und der weltweit verteilten Plurality Community das Buch _Plurality: The Future of Collaborative Technology and Democracy_. Das Buch wurde unter CC0 freigegeben – das heißt, jeder kann mit dem Volltext des Buches machen, was er will, ohne Namensnennung, ohne Bezahlung, ohne Zustimmung einzuholen[^40].
+
+Für den Titel „Plurality“ verwendeten sie ein chinesisches Schriftzeichen: ⿻ (auf Chinesisch „衆“, ausgesprochen etwa zhòng). Dieses Zeichen gehört im Unicode zu den „IDS – Ideographic Description Characters“, die eine Struktur beschreiben, in der „zwei Dinge ineinander verwoben sind“. Sie erklärte internationalen Medien, ⿻ betone das „Ineinander-Verwobensein“ (interweaving): Die Unterschiede vieler Individuen werden nicht ausgelöscht, bilden aber eine gemeinsame Textur. Dieses Konzept ist das genaue Gegenteil von „Genie“: Ein Genie ist ein heller Punkt, der von grauer Umgebung begleitet wird; ⿻ bedeutet, dass jeder Faden von den anderen durchwoben wird und keiner fehlen darf.
+
+Der Fall der Uber-Regulierung, den vTaiwan behandelte, ist ein Beispiel, das sie oft zur Erklärung von ⿻ anführt: Taxiunternehmer und Uber-Befürworter standen sechs Jahre lang unversöhnlich gegenüber, und schließlich wurde Uber unter sieben Zusatzbedingungen legalisiert[^22]. Keine Seite hatte bei diesem Konsens vollständig „gewonnen“, aber auch keine Seite hatte vollständig „verloren“. Sie sagt, das sei die wahre Form der Demokratie – die Arbeit, die Texturen aller Menschen in dasselbe Tuch zu weben.
+
+Am 7. Oktober ernannte das Außenministerium sie zur Botschafterin ohne festen Amtssitz der Republik China (Cyber Ambassador-at-Large)[^41]. Auf ihrer persönlichen Webseite audreyt.org und auf cyberambassador.tw steht als unveränderliche Einleitung derselbe Satz:
+
+> ✦ „I want to be a good enough ancestor for future generations.“ (Ich möchte ein gut genuger Vorfahr für künftige Generationen sein.)[^42]
+
+Am 2. Dezember 2025, in Stockholm, im Saal der Right Livelihood Foundation. Der Right Livelihood Award wird als der „alternative Nobelpreis“ bezeichnet; er wurde 1980 vom schwedisch-deutschen Philanthropen Jakob von Uexküll gegründet, um die Bereiche zu ergänzen, die der Nobelpreis nicht abdeckt.
+
+Audrey Tang ist der erste Taiwanese, der diesen Preis erhielt[^43]. Die Laudatio lautete:
+
+> ✦ „For advancing the social use of digital technology to empower citizens, renew democracy and heal divides.“ (Für die Förderung der gesellschaftlichen Nutzung digitaler Technologie, um Bürger zu stärken, Demokratie zu erneuern und Gräben zu heilen.)[^43]
+
+In ihrer Dankesrede begann sie keineswegs mit dem, was sie getan hat. Sie sprach darüber, was Cyberspace ist:
+
+> ✦ „Cyberspace is a conflict region, and my work turns that conflict into an energy source for co-creation. It is time we work on peace in this zone.“ (Der Cyberspace ist eine Konfliktregion, und meine Arbeit verwandelt diesen Konflikt in eine Energiequelle für gemeinsames Schaffen. Es ist an der Zeit, dass wir in dieser Zone an Frieden arbeiten.)[^43]
+
+Dann wiederholte sie jenen Satz vom Umschlag des Buches Plurality:
+
+> ✦ „The superintelligence we are looking for is already here. It's us.“ (Die Superintelligenz, nach der wir suchen, ist längst da. Es sind wir.)[^44]
+
+Sie nahm die Trophäe entgegen, die als „alternativer Nobelpreis“ gilt, und lenkte auf der Bühne die Aufmerksamkeit auf „wir“ – die Frau, die die ganze Welt als Taiwans Genie behandelt, lehnte zum wiederholten Mal diese Position des „Genies“ ab.
+
+Von jenem Kind von 1989, das in der Grundschule im Förderklassenraum getreten wurde, bis zu dem Menschen von 2025, der mit 44 auf der Bühne von Stockholm steht, dazwischen liegt ein langer Weg, gepflastert aus einer Ablehnung nach der anderen. Jede Ablehnung sieht wie ein Aufbegehren aus, doch im Zusammenhang betrachtet erkennt man, dass es dieselbe Bewegung in verschiedenen Variationen ist: sich weigern, von der Position des „hervorragenden Individuums“ definiert zu werden, und sich stattdessen in die Rolle des Knotens, der Brücke, des Raumbauers zurückstellen.
+
+Sie lehnt das Genie ab. Die Welt besteht darauf, sie als Genie zu behandeln. Doch sie hat diesem Streit nie den Sieg überlassen – nur die Welt braucht lange, um zu verstehen, wovon sie überhaupt spricht.
+
+![Signature SVG von Audrey Tang, 2021 öffentlich freigegeben](/article-images/people/audrey-tang-signature.svg)
+_Signatur von Audrey Tang, im August 2021 öffentlich freigegeben, ursprünglich für die japanische Zeitschrift Bungeishunjū. Autorin: Audrey Tang selbst, [CC0 Public Domain](https://commons.wikimedia.org/wiki/File:Audrey_Tang_signature_(51385705516).svg)._
+
+---
+
+## Weiterführende Links
+
+- Sodagreen – ebenfalls ein taiwanesischer Außenseiter, der in den 2000ern aufstieg, ebenfalls ein langjähriger Kampf um die Verweigerung, sich von einer vorgegebenen Identität einrahmen zu lassen; nur spielte die Bühne in der Musikindustrie statt in der Regierung.
+- Tony Hsiao (蕭上農) – Mitbegründer von INSIDE und iCook, der seine Rolle im taiwanesischen Tech-Ökosystem ebenfalls über das „Überschreiten vieler Felder“ definiert.
+- [Tai-yu Wu (吳大猷)](/de/people/tai-yu-wu) – die Weitergabe der taiwanesischen Wissensträger von der Wissenschaft zur Technologie; als Präsident der Academia Sinica legte Wu das Fundament des taiwanesischen Forschungsapparats.
+- Open Culture Foundation – die Stiftung, die aus der Buchhaltung von g0v zu einer Brücke für Taiwans digitale Rechte heranwuchs; sie traf mehrfach mit dem von Audrey Tang geleiteten Digitalministerium zusammen, in Zusammenarbeit wie in Wachsamkeit.
+- Taiwans Covid-Pandemie und Impfstoffe – in welche Pandemie der Koordinationsstrang der Maskenkarte eingewebt war, und die achtzehn Monate, die Taiwan durch Grenzen und Masken für sich herausholte.
+
+---
+
+## Bildquellen
+
+Dieser Artikel verwendet 3 Bilder, alle zwischengespeichert in `public/article-images/people/`, um heiße Quellserver-Verknüpfungen zu vermeiden. Die drei Bilder stehen unter Wikimedia-Commons-CC-/CC0-Lizenz:
+
+- **hero**: [Portrait Audrey Tang (beschnitten)](<https://commons.wikimedia.org/wiki/File:Portrait_Audrey_Tang_(25915794061,_cropped).jpg>) — Foto: Camille McOuat, 2016-03-09 Paris, CC BY 2.0
+- **scene-mid**: [Re:publica 19 - Day 3](<https://commons.wikimedia.org/wiki/File:Re_publica_19_-_Day_3_(32860400897).jpg>) — Foto: Jan Michalko, 08.05.2019, re:publica Berlin, CC BY-SA 2.0
+- **signature**: [Audrey Tang signature](<https://commons.wikimedia.org/wiki/File:Audrey_Tang_signature_(51385705516).svg>) — Autorin: Audrey Tang selbst, 18.08.2021, CC0 Public Domain
+
+## Referenzen
+
+[^1]: [TechNews: Das Team hinter der Maskenkarte – mit Tastatur das Land retten (23.02.2020)](https://technews.tw/2020/02/23/expose-the-team-behind-mask-map/) — schildert im Detail die Zeitachse: Wu Chan-wei (Howard) deployet mitten in der Nacht, die API-Rechnung erreicht 20.000 US-Dollar, Audrey Tang koordiniert Google und g0v.
+
+[^2]: [Chiang Ming-tsung Medium: Launch der Apotheken-Maskenkartenkarte (02.2020)](https://medium.com/%E6%B1%9F%E6%98%8E%E5%AE%97-kiang/%E8%97%A5%E5%B1%80%E5%8F%A3%E7%BD%A9%E6%8E%A1%E8%B3%BC%E5%9C%B0%E5%9C%96%E4%B8%8A%E7%B7%9A-54e11bd63e84) — der Ingenieur selbst berichtet, wörtlich „die offiziellen Daten kommen voraussichtlich erst am 6.2. um 8 Uhr online“, plus Tangs Koordination der Community-Beteiligung an der Entwicklung.
+
+[^3]: [Offizielle Covid-19-Entscheidungsseite des Gesundheitsministeriums](https://covid19.mohw.gov.tw/ch/cp-4822-53563-205.html) — offizielle Regierungsaufzeichnung, wörtlich: „Staatsministerin Tang Feng (Audrey Tang) lud zivilgesellschaftliche Communities ein, auf Grundlage der offenen Daten des Krankenversicherungsamts die Anwendungsplattform ‚Corona-Maskenabfrage‘ zu erstellen“.
+
+[^4]: [TechNews: Das Team hinter der Maskenkarte (wie [^1])](https://technews.tw/2020/02/23/expose-the-team-behind-mask-map/) — siehe ergänzende Details im Text des Originallinks.
+
+[^5]: [Chinesische Wikipedia: Eintrag „Tang Feng“ (唐鳳)](https://zh.wikipedia.org/zh-tw/%E5%94%90%E9%B3%B3) — grundlegende biografische Daten: Geburt, familiärer Hintergrund, das Papier-Tastenfeld zum Selbstlernen von BASIC in der Kindheit.
+
+[^6]: [Business Today: Von neidischen Mitschülern getreten … das Wunderkind Tang Feng wollte als Kind mehrfach sterben (11.2020)](https://www.businesstoday.com.tw/article/category/183035/post/202011090020/) — die Prügelszene im Förderklassenraum der zweiten Klasse plus die wörtliche Aussage des Mitschülers „Warum bist du nicht gestorben“, plus die Entscheidung der Mutter nach dem Anblick der Blutergüsse beim Baden.
+
+[^7]: [China Times: Tang Feng als jüngste Staatsministerin – Li Ya-ching als Vorbild der Schulreform durch Selbstlernen (25.08.2016)](https://www.chinatimes.com/realtimenews/20160825005980-260405) — Li Ya-ching kehrte 1992 zurück, gründete 1994 die experimentelle Grundschule Zhongzi in Wulai und wurde ihre erste Schulleiterin.
+
+[^8]: [TaiSounds: Der Flucht aus dem „Schulmobbing“ auf die Selbstlernbahn – Tang Fengs „große Entdeckung“ mit 14](https://www.taisounds.com/specialtopic/content/46/23226) — nach dem Rückzug in den Bergen von Wulai lehnte sie mit 14 die Empfehlung für die Jianguo-Oberschule ab.
+
+[^9]: Von mehreren Medien zitiert, von ihr in verschiedenen Interviews wiederholt: „Ich glaube nicht, dass die moderne Welt noch etwas vom Genie versteht“; „Im Zeitalter des Internets hat eigentlich jeder einen IQ von 180“.
+
+[^10]: [Wikipedia: Audrey Tang](https://en.wikipedia.org/wiki/Audrey_Tang) — „Tang started programming at the age of eight and began learning Perl at the age of 12“.
+
+[^11]: Eintrag der chinesischen Wikipedia (wie [^5]) — 2000, mit 19 Jahren bereits Ingenieurin im Silicon Valley; 2014, mit 33, übergab sie die Arbeit bei Socialtext und Apple und erklärte ihren Ruhestand.
+
+[^12]: [Wikipedia: Pugs (compiler)](https://en.wikipedia.org/wiki/Pugs_(compiler) — Wikipedia-Eintrag.
+
+[^13]: [Wikipedia: Audrey Tang (Englisch)](https://en.wikipedia.org/wiki/Audrey_Tang) — „Tang initiated over 100 Perl projects between June 2001 and July 2006, including the popular PAR archiver“.
+
+[^14]: Eintrag der chinesischen Wikipedia (wie [^5]) plus von mehreren Medien wörtlich einheitlich zitiert: „Ob jetzt, in der Vergangenheit oder in der Zukunft: Es ist mir sehr willkommen, wenn man mich mit weiblichen Begriffen anspricht.“ Ursprüngliche Quelle ist der Blog blog.elixus.org von 2005.
+
+[^15]: [Business Today: Interview mit Tang Fengs Vater (09.2016)](https://www.businesstoday.com.tw/article/category/80407/post/201609010032/) — der Vater Tang Kuang-hua wörtlich: „Es gibt keinen Grund, es nicht anzunehmen“.
+
+[^16]: [Frauen Taiwans, NMTH: Taiwans erste transidente Kabinettsmitgliederin und erste Digitalministerin – Tang Feng](https://women.nmth.gov.tw/?p=20105) — Tang Feng wörtlich „Ich bin ‚post-kategorial‘“, plus Hintergrund der Eintragung „keine Angabe“ im Geschlechterfeld 2020 im Kabinettspersonaldatensatz.
+
+[^17]: [Marie Claire Taiwan: Nach dem Mobbing der Kindheit sagt Tang Feng: „Leb gut mit der Ratlosigkeit“](https://www.marieclaire.com.tw/entertainment/story/52923/audrey-tang) — wörtlich „Alles hat eine Lücke, und die Lücke ist der Eingang des Lichts“.
+
+[^18]: [Eintrag der chinesischen Wikipedia (wie [^5]) +](https://www.britannica.com/biography/Audrey-Tang) — siehe ergänzende Details im Text des Originallinks.
+
+[^19]: [Sinorama: Bürger-Hackerpower – g0v, die Regierung auf Null](https://www.taiwan-panorama.com/Articles/Details?Guid=61281c3d-f79c-4db7-93d9-d18b29f90ba0) — der Ausgangspunkt 10.2012, die Visualisierung des Zentralhaushalts, die Liste der Mitgründer.
+
+[^20]: [PNN des öffentlich-rechtlichen Senders PTS: Berichterstattung zum Sunflower-Protest (2014)](https://news.pts.org.tw/article/327548) — wörtlich „alle Kabel, Kameras, sämtliche Livestream-Geräte im Saal wurden von ihm – dem Bürger-Hacker ‚Tang Feng‘ – höchstpersönlich aufgebaut“, plus Tangs Kommentar zum Saal als „Schaustellung und Ritual“, plus die selbst finanzierte Wortprotokollierung.
+
+[^21]: [The Reporter: Einen Dialograum schaffen – Tang Fengs Zauberreise](https://www.twreporter.org/a/g0v-audrey-tang) — wörtlich, dass Tsai Yu-ling im April 2014 in den g0v-Hackathon eintrat; der Ursprung von vTaiwan.
+
+[^22]: [Democracy Technologies: Consensus Building in Taiwan](https://democracy-technologies.org/participation/consensus-building-in-taiwan/) — vTaiwan behandelte 2015–2018 26 Themen; 80 % führten zu konkreten Regierungshandlungen; Legalisierung von Uber unter 7 Bedingungen.
+
+[^23]: [Liberty Times: Gegen die Tradition – Tang Feng arbeitet mittwochs und freitags „aus der Ferne“ (2016)](https://news.ltn.com.tw/news/politics/breakingnews/1859132) — 9.8. erste Begegnung mit Lin Chuan, 15.8. Zustimmung, 1.10. Amtsantritt, die drei Bedingungen beim Eintritt in die Regierung.
+
+[^24]: [Liberty Times: Tang Fengs Fernarbeit – Lin Chuan: „Das ist machbar“ (2016)](https://news.ltn.com.tw/news/politics/breakingnews/1859246) — Lin Chuan wörtlich: „Das Exekutiv-Yuan hat derzeit keine Regelung für Fernarbeit … das ist machbar“.
+
+[^25]: Eintrag der chinesischen Wikipedia (wie [^5]) — mit 35 der jüngste Staatsminister der taiwanesischen Geschichte, die weltweit erste offen transidente politische Persönlichkeit auf Ministerebene.
+
+[^26]: [pdis.nat.gov.tw, Arbeitsprotokolle und die öffentliche Wortprotokollplattform SayIt](https://sayit.pdis.nat.gov.tw/) — Struktur der 20-köpfigen PDIS-Gruppe, halb zivilgesellschaftlich, halb Ministeriumsfreiwillige, plus 30 Praktikanten.
+
+[^27]: [Taipei Times: Audrey Tang in „Top 100 Global Thinkers“ (25.01.2019)](https://www.taipeitimes.com/News/front/archives/2019/01/25/2003708586) — Aufnahme in die hundert globalen Denker des Foreign Policy (Kategorie Leserwahl).
+
+[^28]: [Rest of World: Audrey Tang über ihre „konservativ-anarchistische“ Vision für Taiwans Zukunft (2020)](https://restofworld.org/2020/audrey-tang-the-conservative-anarchist/) — wörtlich „Any top-down, coercion, whether it's from the capitalists or from the state, is equally bad“.
+
+[^29]: [Conversations with Tyler, Episode 106: Audrey Tang](https://conversationswithtyler.com/episodes/audrey-tang/) — wörtlich „I'm working with the government; I'm not working for the government“.
+
+[^30]: [Lindsey auf X: zeitnahes Zitat aus der ICFP-2020-Fragerunde](https://x.com/lindsey/status/1297886318114963456) — wörtlich „In Taiwan we have this strange idea that broadband internet access is a human right“.
+
+[^31]: [SwissInfo: Meinungsfreiheit – humour over rumour](https://www.swissinfo.ch/eng/politics/freedom-of-expression-humour-over-rumour-lessons-from-taiwan-in-digital-democracy/46592080) — siehe ergänzende Details im Text des Originallinks.
+
+[^32]: [Offizielle Website des Digitalministeriums: die bisherigen Minister](https://moda.gov.tw/aboutus/ministers-since-2022/1527) — wörtlich „27.08.2022 bis 20.05.2024“, Amtszeit von Tang Feng.
+
+[^33]: [Liberty Times: Tang Feng übernimmt das Digitalministerium – Budgetpersonal 598 Personen](https://news.ltn.com.tw/news/politics/breakingnews/4021987) — Bericht der Liberty Times.
+
+[^34]: [Liberty Times Financial: Vom Genie-IT-Minister zur freien Dozentin – Rückblick auf drei große Erfolge und Kontroversen unter Tang Feng](https://ec.ltn.com.tw/article/breakingnews/4677986) — digitale Resilienz, OneWeb, SES-Satelliten, Reform des E-Signaturgesetzes, 111-Kurznummern-Nachrichtenplattform.
+
+[^35]: [INSIDE: Ein Jahr Digitalministerium! Zwei große Verdienste und drei Kontroversen unter Tang Feng](https://www.inside.com.tw/article/32615-Taiwan-moda-anniversary) — Einführung des einheitlichen T-Road-Übertragungsstandards in 47 Ministerien der Stufe A plus wörtliche Aussage von Kollegen: „Im Vergleich zu bisherigen Behörden ist Tang Feng eher bereit, Macht nach unten abzugeben“.
+
+[^36]: [Global Views: Tang Fengs „Digitalministerium“ fast ein Jahr – Kritik von außen, keine Erfolge](https://www.gvm.com.tw/article/105627) — wörtliche Kritiken von Liu Shyh-fang und Wu I-ting.
+
+[^37]: [ETtoday: Das Digitalministerium plant 21,1 Milliarden Haushalt – Ko Wen-je erschrocken: Durchschnittlich 30 Millionen pro Person, „was ist das für eine Arbeit?“ (30.08.2022)](https://www.ettoday.net/news/20220830/2327863.htm) — wörtliche kritische Anfrage von Ko Wen-je.
+
+[^38]: [The Reporter: Offene Regierung – wie kommt Tang Feng an den Beamten vorbei?](https://www.twreporter.org/a/open-government-audrey-political-commissar-challenges) — PO wörtlich: „Ich bin seit zwei Monaten PO … ich verstehe nicht genau, wie weit wir eingreifen dürfen“.
+
+[^39]: [Liberty Times Financial: Vom Genie-IT-Minister zur freien Dozentin (wie [^34])](https://ec.ltn.com.tw/article/breakingnews/4677986) — Bericht der Liberty Times.
+
+[^40]: [Plurality Institute: Buchvorstellung von Plurality](https://www.plurality.institute/blog-posts/book-launch-plurality-the-future-of-collaborative-technology-and-democracy-by-e-glen-weyl-audrey-tang-and-the-plurality-community) — gemeinsam verfasst mit Glen Weyl und der Plurality Community, veröffentlicht am 16.04.2024, freigegeben unter CC0.
+
+[^41]: [Eintrag der chinesischen Wikipedia (wie [^5]) +](https://cyberambassador.tw/) — siehe ergänzende Details im Text des Originallinks.
+
+[^42]: [audreyt.org](https://audreyt.org/) — siehe ergänzende Details im Text des Originallinks.
+
+[^43]: [Right Livelihood: Taiwans Audrey Tang erhält den Right Livelihood Award (2025)](https://rightlivelihood.org/news/taiwans-audrey-tang-honoured-with-right-livelihood-award-for-advancing-digital-democracy-and-social-trust/) — Laudatio wörtlich + der wörtliche Ausschnitt von Tangs Dankesrede, beginnend mit „Cyberspace is a conflict region“, + [Focus-Taiwan-Bericht (CNA Englisch)](https://focustaiwan.tw/society/202512030022).
+
+[^44]: cyberambassador.tw wörtlich + philosophische Neufassung vom Buchumschlag von Plurality – „The superintelligence we are looking for is already here. It's us“.


### PR DESCRIPTION
## 新增德文翻譯：唐鳳（Audrey Tang）

本 PR 新增 `knowledge/de/People/audrey-tang.md`（德文），內容自 `knowledge/People/唐鳳.md` 完整重寫翻譯，非逐字直譯。主題為臺灣首位數位政委、跨性別部長級政治人物，政治敏感度高，翻譯時英文引文保留原文＋德文釋義雙軌。

### 品質檢查

| 檢查 | 結果 |
|---|---|
| `article-health.py --profile=ci-deploy` | ✅ `hard=0 warn=0` `passed=True` |
| `verify-translation.py` | ✅ 17 pass / 1 WARN / **0 hard fail**（WARN 為 ratio 2.35 THIN；德文正文 prose 實為 2.81，低估純因 zh 參考資料段極度精簡） |
| 德中字元比（body） | ✅ 2.35（健康區間 2.0–4.0 內） |
| 章節結構 | ✅ 10 個 H2 與原文一致 |
| 腳註 | ✅ **44 個** `[^N]` 全部保留並對應正文引用 |
| URL | ✅ **45 個 URL exact multiset 完全保留** |
| 媒體 | ✅ 3 圖（1 hero + 2 inline，含 SVG 簽名）|
| 延伸閱讀 | ✅ 有 de 版（吳大猷 `/de/people/tai-yu-wu`）保留；無 de 版（蘇打綠、蕭上農、開放文化基金會、疫情）降級純文字 |
| 違禁片語 | ✅ 無 |
| 正文 CJK 標點 | ✅ 無 `；`、`——` |
| YAML | ✅ js-yaml 通過；tags 全 ASCII；zh 14 個核心欄位全數保留；`curation: incubating`（照 en 慣例） |
| lifeTree frontmatter | ⚠️ zh 含 semiont 生成的巨大巢狀 lifeTree 區塊，**照 en sibling 做法省略**（verify 只檢查 14 個頂層欄位，en 亦無 lifeTree 仍通過） |

### 本文件特色

- 7 個正文章節完整翻譯：口罩地圖、被踹昏的 8 歲、24 歲改名、g0v 與太陽花、沒辦公室入閣、保守無政府主義、斯德哥爾摩的「我們」。
- 16 個 ✦ 引用 callout 全保留，英文引文（Any top-down coercion / I'm working _with_ the government / humor over rumor 等）原文＋德譯。
- 一生主線清楚：每一次拒絕「天才」標籤的決定——拒絕建中、拒絕代言人、拒絕辦公室、拒絕當天才。
