### PR TITLE
🇩🇪 de: 許倬雲 — Hsu Cho-yun (Historiker)

### DIFF
--- a/knowledge/de/People/cho-yun-hsu-bridging-historian.md
+++ b/knowledge/de/People/cho-yun-hsu-bridging-historian.md
@@ -1,0 +1,416 @@
+---
+title: 'Hsu Cho-yun: Die chinesische Geschichte, mit zwei Fingern geschrieben – der Großonkel von Wang Leehom'
+description: 'Hsu Cho-yun, 1930 in Xiamen geboren, kam 1949 nach Taiwan und 1970 nach Pittsburgh. Der körperbehinderte Historiker tippte mit zwei Fingern fast 40 Bücher, Akademiemitglied der Academia Sinica und Tang-Preis-Träger 2024; die 50 Mio. NT$ spendete er komplett. Sein Großneffe ist Wang Leehom, sein Neffe Li Chien-fu. Er starb 2025 mit 95: „Im Moment meines letzten Atemzugs lerne ich noch.“'
+date: 2026-05-22
+category: 'People'
+tags:
+  [
+    'Historiker',
+    'Geschichtswissenschaft',
+    'Chinesische Geschichte',
+    'Kulturgeschichte',
+    'Gelehrter',
+    'Wangu Jianghe',
+    'Tang-Preis',
+    'Universität Pittsburgh',
+    'Akademiemitglied der Academia Sinica',
+    'Wang Leehom',
+    'Li Chien-fu',
+  ]
+subcategory: '科學與學術'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-05-22
+lastHumanReview: false
+image: '/article-images/people/hsu-cho-yun-academia-sinica-hero.webp'
+imageCredit: 'Academia Sinica'
+imageLicense: 'Attribution (Wikimedia Commons)'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Cho-Yun_Hsu_%E8%A8%B1%E5%80%AC%E9%9B%B2.jpg'
+sporeLinks:
+  - id: 82
+    platform: 'threads'
+    date: '2026-05-23'
+    url: 'https://www.threads.com/@taiwandotmd/post/DYru52Bk31S'
+  - id: 83
+    platform: 'x'
+    date: '2026-05-23'
+    url: 'https://x.com/taiwandotmd/status/2058183941593719181'
+translatedFrom: 'People/許倬雲.md'
+sourceCommitSha: '09ffe560f'
+sourceContentHash: 'sha256:a7dc8d1152c0f436'
+sourceBodyHash: 'sha256:5272c869278fa371'
+translatedAt: '2026-09-09T01:20:00+08:00'
+---
+
+# Hsu Cho-yun: Die chinesische Geschichte, mit zwei Fingern geschrieben – der Großonkel von Wang Leehom
+
+> **30 Sekunden im Überblick:** Hsu Cho-yun wurde 1930 in Xiamen geboren, kam 1949 mit der Nationalregierung nach Taiwan und zog 1970 nach Pittsburgh. Der Historiker, von Geburt an körperlich beeinträchtigt und ein Leben lang im Rollstuhl, tippte mit den einzigen zwei Fingern, mit denen er Kraft ausüben konnte, fast vierzig Bücher. Er wurde 1980 in die 13. Klasse der Akademiemitglieder der Academia Sinica gewählt und erhielt 2024 den sechsten Tang-Preis für Sinologie – der erste Preisträger taiwanesischer Herkunft im strengen Sinn. Das gesamte Preisgeld von 50 Millionen NT$ spendete er für das „Hsu-Sun-Stipendium“[^1]. Seine älteste Schwester Hsu Liu-fen war die Großmutter von Wang Leehom, seine zweite Schwester Hsu Wan-ching die Mutter von Li Chien-fu – eine wuxiesische Marinekonteradmiral-Familie, die zugleich zum Sinologie-Hörsaal der University of Chicago, zum Dekanatsbüro der NTU-Geschichtsfakultät, zu den Worten und zur Melodie von „Söhne des Drachen“ und zu dem Verwandtschaftswort „mütterlicher Großonkel“ führte, das über zweitausendmal gesucht wurde, ohne dass jemand es je anklickte[^2]. Am 3. August 2025 starb er in Pittsburgh im Alter von 95 Jahren; als ihn die Central News Agency mit 94 Jahren interviewte, sagte er: „Im Moment meines letzten Atemzugs lerne ich noch.“[^3]
+
+Im Juni 2024 flog ein Reporter der Central News Agency nach Pittsburgh und interviewte Hsu Cho-yun, der gerade erfahren hatte, dass ihm der sechste Tang-Preis für Sinologie verliehen worden war. Der 94-Jährige saß im Rollstuhl, beide Hände nach innen gebeugt, das Sehvermögen so weit geschwächt, dass er nicht mehr selbst umblättern konnte, und war in fast allem auf die Hilfe seiner Frau Sun Man-li angewiesen[^4].
+
+Doch jeden Morgen setzte er sich an den Computer und tippte mit den verbliebenen zwei Fingern, die Kraft ausüben konnten, weiter, las und schrieb. Das Buch, an dem er damals schrieb, hieß _Jingwei Huaxia_ (经纬华夏): Dieses über 300.000 Schriftzeichen umfassende, in drei Jahren geschriebene und achtmal überarbeitete Werk über die frühe chinesische Geschichte wurde am Ende vollständig mit diesen zwei Fingern getippt[^5].
+
+Als der Reporter ihn nach seinen Gedanken zur Preisverleihung fragte, sprach er nicht über den Preis. Er sagte: „Ich, mit 94, möchte der Gesellschaft meine Antwort abgeben; ich hoffe, die Gesellschaft sagt mir: Du hast bestanden. Aber mir selbst gegenüber kann ich nicht sagen, dass ich bestanden habe. Im Moment meines letzten Atemzugs lerne ich noch.“[^3]
+
+Ein Jahr später, am 3. August 2025 (in der Morgendämmerung des 4. August nach taiwanesischer Zeit), starb Hsu Cho-yun im Schlaf in Pittsburgh, 95 Jahre alt. Sein letzter Weibo-Beitrag stammte vom 24. Juli und erinnerte an den Krieg von 1938, die Zeit vor der Schlacht von Taierzhuang und den Moment, als die Sichuan-Armee durch Shashi zog. Am nächsten Tag gedachte sein Großneffe Wang Leehom in den sozialen Medien des „siebten Großonkels“[^6].
+
+📝 **Der Auslöser für die Neufassung dieses Artikels waren Daten aus der Google Search Console, nicht die Todesnachricht:** In der englischsprachigen Welt gab es jede Woche über zweitausend Suchen nach „Hsu Cho-yun Wang Leehom“ – alle mit null Klicks. Die Leser wollten wissen, wie Wang mit diesem Historiker verwandt war, aber Taiwan.md hatte diese Brücke nie gebaut. Dieser Artikel erweitert den Rahmen vom Stammbaum bis zur Familie des wuxiesischen Marinekonteradmirals, zu den Worten und zur Melodie von „Söhne des Drachen“, zu den Methoden der University of Chicago, die die Sozialwissenschaften in die Geschichtswissenschaft brachten, und zu dem großen Strom von _Der ewige Strom_ (万古江河), der „China wieder im weltweiten Blick“ verortete – eine Tür, die neue Lesergenerationen neu öffnet.
+
+## Die Zwillinge von Gulangyu in Xiamen und die Kriegsflucht durch Shashi, Hubei, Sichuan und Chongqing
+
+Am 3. September 1930 wurden Hsu Cho-yun und sein Zwillingsbruder Hsu I-yun auf der Insel Gulangyu in Xiamen, Fujian, geboren[^7]. Die Familie stammte aus Wuxi in Jiangsu; der Vater Hsu Feng-tsao war Konteradmiral der Marine der Republik China und hatte an der Xinhai-Revolution teilgenommen; die Mutter Chang Shun-ying stammte aus einer beamteten Gelehrtenfamilie in Wuxi, war gebildet und bildete neben der Sorge für Mann und Kinder das geistige Zentrum der gesamten Großfamilie[^8].
+
+Von den beiden Zwillingen wurde einer gesund geboren (der jüngere Bruder Hsu I-yun), einer war von Geburt an mit deformierten Gliedmaßen behaftet – Hände und Füße nach innen gekrümmt, so dass er sich nur mühsam mit zwei Krücken fortbewegen konnte (der ältere Bruder Hsu Cho-yun). Dieser Kontrast zwischen Zwillingen ist medizinisch äußerst selten[^9]. Für eine chinesische Familie der 1930er Jahre bedeutete das: In allen Umzügen, Kriegen und Fluchten der kommenden Jahrzehnte würde Hsu Cho-yun stets das Kind sein, das getragen, gehuckepack genommen und versorgt wurde.
+
+1935 wurde der Vater versetzt, und die Familie zog von Xiamen nach Shashi in Hubei. Zwei Jahre später brach der Zwischenfall an der Marco-Polo-Brücke aus; der siebenjährige Hsu Cho-yun stieß auf die turbulenteste Epoche der chinesischen Geschichte. In der Folge floh die Familie zwischen Shashi, Hubei, Sichuan und Chongqing hin und her; diese Kindheit der Flucht wurde zu einem Grundton seines lebenslangen historischen Schreibens[^10].
+
+📝 **Sein letzter Weibo-Beitrag blieb in jenem Moment vor der Schlacht von Taierzhuang stehen:** „Ich sah diese jungen Soldaten einen nach dem anderen an mir vorbeiziehen. In jenem Moment wurde ich vom Kind zum Erwachsenen und ahnte vage: Diese jungen Soldaten ziehen durch Shashi, um von Xinyang direkt nach Taierzhuang zu eilen – und am Ende wird keiner von ihnen nach Hause zurückkehren. Kein einziger.“ Darunter fügte er hinzu: „Ein Kind wird nicht durch das Alter zum Erwachsenen, sondern durch die Haltung im Herzen.“[^11] Dieser Beitrag stammte vom 24. Juli 2025: Zehn Tage später starb er in Pittsburgh. Sein Leben lang schrieb er über chinesische Frühgeschichte, Han-Landwirtschaft und West-Zhou-Lehenswesen – doch Anfang und Ende seines eigenen Lebens waren beide an jene Straße entlang des Jangtse in Hubei von 1938 gebunden.
+
+Im Krieg wurde die Bewegungsunfähigkeit unversehens zu Hsus Lesezeit. Später nannte er sich selbst einen „Menschen mit Glück“: „Beim Studieren traf ich gute Lehrer, beim Heiraten eine gute Frau, und selbst die angeborene Behinderung brachte mir einen Vorteil – mehr Zeit am Schreibtisch.“[^12]
+
+1949 zog die Familie Hsu mit der Nationalregierung nach Taiwan; der 19-jährige Hsu trat in die Geschichtsfakultät der National Taiwan University ein. Jene Generation von Intellektuellen, die mit ihrem Wissen vom chinesischen Festland über das Meer nach Taiwan kam, brachte die in Peking und Shanghai etablierten akademischen Traditionen mit, um sie in Taipeh neu Wurzeln schlagen zu lassen: In diesem Umfeld legte Hsu das Fundament einer Sinologie, die dem Dialog mit der westlichen Wissenschaft standhalten konnte[^13].
+
+## Unter Herrlee G. Creel in Chicago: Die Sozialwissenschaften in die chinesische Geschichte bringen
+
+1953 schloss er sein Studium an der Geschichtsfakultät der NTU ab, 1956 folgte der Master am geisteswissenschaftlichen Graduierteninstitut der NTU. Im selben Jahr ging Hsu zur Promotion an die University of Chicago und wohnte in der dortigen Theologischen Fakultät; sein Lehrer war der Sinologe Herrlee G. Creel[^14].
+
+In jenen Jahren erlebte die amerikanische Sinologie einen methodischen Wandel: Die traditionelle „Sinology“ (汉学) setzte auf Textinterpretation und Philologie, während die „China Studies“ begannen, die Werkzeuge der Sozialwissenschaften (Soziologie, Anthropologie, Ökonomie, Politikwissenschaft) einzuführen und China als einen Gegenstand zu behandeln, den moderne Disziplinen analysieren können. Hsu, der 1962 promovierte, stand genau auf diesem Wendepunkt[^15].
+
+Seine Dissertation wurde später zu _Ancient China in Transition: An Analysis of Social Mobility, 722–222 B.C._ umgearbeitet und 1965 von der Stanford University Press veröffentlicht. Das Buch analysierte mit quantitativen Methoden die soziale Mobilität im Zeitalter der Frühlings- und Herbstannalen und der Kriegenden Reiche: Welche Adelsfamilien verschwanden von der politischen Bühne, welche aufsteigenden Klassen stiegen durch militärische Leistung oder Gelehrsamkeit auf, wie lockerte sich die soziale Struktur am Vorabend der Qin-Han-Vereinigung. John K. Fairbank, der Sinologie-Doyen von Harvard, nannte es nach der Lektüre „a little classic“ (ein kleines Klassikerwerk)[^16].
+
+📝 **Dieses Buch war zugleich der methodische Samen für die taiwanesische Geschichtswissenschaft.** Als Hsu 1962 im Alter von 32 nach Taiwan zurückkehrte, ging er zuerst als Assistenzforscher an das Institut für Geschichte und Philologie der Academia Sinica (seit 1956 nebenamtlich, 1962 zum stellvertretenden Forscher aufgestiegen); 1964 wurde er zugleich Professor und Dekan der Geschichtsfakultät der NTU (1964–1970)[^17]. In diesen sechs Jahren tat er etwas, das die taiwanesische Geschichtswissenschaft tiefgreifend veränderte: **Er brachte die Methoden, Schulen und Fragestellungen der Sozialwissenschaften in Taiwans geschichtswissenschaftliche Lehrsäle.** Als Dekan leitete er Workshops und internationale Konferenzen, holte die Methodendebatten der amerikanischen Geschichtswissenschaft an die NTU und bildete eine Kohorte von Studenten aus, die später in der Geschichtswissenschaft der beiden Ufer und Hongkongs wichtige Positionen einnahmen[^18].
+
+Die drei repräsentativen Werke, die er selbst später abschloss – _Han Agriculture_ (1980, englische Ausgabe der University of Washington Press)[^19], _Qiuguang_ (1982, Linking)[^20], _Die Geschichte der Westlichen Zhou_ (1984, Linking)[^21] – lassen sich als drei Selbst-Erprobungen dieser Methode lesen:
+
+| Werk | Zeitabschnitt | Methodisches Instrument |
+| --- | --- | --- |
+| _Han Agriculture_ (漢代農業) | Han-Dynastie | quantitative Rekonstruktion des Bauerlebens, des Marktnetzwerks und des Zusammenspiels mit intensiver Bodenbearbeitung |
+| _Qiuguang_ (求古編) | von der Antike bis Qin-Han | die Evolution des Beamtenapparats zwischen Zentrum und Region, Politik und Gesellschaft |
+| _Die Geschichte der Westlichen Zhou_ (西周史) | Westliche Zhou | Ursprung des „Huaxia“-Bewusstseins, konstruiert durch Verwandtschaftsgruppen (lineage groups) |
+
+Er selbst nannte die Fragen dieser drei Bücher die „drei Grundfarben der chinesischen Kultur“: drei Ausschnitte, in denen ein Historiker dreißig Jahre lang ununterbrochen dieselbe Gruppe fundamentaler Fragen verfolgte – keine drei unzusammenhängenden Studien[^22].
+
+## Ein halbes Jahrhundert in Pittsburgh: Eine makrohistorische Methode, die den Sinocentrismus ablehnt
+
+1970, mit 40 Jahren, wanderte Hsu Cho-yun mit seiner Frau Sun Man-li und dem acht Monate alten einzigen Sohn Hsu Yueh-peng (Leo Hsu) in die USA aus und ging als Professor an die Historische Fakultät der University of Pittsburgh[^23].
+
+Er blieb 28 Jahre in Pittsburgh (1970–1998), stieg vom Gastprofessor (1970–72) über den ordentlichen Professor (1972–82) zum universitätsernannten Lehrstuhlinhaber (1982–98) auf; nach seiner Emeritierung 1998 blieb er bis zu seinem Tod Professor emeritus. Die University of Pittsburgh behielt seinen Titel insgesamt 55 Jahre[^24]. Zugleich verließ er den taiwanesischen Wissenschaftskreis nie: 1981–1997 war er korrespondierender Forscher am Institut für Geschichte und Philologie der Academia Sinica, ab 1989 wurde er nacheinander bis 2006 zum Sonderforscher berufen. Die Academia Sinica in Taipeh, der Campus in Pittsburgh und die Vortragsreisen über die beiden Ufer und Hongkong hinweg: Diese drei Koordinaten bildeten die Landkarte der zweiten Hälfte seiner akademischen Karriere[^25].
+
+In der Pittsburgh-Phase leistete er zwei strukturelle Arbeiten: erstens vertiefte er die Methodik, die Sozialwissenschaften in die chinesische Geschichte einzubringen; zweitens wandte er diese Methode in größerem Maßstab an: nicht nur ein einzelnes Zeitalter, nicht einmal nur China selbst, sondern China im Vergleich im Geflecht der Weltzivilisationsgeschichte[^26].
+
+![Architektur des Nangang-Campus der Academia Sinica, moderne grauweiße Fassade und Platzräume](/article-images/people/hsu-cho-yun-academia-sinica-building.webp)
+_Der Nangang-Campus der Academia Sinica – seit 1956 der langjährige Sitz des Instituts für Geschichte und Philologie, an dem Hsu Cho-yun wirkte, und zugleich die akademische Basis, von der aus er 1980 in die 13. Klasse der Akademiemitglieder gewählt wurde. Foto: KaurJmeb, 20.12.2005. [CC BY-SA 3.0 via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Academia_Sinica.JPG)._
+
+1980, mit 50 Jahren, wurde er in die 13. Klasse der Akademiemitglieder der Academia Sinica gewählt (Sektion Geistes- und Sozialwissenschaften)[^27].
+
+![Offizielles Akademiemitglieds-Porträt von Hsu Cho-yun aus seinen späten Jahren, hellblauer Hintergrund, mit Brille, milden Blicken gerade in die Kamera](/article-images/people/hsu-cho-yun-academia-sinica-portrait.webp)
+_Offizielles Porträt von Hsu Cho-yun aus seinen späten Jahren, Academia Sinica. Foto: Academia Sinica (中央研究院), nach 1980. [Attribution-Lizenz via Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Cho-Yun_Hsu_%E8%A8%B1%E5%80%AC%E9%9B%B2.jpg)._
+
+📝 **Das Wort „Makrogeschichte“ wurde später am häufigsten mit Ray Huang verbunden, doch Hsus Makrogeschichte war eine andere:** Huang fragte, warum China nicht über die traditionellen Herrschaftsmuster hinausgelangen konnte (in _1587, A Year of No Significance_ und _China: A Macro History_); Hsu fragte, wie die chinesische Zivilisation selbst durch ihren Kontakt mit anderen Zivilisationen (Steppe, Indien, Islam, Westen) geprägt wurde – und umgekehrt andere prägte. Seine zentrale Überzeugung war die Ablehnung des Sinocentrismus: China zu verstehen, erfordert, China zurück in den Kontext der Weltgeschichte zu stellen, statt es als ein selbstgenügsames, isoliertes, geschlossenes System zu behandeln, das allein seiner inneren Logik folgt[^28].
+
+1989 wirkte er an der Gründung der Chiang-Ching-kuo-Stiftung für internationalen akademischen Austausch mit; die Initiative stammte von 1986, als er gemeinsam mit Yu Ying-shih, K.C. Chang und anderen chinesischstämmigen Professoren, die in Nordamerika lehrten, kollektiv an Präsident Chiang Ching-kuo appellierte: Sie sorgten sich um das Schwinden der überseeischen Sinologie und hofften, dass Taiwan eine internationale akademische Förderinstitution finanzieren würde, um die Sinologie voranzutreiben[^29]. Nach der Gründung der Stiftung am 12. Januar 1989 war Hsu Vorsitzender des Nordamerika-Komitees; diese Position behielt er bis kurz vor seinem Tod – insgesamt 36 Jahre[^30].
+
+Zu den Studenten, die er in der Pittsburgh-Phase heranzog, gehörten Wang Fan-sen, der später Direktor des Instituts für Geschichte und Philologie der Academia Sinica und Vizepräsident der Academia wurde, sowie Tu Cheng-sheng, der spätere Bildungsminister und Museumsdirektor des Palastmuseums[^31]. Zusammen mit den langjährigen Kooperationspartnern Hsing I-tien und Chen Jo-shui, Historikern derselben Generation, war „der Schülerkreis von Hsu Cho-yun“ ein einflussreiches Netzwerk in der Geschichtswissenschaft der beiden Ufer und Hongkongs in den 1980er bis 2010er Jahren.
+
+## Der Stammbaum: Von Hsu Feng-tsao zu Wang Leehom, drei Generationen sinophoner Kultureliten
+
+Hsu Cho-yun war das siebte von neun Geschwistern: Das ist der Ursprung des „siebten Großonkels“, als den ihn Wang Leehom in seinem Beitrag bezeichnete[^32].
+
+Den Familienkontext aufgeblättert, zeigt sich eine übersehene kulturelle Landkarte des Nachkriegs-Taiwan:
+
+| Rang unter den Geschwistern | Name | Hauptrolle | Verbindung zur nächsten Generation |
+| --- | --- | --- | --- |
+| Älteste Schwester | Hsu Liu-fen | Absolventin der Volkswirtschaft der Tsing-Hua-Universität, Leiterin der Abteilung Rechnungswesen und Statistik der Taipeh-Handelsschule, Autorin von _Prinzipien der Rechnungslegung_ und eines englisch-chinesischen Rechnungswörterbuchs[^33] | → heiratete Wang Hsin-ming → Sohn Wang Ta-chung (Hirnmediziner) → Enkel **Wang Leehom**[^34] |
+| Zweite Schwester | Hsu Wan-ching | Absolventin der Südwest-Kombinierten Universität[^35] | → heiratete Li Mo (stellv. Minister für Bildung und Wirtschaft) → Sohn **Li Chien-fu** (Originalinterpret von „Söhne des Drachen“)[^35] |
+| Siebtes, älterer Zwilling | **Hsu Cho-yun** | Akademiemitglied der Academia Sinica, Historiker | (Hauptfigur dieses Artikels) |
+| Siebtes, jüngerer Zwilling | Hsu I-yun | Chemieingenieur, Vorsitzender der Atomenergiekommission des Exekutiv-Yuans[^36] | — |
+| (Weitere) | — | — | — |
+
+Mit anderen Worten: In dieser Familie bekleidete Hsu Cho-yun zwei Rollen zugleich – er war der „siebte Großonkel“ Wang Leehoms und zugleich der Onkel von Li Chien-fu. Wang Leehom und Li Chien-fu sind Cousins (Hsu Liu-fen ist Wang Leehoms Großmutter, Hsu Wan-ching Li Chien-fus Mutter; Hsu Liu-fen und Hsu Wan-ching sind leibliche Schwestern).
+
+Die Familie Hsu stammte aus einer beamteten Gelehrtenfamilie in Wuxi: Der Vater Hsu Feng-tsao war Konteradmiral der Marine der Republik China, die Mutter Chang Shun-ying aus einer Gelehrtenfamilie. In der nächsten Generation in Taiwan verteilte sie sich auf die Rechnungslegung, das Büro des stellvertretenden Bildungsministers, die Wissenschaft, die Popmusikindustrie und die Kernenergiepolitik. In der dritten Generation folgten die Worte und die Melodie von „Söhne des Drachen“ von 1980 (Text und Musik von Hou Te-chien, uraufgeführt von Li Chien-fu, dem Sohn von Hsu Wan-ching, der Schwester des Vetters Hsu Cho-yun) und Wang Leehom, der Repräsentant der sinophonen Popmusik der 2000er Jahre: zwei Verzweigungen derselben Wuxi-Familie[^37].
+
+📝 **Dass diese Familienlinie eine ernsthafte Darstellung verdient, liegt nicht an klatschigen Aspekten.** Sie zeigt präzise, wie eine Familie der „zweiten Generation der Festlandchinesen“ (waishengren), die 1949 mit der Nationalregierung nach Taiwan kam, innerhalb von drei Generationen ihr kulturelles Kapital auf mehrere der wichtigsten Bereiche des Nachkriegs-Taiwan verteilte: Wissenschaft (Hsu Cho-yun), Bildungspolitik (Li Mo), Rechnungswesen (Hsu Liu-fen), Kerntechnik (Hsu I-yun), Popmusik (Wang Leehom, Li Chien-fu). Wurzeln in China, Aufwachsen in Taiwan, akademische Ausbildung in den USA, Verbreitung in der sinophonen Welt: eine Familie, fünf Ausgänge.
+
+Wang Leehom gedachte am 5. August 2025 in den sozialen Medien dieses „siebten Großonkels“ und schrieb über die Kindheit seines Vaters Wang Ta-chung (Hirnmediziner, Absolvent der NTU-Medizinfakultät)[^38]:
+
+„Eine der wärmsten Erinnerungen aus der Kindheit meines Vaters sind die Gutenachtgeschichten, die ihm sein siebter Onkel vorlas. Sein siebter Onkel, Hsu Cho-yun, war von Kindheit an kränklich und von Geburt an behindert, aber seine geistige Welt war überaus reich und seine Weisheit unerreicht.“
+
+„Obwohl er das siebte von neun Geschwistern war und einen körperlichen Makel hatte, hinterließ er der Welt einen aufrechten, großen Rücken.“
+
+„Sein Körperbau war vielleicht schmächtig, aber sein Geist ragte so hoch wie ein Berg auf. Alles, was er hinterlassen hat, wird nie vergessen werden. Herr Hsu Cho-yun, mögen Sie in Frieden ruhen. Danke, siebter Großonkel. Gott segne Ihre Ruhe.“
+
+Diese Geschichte der Gutenachtgeschichten wurde später von vielen Medien vergrößert: Hsu Cho-yun webte jede Nacht für seinen Neffen (Wang Ta-chung) eine Fortsetzungsgeschichte, vieles davon frei improvisiert, mit Lebensweisheiten darin versteckt[^39]. Ein Onkel, der nicht mit beiden Beinen rennen und springen konnte, hielt seinen kleinen Neffen mit Geschichten im Arm; Jahrzehnte später sprach der Sohn jenes kleinen Neffen mit Popmusik zu den sinophonen Hörern der ganzen Welt. Von Hsu Feng-tsao, dem Marinekonteradmiral der einen Generation, bis zu Wang Leehom, dem Golden-Melody-Sänger der anderen, liegt dazwischen ein Mann, der die chinesische Geschichte mit zwei Fingern schrieb: Diese Linie selbst ist ein Mikrokosmos der chinesischen Diaspora-Geschichte des 20. Jahrhunderts.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/6uA1p-sjjcU" title="許倬雲獲頒唐獎漢學獎 首位台灣出身得主｜中央社影音新聞" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Spezialinterview der Central News Agency vom Juni 2024: Hsu Cho-yun sagt in seinem Haus in Pittsburgh „Im Moment meines letzten Atemzugs lerne ich noch“ – seine Deutung der „Antwort an die Gesellschaft“ in dem Augenblick, als er vom sechsten Tang-Preis für Sinologie erfuhr._
+
+## _Der ewige Strom_: China als großer Strom schreiben, für ein Zeitalter gewöhnlicher Leser
+
+2006 erschien _Der ewige Strom: Wendepunkte und Entfaltung der chinesischen Geschichte und Kultur_ (万古江河) im Hansheng-Verlag in Taipeh[^40].
+
+Dieses Buch mit 270.000 Schriftzeichen ist Hsus chinesische Geschichte für das „Zeitalter des gemeinen Volks“. Im Vorwort schrieb er: „Die Leser von heute sind nicht wie jene früherer Zeiten. In diesem Zeitalter des gemeinen Volks kann sich im Allgemeinen jeder, der mindestens eine Oberschulbildung genossen hat, für Geschichte interessieren. Dieses Buch ist die Geschichte, die ich für diese Generation von Chinesen geschrieben habe.“[^41]
+
+📝 **Die Popularisierung der Gelehrsamkeit ist eine höhere Anforderung, keine Senkung der Schwelle.** Für Absolventen der Oberschule zu schreiben und zugleich die Zustimmung von Universitätsprofessoren zu gewinnen, ist in jeder Sprache eine seltene Fähigkeit. Die Schreibstrategie von _Der ewige Strom_ bestand darin, die lineare Chronik der „Dynastie-Abfolge“ aufzugeben und die „kulturelle Ausbreitung und Kontraktion“ zur Hauptachse zu machen: Die chinesische Zivilisation ist wie ein großer Fluss, vom Rinnsal zum tosenden Strom; unterwegs nimmt sie Nebenflüsse auf, wechselt aber auch ihr Bett, tritt über die Ufer, trocknet aus.
+
+Seine Einstiegspunkte sind die Fragen, die normale Leser wirklich stellen: Was aßen die Menschen im Mittelalter? Worin unterscheiden sich die Jangtse- und die Gelbflusskultur? Warum taucht Taiwan erst in der Neuzeit in der chinesischen Geschichte auf? Was bedeutet Konfuzius’ „Ren“ eigentlich? Warum entstand in China keine Industrialisierung westlichen Typs? Jede dieser Fragen ist ein einzelner populärwissenschaftlicher Aufsatz – doch Hsu verwob sie in einem einzigen Buch[^42].
+
+Nach seiner Veröffentlichung verbreitete sich _Der ewige Strom_ in Taiwan, Hongkong, auf dem chinesischen Festland und in den überseeischen chinesischen Gemeinschaften weit; in zwanzig Jahren erreichte der Absatz millionenfache Größenordnungen (auf dem Festland führten der Sanlian-Verlag und der Guangxi-Normaluniversitätsverlag nacheinander vereinfachte Ausgaben ein)[^43]. Es ist ein populärwissenschaftliches Werk, aber auch die Wissenschaft akzeptierte es: Ein Geschichtsbuch, das Professoren lesen können und zugleich Oberschulabsolventen, ist eine im chinesischsprachigen Raum des 21. Jahrhunderts seltene Schreibleistung.
+
+Danach schrieb er mit demselben Rahmen der „zivilisatorischen Makrogeschichte“ nacheinander drei Schwesterwerke:
+
+**_Ich und der Andere: Die Grenzen zwischen Innnen und Außen in der chinesischen Geschichte_ (2009, China-Times-Kultur / Verlag der Chinesischen Universität Hongkong)**[^44]: Dieses Buch behandelt direkt die historische Frage, „wie China sich selbst definiert und wie es andere definiert“. Hsu schlug sechs Systeme vor, um die Bildung und Auflösung der „Ich/Anderer“-Beziehung zu analysieren: die Interaktion Chinas mit anderen Nationen, die Interaktion des chinesischen Kernlands mit Randethnien, die Interaktion von Zentralgewalt und lokaler Gesellschaft, die Interaktion der oberen und unteren Gesellschaftsschichten, das Netzwerk der Marktwirtschaft und die kulturelle Interaktion zwischen dem herrschenden „Orthodoxen“ und „heterodoxen“ Herausforderern. Er schrieb zurückhaltend: „Bei den ‚innen/außen‘- und ‚ich/anderer‘-Beziehungen komplexer Systeme kommt es nicht auf die Ethnienunterscheidung an, sondern auf die kulturelle Erkenntnis.“[^45]: Gegen den Hintergrund der höchst angespannten politischen Identitäten der beiden Ufer und Hongkongs im Jahr 2009 war dies eine bewusst den historischen Maßstab erweiternde Schreibhaltung.
+
+**_Huaxia-Rede: Der Wandel einer komplexen Gemeinschaft_ (2015, Guangxi-Normaluniversitätsverlag)**[^46]: Dieses Buch geht einen Schritt weiter: Er plädiert dafür, China nicht aus einer „Standbild-Definition“ (wie sieht China in einer bestimmten Dynastie und Zeit aus) zu bestimmen, sondern aus dem „Prozess“ (wie sich China verändert) zu verstehen. Konkret zerlegt er das dynamische Ineinandergreifen der vier Variablen Staat, Wirtschaft, Gesellschaft und Kulturkonzepte.
+
+**_Jingwei Huaxia_ (2023 CITIC / 2024 erweiterte Hongkong-Ausgabe der Joint Publishing)**[^47]: Dies ist das letzte große Werk, das der 93-Jährige mit zwei Fingern und acht Überarbeitungen vollendete. Als Xu Zhiyuan ihn 2019 in Pittsburgh interviewte und 2023 erneut besuchte, war das Buch noch im Entstehen; die erweiterte Ausgabe von 2024 fügte schließlich zwei lange Aufsätze von zusammen etwa 20.000 Schriftzeichen hinzu, über „die große Flut“ und „die Interaktion zwischen der nördlichen Steppe und dem zentralen Tiefland“[^48].
+
+📝 **Diese vier Bücher zusammen sind die vollständige Untersuchung eines Historikers über den Begriff „China“:** vom Fluss-Metapher von _Der ewige Strom_ über die Inn-Außen-Grenzen von _Ich und der Andere_ und die prozessuale Definition von _Huaxia-Rede_ bis zur maßstäblichen Erweiterung vom Kontinent zum Ozean in _Jingwei Huaxia_. In seinen späten Jahren schrieb Hsu die chinesische Geschichte ausdrücklich als „Beziehungsgeschichte zwischen China und der Welt“: Das ist auch die Beurteilung, die ihm die Jury des Tang-Preises 2024 gab: „Professor Hsus Geschichtswissenschaft sieht das Große; seine Abhandlungen zur alten chinesischen Geschichte legen die Essenz langfristiger Geschichte frei, seine Gesamtdarstellungen betonen die kulturelle Aufnahme und den Austausch und suchen die Positionierung Chinas in der Welt.“[^49]
+
+## Ein Führer durch das Werkverzeichnis: vierzig Bücher, fünf Richtungen
+
+Hsu Cho-yun schrieb in seinem Leben fast vierzig Bücher, vom Stoßgebiet über die Frühgeschichte, die Han-Gesellschaft, das West-Zhou-Lehenswesen, die überseeische Sinologie und die Frage der chinesischen Identität bis zu seinen späten Beobachtungen des zeitgenössischen Amerika und Notizen über die Selbstverortung. Für Leser, die sich ihm zum ersten Mal nähern, muss man nicht mit den schweren akademischen Büchern beginnen. Im Folgenden ein Vorschlag in fünf Richtungen, geordnet nach Lesereihenfolge:
+
+**（一）Einstieg: chinesische Makrogeschichte für den gemeinen Leser**
+
+- **_Der ewige Strom: Wendepunkte und Entfaltung der chinesischen Geschichte und Kultur_ (2006, Hansheng)**[^40]: sein meistverbreitetes Buch. Die Fluss-Perspektive von kultureller Ausbreitung und Kontraktion; in 270.000 Schriftzeichen eine chinesische Kulturgeschichte ohne Dynastie-Grenzen.
+
+**（二）Fortgeschritten: die Inn-Außen-Grenzen der Zivilisation**
+
+- **_Ich und der Andere_ (2009, China-Times-Kultur)**[^44]: behandelt die Frage der chinesischen Identität; Rahmen der sechs Systeme.
+- **_Huaxia-Rede_ (2015, Guangxi-Normaluniversitätsverlag)**[^46]: China prozessual definiert, vier Variablen Staat, Wirtschaft, Gesellschaft, Kultur ineinander verwoben.
+- **_Jingwei Huaxia_ (2024, erweiterte Hongkong-Ausgabe der Joint Publishing)**[^47]: acht Überarbeitungen, Maßstabserweiterung „vom Kontinent zum Ozean“.
+
+**（三）Akademische Hauptwerke: die Sozialwissenschaften in der chinesischen Geschichte**
+
+- **_Die Geschichte der Westlichen Zhou_ (1984 Linking, 1986. Zweitauflage, 1990/1993 revidierte Drittauflage, 1994 erweiterte Pekinger Ausgabe der Sanlian, 2020 revidierte Neuauflage)**[^21]: Studie zum Ursprung des „Huaxia“-Bewusstseins durch Verwandtschaftsgruppen.
+- **_Han Agriculture_ (1980, englische Ausgabe der University of Washington Press, später chinesische Übersetzung _Han-Nongye: Die Bildung der frühen chinesischen Agrarwirtschaft_)**[^19]: quantitative Rekonstruktion des Bauerlebens der Han-Chinesen, des Marktnetzwerks.
+- **_Die Theorie der Gesellschaft des alten China_ (englische Ausgabe _Ancient China in Transition_, 1965, Stanford University Press)**[^16]: Umarbeitung der Dissertation, quantitative Analyse der sozialen Mobilität der Frühlings- und Herbstannalen und Kriegenden Reiche; Fairbank nannte sie „a little classic“.
+- **_Qiuguang_ (1982, Linking)**[^20]: die Evolution des Beamtenapparats zwischen Zentrum und Region von der Antike bis Qin-Han.
+
+**（四）Autobiografie und Spätwerk-Gedanken**
+
+- **_Der Weg des Herzens_ (1964 Wen-xing / 1979 Biografische Literatur / 2015 Xiamen-Universität)**[^50]: Autobiografie mit 34, die Denk- und Lernreise von Xiamen über Taipeh nach Chicago.
+- **_Sechzig Jahre Amerika: Die Eindrücke eines Chinesen_ (2019, Linking)**[^51]: seine halben hundert Eindrücke von Amerika und seine Diagnose der amerikanischen Gesellschaft.
+- **_Nach innen gehen, sich niederlassen_ (2022, Peking-Nachrichtenverlag, zusammen mit Feng Jun-wen)**[^52]: Gedankennotizen mit 89 Jahren, ein Buch der Selbstverortung für ein unruhiges Zeitalter.
+
+**（五）Popularisierung und Gespräche**
+
+- **_Hsu Cho-yun erzählt Geschichte_, fünfbändige Reihe**[^53]: die populäre Fassung der Makrogeschichte.
+- **_Hsu Cho-yuns Zehn-Tage-Gespräche: Die Konstellation der heutigen Welt und die Zukunft der Menschheit_ (Joint Publishing Hongkong)**[^54]: die Zusammenfassung seiner späten Gedanken über die Weltlage.
+
+📝 **Wenn man nur ein Buch lesen kann: Beginne mit _Der ewige Strom_.** Will man seine historische Methode verstehen: Das Vorwort der revidierten Neuausgabe von _Die Geschichte der Westlichen Zhou_ ist kraftvoller als das Buch selbst. Will man seine Gesamtansicht über China verstehen: _Ich und der Andere_ ist am komprimiertesten. Will man den Menschen selbst verstehen: _Der Weg des Herzens_ und _Nach innen gehen, sich niederlassen_ zusammen lesen.
+
+## Der Tang-Preis 2024: 50 Millionen NT$ Preisgeld komplett gespendet, das „Hsu-Sun-Stipendium“ eingerichtet
+
+Am 20. Juni 2024 gab die Tang-Preis-Stiftung den Preisträger des sechsten Sinologie-Preises bekannt: Hsu Cho-yun, Preisgeld 50 Millionen NT$ (einschließlich 10 Millionen NT$ Forschungsförderung)[^55].
+
+Er ist der erste Tang-Preis-Sinologie-Preisträger taiwanesischer Herkunft im strengen Sinn: Die Preisträger der fünf vorangegangenen Runden – Yu Ying-shih (Harvard), Stephen Owen (Harvard), Hazama Naoki (Kyoto), Wang Gungwu (Singapur) und Erik Zürcher (Leiden) – absolvierten ihre Mittel- und Grundausbildung sämtlich im Ausland. Hsu hingegen kam 1949 mit der Nationalregierung nach Taiwan, machte seinen Abschluss an der Geschichtsfakultät der NTU (1953) und den Master am geisteswissenschaftlichen Graduierteninstitut der NTU (1956) – ein Gelehrter, der „wahrhaft in Taiwan aufgewachsen ist“[^56].
+
+⚠️ **Die Beurteilung der Tang-Preis-Jury wies direkt auf das Herzstück seiner historischen Arbeit** hin: „Professor Hsus Geschichtswissenschaft sieht das Große; seine Abhandlungen zur alten chinesischen Geschichte legen die Essenz langfristiger Geschichte frei, seine Gesamtdarstellungen betonen die kulturelle Aufnahme und den Austausch und suchen die Positionierung Chinas in der Welt. Seine Werke verraten eine Sorge um das Land, die Nation und die Menschheit; er ist ein Historiker von breiter Bildung, der zugleich die Welt besser machen will.“[^49]
+
+Was jedoch weitaus mehr berichtet wurde, war seine nächste Handlung nach dem Preis: Er spendete das gesamte Preisgeld von 50 Millionen NT$ und richtete das „Hsu-Sun-Stipendium“ ein, um jungen Gelehrten weltweit zu fördern, die an einer Promotion in Sinologie arbeiten[^1]. Das Stipendium trägt den gemeinsamen Namen des Ehepaars (Hsu Cho-yun + Sun Man-li) und würdigt Sun Man-lis 55-jährige Stütze in seiner akademischen Laufbahn.
+
+📝 **Die Bedeutung dieser Handlung ist mehr als Freigebigkeit.** Für Hsu, der 1989 an der Gründung der Chiang-Ching-kuo-Stiftung beteiligt war und lange die nordamerikanische Sinologie-Förderung geleitete, war „die Heranbildung der nächsten Sinologengeneration“ eine seiner Lebensachsen[^29]. Das gesamte Tang-Preisgeld zu spenden bedeutet: „Was meine Generation erreicht hat“ wird direkt in „ob die nächste Generation weitermachen kann“ übersetzt. Für einen Historiker von 94 Jahren, mit geschwächtem Sehvermögen und auf die Hilfe anderer angewiesen, war das die konkreteste Form der Weitergabe, deren er fähig war.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/z-haTCHCQQg" title="2024 Tang Prize Laureate Lecture in Sinology — Hsu Cho-yun 許倬雲" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_Am 28.09.2024 hielt der Preisträger des sechsten Tang-Preises für Sinologie seine Vorlesung „Wegsuche in einer verwirrten Welt“ – per Videobotschaft, nicht in Anwesenheit; Thema war der Ort der makrohistorischen Methode in der zeitgenössischen Welt. Quelle: offizieller YouTube-Kanal der Tang-Preis-Stiftung._
+
+Ende September 2024 fand die Tang-Preis-Woche in Taipeh statt; Hsu konnte aus Gesundheitsgründen nicht anwesend sein und hielt seine Preisträgervorlesung „Wegsuche in einer verwirrten Welt“ per Video. Im selben Monat faßte Xu Zhiyuan in Folge 1 der 8. Staffel von „Shisanhao“ (Fragen an die Zeit) die Interviews zusammen, die er seit 2019 zweimal in Pittsburgh geführt hatte; das Thema, über das Hsu vor der Kamera am meisten sprach, war seine Unruhe über die gegenwärtige Welt: Er sah die Zerrissenheit der amerikanischen Gesellschaft, die Verwirrung Chinas, die Angst Taiwans, und er verwendete „man kommt um das Ende der Qing-Dynastie nicht herum“, um die gegenwärtige internationale Ordnung zu beschreiben[^57].
+
+## Kritik am Nationalismus und die Haltung des „nicht Partei ergreifenden Historikers“
+
+Neben seiner akademischen Karriere weigerte sich Hsu in seinen späten Jahren, in irgendeine nationalistische Erzählung einzusteigen. 2021 sagte er in einem langen Interview: „Ich hoffe, den Ton ‚China, das ist stark‘ nicht mehr zu hören.“ Er warnte die Chinesen davor, die Widersprüche der eigenen Geschichte durch bloße Großmachtgefühle zuzudecken[^58].
+
+„Ich hoffe, den Ton ‚China, das ist stark‘ nicht mehr zu hören“ – dieser Satz kann als die öffentlichste Positionierung seiner späten Jahre gelten[^59]. Die Kritik am chinesischen Nationalismus, die er hier formulierte, entstand nicht aus Feindseligkeit, sondern aus einer Sorge eines „ins Tiefland zurückgekehrten Historikers“ über die Tiefe des chinesischen Selbstbewusstseins. Seine Kritik richtete sich nicht nur auf Tauchangchinesen, sondern umfasste gleichermaßen taiwanesische Nationalisten, und er verweigerte sich beiden Seiten gegenüber mit seiner Haltung, „in keiner nationalistischen Erzählung eine Position zu wählen“[^60].
+
+Im September 2024, im Gespräch mit der Central News Agency mit 94 Jahren, sagte er über Trumps „Schutzgeld-These“ gegenüber seinen Verbündeten: „Wie ein Gangster in einer Konzession“ – er hielt Trump für eine Figur der unmittelbaren Nachkriegs-Weltordnung, die er mit der „Konzession“ verglich (die Glanzzeit dieses Analyse-Tools liegt darin, dass mit einem einzigen Wort die historische Analogie „China um das Ende der Qing-Dynastie“ herbeigerufen wird)[^61].
+
+Diese innere Autorität stammte nicht aus Arroganz, sondern aus dem langen Zeitmaß: Er schrieb eine Zeit lang über das chinesische Bewusstsein der Frühlings- und Herbstannalen, dann über das Zusammenspiel von Ackerbau und Markt der Han-Chinesen, dann über das Lehenswesen der West-Zhou, dann über die Sinologie der Welt – die Datierung eines Zivilisationskontinuums, die ihm die Ruhe gab, die Gegenwart „nur als Zwischenstück“ zu sehen.
+
+## Mit 95 Jahren gestorben, den großen Strom für künftige Leser zurücklassend
+
+Am 3. August 2025 starb Hsu Cho-yun in Pittsburgh in den frühen Morgenstunden im Schlaf (nach taiwanesischer Zeit im Morgengrauen des 4. August), 95 Jahre alt; seine Frau Sun Man-li war an seiner Seite[^64].
+
+Die Academia Sinica setzte eine Pressemitteilung auf und bewertete diesen Akademiemitglieder der 13. Klasse mit: „Akademiemitglied Hsu Cho-yun war mit chinesischem und westlichem Wissen in vorbildlicher Weise vertraut; er war ein weltweit angesehener Führer der Geschichtswissenschaft. Er spezialisierte sich auf die alte Geschichte Chinas, die Sozial- und Kulturgeschichte, sein Werk ist reichhaltig und voller originärer Einsichten; sein Blick ist weit: Er behandelte die alte Geschichte Chinas aus der Perspektive der Weltgeschichte, ohne sich auf China zu beschränken.“[^25] Das Festland-taiwanesische Amt für Taiwan-Angelegenheiten (國台辦) äußerte sich öffentlich „bedauernd“ – es ist ein seltenes Ereignis, dass die beiden Ufer denselben Gelehrten zugleich betrauern, und zugleich die letzte Fußnote der besonderen Stellung Hsu Cho-yuns zwischen den beiden Ufern[^65].
+
+Am 5. August gedachte Wang Leehom in den sozialen Medien des „siebten Großonkels“. Am selben Tag schrieb auch Li Chien-fu einen Beitrag in Erinnerung an diesen „Onkel“: Der ursprüngliche Sänger von „Söhne des Drachen“ und der Text- und Melodienschreiber von „Weil Liebe im Herzen ist“ – Nachkommen desselben Wuxi-Hauses der Familie Hsu – verabschiedeten sich zugleich über drei Generationen hinweg von dem Jungen, der einst mit zwei Krücken ging[^66].
+
+Anfang August veröffentlichte die Historische Fakultät der University of Pittsburgh eine kurze „In Memoriam“-Mitteilung mit dem Titel „Renowned Historian Passes Away at 95“. Diese Universität, an der Hsu 55 Jahre verbracht hatte, schickte ihn mit einem viersilbigen Titel hinaus[^67].
+
+Yeh Kuang-shih (ehemaliger Verkehrsminister und zugleich Mitarbeiter der Chiang-Ching-kuo-Stiftung) schrieb eine Passage in Erinnerung an seine letzte Begegnung mit Hsu: „Hsu Cho-yun war nicht nur wissenschaftlich ausgezeichnet; in allen Dingen des menschlichen Umgangs war er außergewöhnlich, ein wichtiger Wegbereiter der Gründung der Chiang-Ching-kuo-Stiftung.“[^68]
+
+Hsu hinterließ beinahe vierzig Werke. Das früheste, _Der Weg des Herzens_, erschien 1964 in einer ersten Auflage, der Autor war 34; das letzte, _Jingwei Huaxia_, die erweiterte Ausgabe von 2024, der Autor 94: Über sechzig Jahre hinweg verfolgte er mit Lebensschreibwerk (später mit zwei Fingern) denselben großen Strom der chinesischen Geschichte.
+
+✦ 1938: Auf der Jangtse-Straße in Shashi, Hubei, zogen die Sichuan-Truppen an ihm vorbei nach Taierzhuang.
+1949: Auf dem Deck des Hafens von Keelung wehte die Flagge der Nationalregierung im Wind.
+1962: In der Bibliothek der University of Chicago schrieb er zum ersten Mal die Frühlings- und Herbstannalen und die Kriegenden Reiche mit der Methode der Sozialwissenschaften.
+1980: Im Konferenzsaal der Academia Sinica wurde er in die 13. Klasse der Akademiemitglieder gewählt.
+2006: In der Auslage der Hansheng-Buchhandlung stand die erste Auflage von _Der ewige Strom_.
+2024: Am Schreibtisch seines Hauses in Pittsburgh tippte er mit zwei Fingern die achte Fassung von _Jingwei Huaxia_.
+25. Juli 2025: Er schrieb auf Weibo: „Ein Kind wird nicht durch das Alter zum Erwachsenen, sondern durch die Haltung im Herzen“[^11].
+3. August 2025: Im Schlaf atmete er zum letzten Mal aus.
+
+„Im Moment meines letzten Atemzugs lerne ich noch“ – Dieser Satz sagte er in einem Interview mit 94; ein Jahr später wurde er wahr.
+
+Was er zurückließ, ist ein weiterfließender großer Strom, ohne letzte Antwort.
+
+**Weiterführende Lektüre:**
+
+- [Jay Chou](/de/people/jay-chou) – ein Vertreter der sinophonen Popmusik derselben Generation (ein Zeitgenosse von Hsus Großneffe Wang Leehom)
+- Yoga Lin – ein generationsweiter Querschnitt der sinophonen Popmusik (im Generationen-Vergleich mit Wang Leehom)
+- Chen Chien-nien – ein weiteres Beispiel der Erzählung nach langem Zeitmaß über eine kulturelle Persönlichkeit der Kategorie People
+- _Waishengren_ – der Taikwan-Nachkriegskontext der Familien der zweiten Generation von Intellektuellen der Festlandchinesen, die 1949 nach Taiwan kamen (die Familie von Hsu Cho-yun, Hsu Liu-fen und Hsu Wan-ching gehört zu dieser Gruppe)
+- Der Zwischenfall vom 28. Februar 1947 – eine historische Zäsur, der sich die Intellektuellen derselben Generation wie Hsu Cho-yun nach ihrer Übersiedlung nach Taiwan gemeinsam gegenübersahen
+- Samuel Yin: Der Preis der Wissenschaft, den er begründete, ist teurer als der Nobel – der Gründer des Tang-Preises, der 2024 den sechsten Sinologie-Preis an Hsu Cho-yun verlieh; das gesamte Preisgeld von 50 Millionen NT$ spendete dieser für das „Hsu-Sun-Stipendium“[^1]
+
+## Bildnachweis
+
+Dieser Artikel verwendet zwei Bilder mit Wikimedia-Commons-Lizenz (zwei Zuschnitte desselben Originalfotos des Porträts von Hsu Cho-yun + ein Foto der Academia-Sinica-Gebäude), die sämtlich unter `public/article-images/people/` gecacht werden, um Hotlinking der Quellserver zu vermeiden:
+
+- [Cho-Yun Hsu 許倬雲](https://commons.wikimedia.org/wiki/File:Cho-Yun_Hsu_%E8%A8%B1%E5%80%AC%E9%9B%B2.jpg) – Foto: Academia Sinica (中央研究院), nach 1980, Attribution-Lizenz, Wikimedia Commons File:Cho-Yun Hsu 許倬雲.jpg. Das Original 2205×2572 im Hochformat wird in diesem Artikel wie folgt verwendet: (a) Hero-Version: 1:1-Quadratzuschnitt auf 1600×1600; (b) Inline-Version: mit beibehaltener Bildseitenverhältnisses 0.857 auf 1371×1600 verkleinert. Quelle des Credits: https://academicians.sinica.edu.tw/index.php?r=academician-n%2Fshow&id=21
+- [Academia Sinica](https://commons.wikimedia.org/wiki/File:Academia_Sinica.JPG) – Foto: KaurJmeb, 20.12.2005, CC-BY-SA-3.0, Wikimedia Commons File:Academia Sinica.JPG. Außenansicht des Nangang-Campus der Academia Sinica, 1037×778 im Querformat, als räumlicher Anker für Hsus Tätigkeit am Institut für Geschichte und Philologie 1956–1971 und seine Wahl in die 13. Klasse der Akademiemitglieder 1980.
+
+## Quellenangaben
+
+[^1]: [Tang-Preisträger Hsu Cho-yun spendet Preisgeld, richtet „Hsu-Sun-Stipendium“ ein – United Daily News](https://udn.com/news/story/7266/8259020) — Bericht der United Daily News vom 28. September 2024: Hsu Cho-yun spendete das gesamte Preisgeld des sechsten Tang-Preises für Sinologie in Höhe von 50 Millionen NT$ (einschließlich 10 Millionen NT$ Forschungsförderung) und richtete gemeinsam mit seiner Frau Sun Man-li das „Hsu-Sun-Stipendium“ zur Förderung junger Gelehrter der Sinologie-Promotion weltweit ein.
+
+[^2]: [Taiwan.md SC 7d opportunities cluster snapshot – dashboard-analytics.json 2026-05-16](https://taiwan.md/) — Die 7-Tage-Daten der Google Search Console zeigen zu den drei Varianten der Query „hsu cho-yun“ + „wang leehom“ („hsu cho-yun“ „wang leehom“ 1.561 Impressions / „wang leehom“ „hsu cho-yun“ 1.103 / „cho-yun hsu“ „wang leehom“ 290) insgesamt ~2.954 Impressions / 0 Klicks über alle Varianten – die größte unerfüllte Lücke der SC-Opportunities dieser Woche; englischsprachige Leser fragen klar nach der Beziehung der beiden, doch kein Inhalt fängt die Antwort ab.
+
+[^3]: [Tang-Preisträger Hsu Cho-yun, 94, trotz eingeschränkter Beweglichkeit fleißig – Central News Agency](https://www.cna.com.tw/news/ahel/202406200150.aspx) — Sonderinterview der Central News Agency vom 20. Juni 2024 mit Hsu Cho-yun in seinem Haus in Pittsburgh, das seine Reaktion auf die Nachricht vom sechsten Tang-Preis für Sinologie und sein Lebensbild festhält, darunter wörtliche Zitate wie „Mit 94 möchte ich der Gesellschaft meine Antwort abgeben“, „Im Moment meines letzten Atemzugs lerne ich noch“ und „Taiwan lässt mich nicht los“.
+
+[^4]: [Taiwan im Herzen, der große Historiker Hsu Cho-yun mit 95 gestorben – United Daily News](https://udn.com/news/story/7314/8917701) — Bericht der United Daily News vom 4. August 2025 über Hsus späte Jahre: seine Frau Sun Man-li half ihm im Alltag, das Sehvermögen ließ nach, sodass er nicht mehr selbst umblättern konnte, doch er las und schrieb weiter jeden Tag.
+
+[^5]: [Jingwei Huaxia (erweiterte Ausgabe in traditionellen Schriftzeichen) — Joint Publishing Hongkong](https://www.jointpublishing.com/publishing/%E7%B6%93%E7%B7%AF%E8%8F%AF%E5%A4%8F%EF%BC%88%E7%B9%81%E9%AB%94%E5%A2%9E%E8%A8%82%E7%89%88%EF%BC%89/) — Vorstellungsseite der Joint Publishing Hongkong vom Juli 2024 zu „Jingwei Huaxia (erweiterte Ausgabe in traditionellen Schriftzeichen)“; festgehalten: „Mit über 90 Jahren nahm er die Herausforderung an und überarbeitete das Manuskript achtmal“; für die erweiterte Ausgabe verfasste er zudem zwei lange Aufsätze von rund 20.000 Schriftzeichen über „die große Flut“ und „Interaktion zwischen der nördlichen Steppe und dem zentralen Tiefland“.
+
+[^6]: [Historiker Hsu Cho-yun gestorben, 94 Jahre alt, vor dem Tod um das Zitat „Aber das Weh, dass ich die Neun Provinzen nicht vereint sehe“ – Ming Pao](https://news.mingpao.com/pns/%E4%B8%AD%E5%9C%8B/article/20250805/s00013/1754330629859/%E5%8F%B2%E5%AD%B8%E5%AE%B6%E8%A8%B1%E5%80%AC%E9%9B%B2%E9%80%9D%E4%B8%96-%E4%BA%AB%E5%B9%B494%E6%AD%B2-%E7%94%9F%E5%89%8D%E5%BC%95%E3%80%8C%E4%BD%86%E6%82%B2%E4%B8%8D%E8%A6%8B%E4%B9%9D%E5%B7%9E%E5%90%8C%E3%80%8D%E7%82%BA%E6%86%BE) — Ming Pao vom 5. August 2025 mit den Details von Hsus Tod, einschließlich des wörtlichen Inhalts seines letzten Weibo-Beitrags vom 24. Juli 2025, der Entscheidung, in Wuxi ein Grab zu kaufen („Laub fällt zur Wurzel“), und der Aufzeichnung, dass Lu Xius „Shi'er“ („Das Weh, dass ich die Neun Provinzen nicht vereint sehe“) als Epitaph zitiert wurde.
+
+[^7]: [Hsu Cho-yun – Wikipedia (chinesisch)](https://zh.wikipedia.org/zh-tw/%E8%A8%B1%E5%80%AC%E9%9B%B2) — Wikipedia-Artikel zu Hsu Cho-yun mit den Grunddaten: geboren am 3. September 1930 auf Gulangyu, Xiamen, Fujian; Herkunft Wuxi, Jiangsu; Zwillingsbruder Hsu I-yun; Vater Hsu Feng-tsao Konteradmiral der Marine der Republik China; Mutter Chang Shun-ying aus einer Beamtenfamilie in Wuxi.
+
+[^8]: [Cho-yun Hsu – Wikipedia (englisch)](https://en.wikipedia.org/wiki/Cho-yun_Hsu) — englischsprachiger Wikipedia-Artikel zu Cho-yun Hsu; ergänzt Familienhintergrund und Lebenslauf, einschließlich der Identität des Vaters, der Familie der Mutter, der akademischen Zeitachse (1953/1956/1962) und der beruflichen Zeitachse (Academia Sinica 1956–1971 / University of Pittsburgh 1970–1998) sowie der Liste der Hauptwerke.
+
+[^9]: [Der große Historiker Hsu Cho-yun: körperlich behindert, in der Liebe keine Kompromisse – NetEase](https://www.163.com/dy/article/GC2453EB0543WEOC.html) — langer NetEase-Rückblick auf Hsus Leben, mit der Dokumentation des seltenen medizinischen Phänomens des Zwillingkontrasts, dem Familienhintergrund „wohlhabende Bauern / Gelehrten-Tradition“ und dem Verlauf seiner Heirat mit Sun Man-li 1969.
+
+[^10]: [Der große Historiker Hsu Cho-yun gestorben, Kindheit in Chongqing – Chongqing Chenbao PDF](https://epaper.cqcb.com/attachment/202508/05/83b1e412-99db-4dc7-baa3-226e8e2d8419.pdf) — das Gedenk-Sonderheft der Chongqing Chenbao vom 5. August 2025 rekonstruiert die konkrete Spur von Hsus Flucht: 1935 mit dem Vater wegen Versetzung von Xiamen nach Shashi, nach dem Zwischenfall an der Marco-Polo-Brücke 1937 Flucht der Familie durch Hubei/Sichuan/Chongqing.
+
+[^11]: [Xueren Scholar | Der Verstorbene Hsu Cho-yun: Meine wahre Zugehörigkeit ist das in der Geschichte nie stillstehende China – Chinadigitaltimes](https://chinadigitaltimes.net/chinese/720114.html) — Chinadigitaltimes ordnet Hsus letzten Weibo-Beitrag (24. Juli 2025) wörtlich (vereinfachtes Chinesisch) neu ein und hält die Szene der Sichuan-Armee durch Shashi am Vorabend der Schlacht von Taierzhuang 1938 sowie die Reflexion „Ein Kind wird nicht durch das Alter zum Erwachsenen, sondern durch die Haltung im Herzen“ fest.
+
+[^12]: [„Der Weg des Herzens“ – Books.com.tw](https://www.books.com.tw/products/CN11307248) — Verlagsseite von Hsus Autobiografie „Der Weg des Herzens“ (1964), ursprünglich beim Wenxing-Verlag erschienen (1964), später Neuauflage Biografische Literatur 1969/1979, Xiamen-Universitätsverlag 2015; hält seine Lebensauffassung als „Mensch mit Glück“ und die Details seiner Kinderjahre der Flucht fest.
+
+[^13]: [Hsu Cho-yun – Wikipedia (chinesisch)](https://zh.wikipedia.org/zh-tw/%E8%A8%B1%E5%80%AC%E9%9B%B2) — wie [^7]; hält den Zeitpunkt fest, als er 1949 mit der Nationalregierung nach Taiwan kam und in die Geschichtsfakultät der National Taiwan University eintrat.
+
+[^14]: [Lebenslauf des Akademiemitglieds – Academia Sinica](https://academicians.sinica.edu.tw/index.php?r=academician-n/show&id=21) — offizielle Lebenslaufseite der Akademiemitglieder der Academia Sinica mit der vollständigen akademischen Zeitachse: „Bachelor Geschichtsfakultät der National Taiwan University (1953) / Master am geisteswissenschaftlichen Graduierteninstitut der NTU (1956) / Doktor der Geisteswissenschaften, University of Chicago (1962)“.
+
+[^15]: [Creel Center for Chinese Paleography – University of Chicago](http://cccp.uchicago.edu/pages_tw/index_tw.shtml) — offizielle Website des Creel Center for Chinese Paleography der University of Chicago, das Professor Herrlee G. Creel (1905–1994) als Gründungsvater der chinesischen Paläographie würdigt und 2006 eingerichtet wurde.
+
+[^16]: [Ancient China in Transition – Cho-yun Hsu (Stanford University Press 1965)](https://en.wikipedia.org/wiki/Cho-yun_Hsu) — Wikipedia hält fest, dass Hsus Dissertation zu _Ancient China in Transition: An Analysis of Social Mobility, 722–222 B.C._ umgearbeitet und 1965 von der Stanford University Press veröffentlicht wurde; der Harvard-Sinologe John K. Fairbank nannte sie „a little classic“; sie gilt als sein Aufstiegswerk in der englischsprachigen Wissenschaftswelt.
+
+[^17]: [Würdigung des Akademiemitglieds Hsu Cho-yun – Yu Chi-chung Kultur- und Bildungssstiftung](https://www.yucc.org.tw/info/7428) — die Stiftung fasst Hsus vollständige berufliche Zeitachse zusammen, einschließlich der Ämter als Assistenzforscher am Institut für Geschichte und Philologie der Academia Sinica (1956–1962), stellvertretender Forscher (1962–1967), Forscher (1967–1971), außerordentlicher Professor am Fachbereich Geschichte der NTU (1962–1964), Professor und Dekan (1964–1970).
+
+[^18]: [Academia Sinica – Pressemitteilung | Der Doyen der Geschichtswissenschaft ist gefallen, Akademiemitglied Hsu Cho-yun gestorben](https://www.sinica.edu.tw/news_content/55/3258) — offizielle Pressemitteilung der Academia Sinica vom 4. August 2025 mit der wörtlichen offiziellen Bewertung („Akademiemitglied Hsu Cho-yun ... war ein weltweit angesehener Führer der Geschichtswissenschaft“) und der Aufzeichnung seiner akademischen Beiträge zur Einführung der Sozialwissenschaften in die Geschichtswissenschaft während seiner Amtszeit als Dekan des Fachbereichs Geschichte der NTU.
+
+[^19]: [Books.com.tw – Han-Nongye: Die Bildung der frühen Agrarwirtschaft Chinas](https://search.books.com.tw/search/query/key/%E8%A8%B1%E5%80%AC%E9%9B%B2/adv_author/1/) — Books.com.tw-Autorenseite von Hsu Cho-yun mit den chinesischen und englischen Ausgaben von „Han-Nongye: Die Bildung der frühen Agrarwirtschaft Chinas“; das englische Original _Han Agriculture: The Formation of the Early Chinese Peasant Economy_ erschien 1980 bei der University of Washington Press.
+
+[^20]: [Books.com.tw – Qiuguang](https://search.books.com.tw/search/query/key/%E8%A8%B1%E5%80%AC%E9%9B%B2/adv_author/1/) — Books.com.tw-Bibliografie: „Qiuguang“ erste Auflage 1982 bei Linking, Neuauflagen 1984/1989, 2006 Xinxing-Verlag, 2014 Commercial Press, 2022 zweite Auflage; enthält die Essenz von Hsus methodischen Aufsätzen zur Evolution des Beamtensystems von der Antike bis Qin-Han.
+
+[^21]: [Books.com.tw – Die Geschichte der Westlichen Zhou](https://www.books.com.tw/products/0010049667) — Books.com.tw-Produktseite zu „Die Geschichte der Westlichen Zhou“: erste Auflage 1984 bei Linking, zweite Auflage 1986, revidierte dritte Auflage 1990/1993, erweiterte Ausgabe Beijing Sanlian 1994, erweiterte Neuauflage Linking 2020; Hsus akademisches Hauptwerk, das den Ursprung des „Huaxia“-Bewusstseins über Verwandtschaftsgruppen untersucht.
+
+[^22]: [Hsu Cho-yun – Wikipedia (chinesisch)](https://zh.m.wikipedia.org/zh-hk/%E8%A8%B1%E5%80%AC%E9%9B%B2) — Hongkong-Ausgabe der chinesischen Wikipedia; hält den von Hsu selbst so genannten Rahmen der „drei Grundfarben der chinesischen Kultur“ fest – West-Zhou-Verwandtschaftsgruppen, Beamtenwesen des Qiuguang, intensive Bodenbearbeitung und Marktwirtschaft der Han-Agrikultur, die sich gegenseitig ergänzen.
+
+[^23]: [Frau von Hsu Cho-yun, Sun Man-li: Ein Ehepaar sind gute Freunde – NetEase](https://www.163.com/dy/article/J2I0QO5N05566FH1.html) — NetEase fasst Sun Man-lis Leben zusammen, einschließlich der Familie: geboren im Winter 1943, ursprünglich Hsus Studentin, 12 Jahre jünger, Heirat am 9. Februar 1969, Geburt des einzigen Sohns Hsu Yueh-peng (Leo Hsu) im November 1969, 1970 Umzug mit Hsu nach Pittsburgh.
+
+[^24]: [Hsu Cho-yun Papers 1970–2008 | Digital Pitt](https://digital.library.pitt.edu/islandora/object/pitt:US-PPiU-ua90f97/viewer) — Sammlung „Hsu Cho-yun Papers 1970-2008“ der digitalen Bibliothek der University of Pittsburgh; dokumentiert Hsus vollständige Amtszeit in Pitt: Gastprofessor (1970–72), ordentlicher Professor (1972–82), universitätsernannter Lehrstuhlinhaber (1982–98), emeritierter Lehrstuhlinhaber (1998 bis zu seinem Tod).
+
+[^25]: [Academia Sinica – Pressemitteilung | Der Doyen der Geschichtswissenschaft ist gefallen, Akademiemitglied Hsu Cho-yun gestorben](https://www.sinica.edu.tw/news_content/55/3258) — wie [^18]; die offizielle Pressemitteilung der Academia Sinica liefert die vollständige wörtliche offizielle Bewertung und die Zeitachsenaufzeichnung.
+
+[^26]: [Der große Historiker Hsu Cho-yun gestorben: In einem unruhigen Zeitalter braucht es wachsame Menschen mit Weltverbesserermotiv – HK01](https://www.hk01.com/%E4%B8%AD%E5%9C%8B%E8%A7%80%E5%AF%9F/60263747/%E5%8F%B2%E5%AD%B8%E5%A4%A7%E5%AE%B6%E8%A8%B1%E5%80%AC%E9%9B%B2%E9%80%9D%E4%B8%96-%E6%B5%AE%E8%BA%81%E7%9A%84%E6%99%82%E4%BB%A3%E9%9C%80%E8%A6%81%E6%9C%89%E6%BF%9F%E4%B8%96%E6%83%85%E6%87%B7%E7%9A%84%E6%B8%85%E9%86%92%E8%80%85) — Meinungsartikel von HK01, der Hsus akademischen Wendepunkt in der Pittsburgh-Phase hin zu einer „vergleichenden Geschichte der chinesischen und der Weltzivilisation“ und seine methodische Haltung der Ablehnung eines „China-Zentrismus“ skizziert.
+
+[^27]: [Lebenslauf des Akademiemitglieds – Academia Sinica (id=21)](https://academicians.sinica.edu.tw/index.php?id=21&r=academician-n%2Fshow) — wie [^14]; der offizielle Lebenslauf der Academia Sinica bestätigt „gewählt in die 13. Klasse (1980)“.
+
+[^28]: [Ich und der Andere: Die Grenzen zwischen Innen und Außen in der chinesischen Geschichte – Books.com.tw](https://www.books.com.tw/products/0010449809) — Books.com.tw-Seite zu „Ich und der Andere“; hält Hsus akademischen Rahmen von sechs Systemen zur Analyse der „Ich/Anderer“-Beziehung fest sowie seine Kernhaltung, den China-Zentrismus abzulehnen und die kulturelle Erkenntnis über die Ethniengrenze zu stellen.
+
+[^29]: [Chiang Ching-kuo Stiftung für internationalen akademischen Austausch – Wikipedia](https://zh.wikipedia.org/zh-hant/%E8%94%A3%E7%B6%93%E5%9C%8B%E5%9C%8B%E9%9A%9B%E5%AD%B8%E8%A1%93%E4%BA%A4%E6%B5%81%E5%9F%BA%E9%87%91%E6%9C%83) — Wikipedia hält fest, dass die Chiang Ching-kuo Stiftung am 12. Januar 1989 gegründet wurde, nachdem Hsu Cho-yun, Yu Ying-shih, K.C. Chang und andere chinesischstämmige Professoren in Nordamerika 1986 kollektiv an Präsident Chiang Ching-kuo appelliert hatten; Hsu war lange Vorsitzender des Nordamerika-Komitees.
+
+[^30]: [Entstehungshintergrund – Chiang Ching-kuo Stiftung](http://www.cckf.org/zh/about/background) — offizielle Seite der Stiftung zum Entstehungshintergrund; ausführlich verzeichnet sind die Mitbegründer Hu Yu-shih, Yu Ying-shih, K.C. Chang und andere; Hsu leitete die amerikanische Zweigstelle bis kurz vor seinem Tod.
+
+[^31]: [Wang Fan-sen – Wikipedia](https://zh.m.wikipedia.org/zh-hk/%E7%8E%8B%E6%B1%8E%E6%A3%AE) — Wikipedia-Artikel zu Wang Fan-sen; verzeichnet dessen Lehrerbeziehung zu Hsu, seine Karriere als Direktor des Instituts für Geschichte und Philologie der Academia Sinica und als Vizepräsident der Academia – er gilt als einer der akademischen Nachfolger Hsus in Taiwan; Tu Cheng-sheng war nacheinander Bildungsminister und Direktor des Palastmuseums, ebenfalls Mitglied desselben Gelehrt:innenkreises der Generation.
+
+[^32]: [Wang Leehom gedenkt Hsu Cho-yun: Die Weisheit des siebten Großonkels ist unübertroffen – Ming Pao News](https://news.mingpao.com/ins/%E5%85%A9%E5%B2%B8/article/20250805/s00004/1754381648755/%E7%8E%8B%E5%8A%9B%E5%AE%8F%E7%99%BC%E6%96%87%E6%82%BC%E5%BF%B5%E8%A8%B1%E5%80%AC%E9%9B%B2-%E4%B8%83%E8%88%85%E5%85%AC%E6%99%BA%E6%85%A7%E7%84%A1%E4%BA%BA%E8%83%BD%E5%8F%8A) — Ming Pao vom 5. August 2025 überträgt Wang Leehoms Weibo-Trauertext wörtlich, einschließlich der Anrede „siebter Großonkel“ und der Familienreihenfolge „das siebte von neun Geschwistern“.
+
+[^33]: [Wie bedeutend ist Wang Leehoms Familie? Ein Geschichtsprofessor recherchiert 40 Jahre – Business Today](https://www.businesstoday.com.tw/article/category/183027/post/202112190017/) — Bericht von Business Today vom 19. Dezember 2021; der Geschichtswissenschaftler Wu Ming von der Chengchi-Universität recherchiert Wang Leehoms Stammbaum: Großmutter Hsu Liu-fen war die älteste Tochter von Hsu Feng-tsao, Absolventin der Volkswirtschaft der Tsing-Hua-Universität, Leiterin der Abteilung Rechnungswesen und Statistik der Taipeh-Handelsschule, Autorin von „Prinzipien der Rechnungslegung“ und eines englisch-chinesischen Rechnungswörterbuchs.
+
+[^34]: [Wang Leehoms „Großonkel mütterlicherseits mit Akademiemitglied“ war tatsächlich der verstorbene Historiker Hsu Cho-yun – Liberty Entertainment](https://ent.ltn.com.tw/news/breakingnews/5133124) — Liberty Entertainment berichtet im August 2025 über die Linie von Wang Leehoms Großonkel mütterlicherseits – Großmutter Hsu Liu-fen → Vater Wang Ta-chung (Hirnmediziner, Absolvent der NTU-Medizinfakultät) → Wang Leehom – und bestätigt, dass Hsu Cho-yun der siebte Bruder von Hsu Liu-fen war (Hsu Liu-fen älteste Schwester, Hsu Cho-yun an siebter Stelle).
+
+[^35]: [Wang Leehom und Hsu Cho-yun sind beide Verwandte von Li Chien-fu – China Times](https://www.chinatimes.com/newspapers/20150603000453-260102) — China Times vom 3. Juni 2015: Li Chien-fus Vater war Li Mo (Staatssekretär im Ministerium für Bildung und Wirtschaft), seine Mutter Hsu Wan-ching (zweite Schwester von Hsu Cho-yun, Absolventin der Südwest-Kombinierten Universität), sein Onkel mütterlicherseits Hsu Cho-yun; Li Chien-fu und Wang Leehom sind Cousins.
+
+[^36]: [Hsu Cho-yun – Wikipedia (chinesisch)](https://zh.wikipedia.org/zh-tw/%E8%A8%B1%E5%80%AC%E9%9B%B2) — wie [^7]; verzeichnet, dass der Zwillingsbruder Hsu I-yun Chemiewissenschaftler war und die Karriere als Vorsitzender der Atomenergiekommission des Exekutiv-Yuans innehatte.
+
+[^37]: [„Söhne des Drachen“-Li Chien-fu | AV-Fokus](https://focus.lib.ntu.edu.tw/?q=zh-hant/%E5%8F%B0%E7%81%A3%E6%A0%A1%E5%9C%92%E6%B0%91%E6%AD%8C/%E9%BE%8D%E7%9A%84%E5%82%B3%E4%BA%BA-%E6%9D%8E%E5%BB%BA%E5%BE%A9) — AV-Datenbank der NTU-Bibliothek zum Eintrag „Söhne des Drachen“; 1980 mit Text und Musik von Hou Te-chien, uraufgeführt von Li Chien-fu – ein Klassiker des taiwanesischen Campus-Folk; Li Chien-fu ist Hsus Neffe (Sohn von Hsu Wan-ching).
+
+[^38]: [Der große Historiker Hsu Cho-yun gestorben, Wang Leehom gedenkt des Onkels: „Mögen Sie in Frieden ruhen“ – United Daily News](https://udn.com/news/story/7314/8919288) — United Daily News überträgt Wang Leehoms Weibo-Trauertext vollständig, einschließlich Zitaten wie „Eine der wärmsten Erinnerungen aus der Kindheit meines Vaters sind die Gutenachtgeschichten, die ihm sein siebter Onkel vorlas“ und „Sein Körperbau war vielleicht schmächtig, aber sein Geist ragte so hoch wie ein Berg auf“.
+
+[^39]: [Meihua News | Wang Leehom gedenkt des „siebten Großonkels“ Hsu Cho-yun: Er ist der Gigant in unseren Herzen](https://www.i-meihua.com/Article/Detail/31739) — Meihua News fasst die Details von Wang Leehoms Trauertext zusammen und ergänzt mündlich überlieferte Familieninhalte wie „Der siebte Onkel webt jede Nacht eine Fortsetzungsgeschichte für meinen Vater, vieles frei improvisiert, mit vielen Lebensweisheiten darin verborgen“.
+
+[^40]: [Books.com.tw – Der ewige Strom – Wendepunkte und Entfaltung der chinesischen Geschichte und Kultur](https://www.books.com.tw/products/0010323716) — Books.com.tw-Produktseite zu „Der ewige Strom“: 2006 im Hansheng-Verlag in Taipeh erschienen, 270.000 Schriftzeichen, 480 Seiten, Preis NT$450; Hsus chinesische Kulturgeschichte für das „Zeitalter des gemeinen Volks“.
+
+[^41]: [Der ewige Strom (Douban)](https://book.douban.com/subject/1473203/) — Douban-Eintrag zu „Der ewige Strom“ mit Hsus Vorwort wörtlich: „Die Leser von heute sind nicht wie jene früherer Zeiten; in diesem Zeitalter des gemeinen Volks kann sich im Allgemeinen jeder, der mindestens eine Oberschulbildung genossen hat, für Geschichte interessieren. Dieses Buch ist die Geschichte, die ich für diese Generation von Chinesen geschrieben habe.“
+
+[^42]: [Der ewige Strom: Wendepunkte und Entfaltung der chinesischen Geschichte und Kultur – PanSci](https://pansci.asia/archives/books/%E8%90%AC%E5%8F%A4%E6%B1%9F%E6%B2%B3) — PanSci stellt die Schreibstrategie von „Der ewige Strom“ vor: Anstelle einer linearen Erzählung des „Dynastie-Wechsels“ tritt die „kulturelle Ausbreitung und Kontraktion“ – Hsus repräsentatives Werk populärer Historiografie.
+
+[^43]: [Der ewige Strom – Hsu Cho-yun | Readmoo](https://share.readmoo.com/book/642423) — Vorstellungsseite des E-Book-Anbieters Readmoo zu „Der ewige Strom“; verzeichnet die Verbreitungsspur des Buchs in Taiwan, Hongkong, auf dem chinesischen Festland (Sanlian-Verlag und Guangxi-Normaluniversitätsverlag brachten nacheinander vereinfachte Ausgaben heraus) und in überseeischen chinesischen Gemeinschaften.
+
+[^44]: [Ich und der Andere: Die Grenzen zwischen Innen und Außen in der chinesischen Geschichte – Verlag der Chinesischen Universität Hongkong](https://cup.cuhk.edu.hk/index.php?route=product/product&product_id=382) — Verlagsseite des Verlags der Chinesischen Universität Hongkong zu „Ich und der Andere“; 2009 beim China Times Verlag (Taiwan) und dem Verlag der Chinesischen Universität Hongkong erschienen; Hsu schlägt sechs Systeme zur Analyse der chinesischen Identitätsfrage „Ich/Anderer“ vor.
+
+[^45]: [Buchkritik von Du Yaoming: Nur durch Inklusion und Austausch kann ein Land dauerhaft gut regiert werden – RFA](https://www.rfa.org/cantonese/features/bookclub/bk_tym-02042011113139.html) — Buchkritik von Du Yaoming bei Radio Free Asia; zitiert die Kernposition Hsus in „Ich und der Andere“: „Bei den ‚innen/außen‘- und ‚ich/anderer‘-Beziehungen komplexer Systeme kommt es nicht auf die Ethniengrenze an, sondern auf die kulturelle Erkenntnis.“
+
+[^46]: [Huaxia-Rede: Der Wandel einer komplexen Gemeinschaft – Google Books](https://books.google.com/books/about/%E8%8F%AF%E5%A4%8F%E8%AB%96%E8%BF%B0.html?id=N5aZDQAAQBAJ) — Google-Books-Eintrag zu „Huaxia-Rede“; im März 2015 beim Guangxi-Normaluniversitätsverlag erschienen; Hsu schlägt einen „prozessualen“ Rahmen zur Definition Chinas vor – Staatsgewalt, Wirtschaft, Gesellschaft und Kulturideen als vier dynamisch ineinandergreifende Variablen.
+
+[^47]: [Jingwei Huaxia (erweiterte Ausgabe in traditionellen Schriftzeichen) — Joint Publishing Hongkong](https://www.jointpublishing.com/publishing/%E7%B6%93%E7%B7%AF%E8%8F%AF%E5%A4%8F%EF%BC%88%E7%B9%81%E9%AB%94%E5%A2%9E%E8%A8%82%E7%89%88%EF%BC%89/) — wie [^5]; verzeichnet, dass „Jingwei Huaxia“ achtmal überarbeitet wurde und die erweiterte Ausgabe die beiden langen Aufsätze über „die große Flut“ und „die Interaktion zwischen der nördlichen Steppe und dem zentralen Tiefland“ ergänzt.
+
+[^48]: [Staffel 4 von „Shisanhao“, Folge 8: Hsu Cho-yun: Heute stecken die Menschen in einer Sinnkrise, nötig ist Weitblick über das Ungesehene hinaus – YouTube](https://www.youtube.com/watch?v=Sf5chgy-EY8) — offizieller Kanal von Tencent News „Shisanhao“; Folge 8 der 4. Staffel (2019), Xu Zhiyuans erstes Interview mit Hsu in Pittsburgh, zusammen mit dem zweiten Besuch in Folge 1 der 8. Staffel (2023–24) zu einer Dialogreihe der großen Meister gefügt; „Jingwei Huaxia“ ist das Werk, das zwischen den beiden Interviews entstand.
+
+[^49]: [Academia Sinica – Akademiemitglieder-News | Akademiemitglied Hsu Cho-yun erhält den sechsten Tang-Preis für Sinologie](https://www.sinica.edu.tw/News_Content/551/2633) — offizielle Pressemitteilung der Academia Sinica vom 20. Juni 2024 mit der wörtlichen Bewertung der Tang-Preis-Jury: „Professor Hsus Geschichtswissenschaft sieht das Große; seine Abhandlungen zur alten chinesischen Geschichte legen die Essenz langfristiger Geschichte frei, seine Gesamtdarstellungen betonen die kulturelle Aufnahme und den Austausch und suchen die Positionierung Chinas in der Welt.“
+
+[^50]: [Books.com.tw – Der Weg des Herzens](https://www.books.com.tw/products/CN11307248) — wie [^12]; die Veröffentlichungszeitachse von „Der Weg des Herzens“: erste Auflage 1964 beim Wenxing-Verlag, 1969/1979 bei der Biografischen Literatur-Gesellschaft, 2015 beim Xiamen-Universitätsverlag.
+
+[^51]: [Books.com.tw – Sechzig Jahre Amerika: Die Eindrücke eines Chinesen](https://www.books.com.tw/products/0010818440) — Books.com.tw-Produktseite zu „Sechzig Jahre Amerika“; im April 2019 bei Linking erschienen; Hsus Eindrücke aus einem halben Jahrhundert Amerika und seine Diagnose der amerikanischen Gesellschaft.
+
+[^52]: [Books.com.tw – Autor Hsu Cho-yun](https://search.books.com.tw/search/query/key/%E8%A8%B1%E5%80%AC%E9%9B%B2/adv_author/1/) — vollständige Books.com.tw-Autorenseite zu Hsu Cho-yun, einschließlich der Angabe, dass „Nach innen gehen, sich niederlassen“ 2022 beim Peking-Nachrichtenverlag erschien und gemeinsam mit Feng Jun-wen verfasst wurde.
+
+[^53]: [Books.com.tw – Hsu Cho-yun erzählt Geschichte (fünfbändige Sonderausgabe mit Schutzumschlag)](https://www.books.com.tw/products/CN11413817) — Books.com.tw-Bibliografie der fünfbändigen Sonderausgabe der Reihe „Hsu Cho-yun erzählt Geschichte“ – die populäre Fassung der Makrogeschichte.
+
+[^54]: [Hsu Cho-yuns Zehn-Tage-Gespräche: Die Konstellation der heutigen Welt und die Zukunft der Menschheit – Joint Publishing Hongkong](https://www.jointpublishing.com/publishing/%E8%A8%B1%E5%80%AC%E9%9B%B2%E5%8D%81%E6%97%A5%E8%AB%87%EF%BC%9A%E7%95%B6%E4%BB%8A%E4%B8%96%E7%95%8C%E7%9A%84%E6%A0%BC%E5%B1%80%E8%88%87%E4%BA%BA%E9%A1%9E%E6%9C%AA%E4%BE%86/) — Verlagsseite der Joint Publishing Hongkong zu „Hsu Cho-yuns Zehn-Tage-Gespräche“, einer Zusammenfassung der Gespräche über seine späten Gedanken zur Weltlage.
+
+[^55]: [Der Tang-Preis für Sinologie geht an den Historiker Hsu Cho-yun, der erste Preisträger taiwanesischer Herkunft – Central News Agency](https://www.cna.com.tw/news/ahel/202406200042.aspx) — offizieller Bericht der Central News Agency vom 20. Juni 2024: Hsu Cho-yun erhält den sechsten Tang-Preis für Sinologie, alleiniges Preisgeld 50 Millionen NT$ (einschließlich 10 Millionen NT$ Forschungsförderung) — im strengen Sinn der erste Preisträger taiwanesischer Herkunft.
+
+[^56]: [Glückwunsch an den herausragenden Alumnus Professor Hsu Cho-yun zum Tang-Preis für Sinologie – National Taiwan University](https://www.ntu.edu.tw/spotlight/2024/2278_20240620.html) — Glückwunschmeldung der NTU vom 20. Juni 2024 an Hsu Cho-yun (Bachelor Geschichtsfakultät 1953, Master am geisteswissenschaftlichen Graduierteninstitut 1956, Dekan 1964–70) zum Tang-Preis für Sinologie; hält seine langjährige Beziehung zum Fachbereich Geschichte der NTU fest.
+
+[^57]: [Tang-Preis-Sinologie-Gewinner Hsu Cho-yun über Trump und Amerika: „Man kommt um das Ende der Qing-Dynastie nicht herum“ – Global Views Monthly](https://www.gvm.com.tw/article/116018) — Global Views Monthly interviewt Hsu Cho-yun im September 2024; verzeichnet seine Anwendung der Makrogeschichtsmethode mit der Analogie „Man kommt um das Ende der Qing-Dynastie nicht herum“ auf die gegenwärtige internationale Ordnung sowie den Kontext der beiden Pittsburgh-Interviews von „Shisanhao“ (Staffel 8, 2019/2023).
+
+[^58]: [Hsu Cho-yun: Ich hoffe, den Ton „China, das ist stark“ nicht mehr hören zu müssen – Think HK](https://www.thinkhk.com/article/2021-04/27/48632.html) — Think HK überträgt im April 2021 ein langes Interview mit Hsus Kritik am „China-Zentrismus“, einschließlich seiner wörtlichen Haltung „Ich hoffe, den Ton ‚China, das ist stark‘ nicht mehr zu hören“.
+
+[^59]: [Ebenda [^58] – „Ich hoffe, den Ton ‚China, das ist stark‘ nicht mehr zu hören“](https://www.thinkhk.com/article/2021-04/27/48632.html) — Hsus wörtliche öffentliche Spätposition, die den Rahmen von „Ich und der Andere“ und „Huaxia-Rede“ bis zur Kritik am zeitgenössischen chinesischen Nationalismus verlängert.
+
+[^60]: [Besprechungen aus aller Welt | Wer auf der Welt spricht nicht von China? Der ewige Strom, Hsu Cho-yun – Dotdot News](https://www.dotdotnews.com/a/202509/07/AP68bd2e57e4b08d2905357d15.html) — Kommentar von Dotdot News vom September 2025; fasst Hsus späte akademische Haltung zusammen, „in keiner nationalistischen Erzählung eine Position zu wählen“, sowie seine besondere Stellung zwischen chinesischen Nationalisten und taiwanesischen Lokalen.
+
+[^61]: [Trumps Schutzgeld-These, Tang-Preisträger Hsu Cho-yun: Wie ein Gangster im Konzessionsgebiet – Central News Agency](https://www.cna.com.tw/news/ahel/202409280217.aspx) — Bericht der Central News Agency vom 28. September 2024: Hsu Cho-yun sprach vor und nach der Vortragsveranstaltung der sechsten Tang-Preisträger mit der Central News Agency und verglich Trumps „Schutzgeld-These“ gegenüber Verbündeten mit der Haltung ausländischer Mächte gegenüber China im Konzessionsgebiet am Ende der Qing-Dynastie – eine Anwendung seiner Makrogeschichtsmethode auf die Analyse der zeitgenössischen internationalen Ordnung.
+
+[^62]: [Ebenda [^6] – Historiker Hsu Cho-yun gestorben, 94 Jahre alt, vor dem Tod um das Zitat „Aber das Weh, dass ich die Neun Provinzen nicht vereint sehe“ – Ming Pao](https://news.mingpao.com/pns/%E4%B8%AD%E5%9C%8B/article/20250805/s00013/1754330629859/%E5%8F%B2%E5%AD%B8%E5%AE%B6%E8%A8%B1%E5%80%AC%E9%9B%B2%E9%80%9D%E4%B8%96-%E4%BA%AB%E5%B9%B494%E6%AD%B2-%E7%94%9F%E5%89%8D%E5%BC%95%E3%80%8C%E4%BD%86%E6%82%B2%E4%B8%8D%E8%A6%8B%E4%B9%9D%E5%B7%9E%E5%90%8C%E3%80%8D%E7%82%BA%E6%86%BE) — Ming Pao berichtet über Hsus Entschluss, zu Lebzeiten ein Grab in Wuxi zu kaufen und den Grabstein gravieren zu lassen, sowie über das Zitat von Lu Xius „Shi'er“ – „Das Weh, dass ich die Neun Provinzen nicht vereint sehe“.
+
+[^63]: [Hsu Cho-yun | Autor – Global Views–Commonwealth Culture](https://bookzone.cwgv.com.tw/author/102) — Autorenseite von Global Views–Commonwealth zu Hsu Cho-yun; enthält den vollständigen wörtlichen Absatz des von ihm wiederholt zitierten historischen Aphorismus „Die Geschichte lehrt uns, dass jede Zivilisation gerade in ihrer Blüte zugleich ihre Krise vorbereitet“.
+
+[^64]: [Historiker Hsu Cho-yun mit 95 gestorben, spezialisiert auf die chinesische Geschichte, im Vorjahr mit dem Tang-Preis für Sinologie ausgezeichnet – Central News Agency](https://www.cna.com.tw/news/ahel/202508040175.aspx) — Nachruf der Central News Agency vom 4. August 2025: Hsu starb im Schlaf in Pittsburgh, seine Frau Sun Man-li war an seiner Seite; auch die wörtliche Trauer von Ex-Verkehrsminister Yeh Kuang-shih ist festgehalten.
+
+[^65]: [Der große Historiker und Akademiemitglied der Academia Sinica Hsu Cho-yun gestorben, das Festland-Taiwan-Amt: „bedauerlich“ – United Daily News](https://udn.com/news/story/7332/8936819) — United Daily News berichtet im August 2025: Das Amt für Taiwan-Angelegenheiten des chinesischen Festlands trauerte öffentlich um Hsu Cho-yun „bedauerlich“ – ein besonderes Ereignis, in dem beide Ufer zugleich denselben Gelehrten betrauerten.
+
+[^66]: [Li Chien-fu – Wikipedia](https://zh.wikipedia.org/zh-hant/%E6%9D%8E%E5%BB%BA%E5%BE%A9) — Wikipedia-Artikel zu Li Chien-fu: verzeichnet seine Identität als 1980er Originalinterpret von „Söhne des Drachen“, Vater Li Mo, Mutter Hsu Wan-ching, seine Onkel-Beziehung zu Hsu Cho-yun und dass Wang Leehom sein Cousin ist.
+
+[^67]: [In Memoriam – Cho-Yun Hsu | Department of History](https://www.history.pitt.edu/news/memorium-cho-yun-hsu) — offizielle In-Memoriam-Seite des Fachbereichs Geschichte der University of Pittsburgh zu Hsus Tod; bestätigt, dass er „taught at Pitt in History and Sociology from 1970 through the late 1990s“ – eine 55-jährige Zugehörigkeit.
+
+[^68]: [Einst 50 Millionen gespendet! Historiker Hsu Cho-yun gestorben, Yeh Kuang-shih erinnert sich an „das letzte Wiedersehen“ – CTWANT](https://www.ctwant.com/article/436257/) — CTWANT berichtet im August 2025: Ex-Verkehrsminister Yeh Kuang-shih (Mitarbeiter der Chiang-Ching-kuo-Stiftung) erinnert sich an das letzte Wiedersehen mit Hsu, wörtlich: „nicht nur wissenschaftlich ausgezeichnet; außergewöhnlich in allen Dingen des menschlichen Umgangs, ein wichtiger Wegbereiter der Gründung der Chiang-Ching-kuo-Stiftung“.


### PR DESCRIPTION
# 🇩🇪 de: 許倬雲 — Hsu Cho-yun (Cho-yun Hsu, Historiker)

Deutsche Übersetzung von `knowledge/People/許倬雲.md` → `knowledge/de/People/cho-yun-hsu-bridging-historian.md` (Pfad folgt der bereits gemergten en-Mirror-Datei `cho-yun-hsu-bridging-historian`).

## Inhalt

Die deutsche Neufassung erzählt das Leben des Historikers Hsu Cho-yun (1930–2025): Kindheit mit angeborener Behinderung auf Gulangyu (Xiamen), Kriegsflucht durch Hubei/Sichuan/Chongqing, Studium unter Herrlee G. Creel in Chicago (Sozialwissenschaftliche Methoden in der chinesischen Geschichte), ein halbes Jahrhundert in Pittsburgh, das Werk _Der ewige Strom_ (万古江河), Spenden des kompletten Tang-Preisgelds von 50 Mio. NT$ für das „Hsu-Sun-Stipendium“, die Familiengenealogie zu Wang Leehom und Li Chien-fu („Söhne des Drachen“) sowie Kritik am Nationalismus und Tod im Alter von 95.

Text ist eine Neufassung (knappe Übertragung, keine Wort-für-Wort-Übersetzung), in Anlehnung an die Struktur der en-Mirror-Datei.

## Qualitäts-Gates (alle lokal grün)

- **verify-translation.py: 18/18 ALL PASS**
  - translation ratio 2.59 (akzeptabler Bereich 2.0–4.0)
  - 68 Fußnoten, 11 Kapitel (H2) identisch mit zh
  - URL exaktes Multiset (75 URLs) von zh beibehalten
  - Passthrough-Frontmatter (10 Felder) bytes-identisch mit zh
  - sourceCommitSha `09ffe560f` = tatsächlicher aktueller HEAD der zh-Quelldatei
- **article-health.py (pre-commit-Profil): hard=0 warn=0**
  - Fußnotenformat, Fußnotendichte, URL-Gesundheit, Bildpfade (2 inline + 1 hero), Wikilinks, Viz-Health, Subcategory-Parität, SEO-Meta, AI-Residue alle grün
- **CI translation-check-Bedingungen erfüllt** (title/description/translatedFrom vorhanden, >20 Zeilen, Sprache de aktiv, keine forbidden phrases wie „part of china“ / „chinese taipei“)

## Frontmatter-Notizen

- Passthrough-Felder (author/date/featured/readingTime/lastVerified/lastHumanReview/category/image/imageCredit/difficulty) komplett aus zh übernommen
- `sourceCommitSha: 09ffe560f` — die zh-Quelldatei wurde seit diesem Commit nicht verändert (verifiziert gegen `upstream/main`)
- `imageCredit: 'Academia Sinica'` nicht übersetzt (Passthrough, byte-identisch mit zh)

## Weiterführende Lektüre (Further Reading)

Nur verlinkt, wo die de-Version existiert: **Jay Chou** (`/de/people/jay-chou`) — verlinkt. Yoga Lin / Chen Chien-nien / 外省人 / 二二八 / Samuel Yin: de-Versionen existieren noch nicht → als Klartext geführt (keine toten Links).
