### PR TITLE
🇩🇪 de: 施振榮 — Stan Shih (Acer-Gründer)

### DIFF
--- a/knowledge/de/People/stan-shih.md
+++ b/knowledge/de/People/stan-shih.md
@@ -1,0 +1,338 @@
+---
+title: 'Stan Shih: Vom Enteneier-Stand in Lukang zu einer Marke namens Taiwan'
+description: 'Stan Shih (geb. 1944 in Lukang), vom Enteneier-Stand zum Weltkonzern: Er baute Acer zu einer der fünf größten PC-Marken auf und zeichnete die international erforschte Smile Curve. Öffentlich sagt er: „Ich bin der größte Verlierer.“ Mit über achtzig Jahren arbeitet er weiter mit Wagniskapital und KI-Avatar. Woran ihm am meisten liegt: unsichtbare Werte – Talente, Marken, der „Königsweg“.‘
+date: 2026-03-22
+category: 'People'
+tags:
+  [
+    'Person',
+    'Stan Shih',
+    'Acer',
+    'Smile Curve',
+    'Taiwanesische Tech-Industrie',
+    'Unternehmer',
+    'Lukang',
+  ]
+subcategory: '科技與企業'
+author: 'Taiwan.md'
+featured: true
+lastVerified: 2026-07-06
+lastHumanReview: false
+researchReport: 施振榮
+image: '/article-images/people/stanshih-taipei-2014.webp'
+imageCredit: 'Tony Tseng'
+imageLicense: 'CC BY 2.0'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Stan_Shih_at_Taipei_IT_Month_20141205a.jpg'
+relatedDiary:
+  - 2026-07-06-133221-施振榮-rewrite
+translatedFrom: 'People/施振榮.md'
+sourceCommitSha: '6ffd92f94'
+sourceContentHash: 'sha256:b5ded8b5494f423c'
+sourceBodyHash: 'sha256:fb56cb60a16b87a7'
+translatedAt: '2026-09-09T16:30:00+08:00'
+---
+
+# Stan Shih: Vom Enteneier-Stand in Lukang zu einer Marke namens Taiwan
+
+> **30 Sekunden im Überblick:** Stan Shih (geb. 1944) ist ein Kind einer Räucherstäbchen-Familie aus Lukang. Sein Vater starb an Überarbeitung, als Stan drei Jahre alt war; seine Mutter zog ihn auf, indem sie Enteneier, Schreibwaren und patriotische Lose verkaufte. Er arbeitete sich vom Elektronikstudium an der Chiao-Tung-Universität zum Ingenieur hoch, gründete 1976 mit seiner Frau und einigen Partnern mit einer Million NT$ Acer und führte es zu einer der fünf größten PC-Marken der Welt. Er zeichnete die „Smile Curve“, die in Lehrbücher einging und später sogar von der internationalen Wirtschaftswissenschaft erforscht wurde. Er ist auch einer der wenigen taiwanesischen Tech-Patriarchen, die bereit sind, vor der Kamera über ihr Scheitern zu sprechen: Deqi Semiconductor hielt einst den Rekord für den größten Verlust eines einzelnen Unternehmens in Taiwan, Acer verlor 2013 in einem Jahr über 20 Milliarden NT$, und mit über achtzig Jahren – mehr als zehn Stents im Herzen – arbeitet er weiter an Wagniskapital und einem KI-Avatar. Woran ihm sein Leben lang am meisten lag, sind die unsichtbaren Dinge, die man erst viel später ausrechnen kann: Talente, Marken und das, was er den „Königsweg“ (王道) nennt.
+
+Im September 1981, San Francisco, auf dem Gelände der 30. Western Electronics Show (WESCON)[^1].
+
+Auf einem Tisch liegt ein kleiner Computer mit Plastikgehäuse. Seine Form ist merkwürdig: Geschlossen sieht er aus wie ein gewöhnliches Buch, das man beiläufig ins Regal schieben kann[^2]. Auf der Messe dieses Jahres waren 14 Länder und über 500 Aussteller vertreten[^3] – doch rund 20 amerikanische Händler drängten sich um dieses unscheinbare kleine Gerät und erkundigten sich eifrig nach den Vertriebsrechten[^4].
+
+Es heißt „Micro-Professor I“ und stammt von einer taiwanesischen Marke namens Multitech. Der Mann, der es gebaut hat, heißt Stan Shih; damals war er 36. Für viele Taiwanerinnen und Taiwaner der Jahrgänge 1950/1960 war diese buchförmige Maschine das erste Mal, dass sie einen „in Taiwan selbst entwickelten und gebauten Computer“ in den Händen hielten.
+
+## Ein Computer, der sich wie ein Buch schließen lässt
+
+Um das Gewicht dieser Buch-Maschine zu verstehen, müssen wir die Zeit etwas zurückdrehen.
+
+Im Taiwan der 1970er Jahre dominierte Auftragsfertigung. Man montierte und veredelte für andere und verdiente mühsam ein wenig Geld; kaum jemand wagte an „eine eigene Marke, die in die ganze Welt verkauft“ zu denken. Genau das aber war es, woran Stan Shih dachte. 1968 machte er seinen Bachelor in Elektrotechnik an der Chiao-Tung-Universität, 1971 den Master[^5], und stürzte sich dann in das damals modernste Gebiet: den Mikroprozessor. Zuerst entwickelte er bei Huan Yu Electronics Taiwans ersten Tischrechner, danach führte er bei Rungtai ein Team, das Taiwans ersten Taschenrechner und die erste elektronische Armbanduhr der Welt baute[^6].
+
+1976, mit 31 Jahren (die Medien schreiben meist 32 – nach taiwanesischer Zählweise), gründete er zusammen mit seiner Frau Yeh Tzu-hua und den Partnern Tai Chung-ho, Lin Chia-ho, Huang Shao-hua und anderen mit einer Million NT$ ein kleines Unternehmen, das zunächst „Multitech“ hieß[^7]. Er gab sich selbst einen sehr literarischen Titel: „Gärtner des Mikroprozessors“[^8]. Gärtner – kein Herrscher, kein Eroberer. Seine Vorstellung war, langsam eine Industrie zu pflanzen und zu pflegen.
+
+![„Micro-Professor I“ (MPF-I) von Acer aus dem Jahr 1981, buchförmiges Gehäuse, geschlossen ins Regal stellbar](/article-images/people/mpf1-microprofessor-1981.webp)
+_Der „Micro-Professor I“ (MPF-I) von 1981. Dieses auf dem Z80 basierende Mikrocomputer-Trainingsgerät mit buchförmigem Gehäuse wurde für viele Taiwaner zum ersten Eindruck von einem „heimischen Computer“._
+
+Der Micro-Professor I war das Werk dieser kleinen Firma aus dem Jahr 1981 – ein Trainingsgerät zum Erlernen der Mikroprozessor-Technik. Es sollte erstaunlich lange überleben: 1993 verkaufte Acer die Produktlinie an eine Firma in Southampton, England, und noch 2021 wurde es dort in kleinen Stückzahlen produziert[^9]. Von 1981 bis 2021 – rund 40 Jahre lang – verkaufte sich ein kleiner taiwanesischer Computer in der Fremde fast ein halbes Jahrhundert lang.
+
+Die WESCON 1981 war der Mikrokosmos eines Wendepunkts. Eine kleine Firma aus Hsinchu brachte eine buchförmige Maschine mit, und unter über 500 Ausstellern wurde sie von ausländischen Händlern umringt, die nach Vertriebsrechten fragten – der Ehrgeiz der taiwanesischen Tech-Industrie, „sich nicht mit Auftragsfertigung zufriedenzugeben“, wurde zum ersten Mal von der Welt gesehen. Und Stan Shih, der hinter dieser Maschine stand, sollte die nächsten vierzig Jahre damit verbringen, eine Frage zu beantworten, die er selbst aufgeworfen hatte: Wie weit kann eine taiwanesische Marke gehen?
+
+## Die Mutter, die Enteneier verkaufte, und der Junge, der eine Marke aufbauen wollte
+
+Um zu verstehen, warum Stan Shih so beharrlich an „etwas Eigenem machen“ festhielt, müssen wir nach Lukang zurückkehren.
+
+Er wurde am 18. Dezember 1944 in Lukang im Landkreis Changhua geboren, in einer Räucherstäbchen-Familie namens „Shih Mei-yu“. Die Wurzeln dieses Ladens reichen bis ins Jahr 1774 zurück, als ein Vorfahre in Jinjiang, Fujian, einen alten Laden eröffnete; sein Vater Shih Chi-shen war der sechste Generationen-Nachfolger[^10]. Doch diese Herkunft konnte ihn nicht behüten: Der Vater starb an Überarbeitung, als Stan Shih drei Jahre alt war[^11].
+
+Die Familie trug seine Mutter Shih Chen Hsiu-lien. Sie stammte aus Puli im Landkreis Nantou; nach dem Tod ihres Mannes weigerte sie sich entschieden, wieder zu heiraten, und zog ihren Sohn allein groß. 1953 wurde die Familie aufgeteilt; sie bekam einen Laden und verdiente ihr Leben mit dem Verkauf von Enteneiern, Schreibwaren, Gemischtwaren und patriotischen Losen – und nahm zusätzlich Strickarbeit an[^12]. „Patriotische Lose“ waren die offiziellen Lotterien der Kriegsrechtszeit in Taiwan; in jener Zeit war es für kleine Geschäftsleute üblich, mit dem Lotterieverkauf ihr Einkommen aufzubessern.
+
+> 💡 **Wussten Sie?** Stan Shih brachte Acer später in die Top 5 der weltweiten PC-Marken, zeitweise mit einer Marktkapitalisierung von über 100 Milliarden NT$. Doch das eigentliche Startkapital seines Geschäfts stammte – einigen Berichten zufolge – aus dem Enteneier-Laden seiner Mutter, der ihrer Schwiegertochter und ihm das Gründungskapital lieh. Eine Enteneier und patriotische Lose verkaufende Witwe aus Lukang finanzierte einen Sohn, der später in den Weltmarkt der Computer vordringen sollte – diese Linie selbst ist das konkreteste Bild der „Selbstständigkeit aus dem Nichts“ der Nachkriegsgeneration Taiwans.
+
+Ein Kind, das aufwuchs und zusah, wie seine Mutter kalkulierend durchs Leben kam, wählte später einen Weg, der am wenigsten kalkulierend war: eine Marke aufzubauen. Auftragsfertigung: Auftrag angenommen, Geld verdient – stabil. Eine Marke: Forschung, Marketing, Zeit investieren, und Erfolg ist keineswegs sicher. Stan Shih wählte Letzteres. Er sagte oft, Taiwan habe „keinen Mangel an Talenten, nur an Bühnen“[^13] – und die Bühne, die er bauen wollte, war genau das.
+
+Acer wuchs. 1987 kam die Aktie an die Börse und die Firma wurde offiziell in Acer umbenannt[^14]. In den 1990er Jahren war sie eine weltweit bekannte PC-Marke: 1993 überschritt der Umsatz 50 Milliarden, 1995 die 150-Milliarden-Marke, zeitweise stieg Acer zum siebtgrößten PC-Hersteller der Welt auf[^15]. Ein Kind, das aus einer kleinen Hsinchu-Firma und einer vom Enteneier-Verkauf getragenen Familie hervorgegangen war, hatte den Namen Taiwans wirklich auf die Rangliste des Weltmarkts für Computer gesetzt.
+
+## Eine Kurve, die seit dreißig Jahren überarbeitet wird
+
+Die bekannteste Sache an Stan Shih ist eigentlich eine Kurve.
+
+1992, als Acer gerade seine erste große Umgestaltung durchlief, brachte Stan Shih die „Smile Curve“ vor[^16]. Ihre Idee ist simpel: Man legt die obere, mittlere und untere Wertschöpfung einer Industrie auf eine horizontale Achse – links Forschung und Patente, in der Mitte Montage und Fertigung, rechts Marke und Marketing – und auf die vertikale Achse die Höhe des Mehrwerts. Gezeichnet ergibt sich eine Mitte, die tief liegt, und zwei hohe Enden – wie ein lächelndes Gesicht. Seine offizielle Darstellung lautet:
+
+> „1992 befand sich Acer in seiner ersten Umgestaltung. Über die ‚Smile Curve‘ lässt sich erkennen, wo der Mehrwert verteilt ist. Damals kommunizierte ich damit mit den globalen Kollegen und erklärte, dass die Montage zum Teil mit dem geringsten Mehrwert in der Computerindustrie geworden war, und überzeugte die Acer-Kollegen, die Montage in Taiwan aufzugeben und sich auf spezialisierte Bereiche mit höherem Mehrwert zu konzentrieren.“[^17]
+
+Diese Kurve war ursprünglich nur ein strategisches Bild, das er in seinem eigenen Buch vorschlug, um die interne Umstrukturierung zu begründen. Es ist keine peer-reviewte akademische Theorie – keine Originalarbeit, keine statistischen Tests. Das Interessante ist, dass ihr späteres Leben weit über einen Unternehmens-Slogan hinausreichte: Ab den 2000er Jahren begann die internationale Forschungsgemeinschaft der globalen Wertschöpfungsketten (GVC), sie ernsthaft als Analyse-Rahmen zu verwenden; in Oxford und Kanada erschienen nacheinander Aufsätze in Wirtschaftszeitschriften, die die Smile Curve „maßen“ oder „erneut überprüften“[^18]. Eine Linie, die ein aus dem Ingenieurwesen stammender Unternehmer intuitiv gezeichnet hatte, wurde zum Thema, über das die internationale Wirtschaftswissenschaft bis heute debattiert und das sie fortwährend korrigiert.
+
+Gerade weil sie groß genug und einflussreich genug war, rissen die Diskussionen um sie nie ab. Es gibt eine Gegenposition, die „Musashi-Kurve“: 2004 behauptete Suehiro Nakamura vom Nakamura-Forschungsinstitut bei Sony in Japan nach einer Untersuchung von 400 japanischen Fertigungsunternehmen, der profitabelste Abschnitt sei tatsächlich die „Fertigung“ in der Mitte – das genaue Gegenteil der Smile Curve[^19]. Auch auf taiwanesischer Seite gab es Kritik: AppWorks-Mitgründer Jamie Lin schrieb 2014, Taiwan habe die Smile Curve verbogen, sei bei „Design- und Vertriebswegen“ hängen geblieben und habe nie die wahre Lebensader einer Marke berührt – Marketing und Daten[^20]. Ende 2025 nannte ein Kommentar der Asia Times sogar Stan Shih und Acer namentlich und argumentierte mit dem wirtschaftlichen Konzept der „Holländischen Krankheit“, dass ausgelagerte Fertigung in Wahrheit der „schwierigste, technisch anspruchsvollste und am schwersten zu kopierende“ Teil der gesamten Wertschöpfungskette sei[^21].
+
+Hier gibt es einen oft diskutierten Kontrast: TSMC betreibt genau die „mittlere Fertigung“, die in der Smile Curve als Bereich mit dem geringsten Mehrwert gilt – und ist doch zum „beschützenden Nationalberg“ Taiwans, zu einem der wertvollsten Halbleiterunternehmen der Welt herangewachsen. Setzt man TSMC auf diese Kurve, landet es im tiefsten Mittelstück – ein möglicher Blickwinkel, und eine Frage, die sich natürlich stellt: Muss die Kurve aktualisiert werden? (Wichtig zur Klarstellung: Der Rahmen „TSMC als Gegenbeispiel zur Smile Curve“ ist eine Beobachtungsperspektive dieses Artikels, keine von einem Gelehrten oder in einer Arbeit aufgestellte Feststellung.)
+
+Und wer die Frage als Erster direkt beantwortete, war Stan Shih selbst. Auf der offiziellen Website seiner Stan Foundation ergänzte er persönlich einen entscheidenden Satz:
+
+> „Verstehen Sie die ‚Smile Curve‘ nicht falsch – sie bedeutet nicht, die Fertigung aufzugeben. Der Mehrwert ist zwar relativ gering, aber die Fertigung ist groß im Maßstab; in der Summierung bleibt sie wertvoll. Nur vor Angebotsüberschuss muss man sich hüten.“[^22]
+
+Er sagte sogar, die Fehllektüre der Smile Curve als „keine Fertigung“ sei „möglicherweise einer der Gründe für die massenhafte Abwanderung der produzierenden Betriebe Taiwans in den letzten fast zwanzig Jahren“[^23]. Das war seine Korrektur einer Fehllektüre, vor der er selbst am meisten Angst hatte: Er hat nie gesagt, Taiwan solle die Fertigung aufgeben – nur, man solle sich nicht in dem Abschnitt mit dem geringsten Verhandlungsspielraum festsetzen.
+
+![Smile-Curve-Diagramm: horizontale Achse von links nach rechts Forschung, Fertigung, Marketing; vertikale Achse Mehrwert; Kurve in Form eines lächelnden Gesichts mit tiefer Mitte und hohen Enden](/article-images/people/smiling-curve-1992.webp)
+_Die Smile Curve: links Forschung, in der Mitte Fertigung, rechts Marketing, vertikale Achse der Mehrwert. Mitte tief, beide Enden hoch, wie ein lächelndes Gesicht – das Bild, das Stan Shih 1992 für die Acer-Kollegen zeichnete und das später sogar die internationale Wirtschaftswissenschaft untersuchte._
+
+Noch 2019, mit 75, arbeitete er an der Kurve weiter. Bei einer Neujahrsfeier in seinem Wohnhaus schlug er die „Sechs-Dimensionen-Sicht der neuen Smile Curve“ vor und erweiterte den Rahmen von einer Linie auf drei Achsen – obere/mittlere/untere Wertschöpfung, Mehrwert, Branchenbereich – plus drei weitere Dimensionen: Zeit, materiell/immateriell, direkt/indirekt[^24]. Diese neue Version war so komplex, dass er selbst zugab: „Es ist schwer zu zeichnen, noch nicht gezeichnet“[^25]. Hier liegt ein bewegender Kontrast: Die Linie von 1992 ließ sich in einem einzigen Strich erklären; dreißig Jahre später war das, was er durchdacht hatte, so anspruchsvoll geworden, dass es sich kaum noch zeichnen ließ.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/PoCu6GaALkI" title="談王道與共創共生：施振榮 at TEDxTaipei 2012" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_TEDxTaipei 2012, offizieller Vortrag: Stan Shih über den „Königsweg“ und gemeinsames Mitgestalten – die Philosophie, explizite und implizite Werte gemeinsam aufzurechnen, wurde zum Mittelpunkt fast seines gesamten Spätwerks._
+
+Neben der Kurve pflanzte der späte Stan Shih noch einen weiteren, größeren Baum namens „Königsweg“ (王道). Er definierte ihn als „die Führungskunst von großen wie kleinen Organisationen“ – nicht die Kunst von Kaisern – und ins Zentrum stellt er drei Dinge: Wert schaffen, Interessen ausgleichen, nachhaltig wirtschaften[^26]. Und die zentrale Begriffspaarung unter dem Königsweg, die er immer wieder betonte, sind „expliziter Wert“ und „impliziter Wert“: Der explizite Wert ist materiell, direkt, gegenwärtig – schlicht gesagt: ob man Geld verdient; der implizite Wert ist immateriell, indirekt, zukünftig – Marke, Talente, Kultur, Vertrauen, Dinge, die sich erst viel später ausrechnen lassen[^27]. Er seufzte oft: „Die gesamte taiwanesische Gesellschaft legt zu viel Wert auf den expliziten Wert“[^28].
+
+Von einem Buch-Computer über eine Smile Curve zu einer ganzen Philosophie des Königswegs: Stan Shih veränderte langsam seine Gestalt. Zuerst war er ein Ingenieur, der Computer baute, dann wurde er ein Unternehmer und schließlich wuchs er beinahe zu einem Denker heran, der unablässig fragt: „Was ist überhaupt Wert?“
+
+## Das erste Mitglied des Fünf-Milliarden-Clubs
+
+Würde man nur von Marke, Theorie und Philosophie erzählen, wirkte dieser Mann zu glatt, zu perfekt. Doch genau die andere Seite ist es, die Stan Shih für die Taiwaner unvergesslich und respektiert gemacht hat: Er ist einer der wenigen Tech-Patriarchen Taiwans, die bereit sind, öffentlich über ihr Scheitern zu sprechen.
+
+Und sein Scheitern war nicht klein.
+
+1989 gründete Acer zusammen mit dem amerikanischen Texas Instruments das DRAM-Halbleiterunternehmen Deqi Semiconductor[^29]. Der Schritt kam unglücklich. DRAM ist eine Branche mit heftigen Konjunkturzyklen und häufigem Angebotsüberschuss; Deqi traf der Zusammenbruch des Marktes: 1997 und 1998 verlor es in jedem Jahr über 5 Milliarden NT$, zusammen fast 10 Milliarden; allein 1997 stellte Deqi den „Rekord für den höchsten Verlust eines einzelnen Unternehmens“ in Taiwan auf[^30]. Schließlich blieb Acer nichts anderes übrig, als den Schaden zu schlucken und Deqi an TSMC zu verkaufen: 1999 ließ man TSMC für rund 5,47 Milliarden NT$ einen Anteil von 30 Prozent erwerben, im Juli des Folgejahres wurde das gesamte Unternehmen per Aktientausch in TSMC eingegliedert – Deqi ging damit in die Geschichte ein[^31].
+
+Wie sprach Stan Shih darüber? Er wich nicht aus, sondern nahm es mit Selbstironie. Er sagte:
+
+> „Als Deqi früher 5 Milliarden verlor, schrieben die Medien, ich sei im 5-Milliarden-Club … Ich habe immer als Erster die Marke geknackt.“[^32]
+
+Einen Rekordverlust beschreibt er als „erstes Mitglied des Clubs“ – in einem Ton von seltener Offenheit. Damals beschimpften ihn Leute im Internet; seine Antwort: „Damals nannten mich Leute im Netz ein Schwein, und ich sagte: Schweine sind auch sehr klug.“[^33] Aus der Lektion Deqi destillierte er später einen oft zitierten Satz: „Immer wieder zu scheitern und weiterzukämpfen ist ein guter Geist, aber kämpfe keine Schlachten, die du nicht verlieren kannst.“[^34]
+
+Deqi war nicht die einzige Grube. Als Stan Shih 2004 mit 60 in den Ruhestand ging, übergab er Acer an den Italiener Gianfranco Lanci; Lanci trieb die Lieferzahlen so vehement voran, dass Acer zeitweise zur zweitgrößten PC-Marke der Welt wurde[^35]. Doch das Hochjagen der Stückzahlen hatte seinen Preis: In den europäischen Verkaufskanälen stapelte sich unverkäuflicher Lagerbestand, und 2011 verbuchte Acer auf einen Schlag einen Verlust von rund 150 Millionen US-Dollar[^36]. Im März jenes Jahres entschied der Aufsichtsrat, Lanci zu verabschieden – und Stan Shih, als Gründer und größter Aktionär, hielt bei dieser Machtprobe die entscheidenden Stimmen in der Hand[^37]. Acer zahlte den Rekord-Betrag von 1,284 Milliarden NT$ Abfindung – eine Zahl, die damals einen Rekord in der PC-Industrie aufstellte[^38]. Im gesamten Jahr 2011 verlor Acer 6,601 Milliarden NT$[^39].
+
+![Stan Shih auf einem Markenforum 2007. Er gilt als einer der wenigen Patriarchen-Entrepreneure Taiwans, die öffentlich über ihr Scheitern sprechen](/article-images/people/stanshih-brandforum-2007.webp)
+_In Taiwan hört man selten, dass ein Patriarchen-Unternehmer öffentlich über seine Niederlagen spricht. Stan Shih ist die seltene Ausnahme – er legt sein Scheitern ans Tageslicht und macht daraus sogar eine Philosophie._
+
+Der eigentliche Tiefpunkt kam 2013. Die über Jahre teuer zugekauften westlichen Marken Acers (Gateway, Packard Bell, eMachines u. a.) versagten nun kollektiv: Allein im dritten Quartal wurden 9,943 Milliarden NT$ an Wertminderungen immaterieller Vermögenswerte verbucht, das Quartal endete mit einem Verlust von 13,12 Milliarden; zusammen mit den Lagerverlusten des vierten Quartals stieg der Jahresverlust auf 20,579 Milliarden NT$ – das schlimmste Jahr in den 38 Jahren von Acer[^40].
+
+Angesichts dieser angesammelten Niederlagen sagte Stan Shih in einem Interview von 2022 einen Satz, der seither oft zitiert wird:
+
+> „Ich bin der größte Verlierer (er hält die meisten Acer-Aktien unter allen), aber ich bereue es nie.“[^41]
+
+Er trieb die Zahl sogar noch höher. Diese Verluste seien „das Schulgeld, das Acer auf dem Weg zu einem weltweit führenden multinationalen Unternehmen notwendigerweise zahlen musste“, und bekannte: „Ich habe nicht nur zwanzig Milliarden gezahlt, ich habe über hundert Milliarden gezahlt“[^42]. Dieses „über hundert Milliarden“ ist eine selbst beschreibende Rhetorik aus dem Interview – keine Wirtschaftsprüfung hat es so berechnet; doch die Offenheit, mit der er sein Vermögen hingegeben hat und dabei noch lacht, ist echt.
+
+> 📝 **Kuratoren-Notiz**
+> In Taiwans Geschäftskultur ist „Scheitern“ gewöhnlich etwas, das man versteckt – Biografien großer Bosse schreiben meist nur die Siege, Niederlagen werden entweder verschwiegen oder dem Konjunkturzyklus und den Untergebenen zugeschoben. Stan Shih macht es umgekehrt: Er legt seine Niederlagen eine nach der anderen ans Tageslicht und schmiedet sie eigenhändig zu einer Philosophie. Was Respekt verdient, ist, dass er etwas sehr Seltenes vorlebt: „Verlieren-Eingestehen“ als Fähigkeit, als Fähigkeit, mit der man justieren und gewinnen kann. Er sagte: „Mein Charakter gibt leicht zu verlieren – sobald etwas nicht stimmt, justiere ich sofort.“ In einem Umfeld, das daran gewöhnt ist, das Gesicht zu wahren, auch wenn man geschlagen ist, ist genau diese Offenheit ein eindrucksvolles Vorbild durch Taten.
+
+## Zurückkehren, um den eigenen Scherbenhaufen aufzuräumen
+
+Im Moment, als Acer 2013 am Tiefpunkt war, hätte Stan Shih sich eigentlich ganz heraushalten können.
+
+Er war längst pensioniert. In jenem Jahr war er 68, fast zehn Jahre im Ruhestand, das Herz bereits mit mehreren Stents versorgt – er hätte sein Leben durchaus würdevoll weiterführen können. Seine Wohltätigkeit, sein Wagniskapital, seine Königsweg-Philosophie – alles lief in geregelten Bahnen. Acers Verlust von 20,5 Milliarden war die Sache der Nachfolger, nicht seine.
+
+Doch im November jenes Jahres traten Aufsichtsratsvorsitzender J.T. Wang und Geschäftsführer Jim Wong zurück, um die Verantwortung für die Geschäftslage zu übernehmen[^43], und Stan Shih traf eine Entscheidung, die viele überraschte: Er kehrte zurück. Am 21. November übernahm er erneut das Amt des Aufsichtsratsvorsitzenden, kommissarisch auch das des globalen Präsidenten, und leitete die dritte Umgestaltung von Acer ein[^44]. Ein Gründer, der hätte ungeschoren davonkommen können, entschied sich, zurückzukehren und den Scherbenhaufen aufzuräumen, für den er selbst institutionelle Verantwortung trug.
+
+Über diese Zeit scherzte er später mit einer gewissen Ratlosigkeit: „Immer wieder zurück ins Amt – soll ich etwa aus dem Sarg kriechen?“[^45] Und den gelasseneren Satz: „Arbeit kann man auslagern, Verantwortung nicht.“[^46]
+
+Seine erste große Tat nach der Rückkehr war, die richtige Nachfolge für die Leitung zu finden. 2014 holte er Jason Chen von TSMC als CEO. Chen schlug nicht den alten Weg Lancis ein – Marktanteile erkämpfen, Preise unterbieten –, sondern führte Acer zu E-Sport (Predator, Nitro), zu Schul-Chromebooks und richtete eine eigene Forschungseinheit ein[^47]. Diese Wende holte Acer aus dem Tal. 2021 überschritt der Umsatz von Acer wieder die 300-Milliarden-Marke, der Nettogewinn nach Steuern lag bei 10,8 Milliarden, das EPS bei 3,63 NT$ – allesamt neue Höchstwerte der letzten Jahre; die Marktkapitalisierung des Konzerns stieg von gut 50 Milliarden vor Chens Amtsantritt auf fast 100 Milliarden[^48].
+
+Bemerkenswert ist, dass Stan Shih von Anfang bis Ende ein Prinzip wahrte: die Weitergabe an Verdiente, nicht an Söhne. Von Lanci über Wang Chen-tang bis Chen: Dreimal wurde die Führungsposition von Acer übergeben, jedes Mal an professionelle Manager, kein einziges Mal an seinen Sohn[^49]. Sein ältester Sohn Stan Shih Hsuan-hui war zwar 2011 durch die Acer-Übernahme von iGware ins Unternehmen gekommen und wurde 2019 offiziell zum Direktor bestellt – doch die Position war als „die Aktionäre der Familie vertretender Aufsichtssitz“ definiert, nicht als operative Leitung; der Stab des CEO blieb in den Händen professioneller Manager wie Chen[^50]. Wie diese Abgrenzung zwischen Übergabe der operativen Leitung an Verdiente und Übergabe der Aktienposten an den Sohn zu bewerten ist, darüber gehen die Meinungen von außen auseinander; Stan Shih selbst hat sich klar geäußert: Der Eintritt des Sohnes in den Aufsichtsrat diene dazu, „eine langfristig stabile Unterstützungskraft für das professionelle Managementteam des Unternehmens zu werden“[^51].
+
+## Unsichtbare Werte
+
+Worauf Stan Shih sein ganzes Leben wirklich gesetzt hat, sind nicht die Zahlen, die in Bilanzen auftauchen, sondern die Dinge, die er „unsichtbar“ nennt.
+
+Das Konkreteste sind Talente. Er sagt oft: „Mein größter Beitrag für Taiwan ist, eine Bühne zu bieten und viele Talente auszubilden.“[^52] Das ist keine Floskel. In der Frühzeit gab es in Taiwan kaum Unternehmen, die bereit waren, Geld in die Schulung von Mitarbeitern zu stecken, weil die Geschulten oft schnell selbst ein Unternehmen gründeten und zu Konkurrenten wurden. Stan Shihs Haltung aber war: „Die Mitarbeiter machen sich, sobald die Ausbildung abgeschlossen ist, selbstständig und werden zu Wettbewerbern – aber das ist mir egal.“[^53] Acer wurde deshalb zur berühmten „Offiziersakademie der Talente“ der taiwanesischen Tech-Industrie; Generationen von Menschen, die Acer hervorgebracht hatte, verstreuten sich später in die gesamte taiwanesische Elektronikbranche und bildeten neue Verzweigungen.
+
+Ein weiterer unsichtbarer Bereich ist Kunst und Kultur. Dieser Computer-Mann stürzte sich im Alter in die taiwanesische Kulturwelt: 2011 bis 2016 war er Vorsitzender der Nationale Stiftung für Kultur und Kunst[^54]; seit 2021 übernahm er den Vorsitz der Cloud Gate Kultur- und Kunststiftung[^55]; er ist zudem Ehrenvorsitzender des Taiwan Excellent Brand Association und Vorsitzender des Unterstützervereins des OneSong Orchester[^56]. Seine Erklärung dafür ist sehr repräsentativ für seine Weltsicht: „Kultur und Kunst schaffen einen impliziten Zukunftswert; ich möchte, dass dieser Wert von der Öffentlichkeit konkreter wahrgenommen wird.“[^57]
+
+Und wenn von „unsichtbaren Werten“ die Rede ist, kommt man an seiner Beziehung zu TSMC nicht vorbei. 2000 lud Morris Chang Stan Shih ein, unabhängiges Vorstandsmitglied von TSMC zu werden – 21 Jahre lang, bis 2021 trat er zurück, zwischendurch auch als Vorsitzender des Vergütungsausschusses[^58]. Der erstaunliche Bestand an TSMC-Aktien in seiner Hand stammt größtenteils aus dem Aktientausch, als Deqi damals an TSMC verkauft wurde[^59]. Anfang 2026, bei einer öffentlichen Gelegenheit, fragte jemand, wie viele TSMC-Aktien er eigentlich habe; seine Antwort war ganz er selbst: „So viele, dass ich selbst nicht weiß, wie viele es sind.“[^60]
+
+Doch er betrachtet diese Aktien nie als Spekulationsvermögen. Er sagte: „Ich halte Aktien für Immobilien; ich kaufe und verkaufe keine Aktien, ich nehme nur die Dividenden und halte langfristig.“[^61] Das ist nicht nur Gerede. 2021 spendete er 500 TSMC-Aktien samt fünfjähriger Bardividenden an die National Yang Ming Chiao Tung University – mit der ausdrücklichen Anweisung, nur die Dividenden zu spenden, das Aktienkapital nicht anzufassen; in seinen Worten: das „Mutterkapital“ nicht anzurühren[^62]. Selbst beim Spenden praktizierte er die Logik „das Implizite nehmen, das Langfristige behalten“.
+
+> 💡 **Wussten Sie?** Stan Shih, der sein Leben lang für eine Marke kämpfte: Die Marktkapitalisierung von Acer war nie besonders groß. Am selben Handelstag, dem 6. Juli 2026, betrug die Marktkapitalisierung von TSMC rund 64,44 Billionen NT$, die von Acer rund 99,97 Milliarden NT$ – ein Unterschied von über dem Sechshundertfachen[^63]. Interessant daran: Stan Shih weicht dieser Kluft nie aus. Er sagte auf Englisch wörtlich: „If we are talking about making money, we are not good as TSMC.“ In Bezug auf Geldverdienen sind wir TSMC nicht gewachsen. Aber er fügte sofort die zweite Hälfte an: Was den Beitrag und Einfluss auf die Hochtechnologie-Industrie betrifft, glaubt er, dass Acer eine sehr wichtige Rolle gespielt hat[^64]. Schon lange hat er mit seinem eigenen Rahmen „explizit vs. implizit“ eine Antwort auf diese Kluft gefunden: Geld zu verdienen ist explizit, Talente und Einfluss sind implizit – und auf Letzteres hat er sein Leben lang gesetzt.
+
+Er brachte diese Entscheidung sogar auf einen Satz: „Wenn ich mir ein Leben lang nur vorgenommen hätte, Geld zu verdienen, hätte ich heute viel mehr Geld als sie.“[^65] In diesem Satz liegt keine Bosheit, nur ein Mensch, der genau weiß, was er verfolgt. Was er wollte, war nie die schönste Zahl in der Bilanz.
+
+## Ein Avatar namens Adan
+
+Im Jahr 2026 ist Stan Shih 81 Jahre alt.
+
+Mit seiner Gesundheit steht es längst nicht mehr zum Besten: Im Herzen stecken über zehn Stents, dazu kamen Herzinfarkt und Schlaganfall und zweimal war er in Lebensgefahr[^65b]. Doch an Rückzug denkt er überhaupt nicht. Er sagte gegenüber Journalisten unverblümt: „Gegenwärtig genieße ich das Leben; auch wenn andere meinen, die Herausforderungen seien nicht wenige – ein Leben ohne Herausforderungen ist langweilig.“[^66] Und er scherzte halb im Ernst, mit Hilfe der KI-Technologie habe er die Zuversicht, 120 Jahre alt zu werden[^67].
+
+Sein ungewöhnlichstes Werk im Alter aber ist, dass er sich selbst „hergestellt“ hat: einen KI-Avatar namens „Adan“.
+
+Sein Team fütterte sämtliche seiner chinesischen und englischen Schriften und Artikel in eine Wissensbasis; Stan Shih selbst nahm persönlich an mehreren Trainingsrunden mit Frage-Antworten teil, und so entstand eine KI-Version von Stan Shih, die Fragen beantworten kann. Im Januar 2026 ging Adan offiziell im GPT Store online – weltweit kostenlos nutzbar[^68]. Er veröffentlichte sogar ein neues Buch, „Der Erwachensmoment eines Führers: Stan-Papa im Dialog mit der KI“, dessen Inhalt zu neunzig Prozent von diesem KI-Avatar geschrieben wurde; es versammelt 30 Frage-Antwort-Runden, und eine der Fragen lautet genau: „Wie möchtest du, dass die Leute dich in Erinnerung behalten?“[^69]
+
+Denken Sie einmal darüber nach, was das bedeutet: Ein Mann, der sein Leben lang über „implizite Werte“, „Immaterielles“ und „Zukunft“ sprach – über die Dinge, die man nicht sehen und erst viel später ausrechnen kann – verwandelte sich am Ende selbst in ein unsichtbares, aber fortbestehendes Sein. Wenn der Ingenieur, der den Micro-Professor I baute, der Unternehmer, der die Smile Curve vorbrachte, der alte Aufsichtsratsvorsitzende, der über hundert Milliarden verlor und dabei lächelte, eines Tages nicht mehr ist, wird ein Avatar namens Adan irgendwo in der Cloud langsam und immer wieder die Fragen fremder Menschen beantworten.
+
+Von jenem kleinen Computer von 1981, der sich wie ein Buch schließen ließ und um den sich amerikanische Händler drängten, bis zu diesem KI-Avatar von 2026, der im GPT Store sitzt und von jedem etwas fragen lässt, liegen fünfundvierzig Jahre. Vor fünfundvierzig Jahren wollte er, dass die Welt einen in Taiwan gebauten Computer sieht; fünfundvierzig Jahre später will er, dass die Welt eine taiwanesische Art des Denkens in Erinnerung behält.
+
+Er plant, mit 85 Jahren ein zweites Mal in den Ruhestand zu gehen[^70], die Vorsitze seiner gewinnorientierten Unternehmen abzugeben und weiter Wohltätigkeit zu betreiben. Doch wie er in den letzten Jahren aussieht – in Japan ein neues Königsweg-Weißbuch vorstellen, den KI-Avatar online bringen, Interview um Interview annehmen –, wird sich dieses Datum wohl noch weiter nach hinten verschieben.
+
+Das Kind, das in Lukang zusah, wie seine Mutter Enteneier verkaufte, blieb bis zum Schluss der Gärtner, der einen ganzen Garten pflanzen wollte.
+
+**Weiterführende Lektüre:** [Morris Chang](/de/people/tsmc-morris-chang) – der Mann, der Stan Shih für 21 Jahre in den TSMC-Vorstand holte und einen anderen Weg der taiwanesischen Technologie verfolgte. Acer (die Marke, die Stan Shih gründete und auf die Weltbühne führte – hier ihre eigene, vollständige Geschichte): derzeit nur auf Chinesisch verfügbar. TSMC (das Unternehmen, das „Mittelsegment-Fertigung“ betreibt und doch zum „beschützenden Nationalberg“ wurde – zugleich der Ort, an dem Stan Shih die meisten Aktien hält): derzeit nur auf Chinesisch verfügbar. Taiwans industrieller Wandel und Aufstieg (hinter der Smile Curve und dem Königsweg liegt Taiwans vierzigjähriger Weg zwischen Fertigung und Marke): derzeit nur auf Chinesisch verfügbar. Huang Chung-jen (das 1989 von Acer und Texas Instruments gegründete Gemeinschaftsunternehmen Deqi Semiconductor war Taiwans erste DRAM-Fabrik, fünf Jahre vor seiner Powerchip): derzeit nur auf Chinesisch verfügbar.
+
+## Bildnachweis
+
+- **Titelbild / Stan Shih (2014)**: Foto von Tony Tseng, Taiwan IT Month 2014, CC BY 2.0. Quelle [Flickr](https://www.flickr.com/photos/tonytseng/).
+- **Micro-Professor I (MPF-I, 1981)**: Foto von Joho345, Public Domain. Quelle Wikimedia Commons.
+- **Smile-Curve-Diagramm**: erstellt von Rico Shen, CC BY-SA 4.0. Quelle Wikimedia Commons.
+- **Stan Shih (2007, Abschnitt Scheitern/Offenheit)**: Foto von Rico Shen, CC BY-SA 3.0. Quelle Wikimedia Commons.
+
+## Quellenangaben
+
+[^1]: [Bao Shiguang: 1981 baute Stan Shih den ersten selbst entwickelten Computer „Micro-Professor I“](https://time.udn.com/udntime/story/122390/9424956) — Sonderartikel der United Daily News (2026-04-13): Im September 1981 reiste Acer mit dem Micro-Professor I zur 30. Western Electronics Show (WESCON) nach San Francisco.
+
+[^2]: [Wikipedia: Micro-Professor I](https://zh.wikipedia.org/zh-tw/%E5%B0%8F%E6%95%99%E6%8E%88%E4%B8%80%E5%8F%B7) — Die chinesische Wikipedia hält fest: Der Micro-Professor I (MPF-I) basiert auf dem Z80, das Gehäuse wurde in Vakuumformung aus Kunststoff hergestellt; „Wenn das Gehäuse geschlossen ist, kann es zum bequemen Verstauen ins Regal gestellt werden und sieht aus wie ein gewöhnliches Buch“.
+
+[^3]: [Bao Shiguang: 1981 baute Stan Shih den ersten selbst entwickelten Computer „Micro-Professor I“](https://time.udn.com/udntime/story/122390/9424956) — wie zuvor; diese WESCON hatte 14 Länder und über 500 Aussteller.
+
+[^4]: [Bao Shiguang: 1981 baute Stan Shih den ersten selbst entwickelten Computer „Micro-Professor I“](https://time.udn.com/udntime/story/122390/9424956) — wie zuvor; wörtlich: „Vor Ort erkundigten sich rund 20 amerikanische Elektronik-Händler aktiv nach den Vertriebsrechten“.
+
+[^5]: [National Yang Ming Chiao Tung University: Hervorragender Alumnus Stan Shih](https://sec.nycu.edu.tw/sec/ch/app/data/view?module=nycu0044&id=85&serno=29043e87-35f7-4d90-a7f5-102a276e31ce) — Offizielle Seite der NYCU für herausragende Alumni; bestätigt wörtlich seinen Werdegang: Bachelor Elektrotechnik an der Chiao-Tung-Universität (1968), Master am Institut für Elektrotechnik (1971).
+
+[^6]: [National Yang Ming Chiao Tung University: Hervorragender Alumnus Stan Shih](https://sec.nycu.edu.tw/sec/ch/app/data/view?module=nycu0044&id=85&serno=29043e87-35f7-4d90-a7f5-102a276e31ce) — wie zuvor; verzeichnet seine Posten als stellvertretender Leiter bei Huan Yu Electronics (Aug. 1971 – Aug. 1972) und als Leiter bei Rungtai (Sept. 1972 – Sept. 1976); weitere Quellen halten fest, dass er bei Huan Yu Taiwans ersten Tischrechner entwickelte und bei Rungtai Taiwans ersten Taschenrechner sowie die erste elektronische Armbanduhr der Welt mitentwickelte.
+
+[^7]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — Die chinesische Wikipedia hält wörtlich fest: „1976 gründete Stan Shih gemeinsam mit seiner Frau Yeh Tzu-hua und den Partnern Tai Chung-ho, Lin Chia-ho, Huang Shao-hua und anderen Acer; das anfängliche registrierte Stammkapital betrug 1 Million NT$“, ursprünglicher Name Multitech. Einige Berichte nennen „sieben Partner“, die Zahl der Gründer variiert je nach Quelle; daher heißt es hier „und anderen“.
+
+[^8]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — wie zuvor; bei der Acer-Gründung bezeichnete er sich selbst als „Gärtner des Mikroprozessors“.
+
+[^9]: [Wikipedia: Micro-Professor MPF-I](https://en.wikipedia.org/wiki/Micro-Professor_MPF-I) — Die englische Wikipedia hält wörtlich fest: Am 24. Februar 1993 verkaufte Acer die MPF-I-Produktlinie an Flite Electronics International Ltd. in Southampton, England; „As of 2021, Flite continues manufacturing small batches of the MPF1B“ – 2021 wurde weiter in kleinen Stückzahlen produziert, also rund 40 Jahre seit der Markteinführung 1981.
+
+[^10]: [udn Blog: Stan Shihs Herkunft und die Räucherstäbchen-Familie von Lukang](https://blog.udn.com/roselai38/1085192) — Recherche: Stan Shih stammt aus der Lukang-Räucherstäbchen-Familie „Shih Mei-yu“; der Vorfahr Shih Chih-ting gründete 1774 (39. Jahr der Qianlong-Ära) in Jinjiang, Fujian, einen Räucherstäbchen-Laden; der Vater Shih Chi-shen war der sechste Generationen-Nachfolger – deckungsgleich mit der chinesischen Wikipedia.
+
+[^11]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — Die chinesische Wikipedia hält wörtlich fest: „Sein Vater Shih Chi-shen, der sechste Generationen-Nachfolger des Ladenbetriebs, starb an Überarbeitung, als Stan Shih drei Jahre alt war.“
+
+[^12]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — wie zuvor, wörtlich: „Seine Mutter Shih Chen Hsiu-lien stammte aus Puli im Kreis Nantou und weigerte sich nach dem Tod ihres Mannes entschieden, wieder zu heiraten … 1953 wurde die Familie geteilt, Shih Chen Hsiu-lien erhielt einen Laden und verdiente ihren Lebensunterhalt mit Enteneiern, Schreibwaren, Gemischtwaren, patriotischen Losen usw.; auch nahm sie Strickarbeit an, um das Einkommen aufzubessern.“
+
+[^13]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — Kolumne von Kuo I-ling, Business Weekly (2022-04-28), wörtlich: „Taiwan hat keinen Mangel an Talenten, nur an Bühnen, weil wir keine Bühnen haben, auf denen sie sich erproben können.“
+
+[^14]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — Die chinesische Wikipedia hält fest: Acer kam 1987 an die Börse und wurde in Acer umbenannt.
+
+[^15]: [iThome: Acers erste Umgestaltung und die Client-Server-Architektur](https://www.ithome.com.tw/node/6917) — iThome-Fachartikel: Nachdem Acer 1992 in der ersten Umgestaltung die Client-Server-Architektur vorantrieb, überschritt der Umsatz 1993 die 50-Milliarden-Marke, 1995 die 150-Milliarden-Marke, und Acer stieg zum siebtgrößten PC-Hersteller der Welt auf.
+
+[^16]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — Die chinesische Wikipedia hält wörtlich fest: „1992, beim Vorantreiben der Acer-Umgestaltung, brachte Stan Shih die Smile-Curve-Theorie vor“; die Smile Curve erschien erstmals in seinem Buch _Acer: Die Umgestaltung_.
+
+[^17]: [Stan Foundation: Die Smile Curve von 1992](https://stansfoundation.org/articles/bdfb93) — Offizielle Seite der Stan Foundation, wörtlicher Volltext der dreiteiligen Definition und Stan Shihs eigene Darstellung, er habe die Acer-Kollegen überzeugt, „die Montage in Taiwan aufzugeben und sich auf spezialisierte Bereiche mit höherem Mehrwert zu konzentrieren“.
+
+[^18]: [Wikipedia: Smiling curve](https://en.wikipedia.org/wiki/Smiling_curve) — Die englische Wikipedia hat einen Abschnitt „Academic contributions“: Die Smile Curve wird in der GVC-Literatur als Analyse-Rahmen verwendet, etwa in Meng Bo, Ye, Wei (2020) im Oxford Bulletin of Economics and Statistics und Baldwin & Ito (2021) im Canadian Journal of Economics – peer-reviewte Arbeiten prüfen sie fortlaufend.
+
+[^19]: [Wikipedia: Musashi-Kurve](https://zh.wikipedia.org/zh-hant/%E6%AD%A6%E8%97%8F%E6%9B%B2%E7%B7%9A) — Die chinesische Wikipedia hält fest: Die Musashi-Kurve wurde 2004 von Suehiro Nakamura, Leiter des Nakamura-Forschungsinstituts bei Sony, auf Basis einer Untersuchung von 400 japanischen Fertigungsunternehmen vorgeschlagen; sie behauptet, „Fertigung/Montage“ habe den höchsten Gewinnsatz – „in den Eigenschaften dem anderen bekannten Konzept, der Smile Curve, völlig entgegengesetzt“. Benannt nach Miyamoto Musashis Zweischwert-Stil.
+
+[^20]: [Mingrentang (Jamie Lin): Vom historischen Beitrag der Smile Curve zu den Transformationshemmnissen der taiwanesischen Wirtschaft](https://opinion.udn.com/opinion/story/5756/101747) — Kolumne von Jamie Lin, Mitgründer von AppWorks, vom 08.08.2014; kritisiert wörtlich, Taiwan habe die Smile Curve verbogen; die wahre Lebensader einer Marke liege in „Marketingaktivitäten und den dahinterstehenden Daten und Plattformen“; TSMC wird in dem Text nicht erwähnt.
+
+[^21]: [Asia Times: How US manufacturing was gutted with a smile](https://asiatimes.com/2025/12/how-us-manufacturing-was-gutted-with-a-smile/) — Kommentar von Han Feizi vom 21.12.2025; nennt Stan Shih und Acer namentlich und argumentiert mit der „Holländischen Krankheit“ und dem „Baumol-Gesetz“, die Smile Curve unterschätze die Fertigung systematisch; ausgelagerte Fertigung sei in Wahrheit „the hardest, highest-skilled and most difficult to replicate part“.
+
+[^22]: [Stan Foundation: Die neue Smile Curve](https://stansfoundation.org/articles/0828c8) — Offizielle Seite der Stan Foundation, wörtlich, Stan Shih persönliche Korrektur: „Verstehen Sie die ‚Smile Curve‘ nicht falsch – sie bedeutet nicht, die Fertigung aufzugeben. Der Mehrwert ist zwar relativ gering, aber die Fertigung ist groß im Maßstab; in der Summierung bleibt sie wertvoll. Nur vor Angebotsüberschuss muss man sich hüten.“
+
+[^23]: [Stan Foundation: Die neue Smile Curve](https://stansfoundation.org/articles/0828c8) — wie zuvor; Stan Shih ergänzt wörtlich, diese Fehllektüre der Smile Curve als Aufgabe der Fertigung „könnte einer der Gründe für die massenhafte Abwanderung der produzierenden Betriebe Taiwans in den letzten fast zwanzig Jahren sein“.
+
+[^24]: [Stan Foundation: Die neue Smile Curve](https://stansfoundation.org/articles/0828c8) — wie zuvor; Stan Shih zeichnete 2019 die „neue Smile Curve“ mit drei Achsen X (obere/mittlere/untere Wertschöpfung), Y (Mehrwert), Z (Branchenbereich) plus Zeitachse, materiell/immateriell-Achse und direkt/indirekt-Achse; laut ETtoday wurde sie am 11.02.2019 bei der Neujahrsfeier im Wohnhaus im Bezirk Da’an vorgestellt.
+
+[^25]: [Digitimes: Acer-Chenboa Super TaiRa und die neue Smile Curve](https://www.bnext.com.tw/article/51988/acer-lora-super-taira) — Digitimes (2019-01-18): Stan Shih gibt zu, die neue Smile Curve sei „schwer zu zeichnen, noch nicht gezeichnet“, und verwendet Chenboa Super TaiRa (LoRa-Chip, Bruttomarge 30–40 Prozent) als Beispiel für impliziten Wert.
+
+[^26]: [Stan Foundation: Kernidee (Königsweg)](https://stansfoundation.org/about_pages/adde94) — Offizielle Website der Stan Foundation, wörtlich: die drei Kernüberzeugungen des Königswegs „Wert schaffen, Interessen ausgleichen, nachhaltig wirtschaften“; ESG Global Views hält zusätzlich fest, dass Stan Shih den Königsweg als „Führungskunst großer wie kleiner Organisationen“ definiert (nicht wörtlich als Kaiserweg) und 2011 eine Sechs-Dimensionen-Wertbilanz-Theorie vorlegte.
+
+[^27]: [Stan Foundation: Kernidee (Königsweg)](https://stansfoundation.org/about_pages/adde94) — wie zuvor; expliziter Wert ist „materiell, direkt, gegenwärtig“ (also ob man Geld verdient), impliziter Wert ist „immateriell, indirekt, zukünftig“ (Marke, Marketing, Dienstleistungen, Talente usw.).
+
+[^28]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — Kolumne von Kuo I-ling, Business Weekly, wörtlich: „Die gesamte taiwanesische Gesellschaft legt zu viel Wert auf den expliziten Wert (ob man Geld verdient).“
+
+[^29]: [Manager Today: Acer erlitt dreimal schwere Rückschläge, er drehte es dreimal](https://www.managertoday.com.tw/articles/view/67666) — Manager Today (2023-11-08): Acer gründete 1989 gemeinsam mit Texas Instruments das DRAM-Unternehmen Deqi Semiconductor.
+
+[^30]: [Global Views Monthly: Stan Shih zieht erneut den Umhang an, um Deqi neu aufzubauen](https://www.gvm.com.tw/article/5586) — Global Views (Ausgabe Januar 1999), wörtlich: Deqi „stellte auch 1997 den Rekord des höchsten Verlusts eines einzelnen Unternehmens auf, in zwei Jahren beliefen sich die Verluste auf fast zehn Milliarden NT$“; MoneyDJ verzeichnet zusätzlich über 5 Milliarden NT$ Verlust in den Jahren 1997 und 1998.
+
+[^31]: [TSMC: Fusion von TSMC und Deqi Semiconductor](https://pr.tsmc.com/chinese/news/2548) — Offizielle Pressemitteilung von TSMC zu den Einzelheiten der Eingliederung Deqis; laut TSMC-Pressemitteilung news/2512 erwarb TSMC im Juni 1999 zunächst für rund 5,47 Milliarden NT$ bzw. 9,5 NT$ pro Aktie 30 Prozent an Deqi und vollendete die Fusion am 7. Juli 2000 per Aktientausch (gleichzeitig mit der Eingliederung von Worldwide Semiconductor).
+
+[^32]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — Kolumne von Kuo I-ling, Business Weekly, wörtlich: „Als Deqi (Acers Beteiligung) früher 5 Milliarden verlor, schrieben die Medien, ich sei im 5-Milliarden-Club“, „ich habe immer als Erster die Marke geknackt (Rekordverluste aufgestellt)“.
+
+[^33]: [NOWnews: Stan Shih lacht über den Verkauf von Deqi Semiconductor an TSMC](https://www.nownews.com/news/6517208) — NOWnews hält aus Stan Shihs Rede an der Changhua-Oberschule wörtlich fest: „Damals nannten mich Leute im Netz ein Schwein, und ich sagte: Schweine sind auch sehr klug.“ Er fügte hinzu: „Den Deqi-Kollegen bei TSMC ging es später sehr gut, und die Aktionäre haben viel Geld verdient.“
+
+[^34]: [Manager Today: Acer erlitt dreimal schwere Rückschläge, er drehte es dreimal](https://www.managertoday.com.tw/articles/view/67666) — Manager Today (2023-11-08), wörtlich: „Immer wieder zu scheitern und weiterzukämpfen ist ein guter Geist, aber kämpfe keine Schlachten, die du nicht verlieren kannst.“ Kontext: am Beispiel der Deqi-DRAM-Investition als Überlegung zum Umgang mit Hochrisiko-Investitionen.
+
+[^35]: [Business Today: Rückblick auf Lancis Acer-Jahre nach seinem Tod](https://www.businesstoday.com.tw/) — Bericht von Business Today vom 02.02.2023 zu Lancis Tod: Unter Lanci stieg Acer in Europa vom achten Platz bei den PC-Verkäufen auf den vierten, bei Notebook-Marken auf den zweiten; 2010 wurde Acer zeitweise zur zweitgrößten PC-Marke der Welt.
+
+[^36]: [Liberty Times Finanzen: allthingsd-Kreuzcheck / Lancis Abgang und Lagerverluste](https://ec.ltn.com.tw/article/paper/1327913) — Liberty Times Finanzen: Lancis Mengenstrategie führte zu Überlagerbeständen in Europa; allthingsd (22.06.2012) bestätigt „inventory ‚abnormalities‘ that forced the company to take a one-time $150 million write-off“ – deckungsgleich mit „150 Millionen US-Dollar“.
+
+[^37]: [Coolworker: Die Hintergründe von Stan Shihs Absetzung Lancis](https://ec.ltn.com.tw/article/paper/1327913) — Zusammenfassender Bericht: Stan Shih konnte als Gründer und größter Aktionär in der Aufsichtsratsabstimmung „drei Stimmen beeinflussen“ und unterstützte die Wang Chen-tang-Fraktion, sodass Lanci am 31.03.2011 ausschied; Zeitachse: 25. März Prognosesenkung, 28. März offene Konfrontation, 31. März Lancis Rücktritt.
+
+[^38]: [Liberty Times Finanzen: Acer zahlte 1,284 Milliarden NT$, um Lanci zu verabschieden](https://ec.ltn.com.tw/article/paper/1327913) — Liberty Times Finanzen, wörtlich: „2011 verabschiedete sich Acer mit der Rekordzahl von 1,284 Milliarden NT$ von Lanci“; allthingsd bestätigt eine Abfindung von rund 42,9 Millionen US-Dollar (impliziter Kurs etwa 29,9 TWD/USD – beide Angaben stimmen hochgradig überein), ein Rekord in der PC-Industrie.
+
+[^39]: [Liberty Times Finanzen: Acers Verluste 2011](https://ec.ltn.com.tw/article/paper/1327913) — Liberty Times Finanzen: Acer verlor im Gesamtjahr 2011 6,601 Milliarden NT$ und strich zusätzlich 4,3 Milliarden NT$ an Wertminderungen auf Lagerbestände ab.
+
+[^40]: [ETtoday Finanzen: Acers Abschreibungen im Q3-2013-Bericht](https://finance.ettoday.net/news/291407) — ETtoday (2013), wörtlich: „Der Gesamtbetrag der Wertminderungen immaterieller Vermögenswerte im dritten Quartal 2013 belief sich auf 9,943 Milliarden NT$, wobei die Abschreibungen hauptsächlich von der Marke Gateway stammten“; operativer Quartalsverlust 2,57 Milliarden NT$, Nettverlust nach Steuern 13,12 Milliarden NT$, EPS −4,82 NT$; der kumulierte Jahresverlust betrug 20,579 Milliarden NT$ (einschließlich Lagerverlusten im vierten Quartal) — der größte Verlust in den 38 Jahren von Acer.
+
+[^41]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — Kolumne von Kuo I-ling, Business Weekly (2022-04-28), wörtlich: „Ich bin der größte Verlierer (er hält die meisten Acer-Aktien), aber ich bereue es nie.“
+
+[^42]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — wie zuvor, wörtlich: „Das ist das Schulgeld, das Acer auf dem Weg zu einem weltweit führenden multinationalen Unternehmen notwendigerweise zahlen musste. Ich habe nicht nur zwanzig Milliarden gezahlt, ich habe über hundert Milliarden gezahlt.“ „Über hundert Milliarden“ ist eine selbst beschreibende Rhetorik aus dem Interview, keine geprüfte Zahl.
+
+[^43]: [NOWnews: Stan-Shih-Interview und die dritte Acer-Umgestaltung](https://www.nownews.com/news/2793124) — NOWnews-Interview mit Stan Shih, wörtlich: „2013 fiel Acer auf den Tiefpunkt; im November jenes Jahres meldete Acer für das dritte Quartal einen Nettoverlust von 13,12 Milliarden NT$ … Aufsichtsratsvorsitzender Wang Chen-tang und CEO Weng Chien-jen traten beide zurück.“
+
+[^44]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — Die chinesische Wikipedia hält wörtlich fest: „Am 21. November 2013 gab Acer bekannt, dass Aufsichtsratsvorsitzender Wang Chen-tang und Geschäftsführer Weng Chien-jen … beide zurücktraten, um Verantwortung zu übernehmen. Stan Shih übernahm erneut das Amt des Aufsichtsratsvorsitzenden und kommissarisch das des globalen Präsidenten und leitete das dritte Umgestaltungsprojekt von Acer ein.“
+
+[^45]: [Global Views Monthly: Der 81-jährige Stan Shih schafft unentwegt neue Maßstäbe](https://www.gvm.com.tw/article/127819) — Global Views (2026-01-30), wörtlich: „Immer wieder zurück ins Amt – soll ich etwa aus dem Sarg kriechen?“
+
+[^46]: [Global Views Monthly #127819: Interview mit dem 81-jährigen Stan Shih](https://www.gvm.com.tw/article/127819) — wie [^45], wörtlich das Titelzitat: „Arbeit kann man auslagern, Verantwortung nicht.“
+
+[^47]: [CommonWealth: Jason Chen führte Acer von 20,5 Milliarden Verlust zu hundert Milliarden Profit](https://www.cw.com.tw/article/5121738) — CommonWealth: Jason Chen trat 2014 als CEO an, fokussierte mit der „Kleinen-Tiger-Truppe“-Strategie auf E-Sport (Predator, Nitro) und Schul-Chromebooks, richtete eine eigene Forschungseinheit ein und jagte nicht mehr Marktanteilen durch Preisunterbietung nach.
+
+[^48]: [CommonWealth: Jason Chen führte Acer von 20,5 Milliarden Verlust zu hundert Milliarden Profit](https://www.cw.com.tw/article/5121738) — wie zuvor; 2021 überschritt der Acer-Umsatz wieder 300 Milliarden NT$, der Nettogewinn nach Steuern lag bei 10,8 Milliarden, das EPS bei 3,63 NT$ – allesamt neue Höchststände der letzten Jahre; die Marktkapitalisierung des Konzerns wuchs von gut 50 Milliarden vor Chens Amtsantritt auf fast 100 Milliarden.
+
+[^49]: [Central News Agency: Stan Shih über Stan Shih Hsuan-huis Eintritt in Acer](https://www.cna.com.tw/news/afe/201910030333.aspx) — CNA (03.10.2019): Stan Shihs Nachfolgeprinzip lautet „Weitergabe an Verdiente, nicht an Söhne“; die drei Übergaben von 2004 bis 2017 (Lanci, Wang Chen-tang, Jason Chen) gingen allesamt an professionelle Manager, nie an Familienmitglieder.
+
+[^50]: [Digitimes: Stan Shih Hsuan-hui wechselt in den Acer-Aufsichtsrat](https://www.bnext.com.tw/article/54148) — Digitimes (26.07.2019): Stan Shih Hsuan-hui kam 2011 durch die Acer-Übernahme von iGware ins Unternehmen und trat am 26. Juli 2019 offiziell von seinem Managementposten zurück, um Direktor zu werden; die Position ist als „die Aktionäre der Familie vertretender Aufsichtssitz“ definiert, CEO blieb der professionelle Manager Jason Chen.
+
+[^51]: [Digitimes: Stan Shih Hsuan-hui wechselt in den Acer-Aufsichtsrat](https://www.bnext.com.tw/article/54148) — wie zuvor, wörtlich: „Meine Familie vollzieht gerade die Nachfolgeübertragung des ‚Aktienbesitzes‘; in Zukunft wird Hsuan-hui meine Familie vertreten und eine langfristig stabile Unterstützungskraft für das professionelle Managementteam des Unternehmens werden.“
+
+[^52]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — Kolumne von Kuo I-ling, Business Weekly, wörtlich: „Mein größter Beitrag für Taiwan ist, eine Bühne zu bieten und viele Talente auszubilden.“
+
+[^53]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — wie zuvor, wörtlich: „Früher wollte in Taiwan niemand Mitarbeiter schulen; sobald die Schulung abgeschlossen war, machten sie sich selbstständig und wurden zu Konkurrenten – aber das ist mir egal.“
+
+[^54]: [Wikipedia: Stan Shih](https://zh.wikipedia.org/wiki/%E6%96%BD%E6%8C%AF%E6%A6%AE) — Die chinesische Wikipedia hält fest: Stan Shih war von 2011 bis 2016 Vorsitzender der Nationalen Stiftung für Kultur und Kunst.
+
+[^55]: [Informationsnetz nationaler Kulturstiftungen: Cloud Gate Kultur- und Kunststiftung](https://cnpo.moc.gov.tw/) — Amtliche Registerdaten: Stan Shih wurde am 13.07.2021 (Minguo 110) als Vorsitzender der 12. Amtszeit der Cloud Gate Kultur- und Kunststiftung registriert; Forbes sagt zudem, er habe seit 2018 die Cloud-Gate-Angelegenheiten geleitet – beide Darstellungen existieren nebeneinander.
+
+[^56]: [VERSE: Stan Shih über impliziten Zukunftswert](https://www.verse.com.tw/article/shi-zhen-rong) — VERSE-Interview: Stan Shihs Titel umfassen Ehrenvorsitzender des Taiwan Excellent Brand Association, Vorsitzender des Unterstützervereins des OneSong Orchester, Koordinator der Kultur- und Technologie-Entwicklungsallianz u. a.; der Unterstützerverein des OneSong Orchester wurde am 24.06.2018 gegründet.
+
+[^57]: [VERSE: Stan Shih über impliziten Zukunftswert](https://www.verse.com.tw/article/shi-zhen-rong) — wie zuvor, wörtlich: „Kultur und Kunst schaffen einen impliziten Zukunftswert; ich möchte, dass dieser Wert von der Öffentlichkeit konkreter wahrgenommen wird.“
+
+[^58]: [Manager Today: Stan Shih über unabhängige TSMC-Vorstände](https://www.managertoday.com.tw/topic/view/196/post/70146) — Manager Today: Stan Shih war von 2000 bis 2021 unabhängiges TSMC-Vorstandsmitglied und leitete zeitweise den Vergütungsausschuss; die CNA berichtet zusätzlich, dass er 2000 von TSMC-Gründer Morris Chang eingeladen wurde und nach der Hauptversammlung 2021 offiziell ausschied – 21 Jahre Amtszeit.
+
+[^59]: [China Times: Stan Shih über seinen TSMC-Aktienbestand](https://www.chinatimes.com/realtimenews/20260224002810-260404) — China Times (24.02.2026): Sein TSMC-Aktienbestand „stammt größtenteils aus dem Tausch, als er Deqi Semiconductor an TSMC verkaufte“; eine einzelne Quelle (ETtoday) schreibt „mit Acer-Aktien getauscht“ – die meisten Quellen folgen der Deqi-Tausch-Version.
+
+[^60]: [Economic Daily News: Stan Shih weiß nicht, wie viele TSMC-Aktien er hat](https://money.udn.com/money/story/5612/9341762) — Economic Daily News (24.02.2026), wörtlich: „So viele, dass ich selbst nicht weiß, wie viele es sind.“ China Times und ETtoday stimmen wörtlich überein.
+
+[^61]: [China Times: Stan Shih über seinen TSMC-Aktienbestand](https://www.chinatimes.com/realtimenews/20260224002810-260404) — China Times, wörtlich: „Ich halte Aktien für Immobilien; ich kaufe und verkaufe keine Aktien, ich nehme nur die Dividenden und halte langfristig.“
+
+[^62]: [Liberty Times Finanzen: Stan Shih spendet 500 TSMC-Aktien samt 5-Jahres-Dividenden an die NYCU](https://ec.ltn.com.tw/article/breakingnews/3625184) — Liberty Times Finanzen (02.08.2021), wörtlich: Spende „der Bardividenden von 500 TSMC-Aktien für einen Zeitraum von 5 Jahren“; er betonte ausdrücklich, nur die Dividenden zu spenden und das Aktienkapital nicht anzufassen – das „Mutterkapital“.
+
+[^63]: [Yahoo Finance Taiwan: Marktkapitalisierung von TSMC und Acer (06.07.2026)](https://tw.stock.yahoo.com/quote/2330.TW) — Berechnet aus den Aktienkursen desselben Tages (6. Juli 2026) und den ausgegebenen Aktienzahlen: TSMC (2330) rund 64,44 Billionen NT$, Acer (2353) rund 99,97 Milliarden NT$ – ein Unterschied von über dem Sechshundertfachen.
+
+[^64]: [Forbes: Stan Shih Led Acer's March to a Top-Five Global PC Brand](https://www.forbes.com/sites/russellflannery/2024/02/16/stan-shih-led-acers-march-to-a-top-five-global-pc-brand-whats-he-doing-now/) — Forbes-Personeninterview (16.02.2024), wörtlich Stan Shihs englische Originalworte: „If we are talking about making money, we are not good as TSMC“, ergänzt um: Was Beitrag und Einfluss auf die Hochtechnologie-Industrie betrifft, „I think we played a very important role“.
+
+[^65]: [Business Weekly: Warum Gründer Stan Shih sagt: „Ich bin der größte Verlierer“](https://www.businessweekly.com.tw/management/blog/3009647) — Kolumne von Kuo I-ling, Business Weekly, wörtlich: „Wenn ich mir ein Leben lang nur vorgenommen hätte, Geld zu verdienen, hätte ich heute viel mehr Geld als sie“ (im Original „賺得錢“).
+
+[^65b]: [Global Views Monthly #127819: Interview mit dem 81-jährigen Stan Shih](https://www.gvm.com.tw/article/127819) — Global Views (30.01.2026): Stan Shih hat über zehn Stents im Herzen (der Titel der Ausgabe lautet „14 Stents“, der Text „über zehn“ – hier die konservativere Variante), erlebte zweimal Lebensgefahr, zweimal Herzinfarkt, dazu Schlaganfall.
+
+[^66]: [Global Views Monthly #127819: Interview mit dem 81-jährigen Stan Shih](https://www.gvm.com.tw/article/127819) — wie [^45], wörtlich: „Gegenwärtig genieße ich das Leben; auch wenn andere meinen, die Herausforderungen seien nicht wenige – ein Leben ohne Herausforderungen ist langweilig.“
+
+[^67]: [SETN: Stan-Shih-Interview über das 120-Lebensjahr](https://inews.setn.com/news/1813118) — SETN-Interview mit Stan Shih, wörtlich: „Mit KI-Technologie habe ich die Zuversicht, 120 Jahre alt zu werden!“
+
+[^68]: [Global Views Monthly: Stan Shihs KI-Avatar Adan](https://www.gvm.com.tw/article/127819) — Global Views: Stan Shihs Team legte seine chinesischen und englischen Schriften in eine Wissensbasis, er selbst nahm persönlich an Trainingsrunden mit Frage-Antworten teil; so entstand der KI-Avatar „Adan“, der am 1. Januar 2026 im GPT Store online ging und weltweit kostenlos nutzbar ist.
+
+[^69]: [Global Views Monthly: Stan Shihs KI-Avatar Adan und das neue Buch](https://www.gvm.com.tw/article/127819) — wie zuvor; das neue Buch „Der Erwachensmoment eines Führers: Stan-Papa im Dialog mit der KI“ wurde zu rund neunzig Prozent vom trainierten KI-Avatar geschrieben und enthält 30 Frage-Antwort-Runden, darunter „Wie möchtest du, dass die Leute dich in Erinnerung behalten?“
+
+[^70]: [Global Views Monthly: Stan Shih plant den Ruhestand mit 85](https://www.gvm.com.tw/article/127819) — Global Views: Stan Shih kündigte am 06.12.2024 bei einem Dankeskonzert zum 20. Jubiläum seines Ruhestands an, mit 85 ein zweites Mal in den Ruhestand zu gehen, die Vorsitze seiner gewinnorientierten Unternehmen zu übergeben und weiter Wohltätigkeit zu betreiben; im Juni 2026 war er weiterhin in Japan, um ein neues Königsweg-Weißbuch vorzustellen – kein Anzeichen eines Rückzugs.

--- a/knowledge/de/People/stan-shih.md
+++ b/knowledge/de/People/stan-shih.md
@@ -1,6 +1,6 @@
 ---
 title: 'Stan Shih: Vom Enteneier-Stand in Lukang zu einer Marke namens Taiwan'
-description: 'Stan Shih (geb. 1944 in Lukang), vom Enteneier-Stand zum Weltkonzern: Er baute Acer zu einer der fünf größten PC-Marken auf und zeichnete die international erforschte Smile Curve. Öffentlich sagt er: „Ich bin der größte Verlierer.“ Mit über achtzig Jahren arbeitet er weiter mit Wagniskapital und KI-Avatar. Woran ihm am meisten liegt: unsichtbare Werte – Talente, Marken, der „Königsweg“.‘
+description: 'Stan Shih (geb. 1944 in Lukang), vom Enteneier-Stand zum Weltkonzern: Er baute Acer zu einer der fünf größten PC-Marken auf und zeichnete die international erforschte Smile Curve. Öffentlich sagt er: „Ich bin der größte Verlierer.“ Mit über achtzig Jahren arbeitet er weiter mit Wagniskapital und KI-Avatar. Woran ihm am meisten liegt: unsichtbare Werte – Talente, Marken, der „Königsweg“.'
 date: 2026-03-22
 category: 'People'
 tags:
@@ -241,7 +241,7 @@ Das Kind, das in Lukang zusah, wie seine Mutter Enteneier verkaufte, blieb bis z
 
 [^23]: [Stan Foundation: Die neue Smile Curve](https://stansfoundation.org/articles/0828c8) — wie zuvor; Stan Shih ergänzt wörtlich, diese Fehllektüre der Smile Curve als Aufgabe der Fertigung „könnte einer der Gründe für die massenhafte Abwanderung der produzierenden Betriebe Taiwans in den letzten fast zwanzig Jahren sein“.
 
-[^24]: [Stan Foundation: Die neue Smile Curve](https://stansfoundation.org/articles/0828c8) — wie zuvor; Stan Shih zeichnete 2019 die „neue Smile Curve“ mit drei Achsen X (obere/mittlere/untere Wertschöpfung), Y (Mehrwert), Z (Branchenbereich) plus Zeitachse, materiell/immateriell-Achse und direkt/indirekt-Achse; laut ETtoday wurde sie am 11.02.2019 bei der Neujahrsfeier im Wohnhaus im Bezirk Da’an vorgestellt.
+[^24]: [Stan Foundation: Die neue Smile Curve](https://stansfoundation.org/articles/0828c8) — wie zuvor; Stan Shih zeichnete 2019 die „neue Smile Curve“ mit drei Achsen X (obere/mittlere/untere Wertschöpfung), Y (Mehrwert), Z (Branchenbereich) plus Zeitachse, materiell/immateriell-Achse und direkt/indirekt-Achse; laut ETtoday wurde sie am 11.02.2019 bei der Neujahrsfeier im Wohnhaus im Bezirk Da'an vorgestellt.
 
 [^25]: [Digitimes: Acer-Chenboa Super TaiRa und die neue Smile Curve](https://www.bnext.com.tw/article/51988/acer-lora-super-taira) — Digitimes (2019-01-18): Stan Shih gibt zu, die neue Smile Curve sei „schwer zu zeichnen, noch nicht gezeichnet“, und verwendet Chenboa Super TaiRa (LoRa-Chip, Bruttomarge 30–40 Prozent) als Beispiel für impliziten Wert.
 


### PR DESCRIPTION
# 🇩🇪 de: 施振榮 — Stan Shih (Acer-Gründer)

Deutsche Übersetzung von `knowledge/People/施振榮.md` → `knowledge/de/People/stan-shih.md` (Slug folgt der en-Mirror-Datei).

## Inhalt

Die deutsche Neufassung erzählt das Leben von Stan Shih (geb. 1944): Kindheit am Enteneier-Stand seiner Mutter in Lukang, Gründung von Acer 1976 mit 1 Mio. NT$, der Micro-Professor I von 1981, die Smile Curve von 1992 und ihre internationale Rezeption durch die GVC-Forschung, der Königsweg (王道) mit expliziten/impliziten Werten, der Deqi-Verlust (5-Milliarden-Club), die Rückkehr 2013 zur dritten Acer-Umgestaltung (Verlust 20,579 Mrd. NT$), die Weitergabe an Verdiente statt an Söhne, die TSMC-Aktien und Spende an die NYCU, sowie der KI-Avatar „Adan“ (2026).

Text ist eine Neufassung (keine Wort-für-Wort-Übersetzung), strukturiert nach der en-Mirror-Datei.

## Qualitäts-Gates (alle lokal grün)

- **verify-translation.py: 18/18 ALL PASS**
  - translation ratio 2.71 (akzeptabler Bereich 2.0–4.0)
  - 71 Fußnoten (inkl. [^65b]), 9 Kapitel (H2) identisch mit zh
  - URL exaktes Multiset (73 URLs) von zh beibehalten
  - Passthrough-Frontmatter (10 Felder) byte-identisch mit zh; researchReport/relatedDiary ebenfalls übernommen
  - sourceCommitSha `6ffd92f94` = tatsächlicher aktueller HEAD der zh-Quelldatei (unverändert seit diesem Commit)
  - sourceContentHash/sourceBodyHash via offizieller status.py-Algorithmen berechnet und mit en-Mirror identisch
- **article-health.py (pre-commit): hard=0 warn=0** – alle Checks grün (Fußnotenformat, Dichte, URLs, Bilder 3 inline + 1 hero, Wikilinks, Viz, Subcategory-Parität, SEO-Meta, AI-Residue)
- **CI translation-check-Bedingungen erfüllt** (title/description/translatedFrom vorhanden, >20 Zeilen, de aktiv, keine forbidden phrases)

## Frontmatter-Notizen

- Passthrough-Felder (author/date/featured/lastVerified/lastHumanReview/category/image/imageCredit/lastHumanReview) komplett aus zh übernommen
- `sourceCommitSha: 6ffd92f94` – zh-Quelldatei seit diesem Commit unverändert (verifiziert gegen upstream/main)
- `subcategory: '科技與企業'` unübersetzt (SSOT-Klassifikationsschlüssel für Kategorie-Seiten)
- `imageCredit: 'Tony Tseng'` nicht übersetzt (Passthrough)

## Weiterführende Lektüre (Further Reading)

Nur verlinkt, wo die de-Version existiert: **Morris Chang** (`/de/people/tsmc-morris-chang`) – verlinkt. Acer / TSMC / Industrieller Wandel / Huang Chung-jen: de-Versionen existieren noch nicht → als Klartext geführt (keine toten Links).
