### PR TITLE
🇩🇪 de/People: Puma Shen (沈伯洋) — cognitive warfare scholar, Kuma Academy, marked political candidate

### DIFF
--- a/knowledge/de/People/puma-shen.md
+++ b/knowledge/de/People/puma-shen.md
@@ -1,0 +1,421 @@
+---
+title: 'Puma Shen: Er erforschte Chinas kognitiven Krieg. Dann markierte China ihn auf einer Satellitenkarte'
+description: '2021 gründete Puma Shen die Kuma Academy (NT$600 Mio). 2024 zog er als DPP-Abgeordneter ins Parlament ein. 2025 eröffnete China als erstes Verfahren gegen einen gewählten taiwanesischen Politiker wegen „Staatszerstörung“; CCTV warnte „Du bist der Nächste“. 2026 veröffentlichte ein Weibo-Konto die Satellitenkoordinaten seiner Wohnung; die DPP nominierte ihn für das Bürgermeisteramt von Taipeh.'
+date: 2026-04-27
+category: 'People'
+tags:
+  [
+    'kognitiver Krieg',
+    'Kuma Academy',
+    'Abgeordneter',
+    'Chinas United-Front-Arbeit gegen Taiwan',
+    'Doublethink Lab',
+    'transnationale Unterdrückung',
+    'demokratische Verteidigung',
+  ]
+subcategory: '政治人物'
+author: 'Taiwan.md Contributors'
+difficulty: 'intermediate'
+readingTime: 18
+featured: false
+lastVerified: 2026-06-21
+lastHumanReview: true
+researchReport: reports/research/2026-04/沈伯洋.md
+image: /article-images/people/puma-shen-election-2024.webp
+imageCredit: 曾成訓 / Flickr
+imageLicense: CC BY 2.0
+imageSource: https://commons.wikimedia.org/wiki/File:Puma_Shen_in_2024_Taiwan_general_election.jpg
+translatedFrom: 'People/沈伯洋.md'
+sourceCommitSha: '09ffe560f'
+sourceContentHash: 'sha256:ccbab3f1822e47af'
+sourceBodyHash: 'sha256:ec031917f07c2762'
+sporeLinks:
+  - id: 47
+    platform: 'threads'
+    date: '2026-04-28'
+    url: 'https://www.threads.com/@taiwandotmd/post/DXqRxf5EQpg'
+  - id: 48
+    platform: 'x'
+    date: '2026-04-28'
+    url: 'https://x.com/taiwandotmd/status/2048970734253551638'
+translatedAt: '2026-09-09T00:00:00+08:00'
+---
+
+# Puma Shen: Er erforschte Chinas kognitiven Krieg. Dann markierte China ihn auf einer Satellitenkarte
+
+An einem Nachmittag in den 2010er-Jahren ging ein etwas über dreißigjähriger Jurastudent mit dem Direktor der Jugendstrafanstalt durch die Jugendeinrichtung Taipeh. Der Boden war gerade gewischt worden, die Wasserstreifen waren noch feucht. Der Direktor lief hindurch, die Besuchergruppe hinterher. Er blieb stehen, blickte sich um. Zwei Jungen, die gerade wischten, hoben den Kopf, verbeugten sich vor ihm und sagten leise „Danke“.[^1]
+
+An dem Tag, wieder zu Hause, notierte er eine Frage in sein Heft: „Warum behandeln wir Menschen an verschiedenen Orten so unterschiedlich?“[^1] Diese Frage führte ihn später vom Strafrecht zur Kriminologie, von der Wissenschaft zur Zivilverteidigung, von der Erforschung von Chinas kognitivem Krieg gegen Taiwan dazu, von der chinesischen Staatssicherheit strafrechtlich ermittelt zu werden, von CCTV mit „Du bist der Nächste“ gewarnt zu werden und von einem chinesischen Weibo-Konto per kommerziellem Satelliten die Koordinaten seiner Wohnung in Taipeh veröffentlicht zu bekommen.
+
+Er heißt Puma Shen, mit Künstlernamen Puma. Geboren 1982 in Taipeh, außerordentlicher Professor und Direktor des Instituts für Kriminologie an der National Taipei University.[^2] Er erforscht Chinas Informationskrieg, kognitive Kriegführung und transnationale Unterdrückung gegen Taiwan. Sieben Jahre lang erforschte er diese Dinge – im achten Jahr kamen sie zu ihm zurück.
+
+> **30-Sekunden-Überblick:** Puma Shen (geb. 1982), außerordentlicher Professor und Direktor des Instituts für Kriminologie an der National Taipei University. 2021 gründete er mit dem Strategieanalysten Ho Cheng-hui die [Kuma Academy](https://kuma-academy.org/); Robert Tsao spendete NT$600 Millionen, das Ziel: binnen drei Jahren drei Millionen „Kuma Warriors“ auszubilden.[^3] Im Februar 2024 wurde er als DPP-Abgeordneter über die Parteiliste gewählt.[^4] Von Oktober 2024 an wurde er innerhalb eines Jahres sechsmal von China sanktioniert; am 28. Oktober 2025 wurde er als erster gewählter taiwanesischer Politiker von China wegen „Staatszerstörung“ strafrechtlich ermittelt.[^5] Am 9. November ergänzte CCTV einen siebeneinhalbminütigen „Enttarnungs“-Beitrag mit der Warnung „Du bist der Nächste“.[^6] Am Neujahrstag 2026 veröffentlichte ein chinesisches Weibo-Konto per kommerziellem Satelliten die Koordinaten seiner Wohnung und seines Arbeitsplatzes in Taipeh.[^7] Er flog weiter nach Den Haag, nach Deutschland, nach Frankreich; den Valentinstag 2026 verbrachte er auf einem Flug nach Frankreich.[^8] Im Mai nominierte die DPP ihn offiziell für das Bürgermeisteramt von Taipeh, gegen den Amtsinhaber Chiang Wan-an.[^66]
+
+## „Unterbrich den Lehrer nicht und widersprich ihm nicht“
+
+Im Grundschul-Kontaktheft von Puma Shen schrieb ein Lehrer einst: „**Unterbrich den Lehrer nicht und widersprich ihm nicht. Boyang hat einen an sich guten Charakter, ist aber gelegentlich unbeherrscht und überheblich.**“ Seine Mutter schrieb darunter: „**Sein Benehmen ist in der Tat schlecht, er ist überheblich.**“ In der Mittelstufe zeigte er einem Lehrer den Mittelfinger.[^1] Als er mit 37 vom Mirror-Magazin porträtiert wurde, trug er immer noch einen Afrolook, T-Shirt und Shorts. Sein Lieblingscharakter war Yang Guo – „**völlig rebellisch, genauso mag ich es**.“[^1]
+
+Er besuchte hintereinander den Fuxing-Kindergarten, die Fuxing-Grundschule und die Fuxing-Mittelschule und kam nach dem Jianguo-Gymnasium an die juristische Fakultät der National Taiwan University.[^9] Schon in der Mittelstufe nahm er Klassenunterschiede wahr: „Die Mitschüler der Fuxing-Schule diskutierten über neu eröffnete japanische Restaurants, die Jianguo-Mitschüler aßen ein Rippchen-Essensbox-Mittagessen, sie aßen braunes Zucker-Eis, bestellten nur weiße Eiswürfel mit Zuckersirup.“[^1] Während des Studiums begann er als Nachhilfelehrer zu arbeiten, mit dem Künstlernamen „Puma“, weil er leichter zu merken war.[^10] Dieser Name begleitete ihn zwanzig Jahre lang – von der Nachhilfebranche über Wissenschaft und Think Tanks bis in den Legislativ-Yuan. Heute nutzen alle seine offiziellen Social-Media-Konten [@pumashen](https://www.threads.com/@pumashen).[^11]
+
+Was ihn vom „Strafrechtler, der Nachhilfe gab“ zur Kriminologie führte, waren zwei Bilder.
+
+Das erste Bild war der Fall des Großhändlers eines älteren Studenten. Der Mandant des älteren Studenten war ein großes Handelsunternehmen, das einen Obstbauern verklagte. „Der Obstbauer war eingeschüchtert und willigte in einen Vergleich ein, aber die Summe war sehr hoch – im Grunde war eine Familie ruiniert.“ Der ältere Student sagte zu Puma Shen: „So ist das Gesetz nun einmal, wer sich nicht daran hält, ist selbst schuld.“[^1] Puma Shen notierte: „**Wer das Gesetz lange studiert, kann wirklich zu dem Menschen werden, der er eigentlich nie sein wollte.**“[^1]
+
+Das zweite Bild war jenes Wischen in der Jugendstrafanstalt. Die Jungen verbeugten sich vor ihm, und er konnte nicht anders, als daran zu denken: Dieselben Jugendlichen – draußen sind sie die Gejagten, hier sind sie die Bemitleideten; der Maßstab, mit dem man einen Menschen beurteilt, bestimmt, was man ihm antut.
+
+> **📝 Kuratorennotiz**
+> Ein Gelehrter, der später staatliche Gewalt erforschte – sein akademischer Instinkt dafür, „wie Menschen behandelt werden“, begann mit der Verbeugung zweier Jungen, die den Boden wischten. Mehr als zehn Jahre später, als die KPCh gegen ihn ermittelte und CCTV einen Fake-Dokumentarfilm über ihn drehte, schrieb er sich nie als Opfer. Genau dieses Fingerspitzengefühl begann möglicherweise an jenem Tag in der Jugendstrafanstalt.
+
+## Puma und die zweimalige Entscheidung, Amerika zu verlassen
+
+Pumas akademische Laufbahn liest sich so schlicht wie ein Ticketabschnitt. LL.B. Jura NTU (2004), LL.M. Jura University of Pennsylvania (2007), LL.M. Strafrecht NTU (2008), PhD in Kriminologie, Recht und Gesellschaft an der UC Irvine (2017). Seine Doktorväter waren zwei Schwergewichte der Weiße-Kragen-Kriminalitätsforschung: Henry Pontell und Elliott Currie.[^12]
+
+Die fünf Jahre in Irvine lebte er in einer Stadt, die landesweit als „sicherste in den USA“ galt – „die Straßen sehen alle gleich aus, um Diebe zu verwirren, Türen müssen nicht abgeschlossen werden.“[^1] Nach dem Abschluss 2017 erhielt er Angebote für feste Professuren von US-Universitäten wie der North Carolina State University.[^13] Seine fünf Prüfungsprofessoren rieten ihm, nach Taiwan zurückzukehren: „Dir liegt so viel an Taiwan – warum gehst du nicht zurück?“[^1]
+
+Seine eigene Erklärung für die Rückkehr war kurz: „**Die Luft ist schlecht, aber wir sind ja von klein auf damit verschmutzt worden, Plastikweichmacher hatten wir auch schon alle. Es ist eben das eigene Zuhause.**“[^1]
+
+2017 kehrte er nach Taipeh zurück und wurde Assistenzprofessor am Institut für Kriminologie der National Taipei University. Im August 2023 übernahm er die Institutsleitung.[^2] Seine an der Universität ausgewiesenen Forschungsgebiete sind Strafrecht, Rechtssoziologie, Strafrechtspolitik und Weiße-Kragen-Kriminalität.[^2] Seine Promotion stammte allerdings nicht aus einer reinen Juristischen Fakultät – die UC Irvine siedelte seine Ausbildung in der „**School of Social Ecology**“ an, die Kriminologie, Stadtplanung, öffentliche Politik und Umweltpsychologie verbindet.[^14] Dieser Hintergrund bestimmte später seine Perspektive auf Chinas kognitiven Krieg – nicht vom Gesetzestext aus, sondern davon, „wie Menschen in ihrer Umgebung beeinflusst werden“.
+
+Zwei Jahre später richtete er diese Perspektive auf eine andere Richtung.
+
+## „Taiwan kämpfen ist weniger effektiv als Taiwan täuschen“
+
+![Puma Shen bei einem Vortrag über Informationskrieg und Identifikation von Desinformation im Januar 2021 vor einer Behörde des Landkreises Chiayi, mit Mikrofon in der Hand](/article-images/people/puma-shen-information-warfare-lecture-2021.webp)
+
+_Im Januar 2021 hielt Puma Shen im Personalschulungszentrum des Landkreises Chiayi einen Vortrag über Informationskrieg und Identifikation von Desinformation – ein Alltagsschauplatz seiner Forschung über Chinas kognitiven Krieg. Photo: Personalschulungszentrum des Landkreises Chiayi. [Namensnennung über Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Puma_Shen%27s_lecture_about_information_warfare_in_Chiayi_20210227a.jpg)。_
+
+2018 begann Puma Shen, systematisch Belege für Chinas Informationskrieg gegen Taiwan zu sammeln. Er zerlegte Chinas United-Front-Arbeit gegen Taiwan in fünf Linien: das Ministerium für Staatssicherheit, die Abteilung für United-Front-Arbeit des ZK, das Büro für Taiwan-Angelegenheiten des Staatsrates, die Volksbefreiungsarmee und den Kommunistischen Jugendverband.[^15] Jede Linie hat ihr eigenes Budget, ihre Werkzeuge, ihren Rhythmus. Dieser Analyzerahmen wurde später zur Standardsprache, in der die taiwanesische Zivilgesellschaft den kognitiven Krieg versteht.
+
+2019 gründete er mit zivilgesellschaftlichen Forschern Doublethink Lab, das [Taiwan Democracy Lab](https://doublethinklab.org/), und übernahm den Vorsitz.[^16] Am 25. April 2022 veröffentlichten sie den [China Index](https://china-index.io/) – einen „Index des chinesischen Einflusses“ mit 99 Indikatoren, die mehr als 80 Länder in neun Dimensionen abdecken (Medien, Kunst, Wirtschaft, Gesellschaft und Kultur, Militär, Strafverfolgung, Technologie, Politik, Außenpolitik).[^17] Bis heute ist dieser Index eine der am häufigsten zitierten Datenbanken zum chinesischen Einfluss auf die Welt in internationalen Politik- und Medienkreisen. Auf dieser Datenbasis sagte Puma Shen 2023 auch vor der vom US-Kongress beauftragten [US-China Economic and Security Review Commission](https://www.uscc.gov/sites/default/files/2023-03/Puma_Shen_Testimony.pdf) (USCC) aus.[^18]
+
+Im Juli 2024 veröffentlichten Puma Shen und der Doublethink-Lab-Forscher Wu Ming-hsuan gemeinsam [„Taiwan kämpfen ist weniger effektiv als Taiwan täuschen: Q&A zu Chinas kognitivem Krieg gegen Taiwan“](https://www.locuspublishing.com/book/detail/10514) (Locus Publishing). Schon der Titel ist die These. Für die KPCh ist Krieg zu teuer – Taiwaner so zu täuschen, dass sie nicht wählen oder falsch wählen, ist billiger.[^19] Das Buch wurde in der Folge in den Politikseiten von CNA, United Daily News und Liberty Times wiederholt zitiert. Die acht Zeichen „Taiwan kämpfen ist weniger effektiv als Taiwan täuschen“ wurden zur Abkürzung für Chinas Strategie gegen Taiwan.
+
+![Buchcover von „Taiwan kämpfen ist weniger effektiv als Taiwan täuschen“, hellblauer Hintergrund mit großem schwarzen Titel, im Bild eine Hand mit einer Fernbedienung](/article-images/people/puma-shen-fighting-or-fooling-taiwan-book-2024.webp)
+
+_Das von Puma Shen, Wu Ming-hsuan und Doublethink Lab gemeinsam verfasste Buch „Taiwan kämpfen ist weniger effektiv als Taiwan täuschen“ erschien 2024 bei Locus Publishing. Der Umschlagtext bringt die These auf den Punkt: Ein militärischer Angriff auf Taiwan ist extrem teuer, der kognitive Krieg die „Waffe mit dem besten Preis-Leistungs-Verhältnis“. Image: Locus Publishing (fair use, redaktioneller Kommentar)。_
+
+Aber ein Buch zu schreiben, bringt Chinas Staatssicherheit nicht dazu, ein Verfahren zu eröffnen. Was ihn zum „Feind“ machte, war etwas anderes.
+
+## Drei Millionen Kuma Warriors
+
+![Puma Shen bei einem Vortrag mit Mikrofon vor einem Pult, an der Wand hinter ihm die Flagge mit dem Schwarzbären-Motiv der Kuma Academy](/article-images/people/puma-shen-kuma-academy-lecture-2023.webp)
+
+_Im Februar 2023 sprach Puma Shen in einem Vortrag der Kuma Academy, hinter ihm die Kennzeichnungsfahne der Academy. Wer Zivilverteidigung lehrt, ist der KPCh wichtiger als wer Aufsätze schreibt. Photo: S099001. [CC BY 4.0 über Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Dr_Puma_Shen_at_Kuma_Academy_Lecture_24_Feb_2023.jpg)。_
+
+Ende 2021 gründeten Puma Shen und der Forscher der Taiwan Strategic Simulation Society, Ho Cheng-hui, die [Kuma Academy](https://kuma-academy.org/).[^20] Ihr Ziel ist „allgemeine Landesverteidigungsbildung“ – Dinge, die sonst nur Soldaten oder professionelles Rettungspersonal können (Zivilverteidigung, IT-Sicherheit, Betrugsschutz, AED/CPR, Blutstillung und Verband, Notfallverhalten), jedem Taiwaner beizubringen, der lernen will.[^21]
+
+Am 1. September 2022 hielt Robert Tsao, der frühere UMC-Vorsitzende, der gerade wegen seines Eintretens für Taiwans Souveränität den chinesischen Markt verlassen hatte, eine Pressekonferenz ab und kündigte an, NT$600 Millionen an die Kuma Academy zu spenden – Teil seines größeren Anti-China- und Taiwan-Schutz-Spendenplans.[^22] Puma Shen sagte auf der Pressekonferenz: „Wir hoffen, dass in jedem Haushalt ein ‚Kuma Warrior‘ mit entsprechendem Wissen lebt, der in kritischen Momenten die Familie schützt.“[^23] Das Ziel der Kuma Academy stand fest: **binnen drei Jahren drei Millionen „Kuma Warriors“ auszubilden**.[^24]
+
+Was bedeutet »drei Millionen«? Taiwan hat rund 23 Millionen Einwohner; zieht man Kinder, alte und bewegungseingeschränkte Menschen ab, sind drei Millionen ungefähr ein Fünftel der erwachsenen Bevölkerung. Tsao Yuans NT$600 Millionen werden in Etappen ausgezahlt – dieses Geld ist als ein zu prüfendes Projekt gedacht, nicht als hübsche Pressemitteilungs-Zahl.[^25]
+
+Im September 2022 waren die Plätze des ersten Grundlagenlagers der Kuma Academy nach Anmeldestart rasch ausgebucht.[^26] Das Programm umfasst: Feuerwehr, Suche und Rettung, Rettungsmedizin, Evakuierung, Kommunikations- und IT-Sicherheit, Informationserkennung, Aufrechterhaltung der Ordnung sowie AED/CPR, Verletzungsbeurteilung, Blutstillung und Verband.[^27] Die Outdoor-Übung „Operation Blauer Elster“ findet regelmäßig statt und simuliert Evakuierung und Rettung von Nicht-Kombattanten im Kriegsfall.[^28]
+
+Erwähnenswert: Puma Shen selbst ist nicht der gesetzliche Vertreter der Kuma Academy. In einem X-Beitrag von 2024 schrieb er: „Ich würde am liebsten Verantwortlicher der Kuma Academy sein, aber das Problem sind die Vorschriften und die Regeln innerhalb der DPP – ich und meine Angehörigen dürfen der Verantwortliche nicht sein.“[^29] Sein Amt als stellvertretender Exekutivdirektor des DPP-Think-Tanks und später als Abgeordneter zwingt ihn zu rechtlicher Distanz zu der NGO, die er selbst gegründet hat.
+
+> **📝 Kuratorennotiz**
+> Ein Zivilverteidigungssystem, das mit dem Rahmen der Kriminologie entworfen wurde: Jeder siebte Erwachsene weiß, wie er sich selbst rettet, Desinformation erkennt und bei Strom- und Wasserausfall Blut stillt. Pumas Forschung beschreibt, wie der Feind kommt; die Kurse der Kuma Academy trainieren, wie man nach einem Angriff durchhält. Zwei Dinge, die eine Person vorantreibt – diese Symmetrie ist fast unheimlich ruhig.
+
+## Das sechste Mal innerhalb eines Jahres
+
+![Offizielles Porträt von Puma Shen: unverkennbarer Afrolook, runde Brille, weißes Hemd, lächelnd](/article-images/people/puma-shen-legislator-portrait-2024.webp)
+
+_Offizielles Porträt von Puma Shen bei seiner Amtseinführung als Abgeordneter des 11. Legislativ-Yuans 2024. Vom Forscher zum Gesetzgeber zu werden, hob auch die Kosten der Sanktionierung – vom „Markieren eines Wissenschaftlers“ zum „Markieren eines gewählten Abgeordneten“. Photo: Legislativ-Yuan. [Namensnennung über Wikimedia Commons](https://commons.wikimedia.org/wiki/File:Puma_Shen_2024.jpg)。_
+
+Am 15. November 2023 gab die DPP ihre Liste der Parteilisten-Abgeordneten für 2024 bekannt – Puma Shen stand auf Platz 2, nur hinter der Kinderrechts-Aktivistin Lin Yueh-chin.[^30] Am 13. Januar 2024 wurde er gewählt, am 1. Februar trat er sein Mandat als Abgeordneter der 11. Legislaturperiode an.[^4] Er führte die DPP-Fraktion beim Vorantreiben von zehn Gesetzesrevisionen zur nationalen Sicherheit an (Gesetz über die Beziehungen zwischen beiden Seiten der Straße, Hongkong-Macau-Gesetz, Staatsangehörigkeitsgesetz, Gesetz über die nationale Sicherheit, Kommunikations-Überwachungsgesetz, Anti-Infiltration-Gesetz, Cybersicherheitsgesetz, Strafgesetzbuch, Militärstrafgesetz für Heer, Marine und Luftwaffe, Gesetz über die nationale Geheimdienstarbeit).[^31] Ab 2025 übernahm er den Vorsitz im Auswärtigen- und Verteidigungsausschuss des Legislativ-Yuans.[^32]
+
+Doch am 14. Oktober jenes Jahres verkündete Chen Bin-hua, Sprecher des Büros für Taiwan-Angelegenheiten des Staatsrates: Puma Shen, Robert Tsao und die Kuma Academy selbst würden auf die Liste der „unverbesserlichen Separatisten“ (Taiwan-Unabhängigkeits-Hardliner) gesetzt – ihnen und ihren Angehörigen werde der Zutritt zu Festlandchina, Hongkong und Macau verwehrt.[^33] Puma Shen wurde zum ersten Mal namentlich genannt.
+
+Von jenem Tag an kletterte die Eskalationsleiter Stufe für Stufe nach oben. In seinem Facebook-Beitrag vom 28. Oktober 2025 fasste Puma Shen die gesamte Entwicklung in einem Satz zusammen: „**Das ist das 6. Mal innerhalb eines Jahres.**“[^34]
+
+```tw-timeline
+Von der namentlichen Nennung bis zum Verfahren der Volkspolizei – die Eskalation der Sanktionen dauerte nur dreizehn Monate
+2024.10 | Büro für Taiwan-Angelegenheiten nennt Namen | Puma Shen, Robert Tsao, Kuma Academy auf die Liste der „unverbesserlichen Separatisten“ gesetzt
+2025.06 | Firma des Vaters sanktioniert | Chao Yi Co., Ltd. darf keine Geschäfte mit Festlandfirmen und -personen mehr tätigen
+2025.07 | Familienunternehmen Registrierung entzogen | Zoll streicht Importeur-Registrierung von Sicuens
+2025.10 | Volkspolizei Chongqing eröffnet Verfahren | Ermittlungen wegen „Staatszerstörung“, mit Meldehotline
+2025.11 | CCTV enttarnt | Siebeneinhalbminütiger Beitrag, Warnung: „Hör auf damit, sonst bist du der Nächste“
+Quellen: Büro für Taiwan-Angelegenheiten, Liberty Times, CNA, Xinhua, CCTV
+```
+
+Diese sechs Stufen wurden in nur dreizehn Monaten durchschritten. Die Rechtsgrundlage der Mitteilung des Volkspolizei-Büros Chongqing sind das Strafgesetzbuch und die im Juni 2024 von der KPCh veröffentlichte „Meinung zur gesetzmäßigen Bestrafung von Straftaten unverbesserlicher Taiwan-Separatisten, die den Staat zerstören oder zur Zerstörung des Staates anstiften“ (umgangssprachlich „22 Paragraphen zur Bestrafung der Separatisten“).[^38] Die Fallmeldung listete zudem die Melde-E-Mail-Adresse `CQGACTD@163.com` und die Telefonnummer `023-65697660` auf – jedermann war zur Meldung von „Hinweisen“ eingeladen.[^39]
+
+Am Tag der Einleitung des Verfahrens antwortete Puma Shen auf Facebook:
+
+> „Das ist das 6. Mal innerhalb eines Jahres; diesmal wurde direkt durch die Volkspolizei ein Verfahren eingeleitet, der nächste Schritt dürfte eine Fahndung und ein Abwesenheitsurteil sein; egal – schließlich sind ‚**die Taiwaner vor nichts bange**‘.“[^34]
+>
+> „Wer die Probleme Aufwerfenden zu lösen und wer Taiwan Verteidigende zu lösen – das ist wirklich sehr kommunistisch.“[^34]
+
+Im Juni 2025 wurde die Firma Chao Yi seines Vaters Shen Tu-cheng von der KPCh sanktioniert,[^35] einen Monat später entzog der Zoll der Familienfirma Sicuens die Importeur-Registrierung;[^36] er schrieb im selben Ton: „Eine große Ehre, innerhalb eines Jahres zum dritten Mal sanktioniert zu werden.“[^40]
+
+## Die „globale Festnahme“-Drohung von CCTV
+
+Zwölf Tage nach der Einleitung des Verfahrens, am Abend des 9. November 2025, strahlte der Nachrichtensender des Zentralfernsehens CCTV einen rund siebeneinhalb Minuten langen (viele taiwanesische Medien schreiben acht Minuten) „Enttarnung Puma Shen“-Beitrag aus. CCTV behauptete, Puma Shen verbreite über die Kuma Academy die Behauptung, „China werde Taiwan bald mit Waffengewalt angliedern“, und bilde „gewalttätige Taiwan-Unabhängigkeits-Extremisten“ aus. Der Kommentar endete warnend: „**Hör auf damit, sonst bist du der Nächste.**“[^41][^37]
+
+Die Mainland Affairs Council (MAC) definierte den Beitrag noch am selben Tag auf ihrer Pressekonferenz als „transnationale Unterdrückung“ – ein Mittel, das nicht in erster Linie auf Festnahme abzielt, sondern darauf, die taiwanesische Gesellschaft dazu zu bringen, sich vor dem Sprechen selbst zu zensieren.[^42] Puma Shen postete ebenfalls am selben Abend auf Facebook:
+
+> „Könnt ihr nicht aufhören, immer genau das zu tun, wovon ich vorhergesagt habe, dass ihr es tun werdet? **Seid doch etwas kreativer.**“[^43]
+>
+> „China handelt schneller und will mich mit einer Fahndung an der Ausreise hindern. **CCTV hat mit großem Aufwand einen siebeneinhalbminütigen Fake-Dokumentarfilm über mich gedreht und eine globale Fahndung angedroht.**“[^37]
+>
+> „Ob ich nun gefahndet werde oder nicht – **nobody cares, die Taiwaner interessieren sich wirklich nicht für die KPCh.**“[^37]
+
+Er veröffentlichte außerdem ein kurzes Video, das gegen einen CCTV-Screenshot gerichtet war: „Taiwan und China sind **ein Land auf der einen, ein Land auf der anderen Seite**. Versucht nicht, mit konstruierten Anklagen eure Hand nach Taiwan auszustrecken.“[^44]
+
+Die internationale Reaktion formierte sich innerhalb von zwei Tagen. Maya Wang, stellvertretende Asien-Direktorin von Human Rights Watch, erklärte am 31. Oktober, der Fall des Volkspolizei-Büros Chongqing sei ein Fall der transnationalen Anwendung missbräuchlicher chinesischer Gesetze.[^45] Mehrere internationale Menschenrechtsorganisationen solidarisierten sich zeitgleich. Das US-Außenministerium äußerte öffentlich Besorgnis.[^47] Luke de Pulford, Mitbegründer der [Inter-Parliamentary Alliance on China](https://ipac.global/) (IPAC), unterstützte ihn öffentlich.[^48]
+
+Auch der Legislativ-Yuan selbst wurde aktiv. Am 19. November 2025 verabschiedete der Auswärtige- und Verteidigungsausschuss des Legislativ-Yuans – also genau der Ausschuss, dessen Vorsitzender Puma Shen selbst ist – einen von Wang Ting-yu und anderen eingebrachten Misstrauensantrag. Wang sagte in seiner Rede: „**Meinungsverschiedenheiten berechtigen weiterhin zu Schutz durch den Staat und die Verfassung.** Die Volksrepublik China hat kein Recht, aus solch aus der Luft gegriffenen Gründen politische Schritte gegen irgendjemanden zu unternehmen.“[^49]
+
+China hat Puma Shen allerdings noch nicht offiziell auf die Belohnungsliste des Hongkonger National Security Law gesetzt; zeitgleich wurden vor allem der [YouTuber „Pa Chiung“](/people/八炯) und „Minnan Wolf“ mit höchstens RMB 250.000 zur Fahndung ausgeschrieben.[^50] Doch die Kombination aus „Staatszerstörung“-Verfahren und CCTV-„globaler Festnahme“-Drohung hat Puma Shen bereits nahe an diese Position gerückt.
+
+## Die Schraube vor der Haustür
+
+Während die KPCh eskalierte, wurde Puma Shens Privatleben mit eskaliert.
+
+Ende August 2025 sagte er erstmals öffentlich in der Sendung „话时代人物“ von Moderator Cheng Hung-yi, dass er „ständig“ beschattet werde. Der unmittelbarste Fall geschah vor seiner Haustür: Die „Schraube“ eines Motorrads war in Wirklichkeit eine winzige Kamera, deren Batterie unter dem Sitz versteckt war und die äußerlich wie eine Schraube getarnt war. Puma Shen fotografierte das Kennzeichen und meldete es der Polizei – doch keine Stunde später war das Motorrad verschwunden; die Verfolgung des Kennzeichens ist bis heute eine Sackgasse.[^51]
+
+Schwerer zu verdauen waren die Drohbriefe. Den Briefen lag ein Foto von Puma Shen und seiner Frau Tseng Hsin-hui bei, **auf dem auf Tseng Hsin-huis Kleidung ein „Tod“-Zeichen geschrieben war**, verbunden mit der Androhung, ihrer Tochter die Kehle durchzuschneiden.[^51] Puma Shen sagte in der Sendung: „Das ist abscheulich, aber genau das ist es, was die Kommunistische Partei tut – wir waren im Geiste darauf vorbereitet.“ Seine Frau Tseng Hsin-hui reagierte mit Angst, Schlaflosigkeit, gesundheitlichem Verfall und sozialer Phobie.[^51]
+
+> **📝 Kuratorennotiz**
+> Puma Shens Tochter ist nicht seine leibliche Tochter. Er und seine Frau Tseng Hsin-hui adoptierten sie über die Lu-Hsin-Stiftung; nach einem zweijährigen Verfahren nahm Puma Shen 2021 ein 13 Monate altes Mädchen bei sich auf; das Paar erklärte dem Kind die Rolle der leiblichen Mutter mit dem Konzept der „Bauch-Mama“.[^52]
+> Das Kind, das er aufnahm, wurde später zu dem auf dem Drohbrief markierten Koordinatenpunkt, der an sein Haus geschickt wurde.
+
+## Den Haag, Satelliten und der Valentinstag
+
+Aber er zog sich nicht zurück. Nach November reiste er im Gegenteil nur umso intensiver ins Ausland.
+
+Am 12. November 2025 trat er in der Anhörung des [Deutschen Bundestags](https://www.bundestag.de/) zum Thema „Bedrohung von Demokratie und Menschenrechten durch Desinformation autoritärer Staaten“ als Sachverständiger und Abgeordneter auf. Nach der Anhörung sagte er im Interview: „Taiwan sollte vor der chinesischen Bedrohung keine Angst haben – **alle müssen furchtlos sein und an der Seite des Lagers der weltweiten demokratischen Freiheit stehen**.“[^53]
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/VFbmWlBmGP4" title="沈伯洋赴德國會　說明台遭假訊息攻擊｜中央社影音新聞" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_CNA-Videonachrichten: Puma Shen erläutert im November 2025 in der Bundestags-Anhörung als Sachverständiger die gegen Taiwan gerichteten ausländischen Desinformationsangriffe._
+
+Neun Tage später, am 21. November, erreichte er Den Haag und nahm gemeinsam mit der DPP-Abgeordneten [Fan Yun](https://en.wikipedia.org/wiki/Fan_Yun) an der 209. Exekutivratssitzung der [Liberal International](https://liberal-international.org/) (LI) und an der Den Haag-Tagung der [Inter-Parliamentary Alliance on China](https://ipac.global/) (IPAC) teil; vor dem Internationalen Strafgerichtshof (ICC) entstand ein gemeinsames Foto.[^54] Er schrieb vier Zeichen dazu: „Keine Angst.“ Am nächsten Tag sprach er auf dem LI-Panel „Defending Democracy in an Era of Political Manipulation“ und gab der chinesischen Bedrohung ein akademisches Etikett:
+
+> „China will wirklich verhindern, dass ich an diesen internationalen Beteiligungen weitermache, und versucht daher fortlaufend, mich mit Sanktionen an der Ausreise zu hindern. **Genau diese Aktionen beweisen, dass China ein Papiertiger ist** – zum großen Teil symbolische Propaganda für die eigene Bevölkerung, vor der Taiwan keine Angst haben sollte.“[^55]
+>
+> (Mit Blick auf das ICC-Gebäude hinter ihm): „**Hier ist der Ort, an dem Diktatoren wegen Kriegsverbrechen oder Völkermord angeklagt werden.**“[^55]
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/o-OhWUHV4W4" title="沈伯洋赴荷蘭參加國際會議　盼國會外交促成交流合作｜中央社影音新聞" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_CNA-Videonachrichten: Puma Shen reist im November 2025 nach Den Haag, um an den Tagungen von IPAC und Liberal International teilzunehmen und mit parlamentarischer Diplomatie das internationale demokratische Lager anzubinden._
+
+Am Neujahrstag 2026 eskalierte die KPCh.
+
+Ein chinesisches Weibo-Konto mit vielen Followern, „孤烟暮蟬“ (Gu Yan Muchan), postete, dass man Puma Shen verfolgen wolle,[^59] und behauptete, auf eigene Kosten hochauflösende Bilder des kommerziellen Satelliten „Jilin-1“ bestellt zu haben, um Satellitenbilder seiner Wohnung in Taipeh (nahe dem Daan-Waldpark) und seines Arbeitsplatzes (Abschnitt 1 der Jinan Road, nahe den Legislativgebäuden) zu veröffentlichen.[^7] Das staatliche chinesische Medium „今日海峽“ (Today’s Straits) griff es auf und verbreitete es weiter.[^7] Zwei Tage später veröffentlichte das Außenministerium eine Verurteilungserklärung, deren Wortlaut sich von früheren unterschied:
+
+> „Nachdem die chinesischen Staatsmedien zuvor die weltweite Festnahme unseres Abgeordneten Puma Shen angedroht hatten, sind sie nun noch einen Schritt weiter gegangen und haben **mit der niederträchtigen Methode digitaler Autoritarismus – dem Doxxing – die Sicherheit unserer Staatsbürger bedroht** … Dies verletzt nicht nur die in der _Allgemeinen Erklärung der Menschenrechte_ und im _Internationalen Pakt über bürgerliche und politische Rechte_ verankerte Garantie, dass ‚niemand willkürlichen Eingriffen in seine Privatsphäre, Familie oder Wohnung ausgesetzt werden darf‘, sondern ist zugleich eine umfassende Verfolgung der Privatsphäre Einzelner, die **jede zivilisatorische Grenze verliert und zutiefst verachtenswert ist**.“[^56]
+
+Die Polizeibehörde (NPA) kündigte am selben Tag an, die Sicherheit von Puma Shen mit allen Kräften zu gewährleisten.[^57] Das Digitalministerium forderte Meta und Google auf, tätig zu werden; innerhalb weniger Tage wurden die betreffenden Beiträge, Videos und Bilder von den Plattformen genommen.[^58]
+
+Puma Shen selbst antwortete am 3. Januar auf Facebook:
+
+> „**Was China markiert, sind meine Koordinaten – gezeigt wird damit ihr kollektiver Minderwertigkeitskomplex gegenüber dem demokratischen Taiwan.**“[^59]
+>
+> „Was diejenigen angeht, die noch vor Kurzem über Dashcams gelästert haben: Ich sage nicht, dass ihr Komplizen seid, denn euer Niveau reicht dafür noch nicht. Aber akademisch gibt es dafür einen Fachbegriff: ‚**nützliche Idioten**‘ (Useful Idiots).“[^59]
+
+Zwei Wochen später, am 24. Januar, veröffentlichte er auf Facebook einen langen Beitrag, in dem er Chinas Lockdown-Politik für Taiwan 2026 in drei Achsen zerlegte: physisch entwaffnen (die Koalition aus KMT und TPP kürzt die Außen- und Verteidigungsbudgets), geistig kognitiv verändern (der Misstrauens-gegenüber-USA-Diskurs beeinflusst rund fünf Prozent der entscheidenden Wähler), wahltechnisch Ressourcen monopolisieren (Parteivermögens- und Medienrechtsvorhaben). Am Ende des Beitrags schrieb er: „**Meine größte Funktion dürfte wohl die der ‚Zielscheibe‘ sein.**“[^60]
+
+Das Wort „Zielscheibe“ tauchte seither in seiner Erzählung immer wieder auf – es ist ein Etikett, das er sich selbst aufklebt.
+
+Am 7. Februar flog er nach Frankreich, um eine achttägige diplomatische Mission durchzuführen. Der entscheidende Hintergrund für Frankreich: Sitz von [Interpol](https://www.interpol.int/), verbunden mit dem Auslieferungsabkommen zwischen Frankreich und China – theoretisch ist er in genau solchen Ländern dem größten Risiko ausgesetzt, und er reiste dennoch wie geplant. Die Mission umfasste den Austausch über die neue Ausgabe der Broschüre „Landesverteidigung für alle“ des taiwanesischen Verteidigungsministeriums, die Bekämpfung des kognitiven Krieges, soziale Medien und Cyberkrieg sowie nationale Resilienz. Frankreich hatte 2025 selbst ein vergleichbar orientiertes Handbuch für den Notfall angelegt; Puma Shen sagte, die für die Bekämpfung von Desinformation zuständigen französischen Einheiten hätten sich an taiwanesischen Entwürfen orientiert.[^8]
+
+Den Valentinstag (14. Februar) verbrachte er im Flugzeug. Nach der Rückkehr schrieb er auf Facebook: „**Obwohl ich den Druck einer globalen Fahndung durch Peking trage, habe ich die achttägige diplomatische Mission wie geplant abgeschlossen. Letztlich habe ich den Valentinstag jedoch im Flugzeug verbracht.** Es folgt bereits die nächste Mission! Ich werde weiterhin mit meinem Land an der Front stehen.“[^61]
+
+## Von der Zielscheibe zum Kandidaten
+
+Anfang April 2026 tagte der Auswahlausschuss der DPP. Die Politikseite der [United Daily News](https://udn.com/) berichtete, Eingeweihten zufolge wolle die Partei Puma Shen als Kandidaten für das Bürgermeisteramt von Taipeh aufstellen.[^62] Im Lauf des April wurde das nahezu beschlossene Sache. Der frühere Innenminister Hsu Kuo-yung unterstützte ihn öffentlich.[^63] Eine TVBS-Umfrage vom Dezember 2025 zeigte für den amtierenden Bürgermeister von Taipeh, Chiang Wan-an, Zustimmung von rund 64 Prozent, für Puma Shen rund 22 Prozent.[^64] Ein deutlicher Rückstand – aber ob die Wahl gewonnen wird, liegt außerhalb des Rahmens dieses Artikels.
+
+Am 25. April schnitt er sich den über zehn Jahre getragenen Afrolook ab und stand erstmals mit Chiang Wan-an auf einer gemeinsamen Bühne beim Mazu-Fest der Songshan-Cihuitang.[^65] Yang Guo hat sich die Haare kurz schneiden lassen.
+
+Am 13. Mai 2026 wurde aus dem Gerücht Wirklichkeit. Das Zentralexekutivkomitee der DPP beschloss es, der zugleich als Parteivorsitzender amtierende Präsident Lai Ching-te verkündete persönlich, Puma Shen für das Bürgermeisteramt von Taipeh zu nominieren, legte ihm das Wahlkampfband um, und beide riefen Hand in Hand „Dung-suan“. Lai sagte, er besitze „die Höhe internationaler Perspektive, die Breite sektorübergreifender Regierungsführung und die Wärme der Fürsorge für die Bürger“ – er sei der „einzige Kandidat für das Bürgermeisteramt von Taipeh“.[^66][^67] Puma Shen nahm das Band an: „Ich habe mich entschieden, für das Bürgermeisteramt von Taipeh zu kandidieren – lasst mich euer Bürgermeister werden.“[^67] Der Wahltag ist der 28. November, sein Gegner ist der wiedewählende Chiang Wan-an.[^68]
+
+![Puma Shen in schwarzem T-Shirt, mit Brille, Mikrofon in der Hand auf der Bühne, um die Brust ein Band mit der Aufschrift „United-Front-Arbeit ablehnen“](/article-images/people/puma-shen-reject-united-front-rally-2025.webp)
+
+_Am 19. April 2025 nahm Puma Shen an der Kundgebung „United-Front-Arbeit ablehnen, Taiwan schützen“ teil. Wer mit Koordinaten markiert wurde, wählt weiterhin die öffentliche Bühne. Photo: KOKUYO. CC BY-SA 4.0 über Wikimedia Commons。_
+
+Das Rennen bleibt unausgeglichen. Eine Umfrage des TVBS-Umfragezentrums vom 27. Mai ergab für Chiang Wan-an 58 Prozent und für Puma Shen 30 Prozent – eine Differenz von 28 Prozentpunkten; selbst bei den jungen Wählern von 20 bis 29 Jahren lag Puma Shen mit 37 Prozent unter Chiang Wan-ans 60 Prozent.[^69] Internationale Medien beschrieben das Duell als eine Herausforderung mit geringen Aussichten.
+
+```tw-bars
+2026 Umfrage Bürgermeisteramt Taipeh: Chiang Wan-an führt vor Puma Shen mit 28 Prozentpunkten
+Chiang Wan-an | 58 | Amtsinhaber KMT, strebt Wiederwahl an
+*Puma Shen | 30 | von der DPP nominiert
+Quelle: TVBS-Umfragezentrum, 2026-05-27
+```
+
+Von der Verbeugung der wischenden Jungen bis zum Fake-Dokumentarfilm des Zentralfernsehens, von der Forschung an einem Schreibtisch bis zu den Koordinaten auf der Satellitenkarte, vom „darf nicht Verantwortlicher der Kuma Academy sein“ bis zur „offiziellen Kandidatur für das Bürgermeisteramt von Taipeh“ hat Puma Shen mehrfach seine Position gewechselt. Jede Veränderung kommentierte er mit demselben Satz: „Ich bin die Zielscheibe.“ Dieses Wort ist zugleich Selbstironie und nüchterne akademische Beobachtung. In Chinas Erzählung über Taiwan ist er tatsächlich der, der ins Visier genommen werden soll. Ein Gelehrter, der das Etikett des von ihm selbst erforschten Objekts übernimmt, es auf sich klebt und weiterarbeitet – das schaffen nur wenige.
+
+## Wo sind die sich verbeugenden Jungen heute
+
+Zurück zu dem Nachmittag des Wischens. In dem Moment, in dem Puma Shen stehen blieb, ging er um die Wasserstreifen herum. Die Jungen verbeugten sich vor ihm. Mehr als zehn Jahre später saß er auf der anderen Seite der Fallmeldung des Volkspolizei-Büros Chongqing, auf der Kleidung seiner Frau stand das Zeichen „Tod“, die Satellitenkoordinaten seiner Wohnung waren von einem chinesischen Weibo-Konto öffentlich benannt worden.
+
+Er selbst schrieb im Juni 2025 einen sehr kurzen Satz. An dem Tag, als die Firma seines Vaters von der KPCh sanktioniert wurde, antwortete er auf Facebook mit vier Zeichen: „**Eine große Ehre.**“[^40]
+
+Die Frage von damals in der Jugendstrafanstalt ist noch bei ihm: „Warum behandeln wir Menschen an verschiedenen Orten so unterschiedlich?“ Er hat diese Frage zwanzig Jahre lang erforscht. Am Ende kam das, was er erforschte, zu ihm zurück und markierte ihn als Beute. Aber er hat lang genug geforscht, um zu wissen: **Beute muss nicht zuerst zum Opfer werden** – sie kann zuerst zur Fragenden werden. Deshalb erzählte er von Den Haag über den Deutschen Bundestag bis Frankreich an jeder Station mit derselben Grammatik dieselbe Sache: Ihr könnt mir das antun – und ich mache meine Arbeit trotzdem weiter.
+
+Im Mai 2026 legte er das Wahlkampfband um und zog in einen weiteren Wahlkampf. Aber auf der Satellitenkarte der KPCh lag die Zielscheiben-Koordinate weiterhin unverändert.
+
+---
+
+**Weiterführende Lektüre**:
+
+- Kuma Academy – die von Puma Shen und Ho Cheng-hui mitgegründete zivilgesellschaftliche Zivilverteidigungs-Bildungsorganisation, eine Schule, die „hofft, dass Taiwan sie eines Tages nicht mehr braucht“ (keine deutsche Übersetzung verfügbar)
+- Kognitive Kriegführung – der vollständige Rahmen von Chinas Informationskrieg gegen Taiwan, dessen einer der Hauptforscher Puma Shen ist (keine deutsche Übersetzung verfügbar)
+- Pa Chiung – ein ebenfalls von der KPCh ins Visier genommener taiwanesischer YouTuber, gegen den China im November 2025 eine Belohnung von bis zu RMB 250.000 ausgeschrieben hat (keine deutsche Übersetzung verfügbar)
+- Lai Ching-te – ebenfalls auf der Liste der „unverbesserlichen Separatisten“, der Puma Shen im November 2025 öffentlich unterstützte (keine deutsche Übersetzung verfügbar)
+- Taiwans Verteidigung und Militärmodernisierung – wie die Zivilverteidigungsbildung der Kuma Academy die allgemeine Landesverteidigung ergänzt (keine deutsche Übersetzung verfügbar)
+- Das unsichtbare Land – ein Dokumentarfilm, der mit Taiwanern in einem Zivilverteidigungskurs endet; die Kuma Academy ist die reale Version dieser Schlussstunde (keine deutsche Übersetzung verfügbar)
+
+## Bildnachweise
+
+In diesem Artikel werden 6 CC-lizenzierte / öffentlich lizenzierte / Fair-Use-redaktionelle Bilder verwendet, alle in `public/article-images/people/` gecacht, um Hotlinking-Quellserver zu vermeiden; außerdem sind 2 offizielle CNA-Videos eingebettet.
+
+- [Puma Shen Wahlbild 2024 (hero)](https://commons.wikimedia.org/wiki/File:Puma_Shen_in_2024_Taiwan_general_election.jpg) — Photo: 曾成訓 / Flickr, CC BY 2.0
+- [Offizielles Porträt Abgeordneter Puma Shen](https://commons.wikimedia.org/wiki/File:Puma_Shen_2024.jpg) — Photo: Legislativ-Yuan, Namensnennung (Quelle angeben)
+- [Puma Shen bei Kuma-Academy-Vortrag](https://commons.wikimedia.org/wiki/File:Dr_Puma_Shen_at_Kuma_Academy_Lecture_24_Feb_2023.jpg) — Photo: S099001 / Wikimedia Commons, CC BY 4.0
+- [Puma Shen bei Vortrag über Informationskrieg in Chiayi](https://commons.wikimedia.org/wiki/File:Puma_Shen%27s_lecture_about_information_warfare_in_Chiayi_20210227a.jpg) — Photo: Personalschulungszentrum des Landkreises Chiayi, Namensnennung (Quelle angeben)
+- [Puma Shen bei Kundgebung „United-Front-Arbeit ablehnen, Taiwan schützen“](https://commons.wikimedia.org/wiki/File:2025.04.19_%E3%80%8C%E6%8B%92%E7%B5%95%E7%B5%B1%E6%88%B0%EF%BC%8C%E5%AE%88%E8%AD%B7%E5%8F%B0%E7%81%A3%E3%80%8D%E5%A4%A7%E6%9C%83_13.jpg) — Photo: KOKUYO / Wikimedia Commons, CC BY-SA 4.0
+- [Buchcover „Taiwan kämpfen ist weniger effektiv als Taiwan täuschen“](https://www.locuspublishing.com/book/detail/10514) — Image: Locus Publishing, Fair-Use-Redaktionskommentar
+
+Video-Einbettungen: [Puma Shen erklärt im Bundestag Taiwans Desinformationsangriffe](https://www.youtube.com/watch?v=VFbmWlBmGP4) und [Puma Shen nimmt an internationaler Konferenz in den Niederlanden teil](https://www.youtube.com/watch?v=o-OhWUHV4W4), beide vom offiziellen Video-Kanal der Central News Agency (CNA).
+
+## Quellen
+
+[^1]: [Mirror Media, Serie „Ein Blick bis zum Grund“: Der Professor, der das Böse seziert](https://www.mirrormedia.mg/story/20190427pol002) — zweiter Teil der Personenporträt-Serie des Mirror Magazine vom 27.04.2019; dokumentiert Pumas Kontaktheft aus der Kindheit, den Klassenvergleich Fuxing/Jianguo, den Großhändler-Fall seines älteren Studenten, den Besuch in der Jugendstrafanstalt, den Eindruck von Irvine als sicherster Stadt der USA, den Rat seiner fünf Prüfungsprofessoren, zurückzukehren, und das Yang-Guo-Idol; die entscheidende Ursprungsszene für Pumas akademische Wende zur Kriminologie.
+
+[^2]: [National Taipei University, Institut für Kriminologie, Lehrseite Puma Shen](https://crm.ntpu.edu.tw/index.php?option=module&lang=cht&task=pageinfo&id=119) — offizielle Fakultätsseite der Universität; bestätigt, dass Puma Shen derzeit außerordentlicher Professor und Institutsleiter ist; Forschungsgebiete Strafrecht, Rechtssoziologie, Strafrechtspolitik, Weiße-Kragen-Kriminalität.
+
+[^3]: [Kuma Academy offizielle Website: Über uns](https://kuma-academy.org/about) — offizielle Seite der Kuma Academy; stellt die Gründer Puma Shen und Ho Cheng-hui, den Gründungshintergrund, die Kursgestaltung und die Idee der „allgemeinen Verteidigung“ vor.
+
+[^4]: [Legislativ-Yuan weltweites Informationsnetz: Abgeordnetendaten Puma Shen](https://www.ly.gov.tw/Pages/Detail.aspx?nodeid=54301&pid=237147) — offizielle Abgeordnetenseite des Legislativ-Yuans; bestätigt Amtsantritt als Abgeordneter des 11. Legislativ-Yuans am 01.02.2024.
+
+[^5]: [CNA: Volkspolizei-Büro Chongqing eröffnet Verfahren gegen Puma Shen](https://www.cna.com.tw/news/aipl/202510280086.aspx) — Meldung der CNA vom 28.10.2025; dokumentiert vollständig, wie die Fallmeldung des Volkspolizei-Büros Chongqing wegen „des Verdachts der Straftat der Staatszerstörung“ ein Verfahren gegen Puma Shen einleitet, und zitiert Pumas Facebook-Antwort im Wortlaut.
+
+[^6]: [Liberty Times: CCTV enttarnt Puma Shen in 7,5 Minuten](https://news.ltn.com.tw/news/politics/breakingnews/5239735) — Meldung der Liberty Times vom 09.11.2025; dokumentiert, dass der CCTV-Nachrichtenkanal am selben Abend einen „Enttarnungs“-Beitrag über Puma Shen veröffentlichte, der mit der Warnung „Hör auf damit, sonst bist du der Nächste“ endete.
+
+[^7]: [Liberty Times: Chinesisches Weibo-Konto veröffentlicht per kommerziellem Satelliten Koordinaten von Pumas Wohnung und Arbeitsplatz](https://news.ltn.com.tw/news/politics/breakingnews/5297941) — exklusive Meldung der Liberty Times vom Januar 2026; dokumentiert, wie ein chinesisches Weibo-Konto auf eigene Kosten Jilin-1-Satellitenbilder bestellte und die Koordinaten von Pumas Wohnung (nahe Daan-Waldpark) und Arbeitsplatz (Abschnitt 1 der Jinan Road, nahe den Legislativgebäuden) veröffentlichte und das staatliche chinesische Medium „Today’s Straits“ die Meldung aufgriff.
+
+[^8]: [Liberty Times: Furchtlos angesichts der Fahndungsdrohung der KPCh – Puma Shen schließt 8-tägige diplomatische Mission in Frankreich ab](https://news.ltn.com.tw/news/politics/breakingnews/5344003) — Liberty-Times-Meldung vom Februar 2026; dokumentiert Pumas Abreise am 07.02.2026, die 8-tägige diplomatische Mission, den Valentinstag im Flugzeug und die gegenseitige Anregung zwischen Frankreichs „kleinem Orangenbuch“ und Taiwans Verteidigungshandbuch.
+
+[^9]: [Wikipedia: Puma Shen](https://zh.wikipedia.org/zh-tw/%E6%B2%88%E4%BC%AF%E6%B4%8B) — chinesischsprachige Wikipedia-Seite zu Puma Shen; ordnet Familienhintergrund, Ausbildung und frühen Werdegang, einschließlich des vollständigen Bildungswegs über Fuxing-Kindergarten, Fuxing-Grundschule, Fuxing-Mittelschule und Jianguo-Gymnasium.
+
+[^10]: [Mirror Media, „Ein Blick bis zum Grund“: Persönlichkeitsporträt Puma Shen](https://www.mirrormedia.mg/story/20190427pol001) — erster Teil der Serie des Mirror Magazine vom 27.04.2019; dokumentiert Pumas Nachhilfetätigkeit im Studium, die Herkunft des Künstlernamens „Puma“ und die folgende akademische Wende.
+
+[^11]: [Offizielles Threads-Konto @pumashen](https://www.threads.com/@pumashen) — Puma Shens offizielles Konto auf Meta Threads.
+
+[^12]: [Wikipedia (englisch): Puma Shen](https://en.wikipedia.org/wiki/Puma_Shen) — englischsprachige Wikipedia-Seite zu Puma Shen; ordnet den akademischen Zeitstrahl: LL.M. University of Pennsylvania (2007), LL.M. Strafrecht NTU (2008), PhD UC Irvine (2017), Doktorväter Henry Pontell und Elliott Currie.
+
+[^13]: [Wikipedia: Puma Shen (Abschnitt Rückkehrentscheidung)](https://zh.wikipedia.org/zh-tw/%E6%B2%88%E4%BC%AF%E6%B4%8B) — chinesischsprachige Wikipedia; ordnet den Entscheidungskontext, dass Puma Shen nach der Promotion 2017 Angebote für feste US-Professuren etwa der North Carolina State University ablehnte und die Rückkehr nach Taiwan wählte.
+
+[^14]: [Puma Shen auf Threads über seine Promotion](https://www.threads.com/@pumashen/post/DXcG-fKlP1S) — Puma Shen beschreibt auf Threads aus eigener Darstellung, dass sein PhD an der School of Social Ecology der UC Irvine angesiedelt war und Kriminologie, Stadtplanung, öffentliche Politik und Umweltpsychologie verbindet.
+
+[^15]: [USCC: Puma Shen Testimony on CCP Influence Operations PDF](https://www.uscc.gov/sites/default/files/2023-03/Puma_Shen_Testimony.pdf) — der Text seiner Aussage vom März 2023 vor der US-China Economic and Security Review Commission (USCC); analysiert abschnittsweise die bürokratischen Linien von Chinas Informationskrieg gegen Taiwan (Ministerium für Staatssicherheit, Abteilung für United-Front-Arbeit des ZK, Büro für Taiwan-Angelegenheiten des Staatsrates, System der Volksbefreiungsarmee, Netzwerk des Kommunistischen Jugendverbands) mit ihren jeweiligen Werkzeugen und Rhythmen; die wissenschaftliche Originalausgabe seines Rahmens der „fünf Linien“.
+
+[^16]: [Doublethink Lab offizielle Website](https://doublethinklab.org/) — offizielle Website des Taiwan Democracy Lab; stellt den Gründungshintergrund (2019), die Forschungsziele und die Rolle Puma Shens als Vorsitzender vor.
+
+[^17]: [Taipei Times: China Index Launch by Doublethink Lab](https://www.taipeitimes.com/News/taiwan/archives/2022/04/28/2003777359) — Taipei-Times-Meldung vom 28.04.2022; dokumentiert die Veröffentlichung des China Index durch Doublethink Lab (25.04.2022) und das Design mit neun Dimensionen und insgesamt 99 Indikatoren.
+
+[^18]: [USCC: Puma Shen Testimony PDF](https://www.uscc.gov/sites/default/files/2023-03/Puma_Shen_Testimony.pdf) — Volltext der Aussage von Puma Shen 2023, über die offizielle Seite der USCC abrufbar; behandelt Chinas Informationskriegsstrategie gegen Taiwan und die Datenbasis des China Index.
+
+[^19]: [Locus Publishing: Buchseite „Taiwan kämpfen ist weniger effektiv als Taiwan täuschen“](https://www.locuspublishing.com/book/detail/10514) — offizielle Verlagsseite von Locus Publishing; dokumentiert den Hintergrund und die Gliederung des im Juli 2024 erschienenen, von Puma Shen und Wu Ming-hsuan gemeinsam verfassten Buches.
+
+[^20]: [Wikipedia: Kuma Academy](https://zh.wikipedia.org/zh-hans/%E9%BB%91%E7%86%8A%E5%AD%B8%E9%99%A2) — chinesischsprachige Wikipedia; ordnet die Geschichte, dass die Kuma Academy von Puma Shen und Ho Cheng-hui mitgegründet und im Dezember 2021 offiziell gegründet wurde.
+
+[^21]: [Öffentlicher Kursplan der Kuma Academy](https://kuma-academy.oen.tw/events/2a1FgPxa82dXvk4kCA50wRJIlto) — öffentlicher Stundenplan der Kuma Academy (oen-Plattform); listet die Inhalte grundlegender Zivilverteidigungskurse einschließlich Feuerwehr, Suche und Rettung, Evakuierung, Informationserkennung, AED/CPR.
+
+[^22]: [Liberty Times: Robert Tsao spendet NT$3 Milliarden für Anti-China- und Taiwan-Schutz, NT$600 Millionen an die Kuma Academy](https://news.ltn.com.tw/news/politics/breakingnews/4044669) — Liberty-Times-Meldung vom 01.09.2022; dokumentiert vollständig die Pressekonferenz, in der der frühere UMC-Vorsitzende Robert Tsao ankündigte, drei Milliarden NT$ für den Kampf gegen China und zum Schutz Taiwans zu spenden, davon 600 Millionen NT$ an die Kuma Academy.
+
+[^23]: [Liberty Times: Puma Shen auf Kuma-Warrior-Pressekonferenz](https://news.ltn.com.tw/news/politics/breakingnews/4044669) — Liberty-Times-Meldung mit direkten Zitaten aus Puma Shens Rede auf der Pressekonferenz zur 600-Millionen-NT$-Spende vom 01.09.2022.
+
+[^24]: [Liberty Times: Plan der Kuma Academy, in 3 Jahren 3 Millionen Menschen auszubilden](https://news.ltn.com.tw/news/politics/paper/1565297) — Liberty-Times-Meldung über Zielplanung und Zeitrahmen der Kuma Academy, binnen drei Jahren drei Millionen „Kuma Warriors“ auszubilden.
+
+[^25]: [Liberty Times: Auszahlungsmechanismus der NT$600 Millionen in Quartalsraten](https://news.ltn.com.tw/news/politics/breakingnews/4045927) — Liberty-Times-Meldung über den Ausführungsmechanismus von Robert Tsao Yuans 600-Millionen-NT$-Spende: quartalsweise Auszahlung mit Prüfung nach Plan.
+
+[^26]: [Liberty Times: Mehr als 3.000 auf der Warteliste für das erste Grundlagenlager der Kuma Academy](https://news.ltn.com.tw/news/politics/paper/1538534) — Liberty-Times-Meldung; das erste Grundlagenlager der Kuma Academy im September 2022 hatte mehr als 3.000 Bewerber auf der Warteliste – ein Zeichen für den hohen Bedarf Taiwans an Zivilverteidigungsbildung.
+
+[^27]: [Öffentliche Kursinformationen der Kuma Academy](https://kuma-academy.oen.tw/events/2a1FgPxa82dXvk4kCA50wRJIlto) — Kursankündigungen der Kuma Academy auf der oen-Plattform; listet die vollständigen Kursmodule: Feuerwehr, Suche und Rettung, Rettungsmedizin, Evakuierung, IT-Sicherheit, Betrugsschutz, AED/CPR, Blutstillung und Verband.
+
+[^28]: [PTS Nachrichten: Outdoor-Übung „Operation Blauer Elster“ der Kuma Academy](https://news.pts.org.tw/article/743411) — PTS-Nachrichtenmeldung über die halbjährliche Outdoor-Realübungsübung „Operation Blauer Elster“ der Kuma Academy, die Evakuierung und Rettung von Nicht-Kombattanten im Kriegsfall simuliert.
+
+[^29]: [X-Beitrag von Puma Shen: zur Frage seiner Rolle bei der Kuma Academy](https://x.com/pumashen/status/1847806524867170555) — Puma Shen beschreibt in seinem X-Beitrag aus eigener Darstellung, dass ihn seine Ämter als stellvertretender Exekutivdirektor des DPP-Think-Tanks und später als Abgeordneter per Vorschriften daran hindern, gesetzlicher Vertreter der Kuma Academy zu sein.
+
+[^30]: [CNA: DPP-Liste 2024 der Parteilisten-Abgeordneten, Puma Shen auf Platz 2](https://www.cna.com.tw/news/aipl/202311155003.aspx) — CNA-Meldung vom 15.11.2023 über die Bekanntgabe der DPP-Liste der nicht-regionalen Abgeordneten für 2024, auf der Puma Shen auf Platz 2 steht (Platz 1: Lin Yueh-chin).
+
+[^31]: [Fount Media: Die zehn Gesetzesrevisionen des DPP zur nationalen Sicherheit](https://www.fountmedia.io/article/276323) — Fount-Medienbericht über die von der DPP-Fraktion unter Puma Shens Führung vorangetriebene Liste der zehn Gesetzesrevisionen zur nationalen Sicherheit, darunter das Gesetz über Beziehungen zwischen beiden Seiten der Straße, das Hongkong-Macau-Gesetz, das Staatsangehörigkeitsgesetz, das Gesetz über die nationale Sicherheit, das Kommunikations-Überwachungsgesetz, das Anti-Infiltration-Gesetz, das Cybersicherheitsgesetz, das Strafgesetzbuch, das Militärstrafgesetz für Heer, Marine und Luftwaffe und das Gesetz über nationale Geheimdienstarbeit.
+
+[^32]: [Offizielle Informationen des Auswärtigen- und Verteidigungsausschusses des Legislativ-Yuans](https://www.ly.gov.tw/Pages/List.aspx?nodeid=46775) — Seite des Auswärtigen- und Verteidigungsausschusses des Legislativ-Yuans; dokumentiert die turnusmäßige Rotation der Vorsitzenden in der 11. Legislaturperiode (Puma Shen war 2025 einer der Vorsitzenden).
+
+[^33]: [Storm Media: Taiwan Affairs Office nennt Puma Shen, Robert Tsao und die Kuma Academy beim Namen](https://www.storm.mg/article/5254288) — Storm-Media-Bericht vom 14.10.2024 mit vollständiger Abschrift der Pressekonferenz, auf der der Sprecher des Taiwan Affairs Office, Chen Bin-hua, verkündete, Puma Shen, Robert Tsao und die Kuma Academy auf die Liste der „unverbesserlichen Separatisten“ zu setzen.
+
+[^34]: [CNA: Puma Shens Facebook-Antwort auf die Ermittlungen](https://www.cna.com.tw/news/aipl/202510280086.aspx) — CNA-Meldung vom 28.10.2025 mit vollständigen direkten Zitaten aus Pumas Facebook-Beitrag vom selben Tag, einschließlich „Das ist das 6. Mal innerhalb eines Jahres“, „Wer die Probleme Aufwerfenden löst … echt kommunistisch“ und „Die Taiwaner haben vor nichts Angst“.
+
+[^35]: [Taipei Times: Sanktionen gegen die Firma des Vaters](https://www.taipeitimes.com/News/taiwan/archives/2025/06/05/2003838105) — Taipei-Times-Bericht vom 05.06.2025 über die von der KPCh gegen die Firma Chao Yi Co., Ltd. von Puma Shens Vater Shen Tu-cheng verhängten Sanktionen, die Geschäfte mit chinesischen Firmen und Einzelpersonen verbieten.
+
+[^36]: [CNA: Zoll entzieht Sicuens die Registrierung](https://www.cna.com.tw/news/acn/202507160341.aspx) — CNA-Meldung vom 16.07.2025 über die Entziehung der Importeur-Registrierung für Sicuens International Co. Ltd, die Firma von Puma Shens Familie, durch den chinesischen Zoll.
+
+[^37]: [Business Today: CCTV enttarnt Puma Shen in 7,5 Minuten](https://www.businesstoday.com.tw/article/category/183027/post/202511090007/) — Business-Today-Bericht vom 09.11.2025 über den siebeneinhalbminütigen „Enttarnungs“-Beitrag des CCTV-Nachrichtenkanals über Puma Shen, der Pumas Facebook-Antworten im Wortlaut („Fake-Dokumentarfilm“, „Nobody cares“) wiedergibt.
+
+[^38]: [CNA: Rechtsgrundlage „Staatszerstörung“ – die 22 Paragraphen zur Bestrafung der Separatisten](https://www.cna.com.tw/news/aipl/202510280086.aspx) — CNA-Meldung, dass die Rechtsgrundlage für das Verfahren des Volkspolizei-Büros Chongqing das Strafgesetzbuch und die „Meinung zur gesetzmäßigen Bestrafung von Straftaten unverbesserlicher Taiwan-Separatisten, die den Staat zerstören oder zur Zerstörung des Staates anstiften“ (umgangssprachlich „22 Paragraphen zur Bestrafung der Separatisten“) ist.
+
+[^39]: [Xinhua: Originaltext der Fallmeldung von Chongqing](http://www.news.cn/20251028/c50bf44d994d4ac99af0b6be8f264223/c.html) — Xinhua veröffentlichte am 28.10.2025 den Originaltext der Fallmeldung des Volkspolizei-Büros Chongqing, einschließlich der vollständigen Informationen zu Melde-E-Mail-Adresse CQGACTD@163.com und Telefon 023-65697660.
+
+[^40]: [Cnews.com.tw: Puma Shens Reaktion auf die Sanktionierung der Firma seines Vaters](https://cnews.com.tw/235250605a02/) — Cnews-Bericht vom 05.06.2025 über Puma Shens wörtliche Reaktion auf die Sanktionierung der Chao-Yi-Firma seines Vaters durch die KPCh: „Eine große Ehre – innerhalb nur eines Jahres bereits zum dritten Mal von der Taiwan Affairs Office sanktioniert“ und „So eine dumme Sache kann wohl nur China hervorbringen“, sowie seine Deutung, dass seine Sanktionierung auf sein Vorantreiben der Gesetze zur nationalen Sicherheit zurückgeht.
+
+[^41]: [Liberty Times: CCTV warnt „Du bist der Nächste“](https://news.ltn.com.tw/news/politics/breakingnews/5239735) — Liberty-Times-Bericht vom 09.11.2025 über die warnende Kommentarphrase „Hör auf damit, sonst bist du der Nächste“ im CCTV-Beitrag „Enttarnung Puma Shen“ und ihre einschüchternde Bedeutung.
+
+[^42]: [Taipei Times: MAC-Erklärung zur transnationalen Unterdrückung](https://www.taipeitimes.com/News/taiwan/archives/2025/10/29/2003846284) — Taipei-Times-Bericht vom 29.10.2025 über die offizielle Erklärung, in der die Mainland Affairs Council das Verfahren gegen Puma Shen als „transnationale Unterdrückung“ (transnational repression) definierte.
+
+[^43]: [Business Today: CCTV enttarnt Puma Shen (Auszüge aus Shens Facebook-Antwort)](https://www.businesstoday.com.tw/article/category/183027/post/202511090007/) — Business Today überträgt im Wortlaut Pumas Facebook-Beitrag vom 09.11., einschließlich „Könnt ihr nicht aufhören, immer genau das zu tun, wovon ich vorhergesagt habe, dass ihr es tun werdet? Seid doch etwas kreativer.“
+
+[^44]: [CNA: Puma Shens Videoantwort auf CCTV – „ein Land auf der einen, ein Land auf der anderen Seite“](https://www.cna.com.tw/news/aipl/202511090131.aspx) — CNA-Meldung vom 09.11.2025 über Pumas kurzes Video als Antwort auf CCTV, mit drei direkten Zitaten: „Taiwan und China sind ein Land auf der einen, ein Land auf der anderen Seite“, „Versucht nicht, mit konstruierten Anklagen eure Hand nach Taiwan auszustrecken“ und „CCTV, richtet euch gefälligst auf eure Inlandspropaganda“.
+
+[^45]: [Human Rights Watch: Erklärung von Maya Wang](https://www.hrw.org/news/2025/10/31/china-dubious-criminal-investigation-of-taiwanese-legislator) — Der vollständige Text der Erklärung von Maya Wang, stellvertretende Asien-Direktorin von Human Rights Watch, vom 31.10.2025, die den Fall der KPCh als „transnationale Anwendung missbräuchlicher chinesischer Gesetze“ verurteilt.
+
+[^47]: [CNA: US-Außenministerium äußert Besorgnis über Chinas Ermittlungen gegen Puma Shen](https://www.cna.com.tw/news/aipl/202511150018.aspx) — CNA-Meldung vom 15.11.2025 über die öffentlich geäußerte Besorgnis des US-Außenministeriums über die Ermittlungen Chinas gegen Puma Shen und seine Kritik, dass dies die Normen der Beziehungen über die Straße hinweg zerstöre.
+
+[^48]: [Liberty Times: IPAC-Mitbegründer de Pulford unterstützt Puma Shen](https://news.ltn.com.tw/news/politics/breakingnews/5247849) — Liberty-Times-Bericht über die öffentliche Unterstützungsbotschaft von Luke de Pulford, Mitbegründer der Inter-Parliamentary Alliance on China (IPAC), für Puma Shen.
+
+[^49]: [Liberty Times: Auswärtiger- und Verteidigungsausschuss des Legislativ-Yuans verabschiedet Verurteilungsantrag](https://news.ltn.com.tw/news/politics/breakingnews/5250860) — Liberty-Times-Bericht vom 19.11.2025 über den Antrag des Auswärtigen- und Verteidigungsausschusses des Legislativ-Yuans, das gegen Puma Shen gerichtete Verfahren der KPCh zu verurteilen, einschließlich der Reden der Antragsteller wie Wang Ting-yu im Wortlaut.
+
+[^50]: [Liberty Times: China schreibt Belohnung für Pa Chiung und Minnan Wolf aus](https://news.ltn.com.tw/news/politics/breakingnews/5244379) — Liberty-Times-Bericht vom November 2025 über die von der chinesischen Polizei für die YouTuber „Pa Chiung“ und „Minnan Wolf“ ausgeschriebene Belohnung von höchstens RMB 250.000.
+
+[^51]: [Liberty Times: Puma Shen enthüllt Wanze vor seiner Haustür und Drohbrief](https://news.ltn.com.tw/news/politics/breakingnews/5163138) — Liberty-Times-Bericht vom 31.08.2025; Puma Shen berichtet erstmals öffentlich in der Sendung „话时代人物“ von Cheng Hung-yi über die als Motorradschraube getarnte Wanze vor seiner Haustür, den Drohbrief mit Foto seiner Frau und dem „Tod“-Zeichen sowie die Drohung, seiner Tochter die Kehle durchzuschneiden, sowie die Reaktion seiner Frau Tseng Hsin-hui mit Angst und Schlaflosigkeit.
+
+[^52]: [ETtoday „Personen an der Frontlinie“: Interview über die Adoption durch Puma Shen und Tseng Hsin-hui](https://www.ettoday.net/news/20240706/2771565.htm) — ETtoday vom 06.07.2024, Kolumne „Personen an der Frontlinie“, über die Adoption der Tochter „Mochi“ durch Puma Shen und seine Frau Tseng Hsin-hui über die Lu-Hsin-Stiftung – einschließlich des zweieinhalb Jahre dauernden Verfahrens, des Konzepts der „Bauch-Mama“, der Szene „Zum ersten Mal wurde ich wirklich gebraucht“ und Pumas Haltung zur Blutsverwandtschaft.
+
+[^53]: [UDN: Puma Shens Rede in der Anhörung des Deutschen Bundestags](https://udn.com/news/story/124655/9136657) — UDN-Bericht vom 12.11.2025 über Puma Shens Auftritt in der Bundestags-Anhörung „Bedrohung von Demokratie und Menschenrechten durch Desinformation autoritärer Staaten“ und seine Zitate im Interview danach.
+
+[^54]: [CNA: IPAC-Tagung in Den Haag, Foto von Puma Shen und Fan Yun](https://www.cna.com.tw/news/aipl/202511210369.aspx) — CNA-Meldung vom 21.11.2025, die Puma Shen und Fan Yun vor dem Internationalen Strafgerichtshof in Den Haag bei der Tagung der Inter-Parliamentary Alliance on China (IPAC) dokumentiert.
+
+[^55]: [Taipei Times: Shen beim Liberal-International-Panel in Den Haag](https://www.taipeitimes.com/News/front/archives/2025/11/23/2003847673) — Taipei-Times-Bericht vom 23.11.2025 über Puma Shens Rede auf dem Panel der 209. Exekutivratssitzung von Liberal International, mit den drei Zitaten „China is a paper tiger“, „symbolic propaganda for domestic audiences“ und „This is where dictators are tried for war crimes or genocide“.
+
+[^56]: [Außenministerium: Scharfe Verurteilung des Doxxings von Puma Shens Wohnsitz durch die KPCh](https://www.mofa.gov.tw/News_Content.aspx?n=95&s=121443) — Volltext der Verurteilungserklärung des Außenministeriums der Republik China vom 03.01.2026, mit den offiziellen Formulierungen „die niederträchtige Methode digitaler Autoritarismus – das Doxxing“, „verliert jede zivilisatorische Grenze und ist zutiefst verachtenswert“ und „alle inländischen Komplizen, die mit China bei transnationaler Unterdrückung zusammenarbeiten, sollten gesetzlich bestraft werden“.
+
+[^57]: [Liberty Times: Polizeibehörde schützt Puma Shen mit allen Kräften](https://news.ltn.com.tw/news/politics/breakingnews/5298005) — Liberty-Times-Bericht vom 03.01.2026 über die Reaktion der Polizeibehörde (NPA) auf den Satellitenortungsvorfall: Ankündigung, Puma Shens Sicherheit mit allen Kräften zu gewährleisten und lokale Komplizen hart zu verfolgen.
+
+[^58]: [Taiwan News: Meta und Google entfernen Satellitenbild-Beiträge](https://www.taiwannews.com.tw/news/6276185) — Taiwan-News-Bericht vom 05.01.2026 über die Entfernung der Beiträge, Videos und Bilder, in denen „孤烟暮蟬“ und „今日海峽“ Puma Shens Satellitenbilder veröffentlichten, durch Meta und Google auf Verlangen des Digitalministeriums.
+
+[^59]: [Liberty Times: Puma Shens Facebook-Antwort am 03.01. – „kollektiver Minderwertigkeitskomplex“ und „Useful Idiots“](https://news.ltn.com.tw/news/politics/breakingnews/5298010) — Liberty-Times-Bericht vom 03.01.2026 über Puma Shens Facebook-Antwort auf den Satellitenortungsvorfall, einschließlich „Was China markiert, sind meine Koordinaten – gezeigt wird ihr kollektiver Minderwertigkeitskomplex gegenüber dem demokratischen Taiwan“, des akademischen Verweises auf Useful Idiots und der Analyse als „miese Neuauflage des Kansai-Airport-Vorfalls“.
+
+[^60]: [Liberty Times: Puma Shen deckt Chinas drei Achsen der Taiwan-Blockade 2026 auf](https://news.ltn.com.tw/news/politics/breakingnews/5321342) — Liberty-Times-Bericht vom 24.01.2026 über Puma Shens langen Facebook-Beitrag, der die drei Achsen „physisch entwaffnen, geistig kognitiv verändern, wahltechnisch Ressourcen monopolisieren“ enthüllt, einschließlich der selbstironischen Originalformulierung „Meine größte Funktion dürfte wohl die der „Zielscheibe“ sein“.
+
+[^61]: [Taipei Times: Shen kehrt von 8-tägiger Frankreich-Mission zurück](https://www.taipeitimes.com/News/taiwan/archives/2026/02/16/2003852414) — Taipei-Times-Bericht vom 16.02.2026 über Puma Shens Abschluss der achttägigen diplomatischen Mission in Frankreich, den Valentinstag im Flugzeug und seine Facebook-Zusage nach der Rückkehr, „weiterhin mit meinem Land an der Front zu stehen“, in vollständiger Übersetzung.
+
+[^62]: [UDN: Pläne, Puma Shen gegen Taipeh antreten zu lassen](https://udn.com/news/story/124652/9422462) — UDN-Bericht vom April 2026; dokumentiert die Sitzung des DPP-Auswahlausschusses am 07.04. und die Absicht Eingeweihter, Puma Shen als Kandidaten der Partei für das Bürgermeisteramt von Taipeh aufzustellen.
+
+[^63]: [UDN: Hsu Kuo-yung unterstützt Puma Shen für Taipeh](https://udn.com/news/story/124652/9442093) — UDN-Bericht über die öffentliche Unterstützung des früheren Innenministers Hsu Kuo-yung für Puma Shens Kandidatur um das Bürgermeisteramt von Taipeh.
+
+[^64]: [TVBS-Umfragezentrum: Umfrage zum Bürgermeisteramt Taipeh 12/2025](https://cc.tvbs.com.tw/portal/file/poll_center/2025/20251208/f76262efaa46dd37ae3df58e65b2d1eb.pdf) — Volltext-PDF der Umfrage des TVBS-Umfragezentrums vom Dezember 2025 zum Bürgermeisteramt Taipeh: Chiang Wan-an 64 Prozent, Puma Shen 22 Prozent.
+
+[^65]: [UDN: Puma Shen wechselt den Look und steht erstmals mit Chiang Wan-an auf einer Bühne](https://udn.com/news/story/124652/9463754) — UDN-Bericht vom 25.04.2026 über Puma Shens Abschied vom Afrolook, den ersten gemeinsamen Auftritt mit Chiang Wan-an beim Mazu-Fest der Songshan-Cihuitang und die in den Medien gezogenen Vergleiche mit Kimura Takuya, Chang Hsiao-chuan, Bae Yong-joon und anderen.
+
+[^66]: [UDN: Offiziell! DPP beschließt, Puma Shen für das Bürgermeisteramt von Taipeh antreten zu lassen](https://udn.com/news/story/124652/9499591) — UDN-Bericht vom 13.05.2026 über den Beschluss des Zentralexekutivkomitees der DPP, Puma Shen für das Bürgermeisteramt von Taipeh zu nominieren, wobei der zugleich als Parteivorsitzender amtierende Präsident Lai Ching-te persönlich das Wahlkampfband umlegte und beide Hand in Hand „Dung-suan“ riefen.
+
+[^67]: [Yahoo News: Puma Shen tritt offiziell gegen Chiang Wan-an an – Lai Ching-te lobt ihn als einzigen Kandidaten für das Bürgermeisteramt Taipeh](https://tw.news.yahoo.com/%E6%B2%88%E4%BC%AF%E6%B4%8B%E6%AD%A3%E5%BC%8F%E5%8F%83%E9%81%B8%E5%B0%8D%E6%88%B0%E8%94%A3%E8%90%AC%E5%AE%89-%E8%B3%B4%E6%B8%85%E5%BE%B7%E8%AE%9A%E5%8F%B0%E5%8C%97%E5%B8%82%E9%95%B7%E4%B8%8D%E4%BA%8C%E4%BA%BA%E9%81%B8-105042647.html) — direkte Zitate von der Pressekonferenz vom 13.05.2026, einschließlich Lai Ching-tes Aussagen, Puma Shen besitze „die Höhe internationaler Perspektive, die Breite sektorübergreifender Regierungsführung und die Wärme der Fürsorge für die Bürger“ und sei der „einzige Kandidat für das Bürgermeisteramt von Taipeh“, sowie Puma Shens Annahmeerklärung „Ich habe mich entschieden, für das Bürgermeisteramt von Taipeh zu kandidieren – lasst mich euer Bürgermeister werden.“
+
+[^68]: [Focus Taiwan: DPP nominiert Puma Shen für die Bürgermeisterwahl in Taipeh](https://focustaiwan.tw/politics/202605130025) — Meldung der englischsprachigen CNA-Ausgabe Focus Taiwan vom 13.05.2026; bestätigt den Wahltag 28.11.2026 und Chiang Wan-an (KMT, Amtsinhaber) als Gegner und zitiert Lai Ching-tes Würdigung von Puma Shens NGO-Erfahrung bei der Kuma Academy und dem Taiwan Democracy Lab sowie seiner interdisziplinären Ausbildung in Kriminologie, Recht und öffentlicher Politik.
+
+[^69]: [UDN: Neueste Umfrage zu Taipeh – Chiang Wan-an liegt 28 Prozentpunkte vor Puma Shen](https://udn.com/news/story/124652/9529403) — UDN-Bericht über die am 27.05.2026 veröffentlichte Umfrage des TVBS-Umfragezentrums zum Bürgermeisteramt Taipeh: Chiang Wan-an 58 Prozent, Puma Shen 30 Prozent, Differenz 28 Prozentpunkte; bei den jungen Wählern von 20 bis 29 Jahren lag Puma Shen mit 37 Prozent ebenfalls unter Chiang Wan-ans 60 Prozent.


### PR DESCRIPTION
## 🇩🇪 German translation: Puma Shen (沈伯洋)

DPP-Abgeordneter, Kriminologe und Mitbegründer der Kuma Academy — vom Erforscher von Chinas kognitivem Krieg zum ersten gewählten taiwanesischen Politiker, gegen den China wegen „Staatszerstörung“ ermittelt und dessen Wohnung per kommerziellem Satelliten markiert wurde.

### Translate
- **Datei:** `knowledge/de/People/puma-shen.md` (421 Zeilen)
- **Quelle:** `knowledge/People/沈伯洋.md` (zh)
- **H2:** 12 (deckungsgleich mit zh)
- **Fußnoten:** 68 — inkl. Lücke `[^46]` exakt wie im zh-Original (weder zh noch de enthalten 46)
- **URLs:** 77, exakte Multiset-Übereinstimmung mit zh
- **Medien:** 5 Inline-Bilder + Hero, 2 CNA-Video-Embeds, `tw-timeline` + `tw-bars`-Module, 3 Kuratorennotiz-Callouts

### Frontmatter
- Passthrough-Felder **wortgleich** mit zh: `imageCredit` (曾成訓 / Flickr), `subcategory` (政治人物), `author`, `difficulty`, `date`, `featured`, `lastVerified`, `lastHumanReview`, `researchReport`, `image`, `imageLicense`, `imageSource`, `sporeLinks`
- EN_ONLY: Hashes mit offiziellem `status.py` berechnet (`sha256:ccbab3f1822e47af` / `sha256:ec031917f07c2762`), `sourceCommitSha` = aktueller zh-HEAD `09ffe560f`
- `lifeTree` weggelassen (nested; en-sibling enthält ihn ebenfalls nicht)

### Qualitäts-Gates (lokal, vor Commit)
- `article-health.py --profile=pre-commit`: **hard=0, warn=0**
- `verify-translation.py`: **18/18 ALL PASS** (ratio 2.94)

### Weiterführende Lektüre
Alle 6 Verweise auf de-Artikel ohne deutsche Übersetzung → als reiner Text (keine toten `/de/...`-Links).
