### PR TITLE
translate(de): 蘭嶼生態系 → orchid-island-ecosystem

### DIFF
--- a/knowledge/de/Nature/orchid-island-ecosystem.md
+++ b/knowledge/de/Nature/orchid-island-ecosystem.md
@@ -1,0 +1,164 @@
+---
+title: 'Das Ökosystem von Lanyu: Der Lebenscode am Rand des Kuroshio'
+description: 'Lanyu gehört nicht zu Taiwan – biologisch gesehen jedenfalls nicht. Die kleine Insel am Nordende des philippinischen Vulkanbogens ist voll tropischen Lebens, das der Kuroshio herangetragen hat, und hat im jahrtausendealten ökologischen Wissen der Tao (達悟族) ein Gleichgewicht zwischen Mensch und Natur gefunden.'
+date: 2026-04-01
+category: 'Nature'
+tags:
+  [
+    'Lanyu',
+    'Tao (Yami)',
+    'Kuroshio',
+    'Endemische Arten',
+    'Fliegende Fische',
+    'Magellan-Vogelfalter',
+    'Kugelrüsselkäfer',
+    'Naturschutz',
+    'Inselökologie',
+    'Biogeographie',
+  ]
+subcategory: '生態與保育'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-04-01
+lastHumanReview: false
+readingTime: 7
+curation: incubating
+translatedFrom: 'Nature/蘭嶼生態系.md'
+sourceCommitSha: '69b3afd91'
+sourceContentHash: 'sha256:c5b9ea1f1f0ebfd3'
+sourceBodyHash: 'sha256:31718e0ce0828285'
+translatedAt: '2026-09-11T06:55:08+08:00'
+---
+
+> **In 10 Sekunden:** Lanyu (蘭嶼) ist das Nordende des philippinischen Vulkanbogens, eine Raststation des Kuroshio und die Heimat der Tao (達悟族) –
+> und das fremdeste Stück auf Taiwans ökologischer Landkarte.
+
+---
+
+## Eine Insel, die der Kuroshio gebracht hat
+
+Wer von Taitung nach Südosten übersetzt, kreuzt nach rund 50 Kilometern eine kräftige Strömung, die unter dem Rumpf hindurchzieht.
+Das ist der Kuroshio (黑潮), die zweitgrößte Meeresströmung der Welt. Sie beginnt in philippinischen Gewässern, zieht an Taiwans Ostküste nach Norden
+und biegt dann Richtung Japan ab. Sie führt warmes Salzwasser und reichlich Plankton mit sich, aber auch Samen, Insekten
+und Schmetterlingseier, die sie unterwegs nach Norden zustellt.
+
+Lanyu ist eine der Stationen, an denen der Kuroshio auf dieser Route Halt macht.
+
+Geologisch gehört die nur 45 Quadratkilometer große Insel zum **Nordende des philippinischen Vulkanbogens**;
+zwischen ihr und Taiwan liegt ein Graben von über 3.000 Metern Tiefe. Wie tief der Meeresspiegel in den Eiszeiten
+auch sank – dieser Abgrund fiel nie trocken und wurde nie zur Landbrücke. Lanyu war niemals mit Taiwan verbunden,
+zu den philippinischen Batanes-Inseln dagegen unterhält es mit dem Kuroshio ein Förderband, das nie stillsteht.
+
+Genau deshalb erkannte der japanische Naturforscher Tadao Kano (鹿野忠雄), als er 1927 auf Lanyu Kugelrüsselkäfer sammelte,
+in ihnen philippinische und nicht taiwanische Arten. Das Leben auf Lanyu kam immer aus dem Süden.
+(Weiterführende Lektüre: [Die tropische Herkunft von Lanyu: Die Wallace-Linie und Tadao Kanos Inselrätsel])
+
+---
+
+## Die Bewohner der tropischen Grenzzone
+
+### Kugelrüsselkäfer: Edelsteine auf Beinen
+
+Auf Lanyu leben fünf Arten von Kugelrüsselkäfern (_Pachyrrhynchus_ spp.). Ihre Deckflügel sind verwachsen, sie fliegen ihr Leben lang nicht
+und kriechen nur langsam durch den Wald. Gerade weil sie keine Meerenge überqueren können, sind sie die zuverlässigsten
+„lebenden Indikatoren“ der Biogeographie – wo sie vorkommen, gab es einst eine Verbindung zwischen den Inseln.
+
+Die metallisch schimmernden Muster auf ihrem Panzer sind eine Warntracht und sagen Fressfeinden: Ich schmecke nicht.
+Diese Strategie funktionierte Jahrzehnmillionen lang, dem Sammeldruck des Menschen ist sie jedoch nicht gewachsen.
+Alle fünf Kugelrüsselkäfer-Arten von Lanyu stehen heute unter Artenschutz.
+
+### Magellan-Vogelfalter: Der Kurier des Kuroshio
+
+Jedes Frühjahr warten Schmetterlingsbeobachter aus Taitung auf den Waldwegen von Lanyu auf einen bestimmten Falter.
+Der Magellan-Vogelfalter (_Troides magellanus_) ist Taiwans größter Schmetterling, seine Spannweite reicht an 20 Zentimeter heran,
+und der goldgelbe Perlmuttglanz der Hinterflügel fließt im Sonnenlicht wie ein Stück Bernstein, das fliegen kann.
+
+Sein Verbreitungsgebiet reicht von den nördlichen Philippinen bis Lanyu; hergetragen hat ihn die Luftströmung über dem Kuroshio.
+Die Raupen fressen nur die Osterluzei _Aristolochia zollingeriana_ (港口馬兜鈴), die Falter leben kurz und patrouillieren im niedrigen Flug durch den Wald.
+Wegen Lebensraumzerstörung und Sammeldruck gilt die Art heute als geschütztes Wildtier der ersten Kategorie Taiwans.
+
+### Lanyu-Zwergohreule: Die Wächterin der Nacht
+
+Nach Einbruch der Dunkelheit gehört der Wald von Lanyu der Lanyu-Zwergohreule (_Otus elegans botelensis_).
+Die zierliche Eule ist eine endemische Unterart der Insel, ihr Ruf ist tief und regelmäßig im Rhythmus.
+Die Tao nennen sie „Geistervogel“; ruft sie auf dem Dach, so heißt es, werde bald jemand sterben.
+
+Dieses Tabu wurde unbeabsichtigt zu einem wirksamen Schutzmechanismus. Aus Ehrfurcht vor dem Geistervogel
+jagen die Tao seit Generationen keine Zwergohreulen, weshalb die Bestandsdichte auf Lanyu bis heute vergleichsweise stabil ist.
+
+### Palmendieb: Der größte Gliederfüßer an Land
+
+Auf den nächtlichen Waldwegen quert gelegentlich ein Riese die Fahrbahn – der Palmendieb
+(_Birgus latro_). Mit ausgestreckten Scheren erreicht er einen Meter und ist damit der größte an Land lebende Gliederfüßer.
+Er knackt mit seiner Scherenkraft Kokosnüsse, er klettert, und er riecht Nahrung über mehrere Kilometer hinweg.
+
+Auf vielen pazifischen Inseln ist er durch Überfischung bereits bedroht; auf Lanyu gibt es noch Bestände,
+auch weil die traditionellen Sammelgewohnheiten der Tao ein gewisses Maß an Zurückhaltung bewahrt haben.
+
+---
+
+## Die Logik der fliegenden Fische: Das ökologische Wissen der Tao
+
+Jedes Jahr im März, wenn der Nordostmonsun nachlässt und der Kuroshio warmes Wasser an Lanyus Ostküste vorbeiführt,
+lesen die Ältesten der Tao Sterne und Strömungen und rufen den Beginn der Fliegende-Fische-Saison aus.
+
+Die Tatala (拼板舟), aus Planken zusammengesetzte Boote, gehen zu Wasser, die Fischerfeuer brennen, und die Männer fahren nachts hinaus und locken die fliegenden Fische mit Licht über die Bordwand.
+Das ist nicht bloß Fischfang – das ist ein ganzes System des Verstehens und der Selbstbeschränkung gegenüber dem Meer.
+
+Die Tao kennen für die fliegenden Fische strenge Klassifikationen und Tabus: welche Fische eingesalzen werden dürfen, welche sofort verzehrt werden müssen,
+ab welcher Jahreszeit der Fang ruhen muss, ja sogar, welche Fische Männer welcher Altersgruppe fangen dürfen –
+für all das gibt es feine Regeln. Dieses Wissenssystem hat die Fliegende-Fische-Bestände rund um Lanyu langfristig stabil gehalten.
+
+Als moderne Meeresökologen die Fischereiressourcen um Lanyu untersuchten, stellten sie fest, dass die traditionellen Fangzeiten der Tao
+dem Wanderrhythmus der fliegenden Fische genau entsprechen – kein Zufall, sondern **traditionelles ökologisches Wissen**
+(Traditional Ecological Knowledge, TEK), über Generationen aus Beobachtung angesammelt.
+
+Das Tabu gegenüber der Zwergohreule, die Zurückhaltung beim Sammeln von Palmendieben, die Ehrfurcht vor den Meeresschildkröten
+bilden zusammen ein Inselmanagement, das in keiner Fachpublikation steht und doch seit Jahrhunderten funktioniert.
+
+---
+
+## Der Druck auf die Grenzzone
+
+Auf Lanyu wirken mehrere Kräfte aus verschiedenen Richtungen.
+
+**Invasive Arten** sind derzeit eines der hartnäckigsten Probleme. Eidechsen, Hauskatzen
+und allerlei Pflanzensamen aus dem Reisegepäck der Touristen breiten sich in der weitgehend feindfreien Umwelt rasch aus
+und drängen den heimischen Arten den Lebensraum ab.
+
+**Der Tourismusdruck** ist in den letzten Jahren rapide gestiegen. Nächtliches Kunstlicht stört den Verhaltensrhythmus
+von Zwergohreule und Palmendieb; neue Straßen zerschneiden zusammenhängende Waldlebensräume;
+zu viel Schnorcheln und Betreten schädigt die Korallenriffe rund um die Insel.
+
+**Das Zwischenlager für Atommüll** ist seit 1982 in Betrieb; schwach radioaktiver Abfall lagert seither am Südende von Lanyu.
+Die Sorge der Tao vor austretender Strahlung ist nie verstummt, die Verlagerung bleibt bis heute ungelöst
+und ist damit zu einer Gerechtigkeitsfrage geworden, die schwerer wiegt als der Naturschutz.
+
+**Der Klimawandel** ist die langfristigste Bedrohung. Steigende Meerestemperaturen bleichen Lanyus Korallenriffe,
+und die Riffe sind die Grundlage der gesamten küstennahen Fischerei. Der Kuroshio hat Lanyu das Leben gebracht –
+im wärmeren Meer könnte er es auch wieder mitnehmen.
+
+---
+
+## Eine Grenzzone, die weiterbesteht
+
+Bei den Tao heißt es, Lanyu sei _Ponso no Tao_, „Insel der Menschen“.
+Kein „Naturschutzgebiet“, keine „Touristenattraktion“, sondern ein Ort, an dem Menschen wohnen.
+
+In diesem Namen steckt eine ökologische Philosophie: Der Mensch ist Teil des Insel-Ökosystems,
+nicht sein Verwalter und nicht sein Zuschauer. Seit Jahrhunderten teilen die Tao mit Kugelrüsselkäfern,
+Magellan-Vogelfaltern, fliegenden Fischen und Zwergohreulen diese 45 Quadratkilometer Vulkaninsel
+und haben am Rand des Kuroshio eine Logik des Lebens entwickelt, die nur hierhergehört.
+
+Diese Logik wird gerade auf die Probe gestellt.
+
+---
+
+## Literaturverzeichnis
+
+- Lin Liang-kong (林良恭): „Biogeographische Untersuchungen zu den Säugetieren Taiwans“.
+- Yu Kuang-hung (余光弘) & Tung Sen-yung (董森永): _Jahreszeitliche Riten der Fischerdörfer der Yami_, Institut für Ethnologie der Academia Sinica, 1998.
+- **Wang, C.-N. & Hsin, K.-T.** (2013): „Zwischen den Enden der Welt – Wallace und seine biogeographische Leidenschaft“,
+  _Taiwan Natural Science_ (臺灣博物季刊), Ausgabe 120.
+- Lin Chun-yi (林俊義): „Zum Stand des Schutzes der endemischen Arten von Lanyu“, _Taiwanese Journal of Biodiversity_.
+- Hsia Yu-chiu (夏禹九): „Die Fliegende-Fische-Kultur der Tao und der Schutz der Meeresökologie“, _Schriftenreihe zur Erforschung der indigenen Völker Taiwans_.


### PR DESCRIPTION
Adds German translation of `Nature/蘭嶼生態系.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Opus 5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.48 (de band healthy 2.48–3.78, median ~3.14 per `scripts/tools/lang-sync/ratio-bands.json`)

**Structure alignment**: 6 `##` / 4 `###` / 0 footnotes / 0 URLs — 100% preserved

**Gates run locally before push**:

- `verify-translation.py` — 17 PASS, 0 hard fail (only WARN is the ratio row, which the shell wrapper could not resolve on this machine; ratio computed with the same `get_body` + `ratio-bands.json` method and reported above)
- `article-health.py --profile=pre-commit` — hard=0, passed
- `subcategory-translation-parity` — PASS (`subcategory: '生態與保育'` kept verbatim from the zh source, not translated)
- `footnote-density` warns grade F (zero footnotes / zero URLs) — inherited from the zh source, which has no citations either; nothing added or invented in the translation

**Note**: `i18n/de/STYLE.md` does not exist yet — followed TRANSLATE_PROMPT plus the established conventions of the existing German corpus.

Uncertain terminology flagged for reviewer:

- 達悟族 → Tao (達悟族), with `Tao (Yami)` in tags · the endonym is used in running text; the exonym Yami appears only in the tag and in the 1998 monograph title, which uses it
- 球背象鼻蟲 → Kugelrüsselkäfer · descriptive coinage; there is no established German common name for _Pachyrrhynchus_
- 珠光裳鳳蝶 → Magellan-Vogelfalter · follows the German convention of naming _Troides_ species after the species epithet; the 珠光 ("pearl-lustre") sense is carried by "goldgelber Perlmuttglanz" in the body
- 蘭嶼角鴞 → Lanyu-Zwergohreule · _Otus elegans_ is usually Ryukyu-Zwergohreule in German; kept the island name for the endemic subspecies
- 拼板舟 → Tatala (拼板舟), glossed once as "aus Planken zusammengesetzte Boote"
- 港口馬兜鈴 → Osterluzei _Aristolochia zollingeriana_ (港口馬兜鈴)
- 台灣一級保育類野生動物 → "geschütztes Wildtier der ersten Kategorie Taiwans" · descriptive, no official German rendering of the Taiwanese protection tiers exists
- 原住民 → indigene Völker (not "Ureinwohner"), per the style rules

Please review. Happy to iterate.
