### PR TITLE
translate(id): 台灣製香文化與香腳原鄉 → taiwan-incense-making-culture-and-heritage

### DIFF
--- a/knowledge/id/Culture/taiwan-incense-making-culture-and-heritage.md
+++ b/knowledge/id/Culture/taiwan-incense-making-culture-and-heritage.md
@@ -1,0 +1,149 @@
+---
+title: 'Budaya Pembuatan Dupa Taiwan dan Kampung Halaman Batang Dupa'
+description: 'Dari keterampilan membelah batang dupa berusia seabad di Komunitas Yunxiao, Chiayi, hingga industri dupa yang tersebar di seluruh Taiwan — sebuah kerajinan tua tentang ketakwaan, keterampilan tangan, dan keteguhan.'
+date: 2026-03-18
+category: 'Culture'
+tags:
+  [
+    'Pembuatan Dupa',
+    'Kerajinan Tradisional',
+    'Budaya Keagamaan',
+    'Chiayi',
+    'Batang Dupa',
+    'Kepercayaan Rakyat',
+  ]
+subcategory: '工藝與美學'
+author: 'Taiwan.md Contributors'
+difficulty: 'beginner'
+readingTime: 10
+featured: false
+lastVerified: 2026-03-19
+lastHumanReview: true
+translatedFrom: 'Culture/台灣製香文化與香腳原鄉.md'
+sourceCommitSha: 'f712b7242'
+sourceContentHash: 'sha256:90f09bc6a0a80e4d'
+sourceBodyHash: 'sha256:396be33a77ed6ba1'
+translatedAt: '2026-09-11T07:00:02+08:00'
+---
+
+# Budaya Pembuatan Dupa Taiwan dan Kampung Halaman Batang Dupa
+
+## Ikhtisar 30 Detik
+
+Dalam budaya keagamaan tradisional Taiwan, dupa adalah perantara yang menghubungkan manusia dengan dewa-dewi, sekaligus sebuah seni kerajinan tangan yang telah bertahan ratusan tahun. Dari "kampung halaman batang dupa" di Komunitas Yunxiao, Chiayi, ke toko dupa berusia seabad di Lukang yang berdiri sejak 1756, hingga taman budaya seni dupa di Xingang, industri dupa Taiwan menjadi saksi betapa dalamnya akar kepercayaan rakyat di pulau ini.
+
+Di bawah tekanan ganda berupa mekanisasi dan persaingan produk impor berharga murah, masih ada sekelompok perajin Taiwan yang bertahan pada metode pembuatan tangan tradisional, dan memandang mutu sebagai persoalan hati nurani.
+
+Teknik inti kerajinan ini adalah: pembuatan batang dupa, peracikan bubuk dupa, penggulungan bubuk berulang kali, penjemuran hingga bentuknya mantap. Setiap langkah bergantung pada kepekaan tangan untuk menilainya, dan tidak bisa sepenuhnya digantikan mesin.
+
+## Mengapa Ini Penting
+
+Budaya pembuatan dupa memperlihatkan betapa eratnya kepercayaan rakyat Taiwan terpaut pada kehidupan sehari-hari. Di tengah masyarakat yang sudah sangat modern, para perajin dupa yang bertahan pada cara tradisional ini menjaga teknik kerajinan kuno, sekaligus merawat semangat budaya bahwa "kalau dupanya lurus, hati yang menyembah dewa pun ikut lurus".
+
+Perjalanan industri dupa memperlihatkan bagaimana sebuah komunitas lokal di Taiwan membangun identitas budayanya sendiri di sekeliling satu keterampilan tradisional. Sejarah Komunitas Yunxiao yang "setiap rumah membelah batang dupa" mencerminkan gambaran umum perempuan Taiwan pada masa sebelum industrialisasi, yang menopang ekonomi keluarga lewat kerajinan tangan.
+
+Untuk memahami kehidupan keagamaan Taiwan, pewarisan seni kerajinan tangan, dan industri lokal, budaya pembuatan dupa menyediakan satu contoh pengamatan yang konkret.
+
+## Kampung Halaman Batang Dupa: Komunitas Yunxiao, Chiayi
+
+### Kisah Bunga Batang Dupa Seabad
+
+Komunitas Yunxiao yang terletak di dekat Kuil Dizang'an di Kota Chiayi terhubung erat dengan kuil yang ramai dupanya itu karena kedekatan wilayah, dan dari sanalah tumbuh industri pembelahan batang dupa yang berumur lebih dari seratus tahun. Pada masa hidup yang serba sulit itu, para perempuan Komunitas Yunxiao menguasai teknik membelah batang dupa demi membantu ekonomi keluarga, sampai hampir setiap rumah tangga menjadikannya mata pencaharian.
+
+Komunitas Yunxiao pernah menjadi penghasil batang dupa terbesar di Taiwan selatan dan menyandang julukan "kampung halaman batang dupa". Di sana beredar satu kalimat pujian: "Kampung Yunxiao berbunga sepanjang empat musim, dan yang mekar adalah bunga batang dupa" — sebuah gambaran hidup tentang masa ketika setiap rumah sibuk membuat batang dupa. Serat-serat bambu halus itu diikat menjadi bentuk jamur yang indah, bagaikan bunga-bunga yang sedang mekar, dan menjadi pemandangan paling khas di Komunitas Yunxiao.
+
+### Keterampilan dan Ketekunan Sang Perajin
+
+Kisah **Qiu Jinyun, perajin pembelah batang dupa**, memadatkan seluruh perjalanan industri ini (catatan berikut dikutip dari rekaman wawancara Pemerintah Kota Chiayi, data survei lapangan). Ia mulai belajar membelah batang dupa dari ibunya sejak sekolah dasar, dan terus mengerjakannya sampai batang dupa buatan tangan digantikan buatan mesin. Di tangannya yang cekatan, membelah bambu dengan golok terasa seringan melambaikan tangan, dan sifat-sifat bambu ia pahami luar dalam. Hanya dalam satu dua menit, lembaran bambu tipis berubah menjadi tali bambu yang lentur di jari, lalu batang-batang dupa itu diikat menjadi bunga batang dupa berbentuk jamur yang cantik.
+
+**Cai Zengcheng, perajin dupa buatan tangan**, memperlihatkan sisi lain dari tahapan pembuatan dupa. Di depan baskom bundar berdiameter hampir 2 meter, ia mencelupkan batang dupa yang sudah dilapisi dasar ke dalam air, lalu melakukan gerakan berkesinambungan: menyibak, menggulung, mengayun, mengibas, dan menggosok, agar bubuk dupa racikan bahan obat Tionghoa dan cendana menempel merata pada setiap batang dupa. Proses yang sama harus diulang 4 sampai 6 kali, barulah dihasilkan dupa halus buatan tangan dalam berbagai ukuran seperti 1 kaki 3, 1 kaki 6, 1 kaki 7, dan 1 kaki 8.
+
+Guru Cai menegaskan, dahulu seorang perajin harus membuat 150 kati dupa dalam sehari, dan membuat dupa dengan tangan adalah pekerjaan hati nurani dan kesungguhan. Setiap batang dupa harus punya ujung yang rapi dan pangkal yang indah, tebalnya harus merata dari ujung sampai pangkal tanpa bagian yang gemuk atau kurus, dan batangnya harus lurus benar. Menurut catatan survei lapangan, ia sering berkata: "Setiap batang dupa harus indah dan mudah terbakar, tidak boleh bengkok atau patah kakinya. Kalau dupanya lurus, hati yang menyembah dewa pun ikut lurus; kalau dupanya terbakar dengan indah, hati orang yang menyembah pun tenteram dengan sendirinya." (penuturan lisan, dikutip dari catatan budaya pembuatan dupa Pemerintah Kota Chiayi)[^5]
+
+## Peta Industri Dupa Se-Pulau
+
+### Lukang: Pewarisan Toko Dupa Seabad
+
+Industri dupa di Lukang, Changhua, sama tuanya. Di antaranya, **Shi Jinyu Muxiangzhai** berdiri pada 1756, telah diwariskan delapan generasi, dan berumur lebih dari 260 tahun. Industri dupa Lukang terkenal karena kehalusan keterampilan tangannya, terutama dalam memilih bahan wewangian yang sangat cermat. Kayu gaharu tua adalah harta karun yang tergali dari perut bumi akibat pergeseran lapisan tanah; setelah melewati ratusan bahkan ribuan tahun dan menyerap sari matahari dan bulan, ia jauh lebih berharga daripada kayu cendana yang dipanen dalam 60 sampai 100 tahun, dan dipandang sebagai yang terbaik di antara segala dupa.
+
+Industri dupa Lukang menghadapi persaingan produk dupa murah dari Tiongkok daratan, tetapi dengan bertahan pada mutu dan bahan baku alami, mereka berhasil mempertahankan pasar kelas menengah ke atas. Kebutuhan orang modern akan wewangian pun meluas dari sekadar keperluan keagamaan menjadi sarana meredakan tekanan hidup dan menjernihkan suasana ruang, sehingga membuka ruang pasar baru bagi industri dupa tradisional.
+
+### Xingang: Model Baru Wisata Budaya
+
+Sekitar tahun 2002, Xingang di Chiayi mendirikan taman budaya pertama di Taiwan yang bertema "dupa" — **Taman Budaya Seni Dupa Xingang** — yang mengangkat industri dupa tradisional ke tataran budaya dan seni. Taman ini bukan hanya melestarikan kerajinan pembuatan dupa, tetapi lewat pameran dan kegiatan pengalaman langsung juga membuat pengunjung memahami betapa pentingnya kedudukan dupa dalam budaya Taiwan.
+
+Model Xingang memperlihatkan kemungkinan transformasi industri tradisional: beralih dari manufaktur murni ke wisata budaya, menjaga semangat kerajinan sambil meniupkan daya hidup baru ke dalam industrinya.
+
+### Sentra Pembuatan Dupa di Daerah Lain
+
+Tainan, Hemei di Changhua, dan Toucheng di Yilan juga memiliki produsen dupa penting, sehingga terbentuk jaringan industri dupa yang tersebar di seluruh pulau. Para pelaku industri ini masing-masing mengembangkan ciri dan keahliannya sendiri: ada yang mendalami dupa untuk keperluan keagamaan, ada yang menggarap pasar wewangian rumah tangga, dan bersama-sama mereka merawat keberagaman budaya dupa Taiwan.
+
+## Inti Kerajinan Pembuatan Dupa
+
+Pembuatan dupa dengan tangan adalah keterampilan majemuk yang memadukan ilmu bahan, teknik kerajinan, dan penilaian indrawi. Mutu dupa ditentukan oleh tiga mata rantai: pemilihan bahan baku, pelaksanaan tahapan kerja, dan penilaian mutu di ujung proses. Setiap mata rantai menuntut pengalaman bertahun-tahun dari sang perajin.
+
+### Pemilihan dan Pengolahan Bahan Baku
+
+Pembuatan dupa tradisional terutama memakai bahan alami, termasuk berbagai kayu wangi seperti cendana, gaharu, dan kapur barus, dipadukan dengan bahan obat Tionghoa seperti cengkih, kayu manis, dan gansong. Batang dupanya terutama memakai bambu, yang harus dipilih dari bahan bertekstur padat dan berdaya lenting baik, lalu diolah melalui tahap pembelahan dan penjemuran.
+
+### Tahapan Lengkap Pembuatan Dupa
+
+1. **Pembuatan batang dupa**: bambu dibelah menjadi serat halus, lalu diikat menjadi berkas
+2. **Peracikan bubuk dupa**: berbagai bahan wewangian diracik menurut resep tradisional
+3. **Pelekatan bubuk**: batang dupa dicelup air lalu digulingkan pada bubuk dupa
+4. **Pengulangan pelapisan**: diulang 4 sampai 6 kali agar bubuk menempel merata
+5. **Penjemuran hingga mantap**: dikeringkan secara alami atau dengan pengering
+6. **Pemeriksaan mutu dan pengemasan**: dupa bermutu baik disaring lalu dikemas
+
+### Standar Penilaian Mutu
+
+Ciri dupa buatan tangan bermutu tinggi antara lain: batangnya lurus tidak bengkok, bubuknya tersebar merata, abunya tidak mudah rontok saat terbakar, dan aromanya murni tidak menusuk hidung. Para perajin tradisional menegaskan, dupa yang benar-benar baik semestinya "dupanya lurus, hatinya lurus", dan saat terbakar mampu membawa perasaan tenang dan damai bagi orang.
+
+## Tantangan dan Transformasi Industri
+
+### Mekanisasi dan Persaingan Impor
+
+Sejak dekade 1990-an, seiring berkembangnya teknologi pembuatan dupa dengan mesin dan masuknya produk dupa murah dari Tiongkok daratan ke pasar, pembuatan dupa tangan tradisional Taiwan menghadapi tantangan berat. Banyak perajin senior sudah lanjut usia, sementara generasi muda kurang bersedia terjun ke pekerjaan yang berat ini, sehingga pewarisan keterampilannya terancam terputus.
+
+### Transformasi dan Inovasi
+
+Menghadapi tantangan itu, para pelaku industri dupa Taiwan giat mencari jalan transformasi:
+
+1. **Diferensiasi mutu**: bertahan memakai bahan baku alami dan menang lewat mutu
+2. **Perluasan pasar**: melebar dari pasar keagamaan ke pasar wewangian rumah tangga
+3. **Wisata budaya**: memadukan pengalaman wisata untuk mempromosikan budaya dupa
+4. **Pengelolaan merek**: membangun citra merek dan menaikkan nilai tambah produk
+
+### Upaya Pewarisan Keterampilan
+
+Agar budaya dupa tidak punah, sejak dekade 2010-an bermunculan kasus penerus generasi kedua yang melepaskan peluang karier lain dan memilih tinggal di kampung halaman untuk meneruskan usaha dupa keluarga. Sambil menjaga keterampilan tradisional, mereka juga mencoba memasukkan gagasan pengelolaan modern, agar industri dupa yang tua ini menemukan pijakan baru di pasar.
+
+## Makna Spiritual Budaya Dupa
+
+### Hubungan Agama dan Kehidupan
+
+Dalam kehidupan keagamaan Taiwan, dupa adalah perantara yang menghubungkan manusia dengan dewa-dewi. Menyalakan dupa untuk bersembahyang bukan sekadar ritual keagamaan, melainkan juga perwujudan rasa hormat kepada dewa, kerinduan kepada leluhur, dan harapan akan hidup yang baik. Para perajin dupa memahami betul tanggung jawab itu, sehingga mereka membuat setiap batang dupa dengan hati yang khusyuk.
+
+### Perwujudan Semangat Perajin
+
+Budaya dupa Taiwan memperlihatkan semangat perajin yang mendalam: kekeraskepalaan terhadap mutu, keteguhan pada tradisi, dan pengasahan keterampilan tanpa henti. Para perajin dupa ini kerap menekuni pekerjaannya berpuluh tahun, mengasah teknik di dalam tahapan kerja yang berulang, dan memperdalam pemahaman mereka tentang dupa seiring bertambahnya usia. Sembari membuat barang dagangan, yang mereka wariskan sebenarnya adalah sebuah cara hidup dan nilai budaya.
+
+### Perluasan Makna Modern
+
+Dalam kehidupan modern, makna dupa sudah melampaui keperluan keagamaan semata. Menyalakan sebatang dupa yang baik bisa menjadi sekejap ketenangan di tengah hidup yang sibuk, bisa menjadi cara membangun suasana ruang di rumah, bisa pula menjadi tali rasa dengan budaya tradisional. Peralihan dari fungsi praktis menjadi penghiburan batin ini memperlihatkan daya sesuai dan daya hidup kerajinan tradisional di dalam masyarakat modern.
+
+## Renungan Lanjutan
+
+Pelestarian dan pengembangan budaya dupa Taiwan mencerminkan sebuah persoalan yang lebih besar: di tengah modernisasi yang serba cepat, bagaimana kita menempatkan hubungan kita dengan budaya tradisional? Contoh industri dupa memberi tahu kita bahwa kerajinan tradisional tidak bisa bertahan hanya dengan rasa sayang dan perlindungan, melainkan harus menemukan kedudukan dan nilai baru di dalam perubahan zaman.
+
+Bunga batang dupa Komunitas Yunxiao, taman budaya Xingang, toko dupa seabad di Lukang, dan berbagai upaya pengelolaan merek modern — budaya dupa Taiwan sedang menjalani transformasi yang mendalam. Proses ini sekaligus tantangan dan peluang: bagaimana merangkul inovasi sambil menjaga semangat kerajinan, bagaimana mempertahankan ciri budaya di tengah gelombang globalisasi, bagaimana membuat keterampilan tradisional mekar kembali dalam masyarakat modern — semuanya adalah persoalan yang layak terus diikuti.
+
+Bagi siapa pun yang ingin memahami kedalaman budaya Taiwan, budaya dupa menyediakan titik masuk yang sangat baik: ia adalah wadah budaya keagamaan sekaligus hasil kristalisasi seni kerajinan tangan; ia punya ketebalan sejarah sekaligus wujud peralihan modern. Di balik setiap kepul asap dupa yang naik perlahan, tersimpan kearifan sang perajin, kekuatan kepercayaan, dan makna mendalam dari pewarisan budaya.
+
+## Referensi
+
+[^1]: Pemerintah Kota Chiayi, "Keterampilan Tradisional Membelah Batang Dupa dan Membuat Dupa", https://www.chiayi.gov.tw/News_Content.aspx?n=512&s=216163
+[^2]: Shi Jinyu Muxiangzhai Co., Ltd., "Dupa Nomor Satu Lukang", https://www.scy1756.com.tw/
+[^3]: Shih Hsin University Little World, "Pembuatan Dupa Tangan Tradisional Meredup: Generasi Kedua Dupa dan Perajin Senior Bertahan dengan Sepenuh Hati", 24 Mei 2021, https://shuj.shu.edu.tw/blog/2021/05/24/%E5%82%B3%E7%B5%B1%E6%89%8B%E5%B7%A5%E8%A3%BD%E9%A6%99%E5%BC%8F%E5%BE%AE-%E9%A6%99%E4%BA%8C%E4%BB%A3%E8%88%87%E8%80%81%E5%B8%AB%E5%82%85%E6%BD%9B%E5%BF%83%E6%8D%8D%E8%A1%9B/
+[^4]: PeoPo Citizen Journalism, "Industri Senja: Pembuatan Dupa Tangan", https://www.peopo.org/news/276081
+[^5]: Catatan survei lapangan budaya pembuatan dupa Dinas Kebudayaan Pemerintah Kota Chiayi; lihat juga Taiwan Panorama, "Budaya Batang Dupa Komunitas Yunxiao, Chiayi", https://www.taiwan-panorama.com/


### PR DESCRIPTION
Adds Indonesian translation of `Culture/台灣製香文化與香腳原鄉.md`.

**Translation method**: Rewrite-style (not literal) per `docs/prompts/TRANSLATE_PROMPT.md`

**AI-assisted**: Yes (Claude Opus 5)

**Native speaker review**: No (contributor is native Chinese, some Indonesian proficiency)

**Length ratio**: 3.59 (id band healthy 2.00–4.30 per `scripts/tools/lang-sync/ratio-bands.json`; on the upper half of the band, which is where Indonesian tends to sit for prose-heavy Culture articles — no glosses, analogies or cultural explanations were added beyond what the zh source states)

**Structure alignment**: 1 `#` / 9 `##` / 11 `###` / 5 footnotes / 5 URLs — 100% preserved, URL multiset byte-identical

**Gates run locally before push**:

- `verify-translation.py` — 17 PASS, 0 hard fail (only WARN is the ratio row, which the shell wrapper could not resolve on this machine; ratio computed with the same `get_body` + `ratio-bands.json` method and reported above)
- `article-health.py --profile=pre-commit` — hard=0, warn=0, passed
- `subcategory-translation-parity` — PASS (`subcategory: '工藝與美學'` kept verbatim from the zh source, not translated)

**Note**: `i18n/id/STYLE.md` does not exist yet — followed TRANSLATE_PROMPT plus the established conventions of the existing Indonesian corpus (e.g. `## Referensi` for 參考資料).

Uncertain terminology flagged for reviewer:

- 香腳 → batang dupa · literally the bamboo core stick; "kaki dupa" would be a calque that reads oddly in Indonesian
- 香腳原鄉 → kampung halaman batang dupa · kept the affective sense of 原鄉 rather than a neutral "sentra"
- 香腳花 → bunga batang dupa · the local metaphor is preserved, with the mushroom-shaped bundles explained in the body exactly as the zh source does
- 剖香腳 → membelah batang dupa
- 尺3／尺6／尺7／尺8 → 1 kaki 3, 1 kaki 6, 1 kaki 7, 1 kaki 8 · the Taiwanese 台尺 sizing convention; kept as a unit rather than converted to centimetres
- 150 斤 → 150 kati · kati is current in Indonesian, so the unit needed no conversion
- 老沉木 → kayu gaharu tua · agarwood; distinguished from 檀木 (cendana) in the same paragraph
- 甘松 → gansong (_Nardostachys jatamansi_) · no settled Indonesian common name, so the Chinese materia medica name is kept
- 龍腦香 → kapur barus · the Indonesian name is itself the origin of the trade name, which reads naturally here
- 香正，拜神的心才會正 → "kalau dupanya lurus, hati yang menyembah dewa pun ikut lurus" · the double sense of 正 (straight / upright) survives in Indonesian *lurus*, so the wordplay is kept rather than paraphrased

Please review. Happy to iterate.
