### PR TITLE
🇩🇪 de/People: Chen Chih-chung (陳致中) — Stadtrat Kaohsiung, Blacklisting-Klausel, 62 Fußnoten

### DIFF
--- a/knowledge/de/People/chen-chih-chung.md
+++ b/knowledge/de/People/chen-chih-chung.md
@@ -1,0 +1,375 @@
+---
+title: 'Chen Chih-chung: Zweimal in den Stadtrat von Kaohsiung gewählt, zweimal endete die Amtszeit per Gesetz'
+description: '2008 verlor Chen Chih-chung wegen Fernbleibens die Zulassung der University of Virginia. Danach wählte ihn sein Wahlkreis dreimal in den Stadtrat von Kaohsiung; zweimal endete die Amtszeit mit der Urteilsrechtskraft. Das Urteil von 2023 enthielt keine Aberkennung der Ehrenrechte – doch die Blacklisting-Klausel der Wahlgesetze schloss ihn von neuer Kandidatur aus.'
+date: 2026-08-18
+category: 'People'
+tags:
+  [
+    'Chen Chih-chung',
+    'Stadtrat Kaohsiung',
+    'Cianjhen-Siaogang',
+    'Dalinpu-Umsiedlung',
+    'Blacklisting-Klausel',
+    'Wahl- und Abberufungsgesetz',
+    'Kommunalverwaltungsgesetz',
+    'passives Wahlrecht',
+    'New Taiwan National Policy Think Tank',
+    'politische Dynastien',
+  ]
+subcategory: '政治與民主'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-08-18
+lastHumanReview: false
+researchReport: reports/research/2026-08/陳致中.md
+image: '/article-images/people/chen-chih-chung-hero.webp'
+imageCredit: 'VOA 許波'
+imageLicense: 'Public domain'
+imageSource: 'https://commons.wikimedia.org/wiki/File:Chen_Chih-chung.jpg'
+translatedFrom: 'People/陳致中.md'
+sourceCommitSha: 'fa7059f7a'
+sourceContentHash: 'sha256:4b7b7aff6ea75a34'
+sourceBodyHash: 'sha256:560772bbc10e04f9'
+translatedAt: '2026-09-10T00:00:00+08:00'
+---
+
+# Chen Chih-chung: Zweimal wurde er in den Stadtrat von Kaohsiung gewählt – zweimal endete seine Amtszeit in Gesetzesparagraphen
+
+> **30-Sekunden-Überblick:** Chen Chih-chung ist der älteste Sohn des früheren Präsidenten Chen Shui-bian, Absolvent der Juristischen Fakultät der National Taiwan University, mit zwei Masterabschlüssen in Jura (Berkeley und New York University). Von 2010 bis 2022 schickte ihn der Wahlkreis Cianjhen–Siaogang in Kaohsiung dreimal in den Stadtrat; zweimal endete seine Amtszeit jeweils im 8. und im 4. Monat, beide Male gestützt auf Artikel 79 des Kommunalverwaltungsgesetzes, per Verfügung des Exekutiv-Yuans. Im rechtskräftigen Urteil vom 26. April 2023 im Geldwäsche-Fall war keine Aberkennung der bürgerlichen Ehrenrechte enthalten. Einen Monat später nahm der Legislativ-Yuan in dritter Lesung die „Blacklisting-Klausel“ der Wahlgesetze an, die Geldwäschedelikte auf die Liste der Gründe setzt, die von einer Kandidatur ausschließen. In dem Paragraphen standen weder die Worte „lebenslang“ noch eine Frist für die Wiederherstellung.
+
+Am 18. August 2008 begann an der juristischen Fakultät der University of Virginia an der Ostküste der USA das Orientierungsprogramm für Studienanfänger. Auf der Liste stand ein Student aus Taiwan. Er erschien nicht.
+
+## Das Orientierungsprogramm in Virginia, zu dem er nicht erschien
+
+Dieser Student hieß Chen Chih-chung und wollte den Doctor of Jurisprudence (J.D.) machen. Hanna, Senior Director der Public Relations-Abteilung der University of Virginia, erklärte es den taiwanesischen Medien später sehr klar: „Da Chen Chih-chung nicht an dem gestern begonnenen Orientierungsprogramm teilnahm, hat er den Immatrikulationsprozess nicht abgeschlossen und damit seine Studienzulassung an der juristischen Fakultät der University of Virginia verloren.“ Für eine erneute Aufnahme „könnte er erst wieder im nächsten Studienjahr beginnen“.[^1]
+
+Er kehrte nie wieder nach Virginia zurück. Die beiden juristischen Masterabschlüsse von Berkeley und der New York University sind Abschlüsse, die er wirklich erworben hat; der J.D. in Virginia wurde nie begonnen.[^2]
+
+Davor war sein Weg eine klassische Juristenlaufbahn: die Cheng-Gong-Oberschule in Taipeh, 2001 Abschluss der juristischen Fakultät der National Taiwan University (Abteilung Justiz), 2005 Master of Laws an der UC Berkeley, 2006 der zweite LL.M. an der New York University, danach Rückkehr in die USA zur Promotion.[^3] Zu jener Zeit gab es in seinen Lebensplänen keine Wahlen.
+
+Was ihn daran hinderte anzutreten, war ein rechtliches Verfahren, das gerade in Gang gesetzt wurde. Sein Vater Chen Shui-bian wurde 2000 mit Annette Lu zur Regierungspartei des Präsidenten und Vizepräsidenten gewählt – Taiwans erster Parteienwechsel in der Regierungsspitze. Nach dem Ausscheiden aus dem Amt im Mai 2008 geriet der Fluss der Familien-Gelder ins Ausland ins Visier der Ermittlungen; der Fall der Sonderausgaben des Staatspräsidentenbüros, der Fall des Grundstückskaufs in Longtan und der Fall des Ausstellungszentrums Nangang zogen nacheinander vor Gericht. Der Geldwäscheanteil der beiden letzteren Fälle sollte fünfzehn Jahre später darüber entscheiden, ob er weiterhin Stadtrat von Kaohsiung sein konnte.[^4]
+
+Ein Mensch, der Jura studiert hat, wurde zum ersten Mal von Gesetzen neu vermessen – dadurch, dass man ihn eine Einschreibung verpassen ließ.
+
+## Derselbe Wahlkreis – dreimal schickte er ihn hinein
+
+Zwei Jahre später erschien sein Name auf der Kandidatenliste der Stadtratswahl von Kaohsiung.
+
+Am 27. November 2010 holte er im 10. Wahlkreis von Kaohsiung (Cianjhen, Siaogang) als Unabhängiger 32.947 Stimmen und einen Stimmanteil von 16,83 % – die höchste Stimmenzahl in diesem Wahlkreis.[^5] Das ist ein Mehrpersonenwahlkreis: Es werden mehrere Sitze auf einmal vergeben, und auf demselben Stimmzettel buhlen über ein Dutzend Namen um die Stimmen. Bei der Wahl 2022 bewarben sich 17 Kandidaten um 8 Sitze.[^6] In diesem Wahlsystem liegt die Schwelle zur „höchsten Stimmenzahl“ meist bei gut einem Zehntel des Stimmanteils.
+
+![Das China-Steel-Werksgelände in Siaogang, Kaohsiung](/article-images/people/chen-chih-chung-china-steel-siaogang.webp)
+_Das Werksgelände von China Steel in Siaogang. Cianjhen und Siaogang sind die Schwerindustrieregion Kaohsiungs; das küstennahe Industriegebiet erstreckt sich über beide Bezirke und beherbergt das Taipower-Kraftwerk Dalin und die Dalin-Raffinerie der CPC Corporation. Dies sind die Wähler, denen er sich viermal gegenübersah. Photo: Makoto Lin / Präsidentenbüro, CC BY 2.0 über Wikimedia Commons_
+
+Im Jahr nach der höchsten Stimmenzahl erhöhte er den Einsatz: Im September 2011 kündigte er an, für den 9. Wahlkreis von Kaohsiung zur Wahl des Legislativ-Yuans anzutreten. Als im Januar 2012 die Stimmen ausgezählt wurden, holte er 48.941 Stimmen und verlor; der damalige DPP-Abgeordnete Kuo Wen-cheng verlor mit 59.258 Stimmen ebenfalls, der KMT-Kandidat Lin Kuo-cheng wurde mit 70.600 Stimmen gewählt.[^7] Die PTS-Berichterstattung nannte es damals „Spaltungsspiel der Grünen“; Kuo Wen-cheng führte die Wahlniederlage nach der Wahl in einem Interview auf Chen Chih-chungs Stimmenabschöpfung zurück.[^8] Die Niederlage machte seine Position innerhalb der DPP unangenehm: 2013 beantragte er den Wiedereintritt in die Partei; die Parteizentrale lehnte mit der „Fünfjahresklausel“ der Beitrittsordnung ab. Am 17. Februar 2015 hob das Schiedsgericht der DPP diese Ermessensentscheidung auf, und er kehrte in die Partei zurück.[^9]
+
+2018 kehrte er in den 10. Wahlkreis zurück, holte als DPP-Kandidat 15.938 Stimmen und wurde Sechster im Wahlkreis.[^10] Das war das Jahr, in dem Han Kuo-yu zum Bürgermeister von Kaohsiung gewählt wurde – seine Stimmenzahl halbierte sich.
+
+```tw-bars
+Drei Wahlen im selben Wahlkreis: Die Stimmen halbierten sich, dann kehrte er mit 2.600 mehr zurück
+2010 Stadtrat | 32.947 Stimmen | unabhängig, höchste Stimmenzahl im Wahlkreis
+2018 Stadtrat | 15.938 Stimmen | DPP, Platz 6 im Wahlkreis
+*2022 Stadtrat | 18.545 Stimmen | wieder höchste Stimmenzahl, 17 Kandidaten um 8 Sitze
+Quelle: Liberty Times, Newtalk-Nachwahlberichte (auszugsweise Auszählungstabellen der Zentralen Wahlkommission nicht öffentlich)
+```
+
+Mitten in der Amtszeit sollte jemand ihn abberufen. Im August 2020 startete die aus Einwohnern von Cianjhen und Siaogang gebildete „Schädlingsbekämpfungsgruppe Zhen-Gang“ ein Abberufungsverfahren; in der ersten Phase reichte sie 3.500 Unterschriftenzettel ein, 3.300 wurden geprüft und anerkannt und die Schwelle mühelos überschritten.[^11] Seine damalige Antwort war nur zwei Sätze lang: „Wir respektieren unterschiedliche Meinungen der Bevölkerung und erfüllen unsere Pflicht als Volksvertreter“ und „Ich will mich doppelt anstrengen, um die Wähler zu belohnen“.[^11] Die zweite Phase verlief nicht so glatt: Es wurden 29.018 Unterschriftenbögen eingereicht, aber mehr als 13.000 wurden wegen doppelter Unterschriften oder Wählern außerhalb des Wahlkreises gestrichen; es fehlten 12.417 Unterschriften zur gesetzlichen Schwelle von 28.062. Kuo Lun-hao, Sprecher der Initiativgruppe, sagte sehr deutlich: „In der ersten Phase lag die Ausschussquote nur bei 10 %, aber unerwartet lag sie in der zweiten Phase bei über 40 %“ und „In der Siaogang-Region ist die politische Landschaft tief grün; in diesem Wahlkreis ein Abberufungsverfahren gegen Chen Chih-chung anzustrengen, ist höchst unglücklich – wir respektieren die Entscheidung.“ Die Zentrale Wahlkommission erklärte das Abberufungsverfahren am 25. Dezember 2020 für gescheitert.[^12]
+
+Im selben Wahlkreis: Auf der einen Seite schickte man ihn hinauf, auf der anderen wollte man ihn hinunter – keine Seite überwältigte die andere.
+
+Am 26. November 2022 holte er 18.545 Stimmen und einen Stimmanteil von 11,53 % und kehrte damit zur höchsten Stimmenzahl seines Wahlkreises zurück.[^13] In diesen drei Auszählungsnächten lag die Entscheidung wirklich in den Händen der Menschen.
+
+## Sechzig- bis siebzigtausend Menschen, einhundertvierundfünfzig Parkplätze
+
+Am 24. November 2020 um 9 Uhr begann die 35. Sitzung der 4. ordentlichen Versammlung der 3. Wahlperiode des Stadtrats von Kaohsiung mit der allgemeinen Regierungsbefragung. Als er an der Reihe war, fragte er zunächst nach Parkplätzen: „Nehmen wir Gangshanzi in Cianjhen ... dort leben 60.000 bis 70.000 Menschen, aber es gibt nur 154 öffentliche, straßenferne Parkplätze.“ Danach legte er die Parkfördermittel der sechs Großstädte vor: Kaohsiung beantragte etwas mehr als 1,3 Milliarden und bekam etwas mehr als 800 Millionen bewilligt; in derselben Tranche beantragte Neu-Taipeh über 9 Milliarden, Taichung über 3 Milliarden, Tainan über 2 Milliarden – Kaohsiung beantragte am wenigsten unter den sechs Großstädten. Bürgermeister Chen Chi-mai antwortete, der Bebauungsplan für die Umwandlung des taiwanesischen Bahnwerks in Kaohsiung sehe bereits eine Aufstockung der Parkräume vor, und versprach, städtische Grundstücke zu inventarisieren, um das Angebot zu erhöhen.[^14]
+
+![Sitzungssaal des Stadtrats von Kaohsiung](/article-images/people/chen-chih-chung-kcc-chamber.webp)
+_Der Sitzungssaal des Stadtrats von Kaohsiung. Das Wortprotokoll jener allgemeinen Regierungsbefragung vom 24. November 2020 findet sich in Amtsblatt Band 34, Nummer 5. Photo: Informationsbüro der Stadtregierung Kaohsiung über Wikimedia Commons, Namensnennung_
+
+Das eigentliche Herzstück jener Befragung war Dalinpu, der südlichste Punkt des Bezirks Siaogang. Zusammen mit Fengbitou ist es von der Dalin-Raffinerie der CPC, dem Taipower-Kraftwerk Dalin und dem küstennahen Industriegebiet auf drei Seiten umschlossen; die Diskussion über die Umsiedlung begann Mitte der 2010er-Jahre. Auf dem Befragungspult verfolgte er die Gesundheitsuntersuchung und die Entschädigungsbedingungen nach der Überschreitung des Arsenwerts bei den Anwohnern und fragte bei der Finanzierungsfrage: „Wenn die Zentralregierung kein Geld hat – stellen wir es dann selbst zusammen?“ Die Antwort des Bürgermeisters: „Falls wirklich keine Mittel da sind, übernehme ich als Stadtregierung die Verantwortung.“ Danach versprach der Bürgermeister Punkt für Punkt: Die Wohnungsentschädigung erfolge „mit neuen Preisen und gleichem Material wie das Originalhaus – Sie zahlen keinen einzigen Cent“, die Bebauungsdichte könne auf 300 erhöht werden, die Stadtregierung werde mit der Bank of Kaohsiung ein zinsgünstiges Darlehensprogramm koordinieren, die Verschmutzungsentschädigung und die Beschäftigungsquoten für Nachbarn der Staatsunternehmen würden weiter mit dem Wirtschaftsministerium koordiniert, um den Jugendlichen aus Dalinpu Vorrang beim Arbeitsplatz zu garantieren.[^15]
+
+![Der Fenglin-Tempel in Dalinpu](/article-images/people/chen-chih-chung-dalinpu-fenglin-temple.webp)
+_Der Fenglin-Tempel in Dalinpu. Das Umsiedlungsgebiet umfasst sechs Ortsteile rund um Dalinpu und Fengbitou; wie die Tempel der Siedlung mit umgesiedelt werden, gehört zu den Anliegen, die den Bewohnern am wichtigsten sind. Photo: Wikimedia Commons, CC BY-SA 4.0_
+
+In derselben Befragung brachte er noch fünf weitere Punkte vor: die Einführung eines Bewertungssystems für Arbeitsbedingungen („Das Arbeitsamt vergibt Auszeichnungen an ‚glückliche Unternehmen‘ – die Preisträger bekommen eine Trophäe, und dann?“), die Einrichtung eines Gedenkmuseums für den 28. Februar in Kaohsiung, das Betreuungsschlüssel-Verhältnis für Sonderpädagogik, die Zuschüsse für Mittagessen benachteiligter Oberstufenschüler sowie die Investitions- und Beschäftigungszahlen nach der Erweiterung des 5G+AIoT-Parks in der Asien-Neue-Bucht. Beim Thema 28. Februar sprach er über die Erinnerung, die jene Niederschlagung von 1947 in Kaohsiung hinterließ: „Viele Angehörige der Opfer des 228 – auch diese Gruppen und Vereine hoffen, dass Kaohsiung ein eigenes 228-Gedenkmuseum bekommt, zumal unsere Opfer damals am schwersten waren, und es gibt ergreifende Geschichten wie die Selbstverteidigungseinheit der Hsiung-Neh-Mittelschule“[^15] (zum 228-Zwischenfall und den anschließenden Abrechnungen siehe die Artikel über Taiwans Vergangenheitsbewältigung). Bei den Themen Betreuungsschlüssel für Sonderpädagogik und Oberstufen-Mittagessen antwortete der Bürgermeister damals nicht Punkt für Punkt.
+
+Das sind die Zusagen, die er auf dem Befragungspult erhielt. Sechs Jahre später sind sie an jeweils unterschiedliche Orte gelangt. Das Geld für Dalinpu wurde tatsächlich immer mehr. Am 8. Oktober 2019 genehmigte der Exekutiv-Yuan den Plan „Industriepark für den Kreislauf neuer Werkstoffe“ mit Gesamtkosten von 105,4 Milliarden NT$; davon waren 58,981 Milliarden für die Umsiedlungsunterbringung vorgesehen. Am 4. Dezember 2023 hob der Exekutiv-Yuan die Sondermittel für die Umsiedlungsunterbringung auf 80 Milliarden NT$ an, die Gesamtkosten des korrigierten Plans stiegen zugleich auf 151,999 Milliarden. Die damalige CNA-Berichterstattung zeichnete den Weg der Stadtregierung vollständig: „Der Umsiedlungsfall Dalinpu – von der ursprünglich vom Exekutiv-Yuan zugestimmten Summe von 58,981 Milliarden hat die Stadtregierung sie auf 69,431 Milliarden erhöht und am heutigen Tag auf 80 Milliarden durch den Exekutiv-Yuan genehmigt“.[^16]
+
+```tw-stat
+Drei Zahlen, alle „Dalinpu“ – sie bezeichnen nicht dieselbe Sache
+105,4 Mrd. | Gesamtkosten des Industrieparks für den Kreislauf neuer Werkstoffe | am 08.10.2019 vom Exekutiv-Yuan genehmigt
+58,981 → 80 Mrd. | darunter Sondermittel für Umsiedlungsunterbringung | Weg der Stadtregierung: 58,981 → 69,431 → 80 Mrd.
+151,999 Mrd. | Gesamtkosten des korrigierten Plans | am 04.12.2023 genehmigt, zusätzlich 4,045 Mrd. Rücklage
+Quelle: CNA-Bericht über den am 4. Dezember 2023 vom Exekutiv-Yuan genehmigten Inhalt
+```
+
+Nachdem das Geld da war, lief der Zeitplan weiter. Nach Angaben der Stadtregierung Kaohsiung vom August 2026 befindet sich die „Flächenausweisung“ des Parks in der Prüfung durch die Zentrale; die neuen Zufahrtsstraßen im Umsiedlungsgebiet wurden im Juni 2026 in Angriff genommen und sollen im August 2027 fertiggestellt werden; die Grundstücksverlosung und die Auszahlung der Entschädigungen beginnen erst 2027. Die Stadtregierung nannte zugleich die Zustimmungsquoten der Entschädigungspläne: 94,8 % bei den Eigentümern von Wohn- und Geschäftsflächen, 92,7 % bei Nicht-Wohn-Geschäftsflächen, 95,5 % bei Eigentümern von Bodenverbesserungen; bis Ende Juli 2026 hatten über 2.500 Eigentümer eine Zustimmung zum vereinbarten Kaufpreis unterschrieben.[^17] Diese Zahlen entsprechen der von der Stadtregierung selbst veröffentlichten Zählweise.
+
+In derselben Reihe von Berichten fehlt die Stimme der Bewohner. Ihre Unzufriedenheit stammt aus früherer Zeit. Am 9. Mai 2024 versammelten sich über 300 Bewohner aus Dalinpu und Fengbitou vor dem Stadtrat von Kaohsiung und trugen vor, dass die Bedingungen im Umsiedlungsplan nicht den bei den Informationsveranstaltungen versprochenen entsprächen. Hung Hsiu-chu, Leiterin der „Gesunden Mütter und Großmütter“, beklagte, dass man für Restflächen kein Land tauschen könne. Der Bürgermeister von Fenglin (Siaogang), Chang Hsiao-ming, rechnete es den Journalisten vor: „Für das Land, das uns enteignet wird, zahlen sie uns 147.000 NT$ pro Ping; reicht unsere Fläche nicht, müssen wir es für 200.000 pro Ping von der Stadtregierung kaufen.“[^18] Im Juni 2025 kam das PTS-Programm „Our Island“ auf den Fall zurück; Hung Hsiu-chu sagte: „Seit das Umsiedlungsthema aufgeworfen wurde, sind 14 Jahre vergangen – nicht nur die Umsiedlung hängt fest, auch die öffentliche Infrastruktur vor Ort steht praktisch still.“[^19] In den Fortschrittsberichten der Runde 2026 gibt es keinen gleichzeitigen Oppositionsstandpunkt, der befragt worden wäre.
+
+> **📝 Kuratorennotiz**
+> Was ein Stadtrat auf dem Befragungspult erreichen kann, sind Zusagen und Zeitpläne. Was er nicht erreichen kann, ist, noch auf seinem Posten zu sein, wenn dieser Zeitplan abgelaufen ist. Die Grundstücksverlosung in Dalinpu ist für 2027 angesetzt – das wäre das siebte Jahr einer Sache, die er 2020 verfolgte – und seine Abgeordnetenrolle endete im April 2023. Die Amtszeit von Kommunalpolitikern beträgt vier Jahre, der Zyklus großer Bauprojekte mehr als zehn Jahre – diese Zeitdifferenz ist die gemeinsame Lage aller Kommunalpolitiker.
+
+Die anderen beiden Themen, die er 2020 ansprach, nahmen später einen anderen Lauf. Ab dem Schuljahr 2026 sind die Mittagessen an öffentlichen Grund- und Mittelschulen in Kaohsiung vollständig kostenlos – diese Politik umfasst ausdrücklich nicht die Oberstufen. Ein Bericht vom Januar 2026 deckte auf, dass an öffentlichen Gesamtschulen ein „Zwei-Schulen-System“-Streit entstehen würde: kostenlos in der Mittelstufe, kostenpflichtig in der Oberstufe; der Bericht zitierte nur einen anonymen Oberstufenleiter mit dem Vorschlag, die Zuschüsse „vorrangig an benachteiligte Oberstufenschüler“ zu richten; die Stadtregierung hat nicht entschieden.[^20] Damals sagte er: „Die Zuschüsse sollten nicht in der Oberstufe abbrechen“[^15] – sechs Jahre später liegt diese Linie noch immer an derselben Stelle. Für das Betreuungsschlüssel-Verhältnis der Sonderpädagogik gibt es in den öffentlichen Protokollen von Stadtregierung und Stadtrat keine Fortsetzung.
+
+<div class="video-embed" style="position:relative;padding-bottom:56.25%;height:0;overflow:hidden;margin:1.5rem 0;border-radius:8px;">
+  <iframe src="https://www.youtube.com/embed/YPao7-05oL4" title="陳致中質詢 韓國瑜讚：像降龍18掌｜華視新聞 20190516" style="position:absolute;top:0;left:0;width:100%;height:100%;border:0;" loading="lazy" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+_CTS-Nachrichtenbericht vom 16. Mai 2019: Er befragt den damaligen Bürgermeister Han Kuo-yu im Stadtrat von Kaohsiung._
+
+Diese Arbeit – ihren Inhalt hat er selbst gewählt. Ob sie zu Ende gemacht werden kann, entscheidet nicht er.
+
+## Drei Monate verurteilt – und trotzdem den Sitz verloren?
+
+Dass es das erste Mal nicht in seiner Entscheidung lag, geschah im achten Monat seiner Stadtrats-Amtszeit.
+
+Am 17. August 2011 entschied der Oberste Gerichtshof den Meineidsfall der Familie Chen abschließend: Wu Shu-chen wurde zu 9 Monaten verurteilt, Chen Chih-chung, Chen Hsing-yu (Sharon) und Chao Chien-ming jeweils zu 3 Monaten; nur Chen Hsing-yu erhielt zur Bewährung.[^21] Der Tatbestand des Meineids an sich hat nichts mit Geld zu tun: Als die zentrale Ermittlungsstelle der Oberstaatsanwaltschaft den Fall der Sonderausgaben des Staatspräsidentenbüros ermittelte, stellte sie fest, dass die abgerechneten Rechnungen von diesen drei Personen stammten; sie hatten bei der Vernehmung ausgesagt, die Rechnungen dienten Banketten oder Geschenken der Eltern – hinterher stellte sich heraus, dass es sich um Privatverbrauch handelte.[^21]
+
+Drei Monate Freiheitsstrafe – in der Intuition der meisten Menschen die leichteste Stufe, meist durch Zahlung erledigt. Dass er seinen Sitz verlor, hängt davon ab, wie Artikel 41 Absatz 1 des Strafgesetzbuchs formuliert ist. Dieser Paragraf legt die Schwelle für die Umwandlung der Haftstrafe in eine Geldstrafe auf zwei Bedingungen fest, die gleichzeitig erfüllt sein müssen: Die gesetzliche Höchststrafe des Tatbestands darf fünf Jahre nicht übersteigen, und die vom Richter verkündete Strafe muss unter sechs Monaten liegen.[^22] Die erste Bedingung bezieht sich auf den Tatbestand, nicht auf die tatsächlich verhängte Dauer. Meineid ist in Artikel 168 des Strafgesetzbuchs geregelt, die gesetzliche Strafe lautet „Freiheitsstrafe bis zu sieben Jahren“[^23] – sieben Jahre liegen über der Fünfjahresgrenze, daher lag dieser Tatbestand von Anfang an außerhalb der Reichweite der Geldumwandlung, selbst wenn der Richter drei Monate verhängt.
+
+Was zuständig wurde, war Artikel 79 Absatz 1 Nummer 4 des Kommunalverwaltungsgesetzes. Der Wortlaut: „Wer eine andere Straftat als die in den beiden vorhergehenden Nummern genannten begeht, gegen den ein Urteil mit einer Freiheitsstrafe rechtskräftig verhängt wurde und der weder zur Bewährung ausgesetzt noch zur Geldumwandlung vollstreckt wurde noch zur gemeinnützigen Arbeit verurteilt werden kann.“ Erfüllt ein Abgeordneter der Sonderstadt diese Nummer, wird er vom **Exekutiv-Yuan** des Amtes enthoben.[^24] Er hatte keine Bewährung und konnte keine Geldumwandlung leisten – drei Bedingungen erfüllt, die Abgeordnetenqualifikation endete in dem Moment, in dem das Urteil rechtskräftig wurde, ohne auf das Schreiben an den Stadtrat zu warten.[^25] Acht Monate Amtszeit.
+
+Von seiner damaligen Reaktion sind zwei Sätze überliefert. Beim Erhalt der Rechtskraftmeldung sagte er „Politische Manipulation ist zu niederträchtig, das kann ich absolut nicht akzeptieren“[^25], gegenüber Journalisten vier Zeichen: „Wer eine Schuld anhängen will, findet immer einen Vorwand.“[^26]
+
+Artikel 41 Absatz 3 des Strafgesetzbuchs eröffnete einen weiteren Weg: Wer eine verkündete Strafe von unter sechs Monaten erhalten hat und die Voraussetzungen für die Geldumwandlung nicht erfüllt, kann dennoch gemeinnützige Arbeit beantragen.[^22] Er meldete sich selbst bei der Staatsanwaltschaft, beantragte und wurde bewilligt.[^27] Insgesamt 546 Stunden, berechnet aus 91 Tagen à sechs Stunden pro Tag über drei Monate. Ausführungsort war das Gefängnis Daliao; die Arbeit bestand darin, Englischunterricht zu geben und in unterrichtsfreien Zeiten die Bibliothek zu ordnen. Die Staatsanwaltschaft berücksichtigte seine beiden juristischen Masterabschlüsse von Berkeley und der NYU und seine starken Fremdsprachenkenntnisse, als sie diese Anordnung traf, und schloss juristische Beratungstätigkeiten aus.[^28]
+
+Ein Mensch mit vollständiger juristischer Ausbildung unterrichtete im Gefängnis Englisch – mit der Begründung, seine Fremdsprache sei nützlicher als sein Rechtswissen. Diese 546 Stunden halfen seiner Abgeordnetenrolle in keiner Weise: Die Amtsenthebung richtet sich nach dem Zustand im Moment der Rechtskraft, eine erst später bewilligte gemeinnützige Arbeit wirkt nicht zurück.[^24]
+
+Das erste Mal entschied die Rechtsnorm für ihn. Sie blickte auf die Höchststrafe des Tatbestands – nicht darauf, wie schwer er verurteilt wurde.
+
+## Was das Urteil nicht schrieb, schrieb einen Monat später der Legislativ-Yuan
+
+Am 26. April 2023 wies der Oberste Gerichtshof in der Entscheidung Nr. 4948 (111 Tai-Shang-Zi) die Berufungen im Geldwäscheteil des Nangang-Ausstellungszentrum-Falls und des Longtan-Grundstückskauf-Falls zurück. Chen Chih-chung wurde zu 1 Jahr Freiheitsstrafe verurteilt und zu einer Geldstrafe von 1,5 Millionen NT$, die sichergestellten 8.169.015,3 US-Dollar wurden eingezogen. Seine Frau Huang Jui-ching wurde wegen derselben Straftat zu 10 Monaten Freiheitsstrafe verurteilt, zu einer Geldstrafe von 1 Million NT$, vier Jahren Bewährung und einer Zahlung von 1 Million NT$ an die Staatskasse.[^29] Dieselbe Maschine drehte sich erneut: Artikel 79 Absatz 1 Nummer 4 des Kommunalverwaltungsgesetzes, Amtsenthebung durch den Exekutiv-Yuan. Als der Stadtrat von Kaohsiung das Schreiben erhielt, war seine Abgeordnetenqualifikation bereits erloschen.[^30] Diese Amtszeit dauerte vier Monate. Am 11. Mai trat er die Haft an und zahlte am selben Tag die 1,5 Millionen NT$ Geldstrafe; Haftort war das Zweite Gefängnis von Kaohsiung.[^30]
+
+Die offizielle Pressemitteilung der Justizbehörde zu diesem Urteil listete wörtlich Strafmaß, Geldstrafe und Einziehung auf.[^29] Die Urteilszusammenfassung der Taipei Times am nächsten Tag nannte ebenfalls diese drei Punkte.[^31] In beiden Dokumenten steht keine „Aberkennung der bürgerlichen Ehrenrechte“. Einen Monat später sagte er selbst es deutlicher: „Das Gericht hat mich zu einem Jahr verurteilt, ohne Aberkennung der bürgerlichen Ehrenrechte – aber wegen der Blacklisting-Klausel der Wahlgesetze erleide ich lebenslange Aberkennung der bürgerlichen Ehrenrechte.“[^32] In diesem einen Monat tat der Legislativ-Yuan etwas anderes.
+
+```tw-timeline
+2023.04.26 | Geldwäschefall rechtskräftig | Oberster Gerichtshof Nr. 4948 (111 Tai-Shang), 1 Jahr Haft, 1,5 Mio. NT$ Geldstrafe, 8,16 Mio. US-Dollar Einziehung, kein Ehrenrechtsverlust in der Urteilsformel
+2023.05.11 | Haftantritt | Zweites Gefängnis Kaohsiung, Geldstrafe noch am selben Tag bezahlt
+2023.05.26 | Blacklisting-Klausel in dritter Lesung | §26 Wahlgesetz ergänzt um Geldwäschegesetz §§14,15 u. a., Abstimmung: 89 anwesend, 56 dafür, 30 dagegen, 3 Enthaltungen
+2024.02.06 | Bewährung | 272 Tage Haft, Oberlandesgericht ordnet Führungsaufsicht an
+2026.06.12 | Wahlgesetz erneut geändert | Nr. 6 ergänzt um Betrugsdelikte, Nr. 9 lockert Bewährung und gemeinnützige Arbeit; die bisherige Liste in Nr. 6 bleibt unverändert
+Quelle: Pressemitteilung der Justizbehörde, CNA, PTS-Nachrichten, United Daily News
+```
+
+Am 26. Mai 2023 verabschiedete der Legislativ-Yuan in dritter Lesung die Novelle des Artikels 26 des Gesetzes über die Wahl und Abberufung öffentlicher Bediensteter, von den Medien allgemein „Blacklisting-Klausel“ genannt. Sie schließt Personen, die wegen einer ganzen Reihe von Straftaten rechtskräftig verurteilt wurden, von der Kandidatur aus: Sicherheitsdelikte, Wahlbestechung, Korruption, organisierte Kriminalität, Drogen, Schusswaffen – plus §§14 und 15 der Geldwäschebekämpfungsgesetzes. Das Abstimmungsergebnis lautete 89 Anwesende, 56 dafür, 30 dagegen, 3 Enthaltungen[^33]; diese Zahlen stimmen mit der Berichterstattung der Taipei Times überein.[^34] Dieses Gesetz umfasst Abgeordnete des Legislativ-Yuans, lokale Volksvertreter und lokale Verwaltungsspitzen; die Wahl von Präsident und Vizepräsident wird gesondert durch das Gesetz über die Wahl und Abberufung von Präsident und Vizepräsident geregelt, das im selben Jahr entsprechend novelliert wurde.[^35]
+
+Der Wortlaut der Bestimmung weicht von der Darstellung der Medien ab. Im Text des Artikels 26 steht das Wort „lebenslang“ nicht. Der Einstiegssatz lautet „Wer eine der folgenden Voraussetzungen erfüllt, darf nicht als Kandidat registriert werden“; ihn betrifft Nummer 6, formuliert als „wer wegen ... zuvor rechtskräftig verurteilt wurde“, ohne jede Zeitangabe.[^36] Die nationalen Rechtsdatenbank und das gemeinsame System der von der Zentralen Wahlkommission verwalteten Vorschriften zeigen denselben Wortlaut.[^37] Das in den Medien übliche „lebenslange Kandidaturverbot“ ist eine Zusammenfassung des Effekts, dass „diese Nummer keine Wiederherstellungsfrist und keine Rehabilitierungsklausel kennt“. Der Paragraphentext selbst enthält einen Hinweis: Unter den 16 Tatbeständen des Artikels 26 schreiben die vier Nummern zu Insolvenz, Amtsenthebung (Suspension), Ehrenrechtsverlust und Betreuungsverfügung jeweils „noch nicht rehabilitiert“, „noch nicht abgelaufen“, „noch nicht aufgehoben“ – ein Hinweis darauf, dass mit Auflösung des Zustands die Wiederherstellung erfolgt. Die ersten neun Nummern einschließlich Nummer 6 haben alle keinen solchen Vorbehalt.[^36]
+
+Was diese Bestimmung wegnimmt, ist das passive Wahlrecht. Artikel 26 regelt nur die Handlung „als Kandidat registrieren“; Artikel 14 des Wahlgesetzes, „Staatsbürger der Republik China, die das 20. Lebensjahr vollendet haben, haben das Wahlrecht“, wurde durch die beiden Novellen nicht verändert.[^38] Bis heute darf er wählen.
+
+```tw-versus
+Aberkennung der bürgerlichen Ehrenrechte (StGB) | Wahlgesetz Art. 26 Nr. 6
+Vom Gericht im Einzelfall per Urteil ausgesprochen | Vom Legislativ-Yuan per Straftatliste geregelt, wirkt auch ohne Urteilserwähnung
+Außer bei Tod und lebenslanger Haft meist befristet (ein bis zehn Jahre) | Paragraf ohne Frist
+Mit Fristablauf wiederhergestellt | Kein Rehabilitierungsparagraf
+Im Urteil vom 26.04.2023 nicht enthalten | Nach dritter Lesung am 26.05.2023 ist er in der Liste
+Quelle: Artikel 37 StGB und Artikel 26 Wahlgesetz in der nationalen Rechtsdatenbank; Pressemitteilung der Justizbehörde zu 111 Tai-Shang-Zi Nr. 4948
+```
+
+> **📝 Kuratorennotiz**
+> Die gängige Darstellung lautet: „Weil er wegen Geldwäsche rechtskräftig verurteilt wurde, darf er lebenslang nicht mehr kandidieren.“ Dieser Satz verbindet zwei Dinge zu einer Kausalkette und lässt dabei einen Monat und eine dritte Lesung aus. Die Aberkennung der bürgerlichen Ehrenrechte nach dem Strafgesetzbuch ist eine Nebenstrafe, die der Richter im Einzelfall abwägend ausspricht – befristet, mit Wiederherstellung nach Ablauf. Artikel 26 des Wahlgesetzes ist eine Linie, die der Gesetzgeber für eine ganze Klasse von Straftaten gezogen hat; sie wirkt, ohne dass das Gericht sie erwähnen muss, und kennt keine Wiederherstellungsfrist. Dieselbe Person kann per Urteil keine Aberkennung der Ehrenrechte erhalten und dennoch nicht als Kandidat registriert werden.
+
+Gründe für dieses Gesetz sind leicht zu finden. Taiwans Problem der schwarzen Gelder und Krimineller in der Politik ist ein seit Jahrzehnten akkumuliertes Problem; der Gesetzeszweck der Novelle von 2023 war es, Menschen mit Vorstrafen wegen organisierter Kriminalität, Wahlbestechung und Drogen von der Kandidatenliste fernzuhalten – mit 56 Ja-Stimmen über die Parteigrenzen hinweg. Die DPP-Abgeordnete Saidai Tarovecahe (Wu Li-hua) sagte am Tag der dritten Lesung: „Die Novelle dient dazu, Verurteilte aus den Bereichen Schwarzgeld, Schusswaffen und Drogen daran zu hindern, über die Wahl die vom Volk verliehenen Rechte zu erhalten und weiteren Schaden anzurichten.“[^39] Bei der Novelle vom Juni 2026 nutzte die KMT-Abgeordnete Wong Hsiao-ling denselben Rahmen, nur ergänzt um neue Straftattypen: „Diese in dritter Lesung beschlossene Novelle des Wahlgesetzes dient der Wahrung des Verhältnismäßigkeitsprinzips des verfassungsmäßigen Wahlrechts. In den letzten Jahren haben Betrugstäter viele Familien zerstört, daher dürfen sie nicht als Kandidaten registriert werden“ – dieselbe Novelle erweiterte zugleich die Kandidaturberechtigung für Leichtverurteilte mit Bewährung oder Ersatzstrafe.[^40]
+
+Dieses Gesetz hat auch nicht nur einen Menschen getroffen: Lin Wen-jui, von der KMT für die nationale Liste nominierter Kandidat, zog sich wegen eines Wahlbestechungsfalls von 2004 (8 Monate, zwei Jahre Bewährung, zwei Jahre Ehrenrechtsverlust, rechtskräftig 2005) aus der Legislativ-Wahl in Yunlin zurück; für ihn rückte Huwei-Bürgermeister Ting Hsueh-chung nach.[^41]
+
+Die kritische Seite konzentrierte das Feuer auf die Mittel. Der TPP-Abgeordnete Chiu Hsien-chih sagte damals, dies sei „ein großer Rückschritt für die Demokratie“, und argumentierte, dass Einschränkungen der Kandidatur sich nach dem Strafmaß und nicht nach der Straftatart richten sollten.[^39] Der TPP-Abgeordnete Chang Chi-lu fragte, „ob es eine grenzenlose Ausweitung gibt, die der Unschuldsvermutung und dem Verhältnismäßigkeitsprinzip widerspricht“.[^39] Liao Yuan-hao, außerordentlicher Professor an der juristischen Fakultät der National Chengchi University, schrieb einen Kommentar mit dem Beispiel des früheren Tainaner Stadtrats Wang Chia-chen: Als sie die Straftat beging, sah das Gesetz vor, dass eine Bewährung die Kandidatur nicht ausschließt; nachdem sie sich für die Bewährung entschieden und bezahlt hatte, wurde das Gesetz geändert und schloss auch Bewährungsfälle von der Kandidatur aus. Sein Argument: Dies verletze das Gesetzmäßigkeitsprinzip im Strafrecht – „Die Bestrafung einer Handlung setzt voraus, dass das Gesetz zum Zeitpunkt der Handlung sie ausdrücklich vorsieht“ – und der Ehrenrechtsverlust ist eine Nebenstrafe nach Artikel 36 StGB; die Blacklisting-Klausel kommt damit einer Strafe gleich, die es zum Zeitpunkt der Handlung nicht gab.[^42] Wu Wei-chih von der National Policy Foundation griff aus einer anderen Richtung an: „Bei einer rechtskräftig verhängten Strafe von über zehn Jahren verliert der Angeklagte sein politisches Partizipationsrecht – dies verletzt klar die Unschuldsvermutung und das verwaltungsrechtliche Verhältnismäßigkeitsprinzip.“[^43]
+
+Artikel 26 Nr. 6 des Wahlgesetzes verweist bis heute auf „§§14 und 15 des Geldwäschebekämpfungsgesetzes“[^36], während das Geldwäschebekämpfungsgesetz am 1. August 2024 vollständig auf 31 Paragrafen novelliert wurde; die bisherige Strafvorschrift für Geldwäsche liegt nun in §19.[^44][^45] Für beide Dinge sind die Originaltexte der Normen nachprüfbar. Dass das Zitat nicht an das neue Gesetz angepasst wurde, ist eine Lücke, die die Gesetzgebungstechnik hinterließ. Welche Wirkung diese Lücke auf Personen mit rechtskräftigen Urteilen unter den alten Paragrafennummern hat, dazu haben weder die Zentrale Wahlkommission noch das Innenministerium eine öffentliche Auslegung veröffentlicht, und auch in der juristischen Fachwelt wurde öffentlich nicht darüber diskutiert.
+
+Am 12. Juni 2026 änderte der Legislativ-Yuan das Wahlgesetz erneut: Artikel 26 Nr. 6 erhielt den Zusatz „Straftaten nach dem Gesetz zur Bekämpfung von Betrugsstraftaten“; Nummer 9 ergänzte „mit Ausnahme derer, die zur Bewährung ausgesetzt oder zu gemeinnütziger Arbeit verurteilt werden können“; die Präsidialverfügung wurde am 1. Juli bekannt gemacht.[^40][^46] Diese Novelle wird umgangssprachlich „Kao Hung-an-Klausel“ genannt; der DPP-Abgeordnete Li Po-yi warf in der Fraktionsabstimmung der TPP vor, für eine bestimmte Person zu ändern; der TPP-Abgeordnete Hsu Chung-hsin behauptete im Gegenzug, die DPP mache die Regelung für Personen maßgeschneidert, und argumentierte zugleich: „Die Verfassung garantiert in Artikel 17 das Wahlrecht und das passive Wahlrecht der Bürger ... wenn das Wahlgesetz die Kandidatur der Menschen zusätzlich durch Verwaltungsrecht einschränkt, ist das verfassungswidrig“[^40]. Beide Parteien warfen einander vor, für jemanden zu ändern – dieses Schlagabtausch hat nichts mit ihm zu tun: Die ursprünglich schwere Straftatenliste in Nummer 6 wurde nicht um ein einziges Zeichen verändert, er steht weiterhin auf der Liste.
+
+Seine eigene Stellungnahme stammt aus dem Jahr 2023. Während der Haft veröffentlichte er eine Erklärung: „Das Ziel der Blacklisting ist sicherlich richtig, aber die Methode darf nicht verfassungswidrig sein“ und „Manche sagen, ein politisches Todesurteil für Chih-chung sei zum Wohle des großen Ganzen – wenn dem so ist, was soll ich da noch sagen? ‚Wortlos frage ich zum Himmel, selbst Tränen sind keine da!‘“[^47] An diesem Punkt endet der Streit. Die Bestimmung ist seit mehr als drei Jahren in Kraft, und in den öffentlichen Aufzeichnungen gibt es niemanden, der sie vor das Verfassungsgericht gebracht hätte – auch nicht ihn selbst.[^48] So hat die Sache diese Form: Auf der einen Seite die Legitimität des Gesetzeszwecks, schwarze Gelder aus der Politik zu verbannen – parteiübergreifend beschlossen, nicht nur eine Person betreffend; auf der anderen Seite das Argument, dass tatbestandsbasierte Dauerausschlüsse gegen Verhältnismäßigkeit und Gesetzmäßigkeit verstoßen. Beide Seiten haben ihre Positionen öffentlich gesagt, und die Institution, die eine Antwort geben könnte, hat von niemandem einen Antrag erhalten. Und die Migrantenarbeiter, die lange in Taiwan arbeiten und Steuern zahlen, aber nie Wahlrecht und passives Wahlrecht besaßen, stehen außerhalb dieser Debatte – ihre Frage ist eine andere.
+
+## Wer nicht mehr registriert werden kann, liest heute fremde Stimmzettel
+
+Am Morgen des 17. August 2026 saß er am Kopfende einer Pressekonferenz und stellte eine Umfrage zur Bürgermeisterwahl von Taichung vor.
+
+Der KMT-Kandidat Chiang Chi-chen erhielt 42,8 % Zustimmung, der DPP-Kandidat Ho Hsin-chun 36,1 % – ein Abstand von 6,7 Prozentpunkten. Bei der Einschätzung der Wahlchancen lagen Chiang Chi-chen mit 48,2 % gegen Ho Hsin-chun mit 23,6 %. Sein Kommentar: „Der Rückgang des Abstands zeigt, dass der Giftöl-Skandal der Blauen in der Taichung-Wahl geschadet hat“ und „Taichung könnte sehr wohl die Seiten wechseln, viel ist möglich“.[^49]
+
+```tw-dot
+Zustimmung Bürgermeisterwahl Taichung 2026 (%, mit 95-%-Konfidenzintervall)
+Chiang Chi-chen | 42,8 | 39,9 | 45,7
+Ho Hsin-chun | 36,1 | 33,2 | 39,0
+Quelle: New Taiwan National Policy Think Tank, Auftraggeber Ketagalan-Stiftung, Festnetz-Umfrage 11.–13.08.2026
+```
+
+```tw-note
+Anmerkung
+Die obige Tabelle zeigt Punktschätzungen der Zustimmung und das Stichprobenfehlerintervall bei 95 % Konfidenzniveau (±2,88 Prozentpunkte), umgesetzt auf die effektive Stichprobe von 1.159 vollständigen Interviews mit in Taichung gemeldeten Personen ab 20 Jahren. Das Intervall wurde aus dem veröffentlichten Fehlerwert abgeleitet; es soll daran erinnern, dass eine Punktschätzung kein sicherer Wert ist.
+```
+
+Der New Taiwan National Policy Think Tank, der diese Umfrage veröffentlichte, wurde im Januar 2010 von Ku Kuan-min gegründet. Am 1. September 2016 schenkte Ku Kuan-min den Think Tank der Ketagalan-Stiftung; Chen Chih-chung ist seitdem Geschäftsführer und war es auch im August 2026 noch.[^50] Der gesetzliche Vertreter der Ketagalan-Stiftung in der Körperschaftsregistrierung ist die Abgeordnete Chen Ting-fei; seine Position in der Stiftung ist Geschäftsführer – zwei verschiedene Positionen.[^51]
+
+Im Februar desselben Jahres erschien er zweimal auf den Straßen von Cianjhen, beide Male nicht für sich selbst. Am Nachmittag des 5. Februar warb er auf der Cuihong Nordstraße für den Stadtratskandidaten Huang Yen-yu aus demselben Wahlkreis mit den Worten: „Ob in der Sänfte oder beim Tragen der Sänfte – er wird die beste Rolle spielen.“[^52] Am 23. Februar begleitete er mit dem Abgeordneten Lai Jui-lung Huang Yen-yus Fahrzeugkolonne beim Wahlkampf und sagte „Ich kandidiere nicht, ich unterstütze Huang Yen-yu mit ganzer Kraft“ und rief „Vom 2. bis 8. März, abends 18 bis 22:30 Uhr, bewacht bitte eure Festnetztelefone“ – das sind die Zeiten der Telefonumfrage der innerparteilichen Vorwahl.[^53] Sein durch die Amtsenthebung freigewordener Sitz ließ im 10. Wahlkreis sechs Interessenten in den Nominierungskampf der DPP eintreten.[^54]
+
+> **📝 Kuratorennotiz**
+> Artikel 26 des Wahlgesetzes regelt nur eine Handlung: die Registrierung als Kandidat. Er legt nicht fest, wer keine Pressekonferenz leiten, keine Umfragen veröffentlichen, nicht auf der Straße für andere werben oder nicht Geschäftsführer einer Stiftung sein darf. Die Gesetzgeber zogen die Linie bei der Handlung „Registrierung“. Sie hätten die Linie beim politischen Engagement ziehen können – der Paragraf schreibt Registrierung vor. Ein Mensch, der lebenslang nicht als Kandidat registriert werden darf, kann realpolitisch nahezu unverändert einflussreich bleiben. Ob die Linie an der richtigen Stelle liegt, ist eine Frage, die der Paragraf selbst nicht beantworten kann.
+
+Neben dem Plenarsaal und den Pressekonferenzen hat er noch eine öffentliche Identität. Die Selbstbeschreibung seiner Threads-Kontos lautet: alleinerziehender Vater, ehemaliger Stadtrat von Kaohsiung, Geschäftsführer der Ketagalan-Stiftung und des New Taiwan National Policy Think Tanks. Am 28. April 2026 postete er ein Foto, auf dem er im Auto das Handy von Chen Shui-bian wegnimmt, und schrieb, er habe „etwas getan, das die Verwandtschaft außer Kraft setzt“ (ein Akt der „Gerechtigkeit gegen die eigene Familie“), mit dem Text: „Die wirksamste Methode gegen Handysucht: Was bringt es, das Handy zu kontrollieren? Ich nehme es einfach weg.“ Chen Shui-bian kommentierte darunter „Gib es zurück“ und konterte mit einem Foto. Er antwortete wieder: „Diesmal verrechnet – ich hätte es nicht im geschlossenen Raum tun dürfen; nächstes Mal nehme ich es und renne weg“.[^55] Im März desselben Jahres sagte Chen Shui-bian auf seinem eigenen Threads-Konto, dass Chen Chih-chung ihn zu Hause wie die Mutter direkt „Water“ nennt und nie „Papa“ gesagt hat.[^56]
+
+Die Rechtsnorm legt fest, dass er sich nicht registrieren darf; sie legt nicht fest, dass er keine fremden Stimmzettel lesen darf, und auch nicht, dass er im Internet nicht mit seinem Vater um das Handy streiten darf.
+
+## Sind politische Dynastien ein Problem? Taiwan hat noch keine eigene Forschung
+
+Vergrößern wir ihn von einer Person zu einer Frage: Wie viel bewirkt familiärer Hintergrund in der Politik eines Landes – gute oder schlechte Wirkung?
+
+Die internationale Politikwissenschaft ist sich darüber nicht einig. Christian Schafferer veröffentlichte 2023 in „Asian Journal of Comparative Politics“ eine Fallstudie Taiwans; die Zusammenfassung lautet: „legacy politicians are not per se the Pandora's box of low-quality politics“ – Politiker aus politischen Dynastien sind nicht zwangsläufig gleichbedeutend mit niedriger Politikqualität; ihre Verhaltensmuster unterscheiden sich nicht von anderen Netzwerken; die eigentliche Variable ist, ob der Grad politischer Modernisierung verhindern kann, dass sie öffentliche Ressourcen zur Beute der Familie machen.[^57] Nathan Batto untersuchte 2018 in „Asian Survey“ systematisch die Größenordnung von Familienpolitikern auf zentraler und lokaler Ebene Taiwans und fand heraus, dass dynastische Kandidaten dazu neigen, Wahlkreise mit scharfem Wettbewerb zu meiden und in mäßig kompetitiven Umgebungen am besten abschneiden.[^58]
+
+Die Literatur der anderen Seite kommt zum gegenteiligen Ergebnis. Querubin nutzte 2016 Amtszeitbegrenzungen lokaler Verwaltungschefs auf den Philippinen und fand heraus, dass Amtszeitbegrenzungen die Dauerhaftigkeit politischer Dynastien eher verstärkten, weil die Familie, wenn der Amtsinhaber nicht wiedergewählt werden kann, Ehepartner oder Kinder nachrücken lässt.[^59] Tusalem stellte 2013 auf Ebene der philippinischen Provinzen fest, dass dynastisch dominierte Provinzen bei Governance-Indikatoren wie Infrastruktur, öffentlichen Gesundheitsausgaben, Sicherheit und Beschäftigung schlechter abschnitten.[^60] In derselben Literatur gibt es zudem die Studie von Dal Bó et al. von 2009 über 200 Jahre US-Kongressdaten mit dem Ergebnis: Je länger eine Familie im Amt ist, desto stärker verstärkt sich der Vorteil von Nachfahren beim Einzug in den Kongress selbst.
+
+Die Daten dieser Studien stammen von den Philippinen und aus den USA. Wie viele politische Familien es in Taiwan selbst gibt, wie sie in Wahlkreisen konkurrieren und ob sie messbare Auswirkungen auf die lokale Governance haben – dazu gibt es derzeit keine lokale empirische Studie, die diese Fragen direkt beantwortet. Taiwans Politikwissenschaftler haben über das Phänomen gesprochen, meist in beschreibenden Kommentaren, nicht in Daten, auf denen man Urteile gründen könnte.
+
+Wie die Regeln geschrieben werden, hängt davon ab, wie verlässlich das Verständnis des Phänomens ist. Die Liste in Artikel 26 des Wahlgesetzes, ob es in der Liste ein Tor zur Wiederherstellung gibt und in welchem Jahr das Tor geöffnet wird – all das sind Urteile dieser Art. Taiwan trifft diese Urteile derzeit fast ohne lokale empirische Grundlage – durch Abstimmungszahlen im Legislativ-Yuan (weitere Aspekte desselben Problems: siehe Artikel über Taiwans Wahlen und Parteiensystem sowie über Taiwans Justizreform und die Untersuchungshaftregelung).
+
+Diese Frage hat im Alltag eine häufigere Version. Ob Strafentlassene bei der Jobsuche ihre Vorstrafen offenlegen müssen, wie lange Vorstrafenaufzeichnungen aufbewahrt werden sollen, wann Fachleute mit entzogener Lizenz ihre Lizenz neu beantragen können – es geht immer um dieselbe Frage: Wenn ein Mensch getan hat, was das Recht von ihm verlangt, ab wann rechnet die Gesellschaft ihn als fertig ab? Sein Fall ist nur die am sichtbarsten Version dieser Frage.
+
+Am Abend des 6. Februar 2024, kurz nach acht, nach 272 Tagen Haft, verließ er mit seinen persönlichen Gegenständen das Zweite Gefängnis von Kaohsiung durch das Tor, sagte gegenüber den Medien nur „Danke“, und seine Frau Huang Jui-ching fuhr ihn mit dem Auto nach Hause.[^61] An jenem Abend schrieb er auf Facebook zwei Sätze: „Zu Hause – wie ein Traum“ und „So lange kein Handy mehr gehabt, es hakt noch ein wenig“.[^62]
+
+Die Haftstrafe hat einen Endtermin, die Geldstrafe wurde am Tag des Haftantritts bezahlt, die Einziehung vollstreckt. In Dalinpu kommt erst 2027 die Grundstücksverlosung; die Sache, die er auf dem Befragungspult verfolgt hatte, deren Zeit läuft noch. Nur eines hat kein Enddatum.
+
+**Weiterführende Lektüre**:
+
+- Chen Shui-bian – vom Anwalt der Bewegung ohne Partei zum Präsidenten von Taiwans erstem Parteienwechsel; diese Linie ist der Hintergrund für alle Fallnamen dieses Artikels (keine deutsche Übersetzung verfügbar)
+- Chen Hsing-yu – die Schwester, die im Meineid-Fall mitverurteilt wurde, eröffnete später eine Zahnarztpraxis in Tainan; die Art, wie man sie betrachtete, war eine andere als bei ihm (keine deutsche Übersetzung verfügbar)
+- Taiwans Wahlen und Parteiensystem – wie Mehrpersonenwahlkreise, Parteiennominierten und lokale Fraktionen bestimmen, wer auf dem Stimmzettel steht (keine deutsche Übersetzung verfügbar)
+- Taiwans Justizreform und die Untersuchungshaftregelung – Gestaltung und Kontroversen des Strafverfahrens; dieses Urteil und der Amtsenthebungsmechanismus leben in diesem Rahmen (keine deutsche Übersetzung verfügbar)
+- Taiwans Vergangenheitsbewältigung – der 228-Zwischenfall und die anschließenden Abrechnungen; das von ihm auf dem Befragungspult angesprochene 228-Gedenkmuseum in Kaohsiung stammt aus dieser Linie (keine deutsche Übersetzung verfügbar)
+- Kaohsiung – das Industriegebiet von Cianjhen und Siaogang und die anderen Teile dieser Stadt (keine deutsche Übersetzung verfügbar)
+
+## Bildnachweise
+
+Dieser Artikel verwendet 3 Bilder unter Lizenz von Wikimedia Commons, gecacht in `public/article-images/people/`, um Hotlinking von Quellservern zu vermeiden:
+
+- [Facilities of China Steel in Siaogang](https://commons.wikimedia.org/wiki/File:Facilities_of_China_Steel_in_Siaogang.jpg) — Photo: Makoto Lin / Präsidentenbüro, CC BY 2.0 (China-Steel-Werksgelände in Siaogang)
+- [Sitzungssaal des Stadtrats von Kaohsiung](https://commons.wikimedia.org/wiki/File:%E9%AB%98%E9%9B%84%E5%B8%82%E8%AD%B0%E6%9C%83%E8%AD%B0%E5%A0%B4.jpg) — Informationsbüro der Stadtregierung Kaohsiung, Namensnennung (Plenarsaal)
+- [Fenglin-Tempel in Dalinpu](https://commons.wikimedia.org/wiki/File:%E5%A4%A7%E6%9E%97%E8%92%B2%E9%B3%B3%E6%9E%97%E5%AE%AE.jpg) — CC BY-SA 4.0 (Siedlung Dalinpu)
+
+Das eingebettete Video ist ein Nachrichtenbericht des [offiziellen CTS-Kanals CH52](https://www.youtube.com/@CtsTw), per iframe eingebettet; das Urheberrecht liegt bei der Taiwan Television Enterprise (CTS) und wird gemäß den Standard-Einbettungsbedingungen von YouTube verwendet.
+
+## Quellen
+
+[^1]: [Liberty Times: Chen Chih-chung erschien nicht und verlor die Zulassung der University of Virginia](https://news.ltn.com.tw/news/focus/paper/236074) — Fokusseiten-Bericht vom 19.08.2008; zitiert die Erklärung des Senior Director der PR-Abteilung der University of Virginia, Hanna, zum Fernbleiben vom Orientierungsprogramm und zum Erlöschen der Immatrikulation; die einzige Gleichzeitige-Ersthand-Überlieferung dieser Sache.
+
+[^2]: [TVBS: Bericht über Chen Chih-chungs Ausbildung](https://news.tvbs.com.tw/other/443550) — ordnet die Reihe seiner Abschlüsse: Berkeley und NYU als abgeschlossene juristische Master, der J.D. der University of Virginia als der 2008 nie angetretene, nie begonnene Plan.
+
+[^3]: [Abgeordnetenseite des Stadtrats von Kaohsiung: Chen Chih-chung](https://www.kcc.gov.tw/MemberInfo_New.aspx?n=39&sms=9028&msn=2219) — offizielle Stadtrats-Webseite; dokumentiert Ausbildung und Wahlbezirkszugehörigkeit.
+
+[^4]: [Pressemitteilung der Justizbehörde: Oberster Gerichtshof, Entscheidung Nr. 4948 von 111 (Tai-Shang-Zi)](https://www.judicial.gov.tw/tw/cp-1888-853666-7389d-1.html) — offizielle Pressemitteilung zum Urteil, das die Geldwäschenteile des Longtan- und Nangang-Falls abschließend behandelte.
+
+[^5]: [Liberty Times: Chen Chih-chung kündigt Kandidatur zur Stadtratswahl 2018 an](https://news.ltn.com.tw/news/politics/breakingnews/2290287) — enthält das Wahlergebnis von 2010 (32.947 Stimmen, höchste Stimmenzahl im Wahlkreis).
+
+[^6]: [Newtalk: Bericht über Chens Wiederwahl 2022](https://newtalk.tw/news/view/2022-11-26/845563) — dokumentiert die 2022er-Stimmenergebnisse (18.545) und die Sitzstruktur des Wahlkreises.
+
+[^7]: [ETtoday: Auszählungsbericht zur Wahl des Legislativ-Yuans 2012, Wahlkreis Kaohsiung 9](https://www.ettoday.net/news/20120114/19247.htm) — listet einzeln die Stimmen von Chen Chih-chung, Kuo Wen-cheng und Lin Kuo-cheng.
+
+[^8]: [PTS-Nachrichten: Bericht zur Wahl des Legislativ-Yuans 2012, Wahlkreis Kaohsiung 9](https://news.pts.org.tw/article/200671) — dokumentiert die Spaltungstendenz der Grünen und Kuo Wen-chengs Schuldzuweisung nach der Wahl.
+
+[^9]: [Liberty Times: Fall des Wiedereintritts von Chen Chih-chung in die Partei](https://news.ltn.com.tw/news/focus/paper/1235196) — die 2013er-Ablehnung durch die Parteizentrale per „Fünfjahresklausel“ der Beitrittsordnung und die 2015er-Aufhebung durch das Schiedsgericht.
+
+[^10]: [Liberty Times: Chen Chih-chung im Jahr 2018 zum Stadtrat gewählt](https://news.ltn.com.tw/news/politics/breakingnews/4136651) — dokumentiert „15.938 Stimmen, Platz 6“ im Wortlaut.
+
+[^11]: [CNA: Erste Phase des Abberufungsverfahrens gegen Chen Chih-chung erfolgreich](https://www.cna.com.tw/news/firstnews/202008270301.aspx) — Meldung vom August 2020 zur ersten Phase mit den Zahlen von 3.500 eingereichten und 3.300 geprüften Unterschriften.
+
+[^12]: [Newtalk: Abberufungsverfahren gegen Chen Chih-chung gescheitert](https://newtalk.tw/news/view/2020-12-20/511647) — vollständige Zahlen der zweiten Phase (29.018 eingereicht, über 13.000 gestrichen, 12.417 fehlend) sowie die Aussagen der Organisatoren; die Bekanntmachung der Zentralen Wahlkommission siehe [web.cec.gov.tw](https://web.cec.gov.tw/central/article/33273), der Wortlaut liegt in einem PDF-Anhang.
+
+[^13]: [Newtalk: Chen Chih-chung 2022 mit höchster Stimmenzahl wiedergewählt](https://newtalk.tw/news/view/2022-11-26/845563) — wie Anm. 6: Auszählungsergebnis 2022 und Sitzstruktur des Wahlkreises.
+
+[^14]: [Amtsblatt des Stadtrats von Kaohsiung, Band 34, Nr. 5 (Wortprotokoll der 35. Sitzung der 4. ordentlichen Versammlung der 3. Wahlperiode, S. 10320–10360)](https://cissearch.kcc.gov.tw/Upload/Attachment/公報資料/高雄市議會/34卷/5期/34卷5期10320起頁10360迄頁.pdf) — Wortprotokoll der allgemeinen Regierungsbefragung, in der er die Parkplatzfrage und die Mittel für die sechs Großstädte ansprach; vgl. auch die [Zusammenfassungsseite der Befragung auf der Stadtrats-Website](https://www.kcc.gov.tw/News_Content.aspx?n=47&s=13278).
+
+[^15]: [Amtsblatt des Stadtrats von Kaohsiung, Band 34, Nr. 5 (Wortprotokoll derselben Sitzung)](https://cissearch.kcc.gov.tw/Upload/Attachment/公報資料/高雄市議會/34卷/5期/34卷5期10320起頁10360迄頁.pdf) — Wortprotokoll derselben Befragung mit den Zusagen des Bürgermeisters zu Dalinpu, dem 228-Gedenkmuseum und den übrigen Punkten.
+
+[^16]: [CNA: Exekutiv-Yuan genehmigt Erhöhung der Umsiedlungsmittel für Dalinpu auf 80 Milliarden NT$](https://www.cna.com.tw/news/aloc/202312040226.aspx) — Meldung vom 04.12.2023 über die Genehmigung von 80 Milliarden und den Weg der Stadtregierung (58,981 → 69,431 → 80).
+
+[^17]: [Focus News: Fortschritt der Umsiedlungsunterbringung in Dalinpu und Zustimmungsquoten der Entschädigungspläne](https://focus.586.com.tw/2026/08/06/p398391/) — Bericht vom 06.08.2026 über den von der Stadtregierung veröffentlichten Zeitplan und die Zustimmungsquoten; die Beschlussfassung des Umsiedlungs-Projektbüros von 2025 siehe [Taiwan Hot News](https://www.taiwanhot.net/news/1111887/).
+
+[^18]: [PTS-Nachrichten: Einwohner von Dalinpu tragen Anliegen vor dem Stadtrat vor](https://news.pts.org.tw/article/694239) — Vor-Ort-Bericht vom 09.05.2024 mit den Aussagen der Bewohnervertreterin Hung Hsiu-chu und des Bürgermeisters von Fenglin (Siaogang).
+
+[^19]: [PTS „Our Island“: Vierzehn Jahre Dalinpu-Umsiedlung](https://ourisland.pts.org.tw/content/11494) — Bericht vom 29.06.2025, lange Perspektive auf den Stillstand der Umsiedlung, Aussagen der Bewohner.
+
+[^20]: [Economy Daily News: Kostenlose Mittagessen in Kaohsiung schließen Oberstufen aus](https://www.ctee.com.tw/news/20260106701724-431401) — Bericht vom 06.01.2026 über den „Zwei-Schulen-System“-Streit an Gesamtschulen; die bestehende Regelung für kostenlose Mittagessen an Grund- und Mittelschulen siehe [Rechtsvorschriften-System der Stadtregierung Kaohsiung](https://outlaw.kcg.gov.tw/LawContent.aspx?id=GL000058).
+
+[^21]: [Liberty Times: Meineidsurteil von 3 Monaten rechtskräftig, Chen Chih-chung als Stadtrat enthoben](https://news.ltn.com.tw/news/focus/paper/517337) — Bericht vom August 2011 über das abschließende Meineidsurteil des Obersten Gerichtshofs.
+
+[^22]: [Nationale Rechtsdatenbank: Strafgesetzbuch der Republik China, Art. 41](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=C0000001&flno=41) — Voraussetzungen für Geldumwandlung und gemeinnützige Arbeit.
+
+[^23]: [Nationale Rechtsdatenbank: Strafgesetzbuch der Republik China, Art. 168](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=C0000001&flno=168) — Meineid: Freiheitsstrafe bis zu sieben Jahren.
+
+[^24]: [Nationale Rechtsdatenbank: Kommunalverwaltungsgesetz, Art. 79](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=A0040003&flno=79) — Amtsenthebung durch den Exekutiv-Yuan bei rechtskräftig verhängter Freiheitsstrafe ohne Bewährung und ohne Geldumwandlung.
+
+[^25]: [Liberty Times: Amtsenthebung von Chen Chih-chung und seine Reaktion](https://news.ltn.com.tw/news/focus/paper/517337) — wie Anm. 21: Amtsenthebung wirksam ab Rechtskraft-Tag sowie seine Reaktion „politische Manipulation zu niederträchtig“.
+
+[^26]: [TVBS: Chen Chih-chungs Reaktion auf das rechtskräftige Meineidsurteil](https://news.tvbs.com.tw/local/63863) — Titel und Inhalt übernehmen seine wörtliche Antwort „wer eine Schuld anhängen will, findet immer einen Vorwand“.
+
+[^27]: [PTS-Nachrichten: Meineidsurteil 3 Monate, Chen beantragt gemeinnützige Arbeit](https://news.pts.org.tw/article/190121?NEENO=190121) — seine aktive Meldung bei der Staatsanwaltschaft und der bewilligte Antrag.
+
+[^28]: [JustLaw-Rechtsportal: Chen Chih-chung leistet gemeinnützigte Arbeit und unterrichtet im Gefängnis Englisch](https://www.justlaw.com.tw/News01.php?id=6076) — Berechnungsbasis der 546 Stunden, Gefängnis Daliao, der Englischunterricht und der Ausschluss juristischer Beratung.
+
+[^29]: [Pressemitteilung der Justizbehörde: Fall Wu Shu-chen, Chen Chih-chung, Huang Jui-ching – Verstoß gegen das Geldwäschebekämpfungsgesetz](https://www.judicial.gov.tw/tw/cp-1888-853666-7389d-1.html) — Pressemitteilung des Obersten Gerichtshofs zur Entscheidung Nr. 4948 (111 Tai-Shang-Zi), Strafmaß, Geldstrafe und Einziehung, ohne Ehrenrechtsverlust.
+
+[^30]: [CNA: Chen Chih-chung tritt Haft an; Stadtrat hat das Amtsenthebungs-Schreiben des Exekutiv-Yuans erhalten](https://www.cna.com.tw/news/aipl/202305090250.aspx) — dokumentiert, dass seine Abgeordnetenqualifikation bereits erloschen war, als das Schreiben eintraf, sowie den Haftantritt am 11.05.2023.
+
+[^31]: [Taipei Times: Kaohsiungs Chen Chih-chung verliert Sitz, wird verurteilt](https://www.taipeitimes.com/News/taiwan/archives/2023/04/29/2003798825) — Urteilszusammenfassung des nächsten Tages: Strafmaß, Geldstrafe, Einziehung.
+
+[^32]: [CNA: Nach der Wahlgesetz-Novelle Verlust der politischen Betätigung – Chen Chih-chung: „Wortlos frage ich zum Himmel“](https://www.cna.com.tw/news/aipl/202305300273.aspx) — Bericht vom 30.05.2023, enthält seine Aussage über das Jahr Urteil ohne Ehrenrechtsverlust und die Blacklisting-Klausel.
+
+[^33]: [CNA: Wahlgesetz in dritter Lesung erweitert Blacklisting](https://www.cna.com.tw/news/aipl/202305260209.aspx) — Bericht vom Tag der dritten Lesung (26.05.2023) mit dem Abstimmungsergebnis (89 anwesend, 56 dafür).
+
+[^34]: [Taipei Times: Novellen schließen Verurteilte von der Politik aus](https://www.taipeitimes.com/News/front/archives/2023/05/27/2003800505) — Bestätigung der Abstimmungszahlen in englischer Sprache.
+
+[^35]: [Nationale Rechtsdatenbank: Gesetz über die Wahl und Abberufung öffentlicher Bediensteter, Art. 2](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=D0020010&flno=2) — Anwendungsbereich des Gesetzes: Abgeordnete, lokale Volksvertreter und lokale Verwaltungsspitzen.
+
+[^36]: [Nationale Rechtsdatenbank: Gesetz über die Wahl und Abberufung öffentlicher Bediensteter, Art. 26](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=D0020010&flno=26) — die Blacklisting-Klausel im aktuellen Wortlaut, einschließlich der Nr. 6 und der fehlenden Wiederherstellungsfrist.
+
+[^37]: [Gemeinsames System der von der Zentralen Wahlkommission verwalteten Vorschriften: Wahlgesetz](https://law.cec.gov.tw/LawContent.aspx?id=GL000292) — zweite offizielle Rechtsquelle, identischer Wortlaut von Art. 26.
+
+[^38]: [Nationale Rechtsdatenbank: Gesetz über die Wahl und Abberufung öffentlicher Bediensteter, Art. 14](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=D0020010&flno=14) — Wahlrecht für Staatsbürger ab 20 Jahren, unverändert durch beide Novellen.
+
+[^39]: [PTS-Nachrichten: Blacklisting-Klausel des Wahlgesetzes in dritter Lesung verabschiedet](https://news.pts.org.tw/article/638725) — enthält die jeweiligen Aussagen der DPP-Abgeordneten Wu Li-hua, des TPP-Abgeordneten Chiu Hsien-chih und des TPP-Abgeordneten Chang Chi-lu am Tag der dritten Lesung.
+
+[^40]: [United Daily News: „Kao Hung-an-Klausel“ verabschiedet – Legislativ-Yuan novelliert Wahlgesetz in dritter Lesung](https://udn.com/news/story/6656/9562278) — Inhalt der Novelle vom 12.06.2026 (Nr. 6 ergänzt um Betrugsdelikte), mit den Auseinandersetzungen der Fraktionen.
+
+[^41]: [United Daily News: Blacklisting-Klausel trifft Lin Wen-jui](https://udn.com/news/story/6656/7195926) — dokumentiert den Rückzug des KMT-Kandidaten Lin Wen-jui wegen eines Wahlbestechungsfalls von 2004 (rechtskräftig 2005).
+
+[^42]: [Storm Media: Liao Yuan-haos Meinung – die „Blacklisting-Klausel“ verletzt das Verhältnismäßigkeitsprinzip](https://www.storm.mg/article/4949281) — Kommentar des außerordentlichen Professors der NCCU-Fakultät, mit dem Fall Wang Chia-chen als Beispiel zum Gesetzmäßigkeitsprinzip.
+
+[^43]: [National Policy Foundation: Wu Wei-chih „Blacklisting verfassungswidrig – löst Rechtsstaat-Sturm aus“](https://www.npf.org.tw/1/25826) — Kritik aus dem Blickwinkel von Unschuldsvermutung und Verhältnismäßigkeit, einschließlich Bedenken zur Strafmaßschwelle ohne Gewichtung der Straftatart.
+
+[^44]: [Lawbank-Rechtsportal: Geldwäschebekämpfungsgesetz 2024 vollständig novelliert und verkündet](https://www.lawbank.com.tw/news/NewsContent.aspx?NID=203581.00) — dokumentiert die vollständige Novelle vom 01.08.2024 auf 31 Paragrafen.
+
+[^45]: [Nationale Rechtsdatenbank: Geldwäschebekämpfungsgesetz, Art. 19](https://law.moj.gov.tw/LawClass/LawSingle.aspx?pcode=G0380131&flno=19) — die heutige Strafvorschrift für Geldwäsche.
+
+[^46]: [China Times: Lockerung der Kandidatur-Bedingungen, „Kao Hung-an-Klausel“ in dritter Lesung, Präsidialverfügung verkündet](https://www.chinatimes.com/realtimenews/20260701004253-260407) — dokumentiert die Bekanntmachung der Präsidialverfügung am 01.07.2026.
+
+[^47]: [Taiwan Hot News: Legislativ-Yuan verabschiedet „Blacklisting-Klausel“ des Wahlgesetzes in dritter Lesung – Chen Chih-chung: „Wortlos frage ich zum Himmel“](https://taiwanhot.net/news/1033611/) — enthält den Volltext seiner während der Haft veröffentlichten Erklärung, einschließlich „Ziel der Blacklisting richtig, aber Methode darf nicht verfassungswidrig sein“.
+
+[^48]: [Verfassungsgericht: Übersicht angenommener Fälle und Entscheidungen](https://cons.judicial.gov.tw/judcurrentNew1.aspx?fid=38) — öffentliche Fallseite des Verfassungsgerichts. Bis August 2026 wurde kein Antrag gegen die Blacklisting-Klausel gestellt.
+
+[^49]: [ETtoday: Pressekonferenz des New Taiwan National Policy Think Tanks zur Bürgermeisterwahl von Taichung](https://www.ettoday.net/news/20260817/3220548.htm) — Bericht vom 17.08.2026, mit den Unterstützungs- und Wahlchancen-Zahlen sowie seinen Kommentaren.
+
+[^50]: [Offizielle Website des New Taiwan National Policy Think Tanks: Über den Think Tank](https://braintrust.tw/%E9%97%9C%E6%96%BC%E6%99%BA%E5%BA%AB/) — Geschichte des Think Tanks wörtlich: Gründung durch Ku Kuan-min im Januar 2010, Schenkung an die Ketagalan-Stiftung am 01.09.2016, Chen Chih-chung seitdem Geschäftsführer; Details zur Geschichte siehe auch den [Wikipedia-Artikel „新台灣國策智庫“](https://zh.wikipedia.org/zh-tw/%E6%96%B0%E5%8F%B0%E7%81%A3%E5%9C%8B%E7%AD%96%E6%99%BA%E5%BA%AB).
+
+[^51]: [Taiwan Legal Entities: Registrierungsdaten der Ketagalan-Stiftung](https://org.twincn.com/item.aspx?no=43863350) — die Registrierungsdaten zeigen Chen Ting-fei als gesetzlichen Vertreter, getrennt von Chens Position als Geschäftsführer.
+
+[^52]: [United Daily News: Vom Blacklisting von der Kandidatur ausgeschlossen – Chen Chih-chung trägt die Sänfte für Huang Yen-yu](https://udn.com/news/story/124652/9311608) — Bericht vom 05.02.2026 über die Wahlkampfveranstaltung auf der Cuihong Nordstraße in Cianjhen.
+
+[^53]: [Storm Media: Lai Jui-lung und Chen Chih-chung begleiten Huang Yen-yus Fahrzeugkolonne](https://www.storm.mg/article/11105178) — Bericht über die zweite Wahlkampfveranstaltung vom 23.02.2026, einschließlich der Mobilisierungsaufrufe zur Vorwahl.
+
+[^54]: [China Times: Chens Amtsenthebung hinterlässt einen Sitz, die Grünen kämpfen um die Nominierung](https://www.chinatimes.com/newspapers/20251204000605-260107) — dokumentiert die sechs Interessenten für die Nominierung im 10. Wahlkreis nach seiner Amtsenthebung.
+
+[^55]: [SETN: Chen Chih-chungs „Akt der Gerechtigkeit gegen die eigene Familie“ – er nimmt Chen Shui-bians Handy weg](https://www.setn.com/news/1829183) — Bericht vom 28.04.2026, überträgt den Wortwechsel auf Threads.
+
+[^56]: [ETtoday: Chen Shui-bian gesteht, dass Chen Chih-chung ihn nicht „Papa“ sondern „Water“ nennt](https://www.ettoday.net/news/20260328/3139777.htm) — Bericht vom März 2026 über die Enthüllung auf Chens Threads-Konto.
+
+[^57]: [Schafferer, C. (2023). Political dynasties and democratization: A case study of Taiwan](https://journals.sagepub.com/doi/10.1177/20578911221148830) — Fallstudie Taiwans im Asian Journal of Comparative Politics mit dem Ergebnis, dass dynastische Politiker nicht zwangsläufig geringe Politikqualität bedeuten.
+
+[^58]: [Batto, N. F. (2018). Legacy Candidates in Taiwan Elections, 2001–2016](https://online.ucpress.edu/as/article/58/3/486/25032/Legacy-Candidates-in-Taiwan-Elections-2001) — systematische Studie zur Größenordnung von Familienpolitikern in Taiwan, mit dem Befund zum Wettbewerbsverhalten.
+
+[^59]: [Querubin, P. (2016). Family and Politics: Dynastic Persistence in the Philippines](https://doi.org/10.1561/100.00014182) — Studie zu philippinischen Amtszeitbegrenzungen und der Verstärkung dynastischer Dauer.
+
+[^60]: [Tusalem, R. F. (2013). The Effect of Political Dynasties on Effective Democratic Governance](https://doi.org/10.1111/aspp.12037) — Studie auf Provinzebene der Philippinen zu schwächeren Governance-Indikatoren in dynastisch dominierten Provinzen.
+
+[^61]: [PTS-Nachrichten: Chen Chih-chung nach 272 Tagen Haft vorzeitig entlassen](https://news.pts.org.tw/article/680130) — dokumentiert Haftantritt 11.05.2023, Bewährungsentlassung 06.02.2024 und die Details des Haftein- und -austritts.
+
+[^62]: [Epoch Times: Chen Chih-chung postet am Abend der Bewährungsentlassung](https://www.epochtimes.com/b5/24/2/7/n14175626.htm) — enthält seine beiden Facebook-Sätze vom Abend des 06.02.2024: „Zu Hause – wie ein Traum“ und „So lange kein Handy mehr gehabt“; Details am Ort der Entlassung siehe [CNA-Bericht](https://www.cna.com.tw/news/asoc/202402070048.aspx).


### PR DESCRIPTION
## 🇩🇪 German translation: Chen Chih-chung (陳致中)

Sohn des früheren Präsidenten Chen Shui-bian, dreimal gewählter Stadtrat von Kaohsiung (Wahlkreis Cianjhen–Siaogang) – zweimal endete seine Amtszeit mit der Rechtskraft eines Urteils, und die Blacklisting-Klausel der Wahlgesetze von 2023 schloss ihn von einer erneuten Kandidatur aus.

### Übersetzung
- **Datei:** `knowledge/de/People/chen-chih-chung.md` (375 Zeilen, ~66 KB)
- **Quelle:** `knowledge/People/陳致中.md` (zh)
- **H2:** 9 (deckungsgleich mit zh)
- **Fußnoten:** 62 (nummeriert 1–62, ohne Lücke) – inkl. aller 8 Sekundär-Links innerhalb der Fußnotentexte
- **URLs:** 69, exakte Multiset-Übereinstimmung mit zh
- **Medien:** 3 Inline-Bilder + Hero, 1 CTS-Video-Embed (YPao7-05oL4), 6 Visual-Module (`tw-bars`, `tw-stat`, `tw-timeline`, `tw-versus`, `tw-dot`, `tw-note`), 3 Kuratorennotizen
- Alle 5 `[[wikilink]]`-Ziele (Chen Shui-bian, Annette Lu, twn. Transitional Justice, Wahlen/Parteiensystem, Justizreform) haben keine de-Version → als Klartext aufgelöst, keine toten Links

### Frontmatter
- Passthrough-Felder **wortgleich** mit zh: `imageCredit` (VOA 許波), `subcategory` (政治與民主), `author`, `difficulty` (fehlt in zh ebenso), `date`, `featured`, `lastVerified`, `lastHumanReview`, `researchReport`, `image`, `imageLicense`, `imageSource`
- EN_ONLY: Hashes mit offiziellem `status.py` frisch berechnet (`sha256:4b7b7aff6ea75a34` / `sha256:560772bbc10e04f9`), `sourceCommitSha` = zh-HEAD `fa7059f7a` (der en-Mirror zeigt veraltete Werte, daher aus der zh-Quelle neu bestimmt)

### Qualitäts-Gates (lokal, vor Commit)
- `article-health.py --profile=pre-commit`: **hard=0, warn=0**
- `verify-translation.py`: **18/18 ALL PASS**
- de-SEO: Titel 102 ≤ 120, Description 365 ≤ 400 Zeichen
