### PR TITLE
translate(de): 臺灣的鯨豚 → cetaceans-of-taiwan

### DIFF
--- a/knowledge/de/Nature/cetaceans-of-taiwan.md
+++ b/knowledge/de/Nature/cetaceans-of-taiwan.md
@@ -1,0 +1,141 @@
+---
+title: 'Wale und Delfine vor Taiwan'
+description: 'Lebensraum für ein Drittel aller Wal- und Delfinarten der Welt — vom Walfang von einst zum Whale Watching von heute: Wie wurde Taiwan zu einem Zentrum der Meeresökologieforschung?'
+date: 2026-03-19
+category: 'Nature'
+tags:
+  [
+    'Taiwan',
+    'Wale und Delfine',
+    'Meer',
+    'Natur',
+    'Artenschutz',
+    'Whale Watching',
+    'Chinesischer Weißer Delfin',
+    'Kuroshio',
+  ]
+subcategory: '野生動物'
+author: '海女'
+featured: false
+lastVerified: 2026-03-19
+lastHumanReview: false
+readingTime: 12
+translatedFrom: 'Nature/臺灣的鯨豚.md'
+sourceCommitSha: 'f712b7242'
+sourceContentHash: 'sha256:fa8568c6d129180a'
+sourceBodyHash: 'sha256:7c0ff1bf77404541'
+translatedAt: '2026-09-13T08:23:14+08:00'
+---
+
+# Wale und Delfine vor Taiwan
+
+## 30-Sekunden-Überblick
+
+Taiwan liegt am Rand des nordwestlichen Pazifiks. Die außergewöhnlich günstige geographische Lage und ein komplexes Unterwasserrelief haben hier eine vielfältige Meeresökologie hervorgebracht. Die Gewässer im Osten werden vom Kuroshio (黑潮, Kuroshio Current) genährt, im Westen liegt ein weiter Kontinentalschelf.
+
+In diesen Gewässern wurden bereits über **32 Arten** von Walen und Delfinen nachgewiesen — mehr als ein Drittel aller Wal- und Delfinarten weltweit.[^2] Vom quirligen Ostpazifischen Delfin über den geheimnisvollen Pottwal bis zum vom Aussterben bedrohten „Mazu-Fisch" (媽祖魚), dem Chinesischen Weißen Delfin: Taiwan ist nicht nur ein wichtiger Lebensraum für Wale und Delfine, sondern ein Schlüssel-Hotspot der globalen marinen Biodiversität.
+
+---
+
+## Warum ist das wichtig
+
+Wale und Delfine stehen an der Spitze der marinen Nahrungskette und sind **Indikatorarten** für die Gesundheit des Meeres. Ihre Anwesenheit spiegelt den Reichtum und das Gleichgewicht des gesamten Ökosystems wider. Und Taiwans Haltung ihnen gegenüber spiegelt einen tiefgreifenden Wertewandel dieser Insel: von der Nachkriegsgeschichte des Walfangs in den 1950er Jahren über das vollständige Fangverbot in den 1990ern bis zur ersten Whale-Watching-Ausfahrt 1997 hat sich die taiwanische Gesellschaft vom „Nutzen des Meeres" zum „Sich-Annähern und Schützen des Meeres" bewegt. Dieser Weg dokumentiert präzise, wie in Taiwan ein Umweltbewusstsein erwachte.
+
+---
+
+## Ein außergewöhnlich begünstigter Lebensraum
+
+Taiwan ist auf allen vier Seiten von Meer umgeben, doch die Bedingungen im Osten und im Westen unterscheiden sich grundlegend — und genau das schafft die Vielfalt an Walen und Delfinen:
+
+### Die Gewässer im Osten: eine Tiefsee-Autobahn
+
+Die Ostküste fällt steil ab; schon wenig vor der Küste liegt die Wassertiefe über 1.000 Metern. Dazu zieht der Hauptstrom des **Kuroshio** dicht an der Ostküste nach Norden und bringt mit warmem Wasser große Mengen wandernder Fische und Kopffüßer heran. Hier ist das Paradies der tieftauchenden und hochseebewohnenden Arten: Pottwale, Schnabelwale und Delfine aller Art.
+
+### Die Gewässer im Westen: eine Flachwasser-Kinderstube
+
+Die Taiwanstraße ist ein breiter Kontinentalschelf mit geringerer Wassertiefe (im Mittel etwa 60 Meter) und sanftem Relief. Sie eignet sich für küstennah lebende Arten — die bekanntesten sind die endemische Unterart des **Chinesischen Weißen Delfins** (_Sousa chinensis taiwanensis_) und der **Glattschweinswal**.
+
+---
+
+## Die Stars unter Taiwans Walen und Delfinen
+
+Strandungsdaten und Sichtungserhebungen auf See der vergangenen Jahre zeigen: Der Artenreichtum in Taiwans Gewässern ist außerordentlich. Hier einige der häufigeren „Nachbarn aus dem Meer":
+
+### Ostpazifischer Delfin (Spinner Dolphin)
+
+**Die „Balletttänzer des Meeres"**. Am liebsten reiten sie die Bugwelle; sie springen aus dem Wasser und drehen sich dabei mehrfach in der Luft. Beim Whale Watching im Osten sind sie die Art, der man am ehesten begegnet — lebhaft, bewegungsfreudig und meist in großen Gruppen unterwegs.
+
+### Rundkopfdelfin (Risso's Dolphin)
+
+Auch **Risso-Delfin** genannt. Seine Haut ist von weißen Kratzspuren überzogen (Orden, die ihm soziale Auseinandersetzungen eingetragen haben), der Kopf ist rund und stumpf. Er wirkt gesetzter, hält sich gern im Tiefwasser auf, und gestrandete Tiere werden an Taiwans Küsten immer wieder registriert.
+
+### Pottwal (Sperm Whale)
+
+**Der „Tieftauch-Champion"**. Der größte Zahnwal der Welt, mit gewaltigem, kantigem Kopf. Er taucht häufig vor Hualien und Shihtiping (石梯坪) auf, erreicht Tauchtiefen von bis zu 2.000 Metern und hält dabei über eine Stunde lang die Luft an. Seinen schräg stehenden Blas zu sehen, gilt unter Whale Watchern als großes Glück.
+
+### Chinesischer Weißer Delfin (Indo-Pacific Humpback Dolphin)
+
+**Der „Mazu-Fisch" (媽祖魚)**. Er lebt an der Westküste zwischen Miaoli und Tainan und verdankt seinen Namen dem Umstand, dass er um den Geburtstag der Göttin Mazu (dritter Monat des Mondkalenders) herum, wenn die See ruhig ist, leichter zu beobachten ist. Er ist eine **vom Aussterben bedroht**e (Critically Endangered) endemische Unterart; die Gesamtpopulation liegt bei etwa 45 bis 50 Tieren (Erhebung von 2025, aktuellster Stand), und über sechzig Prozent der Individuen tragen äußere Verletzungen. Sie stehen vor einer ernsten Überlebenskrise.[^1]
+
+---
+
+## Vom Walfang zum Whale Watching: die Wende einer Geschichte
+
+### 1950–1980: die Zeit des Walfangs
+
+In der frühen Nachkriegszeit hat auch Taiwan eine Walfangepisode durchlebt. In der **Bananenbucht** (香蕉灣) bei Kenting im Süden, Landkreis Pingtung, gab es eine Walfangstation; Wale und Delfine wurden als Fleischquelle oder Wirtschaftsgut getötet. Es war eine Zeit, in der man dem Meer abverlangte, was man zum Überleben brauchte.
+
+### 1990: die Wasserscheide des Artenschutzes
+
+1990 wurden auf den Penghu-Inseln massenhaft Delfine illegal getötet — ein Vorfall, der international Aufsehen erregte und im Inland einen Sturm der öffentlichen Empörung auslöste. Er wurde zum Wendepunkt des Wal- und Delfinschutzes in Taiwan. Im selben Jahr nahm die Regierung Wale und Delfine in die Schutzliste des Wildtierschutzgesetzes (《野生動物保育法》) auf; Fang, Tötung sowie Handel wurden vollständig verboten.
+
+### 1997: das erste Jahr des Whale Watching
+
+Im Juli 1997 lief in Shihtiping (石梯坪) bei Hualien mit der „Haijing Hao" (海鯨號) Taiwans erstes Whale-Watching-Schiff zu seiner Jungfernfahrt aus. Das markierte den Übergang im Verhältnis der Taiwaner zu Walen und Delfinen — vom „Jagen" zum „Betrachten". Das Whale Watching breitete sich rasch entlang der Ostküste aus (Wushi-Hafen in Yilan, Hafen Hualien, Shihti-Hafen in Hualien, Chenggong in Taitung) und brachte mehr Menschen dazu, die Meeresökologie kennenzulernen.[^3]
+
+---
+
+## Forschung und Citizen Science
+
+Seit den 1990er Jahren hat die Wal- und Delfinforschung in Taiwan tief Wurzeln geschlagen. Die wichtigsten Träger sind:
+
+- **Akademische Einrichtungen**: die National Taiwan University (Team von Professorin Chou Lien-hsiang), die National Cheng Kung University (Team von Professor Wang Jian-ping; die Leitung des Wal- und Delfinzentrums hat inzwischen Professor Wang Hao-wen übernommen), die National Chiayi University (Team von Professor Yang Wei-cheng, heute an der National Taiwan University) und andere.
+- **Museen**: das National Museum of Natural Science (Assoziierte Forscherin Yao Chiou-ju) und das National Museum of Marine Biology and Aquarium.
+- **Zivilgesellschaftliche Organisationen**: die Kuroshio Ocean Education Foundation (黑潮海洋文教基金會, Hualien), die Taiwan Cetacean Society (中華鯨豚協會, New Taipei) und die Wild at Heart Legal Defense Association (臺灣蠻野心足生態協會).
+
+Diese Einrichtungen betreiben seit Langem Sichtungserhebungen auf See, Photo-ID zur Individuenerkennung, akustisches Monitoring, pathologische Strandungsanalysen und populationsökologische Studien. In den letzten Jahren kommt verstärkt **Citizen Science** hinzu: Whale-Watching-Gäste und Fischer werden ermutigt, Sichtungen zu melden, woraus eine umfangreiche Wal- und Delfindatenbank entsteht.
+
+---
+
+## Die drängenden Herausforderungen: der Weg des Artenschutzes
+
+Zwar wird nicht mehr in großem Stil gejagt, doch Taiwans Wale und Delfine sind weiterhin schweren, vom Menschen verursachten Bedrohungen ausgesetzt:
+
+1.  **Verlust und Zerstückelung des Lebensraums**: Offshore-Windkraftausbau und Landgewinnung an der Westküste engen den Lebensraum des Chinesischen Weißen Delfins unmittelbar ein.
+2.  **Konflikte mit der Fischerei**: Fangmethoden wie Treibnetze und Langleinen können zu Beifang (Bycatch) oder zu Verletzungen durch Verheddern führen.
+3.  **Unterwasserlärm**: Der Lärm des Schiffsverkehrs und der Rammarbeiten stört Tiere, die zur Verständigung und Orientierung auf ihr Gehör angewiesen sind.
+4.  **Meeresverschmutzung**: verschluckter Plastikmüll sowie die Anreicherung von Schwermetallen und persistenten organischen Schadstoffen (POPs) in der Nahrungskette.
+
+Die Ocean Conservation Administration der Ocean Affairs Council hat bereits einen „Schutzplan für den Chinesischen Weißen Delfin" veröffentlicht und treibt einen „Schutzplan für Wale und Delfine" voran. Über die Ausweisung wichtiger Lebensräume und die Regulierung von Eingriffen soll gerettet werden, was von diesen Geistern des Meeres noch da ist.
+
+---
+
+## Schluss
+
+Taiwans Wal- und Delfingeschichte ist eine Geschichte über das „Sehen".
+
+Früher sahen wir Fleisch und Öl; heute sehen wir Leben und Staunen. Wenn Sie an der Reling eines Schiffes vor der Ostküste stehen und im Moment des Sprungs das Aufblitzen eines Ostpazifischen Delfins über der Wasseroberfläche sehen, dann verstehen Sie: **Das Meer ist nicht nur ein Lager voller Ressourcen, es ist die Heimat des Lebens.**
+
+Wale und Delfine zu schützen heißt nicht nur, eine Tiergruppe zu schützen. Es heißt, das ganze blaue Territorium zu schützen, das uns umgibt und diese Insel nährt.
+
+---
+
+## Referenzen
+
+[^1]: [Bestandserhebung zur Population des Chinesischen Weißen Delfins – The News Lens 關鍵評論](https://www.thenewslens.com/article/255968) — bestätigt für den Chinesischen Weißen Delfin nach der aktuellsten Erhebung von 2025 eine Population von etwa 45–50 Tieren, über sechzig Prozent davon mit äußeren Verletzungen.
+[^2]: [Schutzplan für Wale und Delfine – Ocean Conservation Administration, Ocean Affairs Council](https://www.oca.gov.tw/userfiles/A47020000A/files/%E9%AF%A8%E8%B1%9A%E4%BF%9D%E8%82%B2%E8%A8%88%E7%95%AB_%E5%85%AC%E5%91%8A%E7%89%88.pdf) — Veröffentlichungsfassung der Schutzpläne der Behörde für den Chinesischen Weißen Delfin sowie für Wale und Delfine.
+[^3]: [Leitfaden für umweltverträgliches Whale Watching – Ocean Conservation Administration, Ocean Affairs Council](https://www.oca.gov.tw/ch/home.jsp?id=192&parentpath=0,6,190) — Regelwerk für den ökotouristischen Whale-Watching-Betrieb in Taiwan.
+[^4]: [Taiwan Cetacean Society (中華鯨豚協會)](https://www.whale.org.tw/) — zivilgesellschaftliche Organisation, die Forschung und Schutz von Walen und Delfinen in Taiwan vorantreibt.
+[^5]: [Kuroshio Ocean Education Foundation (黑潮海洋文教基金會)](https://www.kuroshio.org.tw/newsite/) — Einrichtung in Hualien für Wal- und Delfinforschung und die Förderung von Citizen Science.
+[^6]: [Wild at Heart Legal Defense Association (臺灣蠻野心足生態協會)](https://www.twsousa.org.tw/%E9%97%9C%E6%96%BC%E6%88%91%E5%80%91) — Organisation, die sich für den Schutz des Chinesischen Weißen Delfins einsetzt.
+[^7]: [Ocean Conservation Administration, Ocean Affairs Council (海洋委員會海洋保育署)](https://www.oca.gov.tw/) — Taiwans zuständige Behörde für Meeresschutz; treibt den Schutz von Wal- und Delfinlebensräumen sowie die Regulierung von Eingriffen voran.


### PR DESCRIPTION
Adds German translation of `Nature/臺灣的鯨豚.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Opus 5)

**Native speaker review**: No (contributor is native Chinese, some German proficiency)

**Length ratio**: 3.42 (de band 2.48–3.78 per `scripts/tools/lang-sync/ratio-bands.json`, n=84 median 3.14)

**Structure alignment**: 9 `##` sections / 9 `###` subsections / 7 footnote defs / 7 URLs — 100% preserved (exact URL multiset)

**Local gates run before push**: `verify-translation.py` → 17 pass / 0 fail; `article-health.py` → hard=0 warn=0, incl. `subcategory-translation-parity` ✅ (`subcategory: '野生動物'` kept as the zh grouping key, not translated).

**Note**: `i18n/de/STYLE.md` does not yet exist — followed TRANSLATE_PROMPT + established conventions from the existing de corpus (e.g. `## Referenzen`, `## 30-Sekunden-Überblick`).

Uncertain terminology flagged for reviewer:

- 媽祖魚 → `„Mazu-Fisch" (媽祖魚)` · kept the Chinese alongside; the name is tied to the Mazu birthday sighting window explained in the same paragraph.
- 露脊鼠海豚 → `Glattschweinswal` (_Neophocaena phocaenoides_) · standard German name; please confirm it is the form de readers expect.
- 黑潮 → `Kuroshio` · used the international form, with `(黑潮, Kuroshio Current)` on first mention.
- 香蕉灣 → `Bananenbucht (香蕉灣)` · translated the place name literally with the Chinese retained; an untranslated `Xiangjiao Wan` would also be defensible.
- Researcher names romanised (周蓮香 → Chou Lien-hsiang, 姚秋如 → Yao Chiou-ju, etc.) — please check against any house romanisation rule.

Please review. Happy to iterate.
