### PR TITLE
🧬 [routine] feat: 詞庫的查證欠條有自己的記號，月度 routine 每輪必須逐條交代

### DIFF
--- a/data/terminology/無語.yaml
+++ b/data/terminology/無語.yaml
@@ -49,6 +49,16 @@ notes: |
 
 status: stable
 
+# 上面 notes 的誠信標註是給讀者看的散文；這一格是給儀器看的欠條。
+# 兩者並存的理由：`⚠️ 查證分歧誠信標註` 那串字在詞庫裡多數代表「查證做完了，
+# 標註記錄結論」，拿它當「還沒查」的記號會撈出 6/7 假陽性（2026-09-13 實測）。
+# 讀取工具：scripts/tools/terminology-pending-verification.py
+pending_verification:
+  question: 「無語」在台灣是本有用法，還是 2010 年代從中國反輸入？本條 fork_point／fork_cause 目前寫後者，唯一來源是一則 Threads 留言串。
+  needs: 調閱國家人權博物館出版的《郭淑姿日記》第一冊、第二冊全文逐字核對。二手線索（黃文源風傳媒投書）只見「無聊」（原文作「不聊」）未見「無語」，但投書只引它要用的段落，掃不到不等於沒有。
+  issue: 'https://github.com/frank890417/taiwan-md/issues/1609'
+  opened: '2026-08-28'
+
 sources:
   - '2026-05-04 Threads @gordnbrad 「復興死語」留言串 OP + cyc___yang + ry.pan + 多人附和（DX22Q4sEh7d）'
   - 'https://github.com/frank890417/taiwan-md/issues/1609（讀者以郭淑姿日記提出的反證，待查）'

--- a/docs/pipelines/TERMINOLOGY-TRENDS-PIPELINE.md
+++ b/docs/pipelines/TERMINOLOGY-TRENDS-PIPELINE.md
@@ -29,10 +29,11 @@ upstream_canonical:
 
 ```
 ╭──────────────────────────────────────────────────────────────────────╮
-│   TERMINOLOGY-TRENDS — 月度 7 stage（每月 5 日，Opus）               │
+│   TERMINOLOGY-TRENDS — 月度 8 stage（每月 5 日，Opus）               │
 │                                                                      │
 │   Stage 0: BECOME（write mode）+ git pull                            │
 │   Stage 1: DEMAND — SC 需求缺口（demand-rank 28d）                   │
+│   Stage 1.5: REVISIT — 既有條目的查證欠條逐條處置 🎬                 │
 │   Stage 2: SWEEP — 6-8 切面搜索（每切面 10-15 次）                   │
 │   Stage 3: GAP — 對照詞庫（雙防線查重）🎬                            │
 │   Stage 4: INGEST — 高信心入庫 ≤20 條 🎬（帶肉＋證據＋誠信標註）     │
@@ -46,6 +47,8 @@ upstream_canonical:
 
 | Gate               | Stage | 條件                                                                                       | 不過 = ?             |
 | ------------------ | ----- | ------------------------------------------------------------------------------------------ | -------------------- |
+| 查證欠條逐條處置   | 1.5   | `terminology-pending-verification.py` 每條都在報告裡有一句處置（含「這輪沒碰，因為 X」）   | 對讀者的承諾永久空轉 |
+| 欠條要有結構化欄位 | 4     | 誠信標註留下真正未決的問題時，同條必補 `pending_verification`（question／needs／issue／opened） | 欠條只活在散文裡     |
 | 雙防線查重         | 3     | 檔名 `test -f` ＋ 新詞 china/taiwan 值對全庫值掃描（含簡繁形）兩道都跑                     | 重複條目污染詞庫     |
 | 入庫上限           | 4     | 每輪 ≤ 20 條新檔；超出的進 gap 清單留下輪                                                  | 無人審批的規模擴張   |
 | 帶肉入庫           | 4     | 每條必有 etymology.origin 詞源敘事＋sources 證據 URL（GA4 實證：薄殼進不了長尾）           | AI Slop 式灌庫       |
@@ -57,6 +60,19 @@ upstream_canonical:
 
 **Stage 1 DEMAND**：`python3 scripts/tools/terminology-demand-rank.py --days 28`＋
 `--state MISSING`。MISSING 清單是本輪入庫的第一優先（讀者已在搜）。
+
+**Stage 1.5 REVISIT**：`python3 scripts/tools/terminology-pending-verification.py`。列出既有
+條目掛著的查證欠條（結構化欄位 `pending_verification`，不從散文推論），久的排前面，並印出
+還在 issue 裡等回覆的讀者。**每條都要在 Stage 5 報告裡有一句處置**——查了寫結果、查不到寫
+查到哪裡卡住、要調閱實體書寫「這輪沒碰，因為要調閱 X」。exit 1 代表有欠條，不是工具壞掉。
+
+誕生（2026-09-13 maintainer-am）：本 pipeline 原 7 個 stage 全部在講**新詞入庫**，沒有任何
+一步回頭讀既有條目。`無語` 的斷代主張 2026-08-23 被讀者以《郭淑姿日記》挑戰（issue #1609），
+維護者兩輪都誠實處理並把出處定位到國家人權博物館那兩冊，兩輪都寫「查證工作排進用語趨勢
+routine」——而被指名的這條 routine 沒有任何步驟會讀到那句話。承諾寫在 yaml 註解與 GitHub
+留言裡，執行者沒有對應的動作：§神經迴路「承諾的物理位置決定它會不會被實現」。
+同時釘一件事：`⚠️ 查證分歧誠信標註` 那串字在詞庫裡**多數代表查證已完成**（標註記錄結論），
+拿它當「還沒查」的記號會撈出 6/7 假陽性，所以欠條用自己的結構化欄位（REFLEXES #85）。
 
 **Stage 2 SWEEP**：6-8 個切面、每切面 10-15 次搜索。固定四切面：Threads「支語」搜尋現場
 （瀏覽器或 site: 搜索）／PTT 近月新串／中國年度流行語榜單動態（咬文嚼字、百度沸點）／
@@ -74,6 +90,12 @@ upstream_canonical:
 notes／sources／added）。fork_type 務實判：網路時代功能詞 C、流行語感類 E，**不預設 B**
 （73% B 無佐證是歷史債，不再擴大）。台灣本有對應詞（推坑／工具人／出包型）在 taiwan 欄
 保留為資產。
+
+**誠信標註留下未決問題時，同條必補 `pending_verification`**（hard gate，2026-09-13 新增）：
+標註本身是寫給讀者的散文，欠條是寫給儀器的欄位，兩個都要。四個子欄位 `question`（還沒定的
+是什麼）／`needs`（要做什麼才分得出來）／`issue`（有讀者在等就填 URL）／`opened`（ISO 日期）。
+查證做完之後把欄位移除、結論留在 notes，Stage 1.5 的清單就會自己變短。
+**只寫散文不補欄位 = Stage 1.5 看不到它 = 那張欠條不存在。**
 
 **Stage 5 REPORT**：`reports/terminology-trends/YYYY-MM.md` 短報告（1-2 頁）：本月新進詞／
 收編動態（哪些詞從抵抗走向接受）／誤判翻案／SC 需求變化。這是時間序列的一格，簡潔勝過全面。

--- a/scripts/tools/terminology-pending-verification.py
+++ b/scripts/tools/terminology-pending-verification.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""terminology-pending-verification.py — 詞庫裡「查證還沒做完」的那幾條。
+
+## 為什麼存在
+
+`data/terminology/*.yaml` 的 `notes` 常帶「⚠️ 查證分歧誠信標註」。那段文字有兩種
+用途，而它們在字面上長得一模一樣：
+
+1. **查證做完了**，標註永久記錄當初爭議與結論（「查證結論：…」）——多數是這種
+2. **查證還沒做**，標註是一張欠條，通常還對著一位在 issue 裡等回覆的讀者
+
+拿 `grep 查證分歧誠信標註` 去找第二種，會把第一種一起撈出來（2026-09-13 實測
+7 命中只有 1 條真的還欠著，6/7 假陽性）。所以第二種需要自己的記號，不能借用
+第一種的那個——[REFLEXES #85](../../docs/semiont/REFLEXES.md)「『不知道』需要自己
+的符號」。本工具只認結構化欄位 `pending_verification`，一個字都不從散文推論。
+
+## 誕生
+
+issue #1609：讀者蘇洛 2026-08-23 以白色恐怖受難者郭淑姿的日記挑戰 `無語` 的斷代
+主張。維護者兩輪（08-28／08-31）都誠實處理並把出處定位到《郭淑姿日記》第一、二冊
+（國家人權博物館出版），兩輪都寫「查證工作排進用語趨勢 routine」。而
+`TERMINOLOGY-TRENDS-PIPELINE` 的七個 stage 全部在講**新詞入庫**，沒有任何一步會回頭
+讀既有條目的欠條——承諾寫在 yaml 註解與 GitHub 留言裡，被指名的執行者沒有對應的
+步驟。這是 §神經迴路「承諾的物理位置決定它會不會被實現／memory 是自律，canonical
+SOP 才是閘門」在詞庫這一層的 instance。
+
+## 欄位長相
+
+    pending_verification:
+      question: 一句話說還沒定的是什麼
+      needs: 要做什麼才分得出來（調閱哪一本、搜哪個庫）
+      issue: 'https://github.com/frank890417/taiwan-md/issues/1609'
+      opened: '2026-08-28'
+
+## 殘餘盲點（明寫）
+
+只有散文標註、沒有這個欄位的條目，本工具**看不到**。兩層要靠
+`TERMINOLOGY-TRENDS-PIPELINE` Stage 4 的規則維持同步：誠信標註留下真正未決的問題時
+必須同時補這個欄位。工具不會替那條規則把關，所以這裡不假裝它會。
+
+## 用法
+
+    python3 scripts/tools/terminology-pending-verification.py
+    python3 scripts/tools/terminology-pending-verification.py --json
+    python3 scripts/tools/terminology-pending-verification.py --older-than 30
+
+Exit code：0 = 沒有欠條，或有但都還在 `--older-than` 天數內；
+1 = 有欠條超過 `--older-than` 天（預設 0，所以預設只要有欠條就 exit 1）；
+3 = 工具本身壞掉（讀不到目錄 / yaml 壞檔）。「讀不到」不是綠燈。
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import date, datetime
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+TERM_DIR = REPO_ROOT / "data" / "terminology"
+FIELD = "pending_verification"
+
+
+def fail_loud(message: str) -> None:
+    print(f"❌ terminology-pending-verification: {message}", file=sys.stderr)
+    sys.exit(3)
+
+
+def parse_opened(raw) -> date | None:
+    """`opened` 可能是 YAML 自動轉成的 date，也可能是字串。兩種都接，壞的回 None。"""
+    if isinstance(raw, date) and not isinstance(raw, datetime):
+        return raw
+    if isinstance(raw, datetime):
+        return raw.date()
+    if isinstance(raw, str):
+        try:
+            return date.fromisoformat(raw.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def collect(term_dir: Path, today: date) -> list[dict]:
+    if not term_dir.is_dir():
+        fail_loud(f"讀不到 {term_dir}")
+
+    items: list[dict] = []
+    for path in sorted(term_dir.glob("*.yaml")):
+        try:
+            parsed = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            fail_loud(f"{path.name} 讀取／parse 失敗：{exc}")
+        if not isinstance(parsed, dict):
+            continue
+        block = parsed.get(FIELD)
+        if not block:
+            continue
+        if not isinstance(block, dict):
+            fail_loud(f"{path.name} 的 {FIELD} 不是對應表（實際是 {type(block).__name__}）")
+
+        opened = parse_opened(block.get("opened"))
+        items.append(
+            {
+                "file": path.name,
+                "id": parsed.get("id") or path.stem,
+                "display_taiwan": (parsed.get("display") or {}).get("taiwan"),
+                "display_china": (parsed.get("display") or {}).get("china"),
+                "question": block.get("question"),
+                "needs": block.get("needs"),
+                "issue": block.get("issue"),
+                "opened": opened.isoformat() if opened else None,
+                "days_open": (today - opened).days if opened else None,
+            }
+        )
+
+    # 久的排前面；沒有 opened 的排最後（但仍然列出，不靜默丟掉）
+    items.sort(key=lambda i: (i["days_open"] is None, -(i["days_open"] or 0)))
+    return items
+
+
+def human_report(items: list[dict], older_than: int, today: date) -> str:
+    if not items:
+        return "✅ 詞庫沒有掛著的查證欠條（無 pending_verification 欄位）"
+
+    lines = [f"📌 詞庫查證欠條 {len(items)} 條（{today.isoformat()}）", ""]
+    for i in items:
+        age = f"{i['days_open']} 天" if i["days_open"] is not None else "未寫 opened"
+        lines.append(f"  {i['id']}（{i['file']}）— 掛著 {age}")
+        if i["display_taiwan"] or i["display_china"]:
+            lines.append(f"      台灣：{i['display_taiwan']}　中國：{i['display_china']}")
+        if i["question"]:
+            lines.append(f"      未決：{i['question']}")
+        if i["needs"]:
+            lines.append(f"      要做：{i['needs']}")
+        if i["issue"]:
+            lines.append(f"      讀者在等：{i['issue']}")
+        lines.append("")
+    lines.append(
+        "每輪 TERMINOLOGY-TRENDS 必須逐條寫出處置（查了／查不到／要調閱實體書），"
+        "「這輪沒碰」也要寫成一句話，不能靜默跳過。"
+    )
+    lines.append(
+        "只有散文標註、沒有 pending_verification 欄位的條目本工具看不到；"
+        "兩層同步靠 Stage 4 的規則，不靠這支工具。"
+    )
+    return "\n".join(lines)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="列出詞庫裡還沒做完的查證欠條")
+    ap.add_argument("--json", action="store_true", help="輸出 JSON")
+    ap.add_argument(
+        "--older-than",
+        type=int,
+        default=0,
+        help="只有掛著超過 N 天的欠條才讓 exit code 變 1（預設 0：有欠條就 1）",
+    )
+    ap.add_argument("--today", type=str, default=None, help="ISO 日期，給測試與回溯用")
+    args = ap.parse_args()
+
+    if args.today:
+        try:
+            today = date.fromisoformat(args.today)
+        except ValueError:
+            fail_loud(f"--today 不是 ISO 日期：{args.today}")
+    else:
+        today = date.today()
+
+    items = collect(TERM_DIR, today)
+
+    if args.json:
+        print(json.dumps({"checked_on": today.isoformat(), "pending": items}, ensure_ascii=False, indent=2))
+    else:
+        print(human_report(items, args.older_than, today))
+
+    overdue = [i for i in items if (i["days_open"] or 0) >= args.older_than]
+    sys.exit(1 if overdue else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_terminology_pending_verification.py
+++ b/tests/test_terminology_pending_verification.py
@@ -1,0 +1,123 @@
+"""tests/test_terminology_pending_verification.py — 詞庫查證欠條清單的單元測試。
+
+重點不在「欄位讀得出來」，在**不從散文推論**：`⚠️ 查證分歧誠信標註` 那串字在詞庫裡
+多數代表查證已完成，所以帶那串字但沒有 `pending_verification` 欄位的條目絕對不能被
+撈出來（2026-09-13 實測 7 命中只有 1 條真的還欠著）。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT_REAL = Path(__file__).resolve().parents[1]
+MODULE_PATH = REPO_ROOT_REAL / "scripts" / "tools" / "terminology-pending-verification.py"
+SPEC = importlib.util.spec_from_file_location("terminology_pending_verification", MODULE_PATH)
+MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC and SPEC.loader
+SPEC.loader.exec_module(MODULE)
+
+TODAY = date(2026, 9, 13)
+
+RESOLVED_ENTRY = """id: resolved-one
+display:
+  taiwan: 具體
+  china: 具體
+notes: |
+  ⚠️ 查證分歧誠信標註：詞是台灣本有，爭的是口語修飾用法。
+  查證結論：教育部辭典有據，判定維持。
+status: stable
+"""
+
+PENDING_ENTRY = """id: speechless
+display:
+  taiwan: 無言
+  china: 無語
+notes: |
+  ⚠️ 查證分歧誠信標註（待查證）：讀者以一手史料挑戰斷代主張。
+pending_verification:
+  question: 本有用法還是反輸入？
+  needs: 調閱《郭淑姿日記》第一、二冊
+  issue: 'https://github.com/frank890417/taiwan-md/issues/1609'
+  opened: '2026-08-28'
+status: stable
+"""
+
+
+def write(term_dir: Path, name: str, body: str) -> None:
+    term_dir.mkdir(parents=True, exist_ok=True)
+    (term_dir / name).write_text(body, encoding="utf-8")
+
+
+def test_prose_annotation_alone_is_not_a_pending_item(tmp_path):
+    """帶誠信標註散文但查證已完成的條目，不該出現在欠條清單裡。"""
+    write(tmp_path, "具體.yaml", RESOLVED_ENTRY)
+
+    assert MODULE.collect(tmp_path, TODAY) == []
+
+
+def test_structured_field_is_collected_with_age_and_issue(tmp_path):
+    write(tmp_path, "無語.yaml", PENDING_ENTRY)
+
+    items = MODULE.collect(tmp_path, TODAY)
+
+    assert len(items) == 1
+    assert items[0]["id"] == "speechless"
+    assert items[0]["days_open"] == 16  # 2026-08-28 → 2026-09-13
+    assert items[0]["issue"].endswith("/1609")
+    assert items[0]["display_taiwan"] == "無言"
+
+
+def test_mixed_dir_only_returns_the_one_that_still_owes(tmp_path):
+    """六條已結案 + 一條真欠著 → 只回那一條（這就是本工具存在的理由）。"""
+    for n in ("具體", "挺", "硫酸紙", "肯定", "腦子", "行吧"):
+        write(tmp_path, f"{n}.yaml", RESOLVED_ENTRY.replace("resolved-one", n))
+    write(tmp_path, "無語.yaml", PENDING_ENTRY)
+
+    items = MODULE.collect(tmp_path, TODAY)
+
+    assert [i["id"] for i in items] == ["speechless"]
+
+
+def test_oldest_first_and_missing_opened_goes_last(tmp_path):
+    write(tmp_path, "a.yaml", PENDING_ENTRY.replace("speechless", "newer").replace("2026-08-28", "2026-09-10"))
+    write(tmp_path, "b.yaml", PENDING_ENTRY.replace("speechless", "older").replace("2026-08-28", "2026-07-01"))
+    no_date = PENDING_ENTRY.replace("speechless", "undated").replace("  opened: '2026-08-28'\n", "")
+    write(tmp_path, "c.yaml", no_date)
+
+    items = MODULE.collect(tmp_path, TODAY)
+
+    assert [i["id"] for i in items] == ["older", "newer", "undated"]
+    # 沒寫 opened 的仍然列出來，不被靜默丟掉
+    assert items[-1]["days_open"] is None
+
+
+def test_missing_dir_is_fail_loud_not_green(tmp_path):
+    """讀不到目錄是工具壞了（exit 3），不是「沒有欠條」。"""
+    with pytest.raises(SystemExit) as exc:
+        MODULE.collect(tmp_path / "does-not-exist", TODAY)
+    assert exc.value.code == 3
+
+
+def test_broken_yaml_is_fail_loud(tmp_path):
+    write(tmp_path, "bad.yaml", "id: x\n  : : broken\n   - [\n")
+    with pytest.raises(SystemExit) as exc:
+        MODULE.collect(tmp_path, TODAY)
+    assert exc.value.code == 3
+
+
+def test_non_mapping_field_is_fail_loud(tmp_path):
+    write(tmp_path, "weird.yaml", "id: w\npending_verification: 'just a string'\nstatus: stable\n")
+    with pytest.raises(SystemExit) as exc:
+        MODULE.collect(tmp_path, TODAY)
+    assert exc.value.code == 3
+
+
+def test_real_repo_has_the_1609_debt_registered(tmp_path):
+    """回歸守門：#1609 的欠條必須留在真的詞庫裡，不能被後人順手刪掉而沒人發現。"""
+    items = MODULE.collect(MODULE.TERM_DIR, TODAY)
+    ids = [i["id"] for i in items]
+    assert "speechless" in ids, "無語 的 pending_verification 不見了（issue #1609 仍未查證）"


### PR DESCRIPTION
## 一張欠條寫給了一條不會讀它的 routine

讀者蘇洛 2026-08-23 用白色恐怖受難者郭淑姿的日記挑戰 `無語` 的斷代主張（[#1609](https://github.com/frank890417/taiwan-md/issues/1609)）。維護者兩輪都誠實處理：8/28 加誠信標註並講明本條唯一來源是一則 Threads 留言串、對這種強度的斷代太薄；8/31 把出處定位到國家人權博物館出版的《郭淑姿日記》第一、二冊，並主動講出對讀者說法不利的線索。兩輪都寫了同一句話：**「查證工作排進用語趨勢 routine。」**

而 `TERMINOLOGY-TRENDS-PIPELINE` 的七個 stage 全部在講**新詞入庫**（DEMAND → SWEEP → GAP → INGEST → REPORT → QUEUE → finale）。沒有任何一步會回頭讀既有條目的欠條。9/5 的月度輪跑過了，那條欠條一個字都沒被碰到。承諾寫在 yaml 註解與 GitHub 留言裡，被指名的執行者沒有對應的動作——§神經迴路「承諾的物理位置決定它會不會被實現／memory 是自律，canonical SOP 才是閘門」。

## 為什麼不能拿既有的散文標註當記號

第一直覺是 `grep 查證分歧誠信標註`。實測全庫 2,310 條，7 條命中：

| 條目 | 標註的意思 |
| --- | --- |
| 具體、挺、硫酸紙、肯定、腦子、行吧 | **查證做完了**，標註永久記錄當初爭議與結論（「查證結論：…」） |
| 無語 | **查證還沒做**，標註是一張欠條，而且有讀者在等 |

同一串字承載兩種相反的狀態，6/7 假陽性。所以欠條需要自己的記號，不能借用「已結案」那個——[REFLEXES #85](../blob/main/docs/semiont/REFLEXES.md)。這跟同一個 cycle 修掉的 [#1716](https://github.com/frank890417/taiwan-md/pull/1716)（告警把「整台停了」與「推不上去」混成一個讀數）是同一種病的兩個位置。

## 改動

**結構化欄位**（散文留給讀者，欄位留給儀器，兩個都要）：

```yaml
pending_verification:
  question: 還沒定的是什麼
  needs: 要做什麼才分得出來
  issue: 'https://…/issues/1609'
  opened: '2026-08-28'
```

**新工具** `scripts/tools/terminology-pending-verification.py`：列出欠條，久的排前面，印出還在 issue 裡等回覆的讀者。**一個字都不從散文推論。** 讀不到目錄或 yaml 壞檔 exit 3，不假裝綠燈。

實跑（今天）：

```
📌 詞庫查證欠條 1 條（2026-09-13）
  speechless（無語.yaml）— 掛著 16 天
      未決：「無語」在台灣是本有用法，還是 2010 年代從中國反輸入？
      要做：調閱國家人權博物館出版的《郭淑姿日記》第一冊、第二冊全文逐字核對。
      讀者在等：https://github.com/frank890417/taiwan-md/issues/1609
```

**Pipeline**：Stage 1.5 REVISIT ＋ 兩條 hard gate——(1) 每條欠條在月報裡都要有一句處置，「這輪沒碰，因為要調閱實體書」也算，但不能靜默跳過 (2) Stage 4 誠信標註留下真正未決的問題時，同條必補欄位。查證做完就移除欄位、結論留在 notes，清單自己變短。

## 驗證

- 8 個新測試，含兩道回歸守門：「帶標註散文但已結案的條目不該被撈出來」、「#1609 的欠條不能被後人順手刪掉而沒人發現」
- 全庫 `pytest tests`：**450 passed / 8 skipped**
- 新增的 yaml key 對既有消費者無害（都走 `.get()` 具名取值，無嚴格 schema 驗證）：`extract-china-terms.py` 正常、`terminology-charcheck.js` 2304 檔 SIMPLIFIED_LEAK 0

## 邊界

**判定一個字都沒動。** 斷代究竟站不站得住，仍然要把那兩冊翻過才知道；這個 PR 只讓那件事不再隱形。調閱實體書不是這條 routine 做得到的事，所以它留在清單上等一個能去調閱的人，而不是被寫成「已處理」。

🧬 twmd-maintainer-am @ 2026-09-13
