### PR TITLE
🧬 [routine] heal: /exams/ 的待辦清單補上「站內入口」，那是開站本身不是加分項

### DIFF
--- a/docs/semiont/ARTICLE-INBOX.md
+++ b/docs/semiont/ARTICLE-INBOX.md
@@ -272,8 +272,9 @@ BECOME_TAIWANMD.md Step 5 新增：
 - **Notes**:
   - 一句話核心張力：投稿者已經補完死碼問題（`src/pages/exams.astro` 補進來，模板不再是孤兒），技術面已經不卡；卡的是骨架背後七張人物卡目前只有維基與百度百科撐著，開站要先把地基換成台灣自己的一手來源
   - merge PR #1453 後要做：十二語 `src/pages/{lang}/exams.astro`（現況只有中文讀得到，因為 `getLangFromUrl` 靠網址前綴）、UI 字串補齊、URL 契約修正（模板註解寫 `/exams/gsat/` 但實際建出 `/exams/`）、策展骨架參照來源換成大考中心／教育部／報導者等一手來源、七張人物卡各補一則第三方報導連結（PR #1453 留言已列缺口）
+  - **站內入口（2026-09-13 maintainer-am 補登，原清單漏了這件）**：`src/components/Header.astro` 導覽列目前八項（about／explore／map／data／soundscape／resources／semiont／contribute）沒有 exams，全 repo 指向 `/exams` 的連結只有它自己的模板。頁面自 2026-09-10 02:52 起已部署且在 sitemap 裡，但**讀者要先知道網址才進得去**。沒有入口的區段在讀者那端跟沒開站幾乎沒有差別，所以這件事屬於「開站」本身，不是開完之後的加分項。放哪個位置／叫什麼名字／十三語 UI 字串，照 §自主權邊界屬資訊架構與品牌面，由本 feature session 連同上面幾項一起帶給哲宇定，不各自分開問
   - 由獨立 feature session 做，不進一般文章 REWRITE-PIPELINE 產線
-- **Reference**: [PR #1453](https://github.com/frank890417/taiwan-md/pull/1453)、[OBSERVER-QUEUE.md §36](OBSERVER-QUEUE.md)
+- **Reference**: [PR #1453](https://github.com/frank890417/taiwan-md/pull/1453)、[OBSERVER-QUEUE.md §36](OBSERVER-QUEUE.md)、[Discussion #1704](https://github.com/frank890417/taiwan-md/discussions/1704)（投稿者 idlccp1984 問「為什麼沒發佈」，真正的答案是沒有入口）
 
 ### 台灣豆漿與早餐店 EVOLVE — 跟《台灣早餐文化》併軌，決定兩篇的邊界
 


### PR DESCRIPTION
哲宇 9/5 拍板開 `/exams/` 區段（[OBSERVER-QUEUE §36](../blob/main/docs/semiont/OBSERVER-QUEUE.md) 已決），ARTICLE-INBOX 照著登了 P1 feature entry，清單列了五件事：十二語 page、UI 字串、URL 契約、策展來源換一手、人物卡補第三方報導。**唯獨漏了導覽列入口。**

頁面 2026-09-10 02:52 就部署成功、也在 sitemap 裡，但 `Header.astro` 的八個導覽項目（about／explore／map／data／soundscape／resources／semiont／contribute）沒有 exams，全 repo 指向 `/exams` 的連結只有它自己的模板。投稿者 idlccp1984 因此在 [Discussion #1704](https://github.com/frank890417/taiwan-md/discussions/1704) 問「為什麼沒有請求且頁面沒有發佈」——他看到的現象是真的，原因不是沒發佈，是沒有路走過去。

如果 feature session 把清單上五件事做完、沒做入口，區段在讀者那端還是等於沒開。所以補進清單，並註明它跟「放哪個位置／叫什麼名字／十三語字串」一樣屬資訊架構與品牌面，由該 session 一次帶給哲宇定，不各自分開問。

一行改動，不動任何判定、不碰 `Header.astro`（那是 feature session 的事）。

🧬 twmd-maintainer-am @ 2026-09-13