### PR TITLE
translate(pt): 台灣華語的演化 → taiwan-mandarin-evolution

### DIFF
--- a/knowledge/pt/Culture/taiwan-mandarin-evolution.md
+++ b/knowledge/pt/Culture/taiwan-mandarin-evolution.md
@@ -1,0 +1,136 @@
+---
+title: 'A evolução do mandarim taiwanês — quatrocentos anos de estratigrafia linguística'
+description: 'Quantas camadas de história cabem dentro de uma marmita? Acompanhe a viagem dessa palavra e explore a língua que cresceu naturalmente nesta ilha ao longo de quatrocentos anos'
+date: 2026-03-29
+category: 'Culture'
+tags: ['Mandarim taiwanês', 'Evolução linguística', 'Empréstimos do japonês', 'Vocabulário entre os dois lados do Estreito', 'Identidade linguística']
+subcategory: '語言與文字'
+author: 'Taiwan.md'
+featured: false
+lastVerified: 2026-03-29
+lastHumanReview: false
+readingTime: 12
+terminology_exempt: true # article subject IS the cross-strait term itself
+translatedFrom: 'Culture/台灣華語的演化.md'
+sourceCommitSha: '4b6d28c54'
+sourceContentHash: 'sha256:2b37211d946c848c'
+sourceBodyHash: 'sha256:0b62bbb2f4c7cd6b'
+translatedAt: '2026-09-13T10:45:15+08:00'
+---
+
+> **Visão geral em 30 segundos:** Por que o mandarim falado pelos taiwaneses tem essa forma? Não é resultado de um planejamento de política linguística, mas uma estratigrafia da língua depositada naturalmente por quatrocentos anos de vida na ilha. Dos topônimos deixados pelos holandeses, à infiltração de cinquenta anos dos empréstimos do japonês, à divergência vocabular de 1949, até o cabo de guerra linguístico da era da internet — cada camada é o rastro de uma vida real, não uma posição política.
+
+Em 1895, no primeiro ano em que o Japão tomou posse de Taiwan, as escolas na cidade de Taipé começaram a ensinar uma nova disciplina: japonês. As crianças aprendiam vocabulário novo, palavra por palavra, e o modo de pensar japonês foi se encaixando na estrutura óssea do hokkien taiwanês. Uma dessas palavras era "弁当" (bentō).
+
+Cinquenta anos depois, em 1945, essas crianças já eram adultas, viraram avós. Chamavam a caixa que guardava a comida de "biàndāng" (便當), tão naturalmente quanto chamar o pai de "pai". Naquele mesmo ano, chegou à ilha um grupo de pessoas que falava um mandarim diferente, vindas do continente. Elas chamavam a mesma coisa de "héfàn" (盒飯). Dois grupos, a mesma ilha, a mesma comida, dois nomes.
+
+A história do mandarim taiwanês começa justamente nessa fresta.
+
+## A metáfora da geologia
+
+Os linguistas gostam de usar "camadas geológicas" para descrever a história de uma língua. Assim como um geólogo lê nas rochas uma história de bilhões de anos, ao ouvir alguém falar também é possível sentir séculos de sedimentação cultural.
+
+A estratigrafia linguística desta ilha chamada Taiwan tem pelo menos cinco camadas.
+
+A camada mais profunda é a das línguas austronésias. Antes da grande migração han, Taiwan era habitada por povos indígenas falantes de línguas da família austronésia. O legado linguístico que deixaram para esta ilha está sobretudo escondido nos topônimos. O próprio nome "Taiwan" vem do nome de uma aldeia indígena; o antigo nome de Kaohsiung, "Takao" (打狗), é uma transliteração de uma língua indígena registrada em documentos holandeses do século XVII. Essa camada de língua está hoje desaparecendo rapidamente. A maioria das línguas dos povos indígenas de Taiwan já foi classificada pela UNESCO como línguas em risco de extinção, e algumas delas têm menos de cem falantes nativos. [[台灣原住民語言復振運動]]
+
+A segunda camada é a dos imigrantes hokkien e hakka. A partir do século XVII, grandes levas de imigrantes vindos de Fujian e Guangdong atravessaram o mar rumo a Taiwan, trazendo consigo o hokkien taiwanês (台語) e o hakka. Essas duas línguas não foram apenas dialetos transplantados; em quatrocentos anos de vida na ilha, fundiram-se com tudo ao redor e desenvolveram uma entonação e um vocabulário próprios de Taiwan. Hoje, quando os taiwaneses dizem "a-sà-lih" (阿莎力, direto e sem rodeios), "kó͘-chá" (古早, antigamente) ou "thàu-chá" (透早, de manhã bem cedo), são vestígios cotidianos de como o hokkien taiwanês se infiltrou no mandarim. [[客家文化與語言]]
+
+A terceira camada é a do japonês — também a mais espessa e mais característica de todo o mandarim taiwanês.
+
+## Cinquenta anos de infiltração linguística
+
+De 1895 a 1945, o Japão governou Taiwan por cinquenta anos. O legado linguístico deixado por esses cinquenta anos é muito mais duradouro do que qualquer impacto de política linguística planejada.
+
+O linguista Yang Yun-ping (楊雲萍) deixou uma frase repetidamente citada por gerações posteriores: "A maior conquista do domínio japonês em Taiwan foi fazer com que muitas crianças e jovens esquecessem sua 'língua materna'." Essa frase fala da perda do hokkien taiwanês sob a repressão do período japonês, mas, por outro ângulo, também revela o quanto o japonês penetrou fundo na vida de uma geração inteira.
+
+O japonês que essas pessoas acabaram aprendendo não era aquela fluência de pensar em japonês, de sonhar em japonês. O que aprenderam foi uma substituição em camadas do vocabulário cotidiano: a caixa que guarda comida chama-se "biàndāng" (便當, do japonês 弁当, bentō); a tia chama-se "ōbāsang" (歐巴桑, do japonês おばさん); o motorista chama-se "ūn-chiang" (運將, do japonês 運転手); a placa chama-se "khan-pán" (看板, do japonês 看板); e um jeito franco e direto de ser chama-se "a-sà-lih" (阿莎力, do japonês あっさり).
+
+A pronúncia dessas palavras já foi remodelada pela raiz da língua do hokkien taiwanês. "Ūn-chiang" não é mais pronunciado como o japonês "untenshu" (運転手), mas com a pronúncia própria dos taiwaneses, carregada de intimidade, de familiaridade de vizinhança. A língua foi assim digerida, tornou-se própria, até que quem a usa já esqueceu de onde ela veio.
+
+> 📝 **Nota do curador**
+>
+> A categoria mais fascinante entre os empréstimos do japonês é a das palavras que já se tornaram completamente nativas, a ponto de as pessoas esquecerem que são estrangeirismos. "Pǐnzhí" (品質, do japonês 品質, hinshitsu), "zhùshè" (注射, injeção) e "kānhù" (看護, enfermagem) foram implantadas em Taiwan através do sistema educacional do período japonês. Do outro lado do Estreito, usa-se "zhìliàng" (質量), "dǎzhēn" (打針) e "hùshì" (護士). O mesmo conceito, palavras diferentes — o ponto de partida dessa diferença está justamente naqueles cinquenta anos de caminhos divergentes.
+
+## As marcas gramaticais do substrato do hokkien taiwanês
+
+O mais fácil de passar despercebido não são as palavras emprestadas, mas o modo silencioso como o hokkien taiwanês remodelou a forma como os taiwaneses falam mandarim.
+
+"Wǒ yǒu chīfàn le." (我有吃飯了 — "Eu já comi".)
+
+Qualquer pessoa que cresceu em Taiwan entende essa frase, e nem sequer acha estranho. Mas a estrutura "yǒu (有) + verbo" não existe no mandarim padrão. A forma padrão é "Wǒ chīfàn le" (我吃飯了). O uso de "yǒu" (有) antes do verbo para indicar a conclusão de uma ação é característico do hokkien taiwanês (que diz "guá ū chia̍h-kòe--ah", 我有食過矣). Não é um erro gramatical; é a influência gramatical de fundo do hokkien taiwanês, que se infiltrou naturalmente no padrão gramatical do mandarim ao longo de gerações de conversas cotidianas.
+
+Há um exemplo ainda mais sutil. Os taiwaneses dizem "Tā gěi wǒ dǎ" (他給我打), com o sentido de "Ele me bateu". Aqui, o caractere "gěi" (給) é um transplante semântico do caractere "kā" (共) do hokkien taiwanês, que marca uma relação de passivo ou de objeto afetado, algo completamente diferente do sentido original de "doar/dar" que "gěi" tem no mandarim padrão. Esse uso aparece em muitas conversas cotidianas e em prosas literárias de Taiwan, mas quase não ocorre na fala ou na escrita do continente.
+
+Os linguistas chamam esse fenômeno de "influência de substrato" (substratum influence). O hokkien taiwanês é a língua popular mais antiga desta terra chamada Taiwan; ele sustenta, como uma fundação, o modo como os taiwaneses falam mandarim. Mesmo com o uso do próprio hokkien taiwanês encolhendo, sua estrutura continua viva na gramática do mandarim taiwanês, silenciosa e discretamente.
+
+## 1949: dois dicionários que tomaram caminhos divergentes
+
+Em 1949, o governo nacionalista retirou-se para Taiwan, trazendo consigo um grande contingente de falantes de língua vindos de várias províncias da China: sotaque de Xangai, sotaque de Pequim, sotaque de Sichuan — vários tipos de mandarim se encontraram nesta pequena ilha chamada Taiwan. O governo logo lançou o "Movimento do Mandarim Nacional" (國語運動), fazendo do mandarim padrão baseado na pronúncia de Pequim a língua do ensino escolar. O hokkien taiwanês, o hakka e as línguas indígenas foram excluídos da sala de aula, e os alunos eram castigados por falarem sua língua materna. Em 1955, o governo provincial de Taiwan emitiu um comunicado proibindo as igrejas de usarem o sistema de romanização do hokkien taiwanês, sem exceção nem mesmo para ocasiões religiosas.
+
+Esse período histórico deixou não apenas cicatrizes, mas também uma espécie de cristalização vocabular.
+
+A partir daí, o mandarim de Taiwan seguiu seu próprio caminho. O "Dicionário Revisado do Mandarim Nacional" (重編國語辭典修訂本) do Ministério da Educação registra os usos característicos de Taiwan; o continente, por sua vez, elaborou em 1955 o "Dicionário do Chinês Moderno" (現代漢語詞典), seguindo um caminho de padronização diferente. Depois de décadas de desenvolvimento separado desses dois dicionários, já existem mais de trezentos verbetes com divergência evidente entre o vocabulário de uso comum.
+
+"Jìchéngchē" (計程車) e "chūzūchē" (出租車) — táxi; "ruǎntǐ" (軟體) e "ruǎnjiàn" (軟件) — software; "yìngdié" (硬碟) e "yìngpán" (硬盤) — disco rígido; "pǐnzhí" (品質) e "zhìliàng" (質量) — qualidade. Por trás de cada par de palavras há uma bifurcação de caminhos que cada lado seguiu por conta própria.
+
+> 📊 **Os números falam**
+>
+> O "Manual de Consulta de Termos do Continente" (大陸用語檢索手冊), publicado em 1997 pelo Conselho de Assuntos Continentais do Yuan Executivo (organizado por Zhu Jianing e outros), reuniu as divergências evidentes entre o vocabulário comum de Taiwan e do continente, cobrindo áreas como vida cotidiana, tecnologia, educação e mídia. As divergências se dividem em três tipos principais: palavras herdadas do japonês (biàndāng/héfàn — marmita), divergências na estratégia de tradução (ruǎntǐ/ruǎnjiàn — software), e neologismos criados de forma independente pelos dois lados (wǎnglù/hùliánwǎng — internet).
+
+## O eco linguístico depois da lei marcial
+
+Em 1987, Taiwan levantou a lei marcial, encerrando trinta e oito anos de repressão política. As línguas que haviam sido soterradas também começaram, aos poucos, a ressurgir.
+
+As emissoras de televisão passaram a exibir programas em hokkien taiwanês; o currículo escolar incorporou "línguas locais" (鄉土語言), mais tarde promovidas à categoria de disciplina obrigatória sob o nome de "línguas nativas" (本土語言). O Instituto de Linguística da Academia Sinica incluiu o "mandarim taiwanês" (台灣國語 — a variante do mandarim com traços de substrato do hokkien taiwanês) no âmbito da pesquisa sobre línguas nativas, tratando-o como um fenômeno linguístico digno de estudo independente, e não como uma versão inferior do mandarim padrão.
+
+O hokkien taiwanês, o hakka e as línguas indígenas entraram nos livros didáticos, mas décadas de repressão linguística não se resolvem com uma reforma curricular. O que muitos linguistas fizeram nesse período não foi apenas pesquisa, mas algo mais parecido com um socorro de emergência: gravar em fita o vocabulário que saía da boca dos idosos, correndo contra o tempo antes que a última geração de falantes nativos morresse, para preservar a língua. [[語言多樣性與母語文化]]
+
+Essa também foi uma época de uma estética linguística particular: misturar hokkien taiwanês e mandarim, não por falta de fluência, mas por escolha. "Jiu" (揪, convidar/reunir) carrega uma intimidade a mais do que "yuē" (約, marcar); "Chia̍h-pá--bōe" (呷飽未, "já comeu?") tem um calor a mais do que "Nǐ chī le ma" (你吃了嗎). As pessoas que falam essa língua mista sabem que estão fazendo uma escolha.
+
+## O cabo de guerra linguístico da era da internet
+
+Depois dos anos 2000, uma nova pressão linguística começou a chegar de outra direção.
+
+A internet colocou os falantes das duas margens do Estreito no mesmo espaço. Os taiwaneses começaram a entrar em contato, em fóruns, salas de bate-papo e redes sociais, com uma grande quantidade de termos usados no continente. "Yǐngpiàn" (影片) e "shìpín" (視頻) — vídeo — passaram a coexistir; "bùluòkè" (部落客) e "bózhǔ" (博主) — blogueiro — também; "ànzàn" (按讚) e "diǎnzàn" (點贊) — curtir — igualmente. Algumas palavras se infiltraram por serem práticas de usar; outras provocaram uma rejeição evidente.
+
+Nos anos 2010, com a ascensão das plataformas de vídeos curtos, essa velocidade de infiltração aumentou. Os jovens de Taiwan, sem perceber, começaram a usar "guīmì" (閨蜜) em vez de "sǐdǎng" (死黨) — melhor amiga; "yánzhí" (顏值) em vez de "wàibiǎo" (外表) — aparência; "rénshè" (人設) em vez de "xíngxiàng" (形象) — imagem construída. Essas palavras não vieram de uma influência política; vieram junto com o conteúdo de entretenimento, junto com os algoritmos, junto com os vídeos engraçados.
+
+Foi nesse contexto que surgiu o termo "polícia do vocabulário chinês" (支語警察). Apareceu primeiro nas comunidades de anime e games, depois se espalhou por vários fóruns de discussão, referindo-se a quem se mantém vigilante contra a "continentalização" da língua. Uns acham essa vigilância exagerada, outros acham que é proporcional. Mas, independentemente da posição, esse fenômeno em si revela algo: muitos taiwaneses começaram a se dar conta, ativamente, de que língua falam e de onde ela vem.
+
+> 📝 **Nota do curador**
+>
+> O sistema NoteTA da Wikipédia é a solução técnica mais interessante para esse problema. Esse sistema permite que os editores definam regras de conversão de vocabulário regional para um mesmo artigo: quem lê na variante tradicional de Taiwan vê "ruǎntǐ" (軟體); quem lê na variante simplificada do continente vê automaticamente "ruǎnjiàn" (軟件). Um único banco de dados, múltiplos conjuntos de vocabulário — a divergência linguística vira um problema de engenharia que pode ser resolvido em código. Isso não é unificação, é o reconhecimento da legitimidade da divergência.
+
+## Preservar não é coisa de museu
+
+"Polícia do vocabulário chinês" e "preservação linguística" são duas coisas diferentes, mas nascem da mesma ansiedade: o desaparecimento da língua é real, a mudança da língua também é real, e ambos merecem ser levados a sério.
+
+O linguista Tsao Feng-fu (曹逢甫), ao pesquisar o contato linguístico em Taiwan, escreveu: "O ecossistema linguístico de Taiwan é um campo de contato completo; a influência entre as diferentes línguas é bidirecional e dinâmica." O que ele quer dizer é que tratar qualquer fenômeno linguístico como "puro" ou como "contaminação" é simplificar um processo muito mais complexo do que isso.
+
+Preservar os hábitos vocabulares do mandarim taiwanês não significa congelá-lo num museu, impedindo-o de continuar evoluindo. Significa, sim, preservar, ao longo do processo de evolução, os rastros de experiências de vida reais: a memória da Ferrovia Taiwan embutida na palavra "biàndāng" (marmita); o calor de vizinhança embutido na palavra "ōbāsang" (tia); o substrato do hokkien taiwanês embutido na frase "Wǒ yǒu chīfàn le" (eu já comi); e também o hokkien taiwanês das avós e as línguas indígenas dos anciãos das aldeias, que estão desaparecendo.
+
+A língua está viva. Ela não deixa de mudar só porque foi registrada. Mas a parte que foi registrada pode deixar que as gerações futuras saibam o que esta ilha um dia teve, o que ela um dia sentiu.
+
+É esse o sentido da preservação, não uma razão para o confronto.
+
+---
+
+## Leitura Complementar
+
+[[台灣外來語與語言接觸]]
+[[台灣原住民語言復振運動]]
+[[語言多樣性與母語文化]]
+[[客家文化與語言]]
+
+---
+
+## Leitura Complementar
+
+- Zhu Jianing e outros, *Manual de Consulta de Termos do Continente*, Conselho de Assuntos Continentais do Yuan Executivo, 1997. https://mac.gov.tw
+- Instituto de Linguística da Academia Sinica, Base de Dados de Pesquisa sobre o Mandarim Taiwanês. https://ling.sinica.edu.tw
+- Ministério da Educação, *Dicionário Revisado do Mandarim Nacional* (versão online). https://dict.revised.moe.edu.tw
+- Yang Yun-ping, "A política linguística do domínio japonês em Taiwan", em *Cultura de Taiwan*, 1948.
+- Tsao Feng-fu, *Para onde vai a política linguística de Taiwan*, Editora Avant-Garde, 1995.
+- Wikipédia, verbete "Mandarim taiwanês" (臺灣國語). https://zh.wikipedia.org/wiki/臺灣國語
+- Conselho de Pesquisa, Desenvolvimento e Avaliação do Yuan Executivo, *Relatório sobre a Política Linguística de Taiwan*, 2009. https://www.ndc.gov.tw


### PR DESCRIPTION
Adds Portuguese translation of `Culture/台灣華語的演化.md`.

**Translation method**: Rewrite-style (not literal) per TRANSLATE_PROMPT.md

**AI-assisted**: Yes (Claude Sonnet 5)

**Native speaker review**: No (contributor is native Chinese, some Portuguese proficiency)

**Length ratio**: 3.78 (pt band 2.00–4.30 per `scripts/tools/lang-sync/ratio-bands.json`; calibrated corpus 2.44–3.97)

**Structure alignment**: 9 `##` sections / 0 formal footnotes + 5 inline URLs (matches source exactly — see note below) / 4 wikilinks / 2 curator-note callouts / 1 stats callout — 100% preserved, including the source's own duplicate "延伸閱讀"/"Leitura Complementar" heading (one wikilink-only list, one bullet list with plain URLs) rather than "fixing" it.

**Wikilinks**: all 4 inline wikilinks (`[[台灣原住民語言復振運動]]`, `[[客家文化與語言]]`, `[[語言多樣性與母語文化]]`, `[[台灣外來語與語言接觸]]`) already have pt translations, so per TRANSLATE_PROMPT rule 2 they're kept unchanged (same zh title text) rather than translated or converted to markdown links.

**Local gates run before push**: `verify-translation.py` → 17 pass / 0 fail; `article-health.py` → hard=0, one WARN on `footnote-density` ("Level C: no formal footnotes but 5 inline URLs") — confirmed this is inherited unchanged from the zh source itself (ran the same check against `knowledge/Culture/台灣華語的演化.md`, identical warning), not introduced by the translation. `subcategory-translation-parity` ✅ (`subcategory: '語言與文字'` kept as the zh grouping key, not translated) and `wikilink-target` ✅.

**Note**: `i18n/pt/STYLE.md` not yet exists — followed TRANSLATE_PROMPT + established conventions from the existing pt corpus (`## Referências`/`## Leitura Complementar`, `> **Visão geral em 30 segundos:**`, `📝 **Nota do curador**`).

Uncertain terminology flagged for reviewer:

- Every code-switched term (便當/弁当/biàndāng, 歐巴桑/おばさん/ōbāsang, etc.) is given in Hanyu Pinyin with the Chinese characters and, where relevant, the Japanese source term in parentheses at first mention — there's no established pt-Taiwan-linguistics romanization convention to follow, so pinyin was the most legible default for a Portuguese reader.
- Taiwanese Hokkien examples (「我有食過矣」、「a-sà-lih」等) romanized in Tâi-lô since that's the closest to a standard orthography; flagged in case the pt corpus has a different house convention for Hokkien romanization.
- 支語警察 → `"polícia do vocabulário chinês"` — literal rendering; no existing pt-language term for this specific Taiwan-internet phenomenon.
- 📊 curator-note variant → used `📊 **Os números falam**` since the pt corpus doesn't have one consistent label for this emoji/box type (sampled variants include "Instantâneo de dados", "Ele em números", "Os números em perspectiva").

Please review. Happy to iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jw4QiXsyxGq4HGSinN9L8Q
